### PR TITLE
Livekit voices and CallId in metadata

### DIFF
--- a/agents/livekit/realtime.mjs
+++ b/agents/livekit/realtime.mjs
@@ -178,6 +178,8 @@ export default defineAgent({
           }
         }
       });
+      const { metadata } = call;
+      metadata.aplisay.callId = call.id;
       await TransactionLog.create({ userId, organisationId, callId: call.id, type: 'answer', data: instance.id, isFinal: true });
 
       const { prompt, modelName, options, functions, keys } = agent;
@@ -210,7 +212,7 @@ export default defineAgent({
           },
           execute: async (args) => {
             logger.debug({ name: fnc.name, args, fnc }, `Got function call ${fnc.name}`);
-            let { function_results } = await functionHandler([{ ...fnc, input: args }], functions, keys, sendMessage, {}, { transfer }); // fix metadata here
+            let { function_results } = await functionHandler([{ ...fnc, input: args }], functions, keys, sendMessage, metadata, { transfer }); // fix metadata here
             let [{ result: data }] = function_results;
             logger.debug({ data }, `returning ${JSON.stringify(data)}`);
             return JSON.stringify(data);

--- a/lib/database.js
+++ b/lib/database.js
@@ -26,9 +26,6 @@ const { POSTGRES_DB,
 
 const forceSync = NODE_ENV === 'development' || DB_FORCE_SYNC === 'true';
 
-// This is the maximum size of a notification payload we will send
-//  to the client.  Postgres has a max of 8k for the whole JSON so we
-//  sandbag this to be much smaller to ensure that we don't come close, even with 
 
 const sequelize = new Sequelize(
   POSTGRES_DB,
@@ -149,13 +146,20 @@ Agent.init({
     charset: 'utf8',
     collate: 'utf8_general_ci',
     validate: {
-      handlerSupportsBuiltinFunctions() {
+      async handlerLimitations() {
         const { getHandler } = require('./handlers');
         logger.debug({ getHandler, modelName: this.modelName }, 'Handler');
         let Handler = getHandler(this.modelName);
         logger.debug({ getHandler, Handler, modelName: this.modelName }, 'Handler');
         if (!Handler) {
           throw new Error(`Unknown model name: ${this.modelName}`);
+        }
+        if (this.options?.tts?.voice) {
+          const allVoices = Object.values(await Handler.voices).flat().map(v => Object.values(v)).flat().flat().map(v => v.name);
+          if (!allVoices.includes(this.options.tts.voice)) {
+            logger.error({ options: this.options, voices: allVoices }, 'Voice not supported');
+            throw new Error(`Voice ${this.options.tts.voice} not supported by ${this.modelName}`);
+          }
         }
         const functions = Object.entries(this.functions);
         return functions.every(([name, func]) => {

--- a/lib/handlers/ultravox.js
+++ b/lib/handlers/ultravox.js
@@ -31,10 +31,10 @@ class Ultravox extends Handler {
     return api.get('/voices').then(res => (
       {
         ultravox: {
-          'en-US': res.data.results.map(({ name, description }) => (
+          'any': res.data.results.map(({ name, description }) => (
             {
               name,
-              description: name.length < 20 ? `${name} - ${description}` : description,
+              description: name.length < 20 ? `${name} - ${description}` : (description || name),
               gender: 'unknown',
             }
           ))
@@ -101,6 +101,7 @@ class Ultravox extends Handler {
           metadata
         }));
       }
+      
       joinUrl = new URL(joinUrl);
       websocket && joinUrl.searchParams.append('experimentalMessages', 'debug');
       callId && (this.callId = callId);


### PR DESCRIPTION
The tactical registrar of aplisay-strategy `implementation/regserver-tactical-spec.md` (hitlist H16): a second binary, `regserver`, that customer PBXes register *to* over TLS through a TCP pass-through balancer, with ownership following the socket and calls bridged in both directions exactly as regclient bridges the registrations it holds outward. Items 2 to 9 and 11 of the spec's work breakdown, one commit each.

## What changes for regclient

Two commits touch the existing binary, and both are safe to deploy alone:

- **Never claim a registrar row** (`8fdf6b4`): every claim query carries `coalesce(mode, 'client') = 'client'`, and the projection reads `mode`, `kind` and `bindings`. **Requires llm-agent schema 66 to be live first** (aplisay/llm-agent `feat/registrar-accounts`); against the old schema every claim fails. This predicate must be on every node before the first registrar row exists, or a regclient node would register to our own balancer with the credentials we issued a customer.
- **The call path** (`3cea510`): registrar rows carry bindings, the correlator's rule 0 names an account by its socket, and INVITEs from a PBX are challenged. regclient sets none of the new hooks and behaves as before; the b2bua suite is unchanged in outcome.

## The registrar

- `internal/inboundauth`: the platform flank's challenger generalised (verdicts, per-account lookup, identity rules); `internal/sip/certstore.go`: certificates for names we own, chosen by SNI, reloaded on change.
- `internal/db/registrar.go`: pinned-only poll, `OwnBySocket`, the bindings mirror, boot and shutdown resets.
- `internal/regserver`: binding store with the RFC 3261 §10.3 rules, the REGISTER handler (401 then 403 in constant time, 423, 5 failures a minute then cooling, per-node rate limit), server-side keepalive, the engine, and the registry the b2bua takes its hooks from.
- `cmd/regserver`, `REGSERVER_*` configuration (node name must resolve to `EXT_IP_ADDRESS`; certificate must be publicly trusted and cover the balancer and node names; `REGSERVER_PROXY_PROTOCOL` refuses to start as unimplemented), the Dockerfile parameterised on `CMD`, all three Cloud Build lanes, `deploy/k8s/base-regserver` with a Local-policy Service and a node-naming initContainer, `deploy/k8s/do-beta-regserver` with the LON1 certificate, and a `regserver` compose profile for staging.
- The `register-in` trace kind, `regserver_*` metrics, `GET /debug/registrations/{id}/bindings`, and health fields for bindings and certificate expiry.

## Tests

`go test ./...` is green, including the database tests and the §10.2 integration test (two nodes, a proxy standing in for the balancer, a sipgo PBX, a fake platform: register, call both ways, move nodes with forward-to-owner, keepalive loss, and the sixth wrong password refused without a challenge) with `REGCLIENT_TEST_DSN` set. The integration test found and this branch fixes one real bug: the TLS-only flank's dialog Contact advertised the plaintext port.

## Not in this PR

The 3CX acceptance run (§10.3), and the LON1 infrastructure steps listed in the `do-beta-regserver` overlay header: the pool, the per-node A records and address map, applying the `letsencrypt-dns` ClusterIssuer (the token and secret already exist), the pool firewall, and the `sip.polite.ai` record to the balancer.
