### PR TITLE
Stage /ship workflow (ship-kit install; provisional verify)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,44 @@
+---
+description: Take the open `action` issues all the way to merged on the integration branch (parallel-issues → adversarial review gate → merge-train), using the central ship-kit pinned at runtime.
+argument-hint: "[optional JSON args, e.g. {\"apply\":false} or [29,30]]"
+---
+
+Run the full **issue → PR → merge** pipeline for THIS repo, using the *generalised* workflow scripts from the central **ship-kit** repo (fetched fresh at run time, so every project always runs the latest tuned logic). All project specifics come from this repo's `.claude/ship.config.json`.
+
+Do this:
+
+1. **Load this repo's config.** It must exist; if not, STOP and tell the user to run the ship-kit install (see ship-kit `install.md`).
+   ```bash
+   set -e
+   git fetch origin -q || true
+   CFG=.claude/ship.config.json
+   [ -f "$CFG" ] || { echo "No .claude/ship.config.json — run the ship-kit install first."; exit 1; }
+   rd(){ node -e "console.log((JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))[process.argv[2]])||process.argv[3]||'')" "$1" "$2" "$3"; }
+   BASE=$(rd "$CFG" base next)
+   # Prefer the integration-branch copy of the config so a stale feature branch still
+   # ships with the canonical settings (falls back to the local file).
+   if git show "origin/$BASE:.claude/ship.config.json" > /tmp/ship.config.json 2>/dev/null; then CFG=/tmp/ship.config.json; fi
+   KITREPO=$(rd "$CFG" kitRepo aplisay/ship-kit)
+   KITREF=$(rd "$CFG" kitRef main)
+   echo "config=$CFG base=$BASE kit=$KITREPO@$KITREF"
+   ```
+   (Then read the resolved `$CFG` file with the Read tool — that JSON object is the `cfg` you pass as workflow args in step 3.)
+
+2. **Materialise the kit.** Clone the central kit at its pinned ref into a scratch dir (private repo → use `gh` for auth):
+   ```bash
+   DIR=$(mktemp -d)
+   gh repo clone "$KITREPO" "$DIR" -- --depth 1 --branch "$KITREF" -q
+   echo "$DIR/workflows"
+   ```
+
+3. **Run the wrapper by path**, merging the repo's config with any `$ARGUMENTS` the user passed and pointing the nested children at the cloned kit:
+   - Read `$CFG` into an object `cfg`.
+   - `Workflow({ scriptPath: "<DIR>/workflows/ship-issues.js", args: { ...cfg, _dir: "<DIR>/workflows", ...$ARGUMENTS } })`
+   - If `$ARGUMENTS` is empty, just pass `{ ...cfg, _dir: "<DIR>/workflows" }` (defaults: discover open `action` issues, `apply: true`, squash-merge into the configured base).
+   - `$ARGUMENTS` may be a JSON object (`{"apply":false}`, `{"issues":[29,30]}`) or a bare array of issue numbers (`[29,30]`) — merge an object in directly; if it's an array, pass it as `issues`.
+
+4. **Report** when it finishes: issues planned vs deferred, PRs opened (with the merge order), the review gate outcome (which PRs passed, which were **held for a human** after exhausting fix iterations, and the lens-divergence rate), what merged vs where it stopped, any blocked issues, and any issues closed by the train.
+
+`ship-issues` runs `parallel-issues` (plan → implement each issue on an isolated worktree → verify with the repo's configured checks → open one PR per issue against the base), then runs an **adversarial review gate** on each PR (default 3 independent full-scope reviewers; a flagged PR is re-fixed from the review feedback and re-reviewed up to `maxFixIterations` times — default 2 — before being held open for a human), and finally feeds the PRs that **passed review** into `merge-train` with `apply: true` (each PR merged only after its merged tree passes verify; resolved issues are closed explicitly since the base is not the default branch).
+
+Review knobs (all optional in `$ARGUMENTS`): `apply:false` produces PRs + a local dry-run integration with nothing merged; `review:false` skips the gate; `reviewLenses` (1–3, default 3) sets reviewers per PR; `fullScope:false` reverts to the partitioned correctness/regressions/conventions lenses; `maxFixIterations` (default 2) caps the re-fix attempts before holding.

--- a/.claude/ship.config.json
+++ b/.claude/ship.config.json
@@ -1,0 +1,23 @@
+{
+  "kitRepo": "aplisay/ship-kit",
+  "kitRef": "main",
+  "repo": "aplisay/llm-agent",
+  "base": "next",
+  "releaseBranches": ["main", "master"],
+  "actionLabel": "action",
+  "lockLabel": "in-progress",
+  "contextDoc": "docs/CONTEXT.md",
+  "stackSentinels": ["index.mjs", "api/api-doc.yaml", "package.json", "docs/CONTEXT.md"],
+  "hotFiles": [
+    "index.mjs",
+    "api/api-doc.yaml",
+    "lib/ws-handler.js",
+    "lib/handlers/index.js",
+    "lib/database.js",
+    "lib/models/index.js",
+    "package.json"
+  ],
+  "install": "yarn install --frozen-lockfile",
+  "verify": ["cd agents/livekit && yarn build"],
+  "reviewFocus": "Node/Express API backend (index.mjs + express-openapi against api/api-doc.yaml; lib/* services; gateway agents under agents/{livekit,pipecat,jambonz}). PROVISIONAL CONFIG — see docs/CONTEXT.md: the verify command, install, hotFiles and conventions still need a domain pass before the first real /ship run (e.g. the agents/livekit build uses tsup and its own lockfile; the full test suite needs docker/DB and is not yet in the gate). Watch the lib → agents/livekit/dist layering coupling (issue #123): a declared type at that boundary is not runtime-safe."
+}

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,84 @@
+name: Agent task
+description: A scoped improvement to be implemented by a parallel agent (one issue → one PR).
+title: "[task]: "
+labels: ["action"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Scope this so a single agent can finish it in one focused PR. The clearer the
+        **acceptance criteria** and **lane**, the cleaner the parallel run + merge.
+        See `docs/CONTEXT.md`.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences — what should change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / context
+      description: Why this matters; any background, links, or screenshots.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: A checklist the agent (and reviewer) can verify against.
+      value: |
+        - [ ]
+        - [ ] The repo's configured verify check passes (see docs/CONTEXT.md → Definition of Done)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: lane
+    attributes:
+      label: Lane(s) — primary area/files this touches
+      description: |
+        Used to plan the merge order and flag PRs that will collide. Pick all that apply.
+        The first two are high-contention shared files — overlap there means PRs merge
+        sequentially (later ones rebased).
+      multiple: true
+      options:
+        - "API surface — api/api-doc.yaml, api/paths/*"
+        - "Server entry / wiring — index.mjs, lib/ws-handler.js, lib/handlers/*"
+        - "LLM model adapters — lib/models/* (anthropic, openai, gemini, livekit, pipecat, ultravox, …)"
+        - "Gateway agent — agents/livekit | agents/pipecat | agents/jambonz"
+        - "Database / models — lib/database.js, lib/database-models/*"
+        - "Voices — lib/voices/*, lib/model-voices.js"
+        - "Auth / scope / admin — lib/auth/*, lib/scope.js, lib/admin-gate.js"
+        - "Usage / billing — lib/usage.js"
+        - "Docs / config / CI"
+        - "Other / not sure"
+    validations:
+      required: true
+
+  - type: input
+    id: files
+    attributes:
+      label: Files likely touched (optional, more specific than lane)
+
+  - type: input
+    id: dependencies
+    attributes:
+      label: Depends on (issue numbers)
+      description: Issues whose code this needs. The planner will sequence/defer these.
+      placeholder: "#73, #74"
+
+  - type: dropdown
+    id: ui
+    attributes:
+      label: Does this change the public API surface?
+      description: If yes, update api/api-doc.yaml and call it out (it is a hot/shared file).
+      options:
+        - "No"
+        - "Yes"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+# Optional: add contact_links here, e.g. a pointer to docs/CONTEXT.md or a workflow doc.
+# contact_links:
+#   - name: How the parallel-agent (/ship) workflow works
+#     url: https://github.com/aplisay/ship-kit
+#     about: Read this before filing a batch of agent tasks — it explains lanes, the review gate, and the merge-train.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!-- One issue → one focused PR. Base = `next` (never `main` — main is release-only/tagged).
+     See docs/CONTEXT.md (Definition of Done + coordination / hot files). -->
+
+Closes #
+
+## What changed
+<!-- The change, in 1–3 bullets. Keep the diff small and single-purpose. -->
+-
+
+## Why
+<!-- The motivation / the issue's intent. -->
+
+## Lane(s) / files touched
+<!-- Match the issue's lane. Call out any high-contention shared files
+     (index.mjs, api/api-doc.yaml, lib/ws-handler.js, lib/handlers/*, lib/database.js,
+     lib/models/index.js, package.json) so the merge-train sequences this correctly. -->
+
+## How verified
+<!-- Paste the result of the repo's verify check (see docs/CONTEXT.md → Definition of Done). -->
+```
+
+```
+
+## Checklist
+- [ ] The repo's configured verify check passes locally
+- [ ] No temporary scaffolding/debug code left behind
+- [ ] Public API changes are reflected in `api/api-doc.yaml`
+- [ ] Follows the conventions in docs/CONTEXT.md
+- [ ] Rebased on the latest `next`

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,11 @@ agent.json
 **/__pycache__
 *.pyc
 docs/security.md
+
+# ship-kit: track the /ship command + config; keep the rest of .claude ignored
+!.claude/
+.claude/*
+!.claude/commands/
+.claude/commands/*
+!.claude/commands/ship.md
+!.claude/ship.config.json

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -1,0 +1,121 @@
+# CONTEXT.md — agent onboarding for `llm-agent`
+
+> **STATUS: STARTER / PROVISIONAL.** This file was scaffolded as part of the ship-kit
+> install and captures the structure that is observable from the tree. The sections marked
+> **TODO(domain)** need a pass from someone who knows the system *before the first real
+> `/ship` run*, because the parallel agents and reviewers rely on this file being correct.
+> In particular: confirm the Definition of Done (§4), conventions (§10), and hot files (§11).
+
+You are editing **llm-agent**, Aplisay's voice-agent orchestration backend: an HTTP/WebSocket
+API that provisions and drives conversational voice agents across multiple gateways
+(LiveKit, Pipecat, Jambonz) and LLM providers. Read this fully before touching code.
+
+## 1. What this project is
+
+A Node/Express service (`index.mjs`) exposing an OpenAPI-described REST API plus a WebSocket
+channel, backed by a database, that creates agents, places/receives calls, streams
+transcripts, handles transfers/recording, and meters usage. Gateway-specific agent code
+lives under `agents/`.
+
+## 2. Tech stack (versions that matter)
+
+- **Node + ES modules** (`.mjs`/`.js`, `"type": "module"`-style imports).
+- **Express** + **express-openapi** driven by `api/api-doc.yaml` (+ `api/paths/*`).
+- **yarn** at the repo root. **`agents/livekit`** is **TypeScript built with tsup**
+  (`dist/`) and has its **own lockfile** (pnpm) — it is effectively a sub-project.
+- **Jest** tests, split into DB-backed and no-DB configs; DB tests use **docker-compose**.
+- TODO(domain): pin the Node version and any other version that changes commands.
+
+## 3. Getting started
+
+```bash
+yarn install
+# agents/livekit is a separate build (TypeScript → dist via tsup):
+cd agents/livekit && yarn build && cd -
+yarn develop            # NODE_ENV=development … nodemon index.mjs
+```
+TODO(domain): document required env (`environment-example`) and any service deps.
+
+## 4. How to verify a change (the Definition of Done)
+
+**Current gate (provisional): the `agents/livekit` build must pass** —
+`cd agents/livekit && yarn build`. This catches the `lib → agents/livekit/dist` layering
+class of breakage (see issue #123) at low cost. It matches `verify` in
+`.claude/ship.config.json`.
+
+TODO(domain): decide the real gate. Candidates to add once validated in a worktree:
+- `yarn test:no-db` (jest, no database) — fast, no docker.
+- the full `yarn test:db` (needs docker/DB via `tests/docker-compose.test.yml`) — heavier;
+  likely too slow/fragile to run per-PR in parallel worktrees without tuning.
+The gate must be runnable on an isolated worktree with only `yarn install` + the livekit
+build available. Keep it deterministic.
+
+## 5. Architecture & where things live
+
+- `index.mjs` — server entry: Express + express-openapi (`api/api-doc.yaml`), HTTP server,
+  WebSocket server (`lib/ws-handler.js`), handler cleanup (`lib/handlers/index.js`).
+- `api/` — `api-doc.yaml` (the OpenAPI surface) + `paths/` (operation handlers).
+- `lib/` — the core services:
+  - `models/*` — LLM/gateway adapters: `anthropic, openai, gemini, google-vertexai, groq,
+    ultravox, livekit, pipecat` + `index.js`, `llm.js`.
+  - `database.js`, `database-models/*` — persistence.
+  - `handlers/`, `ws-handler.js` — request/WebSocket lifecycle.
+  - `agent-set-service.js`, `agent-set-labels.js`, `set-builder-agent.js`, `subagent.js`,
+    `builtin-agents.js` — agent-set / multi-agent features.
+  - `voices/*`, `model-voices.js` — voice catalogue.
+  - `auth/*`, `scope.js`, `admin-gate.js` — auth & RBAC.
+  - `usage.js` — usage metering (billing pipeline).
+  - `recording/`, `call-hook.js`, `jambonz.js`, `concurrency/`, `schemas/`, `utils/`.
+- `agents/` — `livekit` (TS/tsup), `pipecat`, `jambonz`: the per-gateway agent runtimes.
+- `middleware/`, `tools/`, `scripts/`, `data/`, `deploy/`.
+- `docs/*.md` — extensive design docs (architecture, recording, transfers, MCP, etc.).
+
+## 6. API surface
+
+`api/api-doc.yaml` is the contract; operations resolve to `api/paths/*`. Any change to the
+public API MUST update `api/api-doc.yaml` — it is a hot/shared file.
+
+## 7. Data flow, services & boundaries
+
+Calls flow API/WS → a gateway agent (`agents/*`) → an LLM provider (`lib/models/*`).
+**Layering caution:** `lib/models/livekit.js` imports the LiveKit agent's compiled `dist`
+(issue #123) — a declared TypeScript type at that boundary is **not** runtime-safe; a
+reviewer must treat that class of defect as blocking.
+TODO(domain): document the auth model and the DB/service boundaries.
+
+## 8. (n/a) UI
+This is a backend service — no UI.
+
+## 9. Persistence / external systems
+
+A database (see `lib/database.js`, `lib/database-models/*`); external gateways (LiveKit,
+Pipecat, Jambonz) and LLM providers. DB tests run against docker-compose.
+TODO(domain): name the DB engine, migrations, and required external creds.
+
+## 10. Conventions, gotchas & non-negotiables
+
+TODO(domain): the rules a reviewer enforces. Seeds:
+- Keep the public API (`api/api-doc.yaml`) and its `api/paths/*` handlers in sync.
+- Respect the `lib → agents/*/dist` layering (don't deepen the inversion of issue #123).
+- ES-module import style; match existing logging (`lib/logger.js`).
+
+## 11. Working in parallel (coordination)
+
+**High-contention shared files** (edits force sequential merges — match `hotFiles` in
+`.claude/ship.config.json`):
+`index.mjs`, `api/api-doc.yaml`, `lib/ws-handler.js`, `lib/handlers/index.js`,
+`lib/database.js`, `lib/models/index.js`, `package.json`.
+TODO(domain): confirm/extend this list from real merge experience.
+
+## 12. Quick file index
+
+| Touching… | Look at… |
+|---|---|
+| The API surface | `api/api-doc.yaml` → `api/paths/*` |
+| Server/WS wiring | `index.mjs`, `lib/ws-handler.js`, `lib/handlers/*` |
+| An LLM/gateway adapter | `lib/models/*` |
+| A gateway runtime | `agents/{livekit,pipecat,jambonz}` |
+| Persistence | `lib/database.js`, `lib/database-models/*` |
+| Voices | `lib/voices/*`, `lib/model-voices.js` |
+| Auth / RBAC | `lib/auth/*`, `lib/scope.js`, `lib/admin-gate.js` |
+| Usage / billing | `lib/usage.js` |


### PR DESCRIPTION
## Stage the `/ship` workflow for llm-agent

Installs the `/ship` parallel **issue → PR → merge** pipeline (the one now live on
`next-website`), driven by the central private kit **`aplisay/ship-kit`** which is fetched
at run time — so the workflow *logic* lives in one place and improves everywhere at once.
This PR adds only llm-agent's project-specific footprint.

This was done in a worktree off `origin/next` and **does not touch the `billing` branch**.

### What's in the diff
- `.claude/commands/ship.md` — generic `/ship` command (clones the kit, reads the config, runs by path)
- `.claude/ship.config.json` — llm-agent knobs (`base: next`, `verify: ["cd agents/livekit && yarn build"]`)
- `.github/ISSUE_TEMPLATE/agent-task.yml` + `config.yml`, `.github/pull_request_template.md`
- `docs/CONTEXT.md` — **STARTER** onboarding doc (structure is real; domain specifics marked `TODO(domain)`)
- `.gitignore` — tracks just the two `.claude` ship files (the rest of `.claude` stays ignored)

### ⚠️ Provisional — needs a domain pass before the first real `/ship` run
The pipeline is wired but deliberately conservative. **Do these before running `/ship` for real:**

1. **Verify gate.** It's build-only right now: `cd agents/livekit && yarn build` (cheap, and
   it catches the `lib → agents/livekit/dist` coupling class of [#123](https://github.com/aplisay/llm-agent/issues/123)).
   Decide the real Definition of Done — likely add `yarn test:no-db`; the full `yarn test:db`
   needs docker/DB and is probably too heavy to run per-PR in parallel worktrees without
   tuning. Confirm the gate runs on an isolated worktree with only `yarn install` + the
   livekit build available (note `agents/livekit` has its own lockfile).
2. **`docs/CONTEXT.md`** — fill the `TODO(domain)` sections (§4 DoD, §10 conventions, §11 hot
   files, env/DB). Agents and reviewers depend on this being correct.
3. **Labels** — not created yet (deferred to avoid touching repo state while billing is
   active). When ready:
   ```bash
   gh label create action      --color 0E5C57 --description "Ready for action"
   gh label create in-progress --color FBCA04 --description "An agent is actively implementing this issue"
   ```
   Then triage which open issues get the `action` label.
4. **Run `/ship` from an llm-agent-rooted session** (a fresh chat whose working dir is this
   repo) — the workflow's worktree isolation targets the session's repo, so it must not be
   launched from another project's session. Start with `/ship {"apply": false}` (dry-run, no
   merges) or `/ship [<issue>]` on one scoped issue.

### Coordination
Landing this onto `next` is independent of the `billing` work. Merge whenever convenient;
the only follow-ups are the four items above. The kit itself: `aplisay/ship-kit` (private),
see its `README.md` / `install.md`.
