### PR TITLE
Fix: end consultation call record on consultative transfer rejection

### DIFF
--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -1281,14 +1281,47 @@ export async function rejectConsultativeTransfer(
   );
 
   try {
-    // Step 1: End consultation call and create transaction logs for transcript
-    //         we do this first because later steps will likely cause an async
-    //         hangup which will cause the consultation call to be ended through
-    //         a different path.
+    // Step 1: End consultation call and create transaction logs for transcript.
+    //         We do this first because later steps cause an async hangup of the
+    //         transfer target. On the rejection path there is no other code path
+    //         that ends the consultation call record (destroyInProgressTransfer
+    //         short-circuits once setConsultInProgress(false) is set below), so
+    //         it must happen here or the record is left started but never ended.
 
     if (!finalSummary) {
       // If no transcript available, use default message
       finalSummary = "Transfer target declined the transfer";
+    }
+
+    const consultCall = getConsultCall();
+    if (consultCall) {
+      try {
+        if (transferSession) {
+          const transcript = getTransferAgentTranscript(transferSession);
+          if (transcript) {
+            const { userId, organisationId } = agent;
+            await createTransactionLog({
+              userId,
+              organisationId,
+              callId: consultCall.id,
+              type: "agent",
+              data: transcript,
+              isFinal: true,
+            });
+            logger.info(
+              { consultCallId: consultCall.id },
+              "created transaction log for consultation transcript"
+            );
+          }
+        }
+        await consultCall.end(finalSummary);
+        logger.info(
+          { consultCallId: consultCall.id },
+          "ended consultation call"
+        );
+      } catch (e) {
+        logger.error({ e }, "error ending consultation call");
+      }
     }
 
     setConsultInProgress(false);


### PR DESCRIPTION
## Problem

A consultative (warm) transfer that ends in **rejection** leaves its consultation call record started but never ended. This was observed in production on `agent-runner-production-be4` for consult call `8841ef58-d46b-448e-be21-a8417120837f`: the record has `created consultation call record` and `started consultation call` log lines but no end.

The common trigger is the transfer target ringing out to **voicemail** — the voicemail box answers, the transfer agent decides to reject, and/or the target hangs up (`CLIENT_INITIATED`). The rejection is handled by `rejectConsultativeTransfer`, which cleaned up the room and session but **never ended the call record**.

## Root cause

`rejectConsultativeTransfer` destructured `getConsultCall` but never called it. Of the three consult-cleanup paths, only the reject path was missing `consultCall.end()`:

| Path | Function | Ended consult call? |
|------|----------|--------------------|
| Accept | `finaliseConsultativeTransfer` | ✅ |
| Caller hangs up | `destroyInProgressTransfer` | ✅ |
| **Reject** | `rejectConsultativeTransfer` | ❌ (this fix) |

The pre-existing "Step 1" comment claimed the call would be ended "through a different path", but no such path exists — and `destroyInProgressTransfer` short-circuits on its `getConsultInProgress()` guard once `rejectConsultativeTransfer` sets `setConsultInProgress(false)`, so it can never rescue the orphaned record.

## Fix

End the consultation call (and write the transcript transaction log) at the top of the reject cleanup — before the async hangup of the transfer target — mirroring `destroyInProgressTransfer`. All symbols used were already in scope in the function.

## Testing

- `esbuild` parses the edited file cleanly.
- Change is a mechanical mirror of the already-working `destroyInProgressTransfer` end-of-call logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)