### PR TITLE
fix(livekit): persist consult-leg transcript to the consult call record

### DIFF
--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -877,6 +877,46 @@ Be helpful, informal, but respectful and concise as if talking to a colleague in
     });
     setTransferSession(transferSession);
 
+    // Persist the consultation conversation onto the consult CALL RECORD.
+    // Historically the consult leg had NO transcript wiring at all (only usage
+    // metering below), so its transcript was always empty. Mirror the main
+    // session's ConversationItemAdded -> transaction-log capture, but target the
+    // consult call: buffer each turn and attach the buffer as the consult call's
+    // batched transaction logs, which consultCall.end() flushes on every terminal
+    // path (accept / reject / init-fail / destroy). See api-client call.end and
+    // finaliseConsultativeTransfer/endConsultationRecord.
+    const consultTranscriptLogs: Array<{
+      userId: string;
+      organisationId: string;
+      callId: string;
+      type: string;
+      data: string;
+      isFinal: boolean;
+      createdAt: Date;
+    }> = [];
+    transferSession.on(
+      voice.AgentSessionEventTypes.ConversationItemAdded,
+      ({
+        item: { type, role, content },
+        createdAt,
+      }: voice.ConversationItemAddedEvent) => {
+        if (type !== "message") return;
+        const text = content.join("");
+        if (!text) return;
+        consultTranscriptLogs.push({
+          userId: context.agent.userId,
+          organisationId: context.agent.organisationId,
+          // Resolved once the consult call exists; turns captured before the
+          // record is created are back-filled where it is attached below.
+          callId: context.getConsultCall()?.id ?? "",
+          type: role === "user" ? "user" : "agent",
+          data: JSON.stringify(text),
+          isFinal: true,
+          createdAt: createdAt ? new Date(createdAt) : new Date(),
+        });
+      },
+    );
+
     // Meter the consult leg's llm/tts/stt onto the consult call record. The
     // consult LLM is the primary's, so resolve vendors from the primary model.
     // Per-session, so it never double-counts the primary call's usage.
@@ -926,6 +966,12 @@ Be helpful, informal, but respectful and concise as if talking to a colleague in
       },
     });
     context.setConsultCall(consultCallRecord);
+    // Attach the buffered consult transcript so consultCall.end() flushes it, and
+    // back-fill callId for any turns captured before this record existed.
+    for (const consultLog of consultTranscriptLogs) {
+      if (!consultLog.callId) consultLog.callId = consultCallRecord.id;
+    }
+    (consultCallRecord as any).batchedTransactionLogs = consultTranscriptLogs;
     consultUsageMeters.set(consultCallRecord, consultUsageMeter);
     logger.info(
       { consultCallId: consultCallRecord.id, consultRoomName },


### PR DESCRIPTION
## Problem

The consultation (attended-transfer) **leg's transcript is empty** — on prod and everywhere.

During a consultative transfer the platform creates a separate consult `Call` record and a `TransferAgent` session (`transferSession`) that talks to the transfer target. That session is only given **usage metering** (`consultUsageMeter.wire(transferSession)`) — it has **no `ConversationItemAdded` → transaction-log capture**, which is how the main call's transcript is persisted. So the consult conversation is never written to the consult call record and its transcript is always empty.

Confirmed the same gap exists on both `next` and `main`, and `git log -S` shows a handler for this **never existed** — this is an unimplemented gap, not a regression.

## Fix

Wire a `ConversationItemAdded` handler on `transferSession` that mirrors the main session's capture but targets the **consult** call: each message turn is buffered and attached as the consult call's `batchedTransactionLogs`, which the enriched `consultCall.end()` flushes on **every** terminal path (accept / reject / init-fail / destroy). The server `/api/agent-db/call/{id}/end` handler already `bulkCreate`s those logs against the consult call id **and builds the call's transcript from them**, so the consult leg now has a populated transcript.

## Why it's safe

- **Flushes once, on all paths** — all four consult end-sites call `consultCall.end()`; `call.end` is idempotent (`_endCalled` guard) and none pass explicit `transactionLogs`, so the batched array flushes exactly once (no double-send).
- **Correct target** — logs carry the consult call id (and the server also forces the URL call id onto every log), attached to the consult call's own batched array; no interaction with the main call's transcript or its `getConsultInProgress()` guard.
- **No lost turns** — turns emitted before the consult record exists are buffered and back-filled when the record is attached.
- **Unguarded by design** — the consult conversation must always be captured (the main session's suppress-during-consult guard is a separate concern, untouched here).

## Verification

- `yarn build` succeeds; `tsc --noEmit` clean for `transfer-handler.ts` (only the pre-existing `UsageVendors` errors remain, unrelated).
- Traced end-to-end: session `ConversationItemAdded` → buffered log → `consultCall.batchedTransactionLogs` → `consultCall.end()` → server `TransactionLog.bulkCreate` + transcript build.

Not yet exercised against a live consult on staging — worth a smoke test (successful accept **and** a reject) to confirm the consult call's transcript is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
