### PR TITLE
Transfer-out

### DIFF
--- a/agents/livekit/lib/bridge-transcription.ts
+++ b/agents/livekit/lib/bridge-transcription.ts
@@ -1,0 +1,468 @@
+/**
+ * Transcription of the human↔human segment of a bridged transfer
+ * (`options.bridgedTransferTranscribe`).
+ *
+ * After a bridged transfer the AI has left the conversation, so nothing
+ * transcribes the caller↔transfer-target conversation. When the option is
+ * set the worker collects a speaker-labelled transcript of that segment:
+ * the muted agent participant stays connected to the room after
+ * `detachPrimaryAgentMediaAfterBridge` (the same connection the
+ * bridgedTransferToAgent DTMF watch rides on), so this module opens one
+ * rtc-node {@link AudioStream} per bridged human — the caller and the
+ * transfer target are distinct room participants with their own audio
+ * tracks — and runs each through a fresh STT stream.
+ *
+ * STT vendor selection mirrors the worker's own pipeline resolution: the
+ * agent's configured `options.stt` via LiveKit Inference
+ * (`inference.STT.fromModelString(resolvePipelineStt(agent))`, exactly what
+ * AgentSession does with a string `stt`), defaulting to Deepgram when the
+ * agent is a realtime model with no pipeline STT configured — the same
+ * default as pipecat's `build_stt_service`. When
+ * `LIVEKIT_PIPELINE_USE_PROVIDER_KEYS` is set the direct Deepgram plugin is
+ * used instead, again matching the pipeline. `options.
+ * bridgedTransferTranscribe.provider` is IGNORED on LiveKit (it tunes the
+ * voiceblender container's native STT); `language` is honoured best-effort
+ * by threading it through the agent's STT options.
+ *
+ * Final utterances land in a {@link BridgeTranscriptCollector}, which posts
+ * each one to the bridged-segment call record's transaction log (`user` =
+ * caller, `agent` = transfer target — the B-party occupies the agent slot
+ * of a two-party transcript) following the worker's streamed-vs-batched
+ * convention (`instance.streamLog`), and renders the merged history for the
+ * takeover agent's prompt.
+ *
+ * Everything here is best-effort: an STT failure must never disturb the
+ * bridged call or the DTMF watch. See the pipecat reference implementation
+ * (agents/pipecat/pipecat_aplisay/bridge_transcript.py) and
+ * docs/call-transfers.md ("Transcribing the bridged segment").
+ */
+
+import { inference, stt } from "@livekit/agents";
+import { AudioStream, RoomEvent, TrackKind } from "@livekit/rtc-node";
+import type {
+  AudioFrame,
+  RemoteParticipant,
+  RemoteTrack,
+  RemoteTrackPublication,
+  Room,
+  Track,
+} from "@livekit/rtc-node";
+import type { ReadableStream } from "node:stream/web";
+import logger from "./logger.js";
+import { createTransactionLog } from "./api-client.js";
+import type { Agent, Call } from "./api-client.js";
+import { resolvePipelineStt } from "./pipeline-inference-options.js";
+import {
+  buildProviderPipelineStt,
+  pipelineUsesProviderApiKeys,
+} from "./pipeline-provider-keys.js";
+
+/** Speaker labels — the exact strings pipecat's collector renders. */
+export const CALLER = "caller";
+export const TARGET = "transfer target";
+
+/** caller → "user", transfer target → "agent" (the B-party occupies the agent slot). */
+const SPEAKER_LOG_TYPE: Record<string, string> = {
+  [CALLER]: "user",
+  [TARGET]: "agent",
+};
+
+/** Both bridged humans are telephony audio; STT streams resample as needed. */
+const BRIDGE_STT_SAMPLE_RATE = 16000;
+/** How long to wait for a bridged participant / its audio track to appear. */
+const TRACK_WAIT_TIMEOUT_MS = 15000;
+
+/** Normalised `options.bridgedTransferTranscribe`. `provider` is unused on LiveKit. */
+export interface BridgedTranscribeConfig {
+  provider: string;
+  language: string | null;
+}
+
+/**
+ * Normalise `options.bridgedTransferTranscribe` to null (off) or
+ * `{provider, language}`. Lenient — the server validated the shape at save
+ * time. Mirrors pipecat's `parse_transcribe_option`: absent/false/
+ * `enabled:false` → off; `true` → defaults.
+ */
+export function parseBridgedTranscribeOption(
+  options: any,
+): BridgedTranscribeConfig | null {
+  const raw = options?.bridgedTransferTranscribe;
+  if (raw === undefined || raw === null || raw === false) return null;
+  if (raw === true) return { provider: "elevenlabs", language: null };
+  if (typeof raw !== "object" || Array.isArray(raw) || raw.enabled === false) {
+    return null;
+  }
+  return {
+    provider: String(raw.provider || "elevenlabs"),
+    language: typeof raw.language === "string" && raw.language.trim()
+      ? raw.language.trim()
+      : null,
+  };
+}
+
+/**
+ * Accumulates final utterances from the two bridged humans (mirrors
+ * pipecat's BridgeTranscriptCollector).
+ *
+ * `call` is the bridged-segment call record (`telephony:bridged-call`) the
+ * entries are logged against; `streamLog` follows the worker's convention
+ * (live POST per entry when `instance.streamLog`, otherwise batched onto
+ * the record's `batchedTransactionLogs`, flushed by `call.end()`).
+ */
+export class BridgeTranscriptCollector {
+  private readonly entries: Array<{
+    at: number;
+    speaker: string;
+    text: string;
+  }> = [];
+
+  constructor(
+    private readonly call: Call,
+    private readonly streamLog: boolean,
+    /** Injectable monotonic clock (tests). */
+    private readonly now: () => number = () => performance.now(),
+  ) {}
+
+  get length(): number {
+    return this.entries.length;
+  }
+
+  async add(speaker: string, text: string): Promise<void> {
+    const trimmed = (text || "").trim();
+    if (!trimmed) return;
+    this.entries.push({ at: this.now(), speaker, text: trimmed });
+    const entry = {
+      userId: this.call.userId,
+      organisationId: this.call.organisationId,
+      callId: this.call.id,
+      type: SPEAKER_LOG_TYPE[speaker] ?? "user",
+      data: trimmed,
+      isFinal: true,
+      createdAt: new Date(),
+    };
+    if (this.streamLog) {
+      try {
+        await createTransactionLog(entry);
+      } catch (e) {
+        logger.warn(
+          { e, callId: this.call.id },
+          "bridgedTransferTranscribe: transcript log post failed",
+        );
+      }
+    } else {
+      const batched = ((this.call as any).batchedTransactionLogs ??= []);
+      batched.push(entry);
+    }
+  }
+
+  /**
+   * Merged, chronologically ordered `> caller:` / `> transfer target:`
+   * lines — same shape as `${parentTranscript}` and pipecat's render().
+   */
+  render(): string {
+    return [...this.entries]
+      .sort((a, b) => a.at - b.at)
+      .map((e) => `> ${e.speaker}: ${e.text}\n`)
+      .join("");
+  }
+}
+
+/**
+ * A fresh STT instance for one bridged human, safe to run alongside
+ * anything else. Reuses the agent's configured STT vendor exactly as the
+ * pipeline does — `inference.STT.fromModelString(resolvePipelineStt(...))`
+ * (what AgentSession does with a string `stt`), whose default is Deepgram
+ * nova-3 when `options.stt` is absent (realtime models) — or the direct
+ * Deepgram plugin under LIVEKIT_PIPELINE_USE_PROVIDER_KEYS. A `language`
+ * from the transcribe option overrides the agent's STT language.
+ */
+export function buildBridgeStt(agent: Agent, language?: string | null): stt.STT {
+  const effectiveAgent: Agent = language
+    ? ({
+        ...agent,
+        options: {
+          ...(agent.options || {}),
+          stt: { ...((agent.options as any)?.stt || {}), language },
+        },
+      } as Agent)
+    : agent;
+  if (pipelineUsesProviderApiKeys()) {
+    return buildProviderPipelineStt(effectiveAgent);
+  }
+  return inference.STT.fromModelString(resolvePipelineStt(effectiveAgent));
+}
+
+function findRemoteParticipant(
+  room: Room,
+  identity: string,
+): RemoteParticipant | undefined {
+  for (const p of room.remoteParticipants.values()) {
+    if (p?.identity === identity) return p;
+  }
+  return undefined;
+}
+
+/** Resolve a room participant by identity, waiting for it to join if needed. */
+function waitForRemoteParticipant(
+  room: Room,
+  identity: string,
+  timeoutMs: number = TRACK_WAIT_TIMEOUT_MS,
+): Promise<RemoteParticipant> {
+  const existing = findRemoteParticipant(room, identity);
+  if (existing) return Promise.resolve(existing);
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      room.off(RoomEvent.ParticipantConnected, onConnected);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(`participant ${identity} did not join within ${timeoutMs}ms`),
+      );
+    }, timeoutMs);
+    const onConnected = (p: RemoteParticipant) => {
+      if (p?.identity === identity) {
+        cleanup();
+        resolve(p);
+      }
+    };
+    room.on(RoomEvent.ParticipantConnected, onConnected);
+    // Close the check-then-listen race.
+    const now = findRemoteParticipant(room, identity);
+    if (now) {
+      cleanup();
+      resolve(now);
+    }
+  });
+}
+
+function subscribedAudioTrack(
+  participant: RemoteParticipant,
+): Track | undefined {
+  for (const pub of participant.trackPublications.values()) {
+    if (pub.kind === TrackKind.KIND_AUDIO && pub.track) return pub.track;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the participant's subscribed audio track. The worker connects
+ * with AutoSubscribe.SUBSCRIBE_ALL (ctx.connect() default), so tracks
+ * normally arrive subscribed; ask explicitly (setSubscribed) and wait on
+ * RoomEvent.TrackSubscribed otherwise.
+ */
+function waitForAudioTrack(
+  room: Room,
+  participant: RemoteParticipant,
+  timeoutMs: number = TRACK_WAIT_TIMEOUT_MS,
+): Promise<Track> {
+  const existing = subscribedAudioTrack(participant);
+  if (existing) return Promise.resolve(existing);
+  for (const pub of participant.trackPublications.values()) {
+    if (pub.kind === TrackKind.KIND_AUDIO) {
+      try {
+        (pub as RemoteTrackPublication).setSubscribed(true);
+      } catch (e) {
+        logger.debug(
+          { e, identity: participant.identity },
+          "bridgedTransferTranscribe: setSubscribed failed",
+        );
+      }
+    }
+  }
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timer);
+      room.off(RoomEvent.TrackSubscribed, onSubscribed);
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `no subscribed audio track for ${participant.identity} within ${timeoutMs}ms`,
+        ),
+      );
+    }, timeoutMs);
+    const onSubscribed = (
+      track: RemoteTrack,
+      _publication: RemoteTrackPublication,
+      p: RemoteParticipant,
+    ) => {
+      if (p?.identity === participant.identity && track.kind === TrackKind.KIND_AUDIO) {
+        cleanup();
+        resolve(track);
+      }
+    };
+    room.on(RoomEvent.TrackSubscribed, onSubscribed);
+    // Close the check-then-listen race.
+    const now = subscribedAudioTrack(participant);
+    if (now) {
+      cleanup();
+      resolve(now);
+    }
+  });
+}
+
+/** Live bridged-segment transcription: snapshot for the takeover prompt + teardown. */
+export interface BridgeTranscriptionHandle {
+  /** Chronologically merged `> caller:` / `> transfer target:` lines so far. */
+  render(): string;
+  /** Stop both STT streams and audio pumps. Idempotent. */
+  dispose(): void;
+}
+
+export interface ArmBridgedTranscriptionParams {
+  /** The worker's connected RTC room (ctx.room). */
+  room: Room;
+  /** Server-side room name, for logging. */
+  roomName: string;
+  /** Identity of the original caller participant. */
+  callerIdentity?: string | null;
+  /** Identity of the bridged transfer-target participant. */
+  targetIdentity: string;
+  /** The telephony:bridged-call record covering the caller↔target bridge. */
+  bridgedCall: Call;
+  /** The transferring agent — source of the STT vendor configuration. */
+  agent: Agent;
+  transcribe: BridgedTranscribeConfig;
+  /** instance.streamLog: live transaction-log POST per utterance vs batch. */
+  streamLog: boolean;
+}
+
+/**
+ * Arm bridged-segment transcription: one STT stream per bridged human,
+ * fed from that participant's room audio track. Self-disposes when either
+ * bridged leg disconnects or the room connection drops; the takeover path
+ * disposes it explicitly. Never throws — transcription is best-effort.
+ */
+export function armBridgedTranscription(
+  params: ArmBridgedTranscriptionParams,
+): BridgeTranscriptionHandle {
+  const {
+    room,
+    roomName,
+    callerIdentity,
+    targetIdentity,
+    bridgedCall,
+    agent,
+    transcribe,
+    streamLog,
+  } = params;
+
+  const collector = new BridgeTranscriptCollector(bridgedCall, streamLog);
+  let disposed = false;
+  const cleanups: Array<() => void> = [];
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    room.off(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
+    room.off(RoomEvent.Disconnected, onRoomDisconnected);
+    for (const fn of cleanups.splice(0)) {
+      try {
+        fn();
+      } catch (e) {
+        logger.debug({ e, roomName }, "bridgedTransferTranscribe: cleanup step failed");
+      }
+    }
+    logger.debug(
+      { roomName, entries: collector.length },
+      "bridgedTransferTranscribe: transcription disposed",
+    );
+  };
+
+  const onParticipantDisconnected = (p: RemoteParticipant): void => {
+    const identity = p?.identity ?? (p as any)?.info?.identity;
+    if (
+      identity === targetIdentity ||
+      (callerIdentity && identity === callerIdentity)
+    ) {
+      dispose();
+    }
+  };
+  const onRoomDisconnected = (): void => {
+    dispose();
+  };
+  room.on(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
+  room.on(RoomEvent.Disconnected, onRoomDisconnected);
+
+  const runLeg = async (identity: string, speaker: string): Promise<void> => {
+    try {
+      const participant = await waitForRemoteParticipant(room, identity);
+      if (disposed) return;
+      const track = await waitForAudioTrack(room, participant);
+      if (disposed) return;
+
+      const sttInstance = buildBridgeStt(agent, transcribe.language);
+      const sttStream = sttInstance.stream();
+      const audioStream = new AudioStream(track, {
+        sampleRate: BRIDGE_STT_SAMPLE_RATE,
+        numChannels: 1,
+      });
+      const stop = () => {
+        try {
+          sttStream.detachInputStream();
+        } catch {
+          /* not attached / already closed */
+        }
+        try {
+          sttStream.close();
+        } catch {
+          /* already closed */
+        }
+        void sttInstance.close().catch(() => {});
+        void (audioStream as unknown as ReadableStream<AudioFrame>)
+          .cancel()
+          .catch(() => {});
+      };
+      cleanups.push(stop);
+      if (disposed) {
+        // dispose() ran between the awaits above and the push — unwind now.
+        stop();
+        return;
+      }
+      sttStream.updateInputStream(
+        audioStream as unknown as ReadableStream<AudioFrame>,
+      );
+      logger.info(
+        { roomName, identity, speaker, label: sttInstance.label },
+        "bridgedTransferTranscribe: STT stream armed for bridged leg",
+      );
+      for await (const ev of sttStream) {
+        if (disposed) break;
+        if (ev.type === stt.SpeechEventType.FINAL_TRANSCRIPT) {
+          const text = ev.alternatives?.[0]?.text ?? "";
+          if (text) await collector.add(speaker, text);
+        }
+      }
+    } catch (e) {
+      // Best-effort: a failed leg must not disturb the bridge, the other
+      // leg's transcription, or the DTMF watch.
+      if (!disposed) {
+        logger.warn(
+          { e, roomName, identity, speaker },
+          "bridgedTransferTranscribe: leg transcription failed (continuing without it)",
+        );
+      }
+    }
+  };
+
+  if (callerIdentity) {
+    void runLeg(callerIdentity, CALLER);
+  } else {
+    logger.warn(
+      { roomName },
+      "bridgedTransferTranscribe: no caller identity; transcribing target leg only",
+    );
+  }
+  void runLeg(targetIdentity, TARGET);
+
+  logger.info(
+    { roomName, callerIdentity, targetIdentity, language: transcribe.language, streamLog },
+    "bridgedTransferTranscribe: bridged-segment transcription armed",
+  );
+
+  return { render: () => collector.render(), dispose };
+}

--- a/agents/livekit/lib/bridged-transfer-to-agent.ts
+++ b/agents/livekit/lib/bridged-transfer-to-agent.ts
@@ -1,0 +1,445 @@
+/**
+ * Human-to-agent transfers (`options.bridgedTransferToAgent`).
+ *
+ * After a **bridged** transfer (blind bridge or the bridged finalise of a
+ * consultative transfer), the caller is talking to a human transfer target
+ * and the AI has left the conversation. `options.bridgedTransferToAgent`
+ * lets the *transfer target* hand the caller back to an AI agent by
+ * pressing a DTMF sequence:
+ *
+ *     "options": {
+ *       "bridgedTransferToAgent": {
+ *         "1":  { "agent": "<uuid>" },
+ *         "*7": { "agent": "<uuid>", "includeHistory": false }
+ *       }
+ *     }
+ *
+ * While the option is set, transfers are forced onto the bridged path (a
+ * SIP REFER would hand the call off-platform, where no DTMF can be
+ * observed — see handleTransfer). After the bridge the agent participant
+ * stays in the room (muted, media detached) so the job keeps its room
+ * connection; this module consumes LiveKit's SIP DTMF room events
+ * (`RoomEvent.DtmfReceived`) on that connection, filtered to the
+ * transfer-target participant's identity ONLY — the caller's digits never
+ * trigger it.
+ *
+ * On a match the watch (1) reserves a continuation call record (parentId =
+ * the original agent call, mirroring the pipecat implementation and
+ * docs/call-transfers.md), (2) removes the transfer-target participant and
+ * ends the telephony:bridged-call record, and (3) starts the mapped
+ * agent's full voice stack on the same room via the runtime's
+ * restartWithAgent machinery, with the original agent↔caller conversation
+ * embedded in the incoming agent's prompt when `includeHistory` (default
+ * true). If the takeover cannot start (target agent at its concurrency
+ * limit, misconfigured target), the bridge is left intact — the humans
+ * stay connected — and the matcher re-arms so the target can retry.
+ *
+ * See docs/call-transfers.md ("Human to agent transfers") and the pipecat
+ * reference implementation (agents/pipecat/pipecat_aplisay/bridged_transfer.py).
+ */
+
+import { RoomEvent } from "@livekit/rtc-node";
+import type { RemoteParticipant, Room } from "@livekit/rtc-node";
+import logger from "./logger.js";
+import { getInternalAgentById } from "./api-client.js";
+import type { Agent, Call } from "./api-client.js";
+import type { SipParticipant } from "./types.js";
+
+// Matches the server-side validation in lib/database.js — 1-8 chars of the
+// keypad symbols RFC 4733 carries end-to-end (A-D are unsupported).
+const DTMF_KEY_RE = /^[0-9*#]{1,8}$/;
+
+/** One entry of the bridgedTransferToAgent map, normalised. */
+export interface BridgedTransferTarget {
+  key: string;
+  agentId: string;
+  includeHistory: boolean;
+}
+
+/**
+ * Parse `options.bridgedTransferToAgent` into key → target.
+ *
+ * The server has already validated + normalised the option (values are
+ * `{agent, includeHistory?, fromLabel?}` objects with UUID agents), but be
+ * lenient here: skip malformed entries with a log rather than failing the
+ * call. Plain-string values are shorthand for `{agent: <string>}`; the
+ * `fromLabel` annotation (agent-set label round-tripping) is ignored.
+ * Returns null when the option is absent/empty/unusable.
+ */
+export function parseBridgedTransferMap(
+  options: any,
+): Map<string, BridgedTransferTarget> | null {
+  const raw = options?.bridgedTransferToAgent;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const targets = new Map<string, BridgedTransferTarget>();
+  for (const [rawKey, rawValue] of Object.entries(raw)) {
+    const key = String(rawKey);
+    if (!DTMF_KEY_RE.test(key)) {
+      logger.warn({ key }, "bridgedTransferToAgent: ignoring malformed key");
+      continue;
+    }
+    const entry: any =
+      typeof rawValue === "string" ? { agent: rawValue } : rawValue;
+    const agentId = entry && typeof entry === "object" ? entry.agent : undefined;
+    if (!agentId || typeof agentId !== "string") {
+      logger.warn(
+        { key },
+        "bridgedTransferToAgent: ignoring entry without an agent id",
+      );
+      continue;
+    }
+    // Static flags arrive as booleans or the legacy "true"/"false" string
+    // idiom (cf. transfer_agent's includeHistory); default is true.
+    const rawInclude = entry.includeHistory;
+    const includeHistory =
+      typeof rawInclude === "string"
+        ? rawInclude.trim().toLowerCase() !== "false"
+        : rawInclude !== false;
+    targets.set(key, { key, agentId, includeHistory });
+  }
+  return targets.size ? targets : null;
+}
+
+/**
+ * Multi-digit DTMF matcher with inter-digit timeout semantics.
+ *
+ * Feed digits as they arrive; `onMatch(key)` fires (once) when a configured
+ * sequence is recognised:
+ *
+ * - a buffer that exactly matches a key AND cannot be extended into a
+ *   longer key fires immediately;
+ * - a buffer that matches a key but is also a prefix of a longer key fires
+ *   after `timeoutMs` of keypad silence (giving the longer key a chance);
+ * - a buffer that is only a proper prefix resets after `timeoutMs`;
+ * - non-matching digits slide out of the buffer (oldest first), so a stray
+ *   press doesn't poison a following valid sequence.
+ *
+ * `timeoutMs` intentionally reuses the platform's DTMF aggregation default
+ * (`options.dtmfTimeout`, 1500 ms). Fires once, but re-arms if the match
+ * handler rejects (e.g. target agent at its concurrency limit) so a retry
+ * press can work while the bridge is still up.
+ */
+export class DtmfSequenceMatcher {
+  private buffer = "";
+  private timer: NodeJS.Timeout | null = null;
+  private fired = false;
+
+  constructor(
+    private readonly keys: string[],
+    private readonly onMatch: (key: string) => Promise<void>,
+    private readonly timeoutMs: number = 1500,
+  ) {}
+
+  cancel(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  feed(digit: string): void {
+    if (this.fired) return;
+    this.cancel();
+    this.buffer += String(digit);
+    // Slide until the buffer is a prefix of at least one key.
+    while (
+      this.buffer &&
+      !this.keys.some((k) => k.startsWith(this.buffer))
+    ) {
+      this.buffer = this.buffer.slice(1);
+    }
+    if (!this.buffer) return;
+    const exact = this.keys.includes(this.buffer);
+    const extendable = this.keys.some(
+      (k) => k !== this.buffer && k.startsWith(this.buffer),
+    );
+    if (exact && !extendable) {
+      this.fire(this.buffer);
+      return;
+    }
+    // Exact-but-extendable resolves on timeout to the exact key; a bare
+    // prefix resolves on timeout to a reset.
+    this.timer = setTimeout(() => this.onTimeout(exact), this.timeoutMs);
+  }
+
+  private onTimeout(exact: boolean): void {
+    if (this.fired) return;
+    const buffer = this.buffer;
+    this.buffer = "";
+    this.timer = null;
+    if (exact && this.keys.includes(buffer)) {
+      this.fire(buffer);
+    }
+  }
+
+  private fire(key: string): void {
+    this.fired = true;
+    this.buffer = "";
+    this.cancel();
+    void this.onMatch(key).catch((e) => {
+      logger.error(
+        { e, key },
+        "bridgedTransferToAgent: takeover on DTMF match failed",
+      );
+      // Allow another attempt if the takeover errored (e.g. target agent at
+      // its concurrency limit) — the bridge is still up.
+      this.fired = false;
+    });
+  }
+}
+
+/**
+ * The live takeover capability the voice runtime registers once its stack
+ * is up (see runAgentWorker's registerBridgedTakeover). Kept behind an
+ * interface so this module never imports the runtime (no cycle).
+ */
+export interface BridgedTakeoverRuntime {
+  /** Formatted "Caller:/Agent:" transcript of the agent↔caller conversation so far. */
+  getConversationHistoryText(): string;
+  /**
+   * Full agent-stack takeover on the live room (restartWithAgent in
+   * takeover mode): reserves the continuation call FIRST (throws on busy,
+   * leaving the bridge up), runs `onReserved` once the slot is held, then
+   * starts `newAgentDef`'s voice stack talking to the caller.
+   */
+  takeover(params: {
+    newAgentDef: Agent;
+    instructions: string;
+    /** Field source for the continuation call record (the bridged record). */
+    parentCall: Call;
+    /** parentId for the continuation record (the original agent call). */
+    parentId: string;
+    /** Invoked once the continuation slot is reserved — drops the bridge. */
+    onReserved: () => Promise<void>;
+  }): Promise<void>;
+}
+
+/**
+ * Compose the incoming agent's system prompt. Mirrors the transfer_agent
+ * handover composition and the pipecat reference (compose_takeover_prompt).
+ */
+export function composeTakeoverPrompt(
+  newAgentDef: Agent,
+  historyText: string,
+  includeHistory: boolean,
+): string {
+  let prompt = newAgentDef.prompt || "You are a helpful assistant.";
+  prompt +=
+    "\n\nYou have just taken over a live call. The caller was previously " +
+    "speaking with another agent and was then transferred to a human, who " +
+    "has now handed the call back to you.";
+  if (includeHistory && historyText) {
+    prompt +=
+      "\n\n# Conversation between the caller and the previous agent\n" +
+      historyText +
+      "\n\n(The conversation the caller had with the human after the " +
+      "transfer was not recorded.)";
+  } else if (!includeHistory) {
+    prompt += " Treat this as a fresh conversation: disregard any prior context.";
+  }
+  return prompt;
+}
+
+export interface ArmBridgedTransferWatchParams {
+  /** The worker's connected RTC room (ctx.room) — delivers DtmfReceived. */
+  room: Room;
+  /** Server-side room name, for RoomServiceClient operations. */
+  roomName: string;
+  /** Identity of the bridged transfer-target SIP participant. ONLY its digits are watched. */
+  targetIdentity: string;
+  /** The original caller's identity, so the watch dies with either bridged leg. */
+  callerIdentity?: string | null;
+  targets: Map<string, BridgedTransferTarget>;
+  /** Inter-digit timeout (agent options.dtmfTimeout, default 1500ms). */
+  dtmfTimeoutMs: number;
+  /** The telephony:bridged-call record covering the caller↔target bridge. */
+  bridgedCall: Call;
+  /** The transferring agent — organisation guard for the target-agent fetch. */
+  agent: Agent;
+  /** Conversation transcript snapshot captured at bridge time. */
+  historyText: string;
+  runtime: BridgedTakeoverRuntime;
+  setBridgedParticipant: (p: SipParticipant | null) => void;
+  setBridgedCallRecord: (call: Call | null) => void;
+  /**
+   * Hangs up a participant (RoomServiceClient.removeParticipant), injected by
+   * the transfer handler so this module carries no client of its own.
+   */
+  removeParticipant: (roomName: string, identity: string) => Promise<unknown>;
+}
+
+/**
+ * Arm the post-bridge DTMF watch: subscribe to the room's SIP DTMF events,
+ * run the sequence matcher over the transfer target's presses, and on a
+ * match perform the human→agent takeover. Returns a disposer; the watch
+ * also disposes itself when the caller or target disconnects or the room
+ * connection drops.
+ */
+export function armBridgedTransferWatch(
+  params: ArmBridgedTransferWatchParams,
+): () => void {
+  const {
+    room,
+    roomName,
+    targetIdentity,
+    callerIdentity,
+    targets,
+    dtmfTimeoutMs,
+    bridgedCall,
+    agent,
+    historyText,
+    runtime,
+    setBridgedParticipant,
+    setBridgedCallRecord,
+    removeParticipant,
+  } = params;
+
+  let disposed = false;
+  // Set once a match commits to bringing the bridge down, so our own
+  // removeParticipant on the target doesn't dispose the in-flight takeover.
+  let takingOver = false;
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    matcher.cancel();
+    room.off(RoomEvent.DtmfReceived, onDtmf);
+    room.off(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
+    room.off(RoomEvent.Disconnected, onRoomDisconnected);
+    logger.debug(
+      { roomName, targetIdentity },
+      "bridgedTransferToAgent: DTMF watch disposed",
+    );
+  };
+
+  const onMatch = async (key: string): Promise<void> => {
+    const target = targets.get(key);
+    if (!target || disposed) return;
+    logger.info(
+      { key, agentId: target.agentId, bridgedCallId: bridgedCall.id },
+      "bridgedTransferToAgent: DTMF match — starting takeover",
+    );
+    takingOver = true;
+    try {
+      // Resolve the mapped agent (same-organisation guard) and validate it
+      // can take over a live LiveKit call. Any throw from here leaves the
+      // humans talking: the matcher logs and re-arms for a retry press.
+      const newAgentDef = await getInternalAgentById(
+        target.agentId,
+        agent.organisationId,
+      );
+      if ((newAgentDef.type ?? "interactive-audio") !== "interactive-audio") {
+        throw new Error(
+          `bridgedTransferToAgent target ${target.agentId} is type ${newAgentDef.type} and cannot take over a live call`,
+        );
+      }
+      const targetModelName = newAgentDef.modelName || "";
+      if (targetModelName.split(":")[0] !== "livekit") {
+        throw new Error(
+          `bridgedTransferToAgent target ${target.agentId} uses ${targetModelName}; a live LiveKit call can only be taken over by a livekit: agent`,
+        );
+      }
+
+      const instructions = composeTakeoverPrompt(
+        newAgentDef,
+        historyText,
+        target.includeHistory,
+      );
+
+      await runtime.takeover({
+        newAgentDef,
+        instructions,
+        parentCall: bridgedCall,
+        // Child of the original agent call (the bridged record's parent) —
+        // matches the pipecat implementation and docs/call-transfers.md
+        // ("parentId linking back to the original call").
+        parentId: bridgedCall.parentId || bridgedCall.id,
+        onReserved: async () => {
+          // The continuation slot is held: commit. Clear the bridged state
+          // FIRST so the runtime's ParticipantDisconnected handler doesn't
+          // treat the target removal as end-of-call, then drop the target
+          // and close the bridged record. Best-effort — from here the
+          // takeover proceeds regardless.
+          setBridgedParticipant(null);
+          setBridgedCallRecord(null);
+          try {
+            await removeParticipant(roomName, targetIdentity);
+          } catch (e) {
+            logger.warn(
+              { e, roomName, targetIdentity },
+              "bridgedTransferToAgent: transfer target removal failed (may already be gone)",
+            );
+          }
+          await bridgedCall
+            .end(`Transfer target handed call back to agent ${newAgentDef.id}`)
+            .catch((e) => {
+              logger.error(
+                { e, bridgedCallId: bridgedCall.id },
+                "bridgedTransferToAgent: failed to end bridged call record",
+              );
+            });
+        },
+      });
+      dispose();
+    } catch (e) {
+      takingOver = false;
+      throw e; // DtmfSequenceMatcher logs and re-arms
+    }
+  };
+
+  const matcher = new DtmfSequenceMatcher(
+    [...targets.keys()],
+    onMatch,
+    dtmfTimeoutMs,
+  );
+
+  const onDtmf = (
+    _code: number,
+    digit: string,
+    participant: RemoteParticipant,
+  ): void => {
+    if (disposed) return;
+    // The transfer target ONLY — the caller's digits must never trigger a takeover.
+    if (participant?.identity !== targetIdentity) return;
+    logger.debug(
+      { digit, identity: participant.identity },
+      "bridgedTransferToAgent: DTMF from transfer target",
+    );
+    matcher.feed(digit);
+  };
+
+  const onParticipantDisconnected = (p: RemoteParticipant): void => {
+    if (disposed || takingOver) return;
+    const identity = p?.identity ?? (p as any)?.info?.identity;
+    if (
+      identity === targetIdentity ||
+      (callerIdentity && identity === callerIdentity)
+    ) {
+      logger.info(
+        { identity, roomName },
+        "bridgedTransferToAgent: bridged leg disconnected, disposing DTMF watch",
+      );
+      dispose();
+    }
+  };
+
+  const onRoomDisconnected = (): void => {
+    dispose();
+  };
+
+  room.on(RoomEvent.DtmfReceived, onDtmf);
+  room.on(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
+  room.on(RoomEvent.Disconnected, onRoomDisconnected);
+
+  logger.info(
+    {
+      roomName,
+      targetIdentity,
+      keys: [...targets.keys()].sort(),
+      dtmfTimeoutMs,
+      bridgedCallId: bridgedCall.id,
+    },
+    "bridgedTransferToAgent: post-bridge DTMF watch armed",
+  );
+  return dispose;
+}

--- a/agents/livekit/lib/bridged-transfer-to-agent.ts
+++ b/agents/livekit/lib/bridged-transfer-to-agent.ts
@@ -217,25 +217,38 @@ export interface BridgedTakeoverRuntime {
 /**
  * Compose the incoming agent's system prompt. Mirrors the transfer_agent
  * handover composition and the pipecat reference (compose_takeover_prompt).
+ * When the bridged segment was transcribed (`bridgedTransferTranscribe`),
+ * the human↔human conversation is carried too; otherwise (with history on)
+ * the prompt notes the human segment was not recorded.
  */
 export function composeTakeoverPrompt(
   newAgentDef: Agent,
   historyText: string,
   includeHistory: boolean,
+  bridgeTranscript: string = "",
 ): string {
   let prompt = newAgentDef.prompt || "You are a helpful assistant.";
   prompt +=
     "\n\nYou have just taken over a live call. The caller was previously " +
     "speaking with another agent and was then transferred to a human, who " +
     "has now handed the call back to you.";
-  if (includeHistory && historyText) {
+  if (!includeHistory) {
+    prompt += " Treat this as a fresh conversation: disregard any prior context.";
+    return prompt;
+  }
+  if (historyText) {
     prompt +=
       "\n\n# Conversation between the caller and the previous agent\n" +
-      historyText +
+      historyText;
+  }
+  if (bridgeTranscript) {
+    prompt +=
+      "\n\n# Conversation between the caller and the human transfer target\n" +
+      bridgeTranscript;
+  } else if (historyText) {
+    prompt +=
       "\n\n(The conversation the caller had with the human after the " +
       "transfer was not recorded.)";
-  } else if (!includeHistory) {
-    prompt += " Treat this as a fresh conversation: disregard any prior context.";
   }
   return prompt;
 }
@@ -258,6 +271,16 @@ export interface ArmBridgedTransferWatchParams {
   agent: Agent;
   /** Conversation transcript snapshot captured at bridge time. */
   historyText: string;
+  /**
+   * Live bridged-segment transcription (`options.bridgedTransferTranscribe`),
+   * when armed. Its render() is snapshotted at DTMF-match time so the
+   * takeover prompt carries the human↔human conversation; the takeover
+   * commit disposes it (the bridge is coming down).
+   */
+  bridgeTranscription?: {
+    render(): string;
+    dispose(): void;
+  } | null;
   runtime: BridgedTakeoverRuntime;
   setBridgedParticipant: (p: SipParticipant | null) => void;
   setBridgedCallRecord: (call: Call | null) => void;
@@ -288,6 +311,7 @@ export function armBridgedTransferWatch(
     bridgedCall,
     agent,
     historyText,
+    bridgeTranscription,
     runtime,
     setBridgedParticipant,
     setBridgedCallRecord,
@@ -340,10 +364,14 @@ export function armBridgedTransferWatch(
         );
       }
 
+      // Snapshot the human↔human transcript NOW — the collector stops (and
+      // the bridge comes down) as the takeover commits.
+      const bridgeTranscript = bridgeTranscription?.render() ?? "";
       const instructions = composeTakeoverPrompt(
         newAgentDef,
         historyText,
         target.includeHistory,
+        bridgeTranscript,
       );
 
       await runtime.takeover({
@@ -362,6 +390,16 @@ export function armBridgedTransferWatch(
           // takeover proceeds regardless.
           setBridgedParticipant(null);
           setBridgedCallRecord(null);
+          // Stop the bridged-segment transcription before the target is
+          // removed (the transcript snapshot was taken at match time).
+          try {
+            bridgeTranscription?.dispose();
+          } catch (e) {
+            logger.warn(
+              { e },
+              "bridgedTransferToAgent: bridge transcription dispose failed",
+            );
+          }
           try {
             await removeParticipant(roomName, targetIdentity);
           } catch (e) {

--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -29,6 +29,11 @@ import {
 } from "./voice-session-resources.js";
 import { userOwnsPhoneNumber, userOwnsRow } from "./scope.js";
 import { deleteRoomWithRetry } from "./livekit-helpers.js";
+import {
+  parseBridgedTransferMap,
+  armBridgedTransferWatch,
+  type BridgedTakeoverRuntime,
+} from "./bridged-transfer-to-agent.js";
 
 const { LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET } = process.env;
 
@@ -95,6 +100,10 @@ export interface TransferContext {
   getTransferState: () => { state: TransferState; description: string };
   // Bridged call record setter
   setBridgedCallRecord: (call: Call | null) => void;
+  // Live human→agent takeover capability registered by the voice runtime
+  // (options.bridgedTransferToAgent); null/absent when no runtime is up
+  // (e.g. transfer-only fallback mode).
+  getBridgedTakeover?: () => BridgedTakeoverRuntime | null;
   // Promise resolvers for consultative transfer decision
   resolveConsultativeDecision?: (
     accepted: boolean,
@@ -370,6 +379,69 @@ async function finaliseBridgedCall(
 }
 
 /**
+ * Arm the post-bridge human→agent DTMF watch (options.bridgedTransferToAgent)
+ * once a bridged transfer has completed — the blind bridge and the bridged
+ * consultative finalise both land here. No-op unless the option is set, the
+ * bridged call record exists, and the voice runtime has registered its
+ * takeover capability (transfer-only fallback mode has none). The transcript
+ * snapshot is taken here, at bridge time, because the superseded agent
+ * session may be torn down while the humans talk.
+ */
+function armBridgedTransferToAgentWatch(
+  context: TransferContext,
+  bridgedCallRecord: Call | null,
+  targetIdentity: string,
+): void {
+  const targets = parseBridgedTransferMap(context.options);
+  if (!targets) return;
+  const runtime = context.getBridgedTakeover?.();
+  if (!runtime) {
+    logger.warn(
+      { roomName: context.room?.name },
+      "bridgedTransferToAgent configured but no takeover runtime registered; watch not armed",
+    );
+    return;
+  }
+  if (!bridgedCallRecord) {
+    logger.warn(
+      { roomName: context.room?.name },
+      "bridgedTransferToAgent: no bridged call record; watch not armed",
+    );
+    return;
+  }
+  const rtcRoom: Room | null | undefined = context.ctx?.room;
+  if (!rtcRoom || !context.room?.name) {
+    logger.warn(
+      { hasRtcRoom: Boolean(rtcRoom), roomName: context.room?.name },
+      "bridgedTransferToAgent: no connected room; watch not armed",
+    );
+    return;
+  }
+  // Same inter-digit timeout as ordinary DTMF input buffering.
+  const dtmfTimeoutOption = context.options?.dtmfTimeout;
+  const dtmfTimeoutMs =
+    typeof dtmfTimeoutOption === "number" && dtmfTimeoutOption >= 0
+      ? Math.max(250, dtmfTimeoutOption)
+      : 1500;
+  armBridgedTransferWatch({
+    room: rtcRoom,
+    roomName: context.room.name!,
+    targetIdentity,
+    callerIdentity: context.participant?.identity ?? null,
+    targets,
+    dtmfTimeoutMs,
+    bridgedCall: bridgedCallRecord,
+    agent: context.agent,
+    historyText: runtime.getConversationHistoryText(),
+    runtime,
+    setBridgedParticipant: context.setBridgedParticipant,
+    setBridgedCallRecord: context.setBridgedCallRecord,
+    removeParticipant: (name, identity) =>
+      roomService.removeParticipant(name, identity),
+  });
+}
+
+/**
  * Case 1: Blind transfer by bridging
  * Used for WebRTC or SIP participants without canRefer capability
  */
@@ -421,7 +493,15 @@ async function handleBlindBridgeTransfer(
 
     logger.info({ p }, "new participant created (blind bridge)");
     setBridgedParticipant(p);
-    await finaliseBridgedCallFn();
+    const bridgedCallRecord = await finaliseBridgedCallFn();
+
+    // Human→agent hand-back (options.bridgedTransferToAgent): watch the
+    // transfer target's DTMF for the life of the bridge. No-op when unset.
+    armBridgedTransferToAgentWatch(
+      context,
+      bridgedCallRecord,
+      p.participantIdentity,
+    );
 
     setTransferState("none", "Transfer completed successfully");
     return {
@@ -1236,7 +1316,16 @@ async function finaliseConsultativeTransfer(
       await endConsultationRecord();
       await deleteConsultationRoom();
 
-      await finaliseBridgedCallFn();
+      const bridgedCallRecord = await finaliseBridgedCallFn();
+
+      // Human→agent hand-back (options.bridgedTransferToAgent): the target is
+      // now bridged into the caller room under the consult identity — watch
+      // its DTMF for the life of the bridge. No-op when unset.
+      armBridgedTransferToAgentWatch(
+        context,
+        bridgedCallRecord,
+        transferTargetIdentity,
+      );
     }
 
     return {
@@ -1796,7 +1885,16 @@ export async function handleTransfer(
   // Check if forceBridged is set from phone registration endpoint options
   // This overrides args.forceBridged if set to true
   const forceBridgedFromEndpoint = context.forceBridged === true;
-  const effectiveForceBridged = forceBridgedFromEndpoint || args.forceBridged === true;
+  // Human-to-agent transfers (options.bridgedTransferToAgent): while the map
+  // is set, the transfer target's DTMF must remain observable AFTER the
+  // handover, so transfers are forced onto the bridged path — a SIP REFER
+  // hands the call off-platform where no DTMF can be seen. Overrides the
+  // REFER resolution for both blind transfers and the consultative finalise.
+  const bridgedTransferToAgent = parseBridgedTransferMap(options) !== null;
+  const effectiveForceBridged =
+    forceBridgedFromEndpoint ||
+    args.forceBridged === true ||
+    bridgedTransferToAgent;
 
   logger.info(
     {
@@ -1812,6 +1910,7 @@ export async function handleTransfer(
       canRefer,
       forceBridged: args.forceBridged,
       forceBridgedFromEndpoint,
+      bridgedTransferToAgent,
       effectiveForceBridged,
       aplisayId,
     },

--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -34,6 +34,11 @@ import {
   armBridgedTransferWatch,
   type BridgedTakeoverRuntime,
 } from "./bridged-transfer-to-agent.js";
+import {
+  parseBridgedTranscribeOption,
+  armBridgedTranscription,
+  type BridgeTranscriptionHandle,
+} from "./bridge-transcription.js";
 
 const { LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET } = process.env;
 
@@ -379,13 +384,16 @@ async function finaliseBridgedCall(
 }
 
 /**
- * Arm the post-bridge human→agent DTMF watch (options.bridgedTransferToAgent)
- * once a bridged transfer has completed — the blind bridge and the bridged
- * consultative finalise both land here. No-op unless the option is set, the
- * bridged call record exists, and the voice runtime has registered its
- * takeover capability (transfer-only fallback mode has none). The transcript
- * snapshot is taken here, at bridge time, because the superseded agent
- * session may be torn down while the humans talk.
+ * Arm the post-bridge watches (options.bridgedTransferToAgent — the
+ * human→agent DTMF watch — and options.bridgedTransferTranscribe — the
+ * bridged-segment transcription) once a bridged transfer has completed:
+ * the blind bridge and the bridged consultative finalise both land here.
+ * No-op unless at least one option is set and the bridged call record
+ * exists. Transcription arms standalone (no bta map, no runtime needed);
+ * the DTMF watch additionally requires the voice runtime's takeover
+ * capability (transfer-only fallback mode has none). The pre-transfer
+ * transcript snapshot is taken here, at bridge time, because the
+ * superseded agent session may be torn down while the humans talk.
  */
 function armBridgedTransferToAgentWatch(
   context: TransferContext,
@@ -393,19 +401,12 @@ function armBridgedTransferToAgentWatch(
   targetIdentity: string,
 ): void {
   const targets = parseBridgedTransferMap(context.options);
-  if (!targets) return;
-  const runtime = context.getBridgedTakeover?.();
-  if (!runtime) {
-    logger.warn(
-      { roomName: context.room?.name },
-      "bridgedTransferToAgent configured but no takeover runtime registered; watch not armed",
-    );
-    return;
-  }
+  const transcribe = parseBridgedTranscribeOption(context.options);
+  if (!targets && !transcribe) return;
   if (!bridgedCallRecord) {
     logger.warn(
       { roomName: context.room?.name },
-      "bridgedTransferToAgent: no bridged call record; watch not armed",
+      "bridged transfer watch: no bridged call record; watch not armed",
     );
     return;
   }
@@ -413,7 +414,44 @@ function armBridgedTransferToAgentWatch(
   if (!rtcRoom || !context.room?.name) {
     logger.warn(
       { hasRtcRoom: Boolean(rtcRoom), roomName: context.room?.name },
-      "bridgedTransferToAgent: no connected room; watch not armed",
+      "bridged transfer watch: no connected room; watch not armed",
+    );
+    return;
+  }
+
+  // Bridged-segment transcription (options.bridgedTransferTranscribe): one
+  // STT stream per bridged human, entries logged against the bridged call
+  // record. Best-effort — a failure here must not disturb the bridge or
+  // the DTMF watch below. Arms standalone when no bta map is configured;
+  // the record's ending (participant disconnect handlers / takeover) flushes
+  // any batched entries.
+  let bridgeTranscription: BridgeTranscriptionHandle | null = null;
+  if (transcribe) {
+    try {
+      bridgeTranscription = armBridgedTranscription({
+        room: rtcRoom,
+        roomName: context.room.name!,
+        callerIdentity: context.participant?.identity ?? null,
+        targetIdentity,
+        bridgedCall: bridgedCallRecord,
+        agent: context.agent,
+        transcribe,
+        streamLog: context.instance?.streamLog === true,
+      });
+    } catch (e) {
+      logger.warn(
+        { e, roomName: context.room?.name },
+        "bridgedTransferTranscribe: failed to arm transcription (continuing without it)",
+      );
+    }
+  }
+
+  if (!targets) return;
+  const runtime = context.getBridgedTakeover?.();
+  if (!runtime) {
+    logger.warn(
+      { roomName: context.room?.name },
+      "bridgedTransferToAgent configured but no takeover runtime registered; watch not armed",
     );
     return;
   }
@@ -433,6 +471,7 @@ function armBridgedTransferToAgentWatch(
     bridgedCall: bridgedCallRecord,
     agent: context.agent,
     historyText: runtime.getConversationHistoryText(),
+    bridgeTranscription,
     runtime,
     setBridgedParticipant: context.setBridgedParticipant,
     setBridgedCallRecord: context.setBridgedCallRecord,
@@ -495,8 +534,10 @@ async function handleBlindBridgeTransfer(
     setBridgedParticipant(p);
     const bridgedCallRecord = await finaliseBridgedCallFn();
 
-    // Human→agent hand-back (options.bridgedTransferToAgent): watch the
-    // transfer target's DTMF for the life of the bridge. No-op when unset.
+    // Human→agent hand-back (options.bridgedTransferToAgent) and bridged-
+    // segment transcription (options.bridgedTransferTranscribe): watch the
+    // transfer target's DTMF / transcribe both humans for the life of the
+    // bridge. No-op when neither option is set.
     armBridgedTransferToAgentWatch(
       context,
       bridgedCallRecord,
@@ -1318,9 +1359,11 @@ async function finaliseConsultativeTransfer(
 
       const bridgedCallRecord = await finaliseBridgedCallFn();
 
-      // Human→agent hand-back (options.bridgedTransferToAgent): the target is
-      // now bridged into the caller room under the consult identity — watch
-      // its DTMF for the life of the bridge. No-op when unset.
+      // Human→agent hand-back (options.bridgedTransferToAgent) and bridged-
+      // segment transcription (options.bridgedTransferTranscribe): the target
+      // is now bridged into the caller room under the consult identity —
+      // watch its DTMF / transcribe both humans for the life of the bridge.
+      // No-op when neither option is set.
       armBridgedTransferToAgentWatch(
         context,
         bridgedCallRecord,
@@ -1891,10 +1934,16 @@ export async function handleTransfer(
   // hands the call off-platform where no DTMF can be seen. Overrides the
   // REFER resolution for both blind transfers and the consultative finalise.
   const bridgedTransferToAgent = parseBridgedTransferMap(options) !== null;
+  // Bridged-segment transcription (options.bridgedTransferTranscribe)
+  // likewise needs the media to stay on-platform — the humans' audio tracks
+  // must remain observable in the room — so it forces the bridged path too.
+  const bridgedTransferTranscribe =
+    parseBridgedTranscribeOption(options) !== null;
   const effectiveForceBridged =
     forceBridgedFromEndpoint ||
     args.forceBridged === true ||
-    bridgedTransferToAgent;
+    bridgedTransferToAgent ||
+    bridgedTransferTranscribe;
 
   logger.info(
     {
@@ -1911,6 +1960,7 @@ export async function handleTransfer(
       forceBridged: args.forceBridged,
       forceBridgedFromEndpoint,
       bridgedTransferToAgent,
+      bridgedTransferTranscribe,
       effectiveForceBridged,
       aplisayId,
     },

--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -25,6 +25,7 @@ import {
   inactivityAwayTimeoutSecs,
 } from "./voice-session-factory.js";
 import { resolveUsageVendors } from "./usage-vendors.js";
+import type { BridgedTakeoverRuntime } from "./bridged-transfer-to-agent.js";
 
 export async function runAgentWorker({
   ctx,
@@ -53,6 +54,7 @@ export async function runAgentWorker({
   setActiveAgentCall,
   startHandoverTone,
   stopHandoverTone,
+  registerBridgedTakeover,
   transferOnly = false,
   transferArgs,
 }: RunAgentWorkerParams & {
@@ -61,6 +63,13 @@ export async function runAgentWorker({
     state: "none" | "dialling" | "talking" | "rejected" | "failed";
     description: string;
   };
+  /**
+   * Hands the worker the live human→agent takeover capability for
+   * `options.bridgedTransferToAgent` (see bridged-transfer-to-agent.ts); the
+   * transfer handler reads it when arming the post-bridge DTMF watch.
+   * Re-registered with null on teardown.
+   */
+  registerBridgedTakeover?: (rt: BridgedTakeoverRuntime | null) => void;
 }) {
   /** When true, recording uses SDK RecorderIO (pipeline tee); we upload OGG in cleanup. */
   let useRecorderIO = false;
@@ -574,6 +583,9 @@ export async function runAgentWorker({
     }
     isCleaningUp = true;
 
+    // The call is coming down: no bridged human→agent takeover can start now.
+    registerBridgedTakeover?.(null);
+
     const exitStatus: {
       callEnded: boolean;
       roomDeleted: boolean;
@@ -875,11 +887,34 @@ export async function runAgentWorker({
    * transcripts from here on are attributed to the new agent + model, and the
    * original call ends with a pointer to its continuation. Prompt-only
    * (in-place) swaps deliberately do NOT do this.
+   *
+   * `opts.takeover` switches the machinery into bridged human→agent takeover
+   * mode (options.bridgedTransferToAgent): the "call being continued" is the
+   * telephony:bridged-call record rather than getActiveCall(), the child's
+   * parentId points at the original agent call, the bridge is dropped by the
+   * `onReserved` hook once the concurrency slot is held (a busy rejection
+   * still throws before anything is touched, leaving the humans talking),
+   * and the parent record is NOT ended here — the hook already ended the
+   * bridged record with its own reason, and the original agent call ended at
+   * bridge time.
    */
   const restartWithAgent = async (
     newAgentDef: Agent,
     instructions: string,
+    opts?: {
+      takeover?: {
+        /** Field source for the continuation record (the bridged call). */
+        parentCall: Call;
+        /** parentId for the continuation record (the original agent call). */
+        parentId: string;
+        /** Drops the bridge once the continuation slot is reserved. */
+        onReserved: () => Promise<void>;
+        /** Transcript marker, injected onto the NEW call record. */
+        announcement: string;
+      };
+    },
   ): Promise<void> => {
+    const takeover = opts?.takeover;
     const targetModelName = newAgentDef.modelName!;
     const targetHandler = targetModelName.split(":")[0];
     if (targetHandler !== "livekit") {
@@ -888,11 +923,11 @@ export async function runAgentWorker({
       );
     }
 
-    const oldCall = getActiveCall();
+    const oldCall = takeover?.parentCall ?? getActiveCall();
     // Reserve the continuation call (concurrency slot) BEFORE touching the
     // running session, so a busy rejection leaves the current agent intact.
     const newCall = (await createCall({
-      parentId: oldCall.id,
+      parentId: takeover?.parentId ?? oldCall.id,
       userId: oldCall.userId,
       organisationId: oldCall.organisationId,
       instanceId: oldCall.instanceId,
@@ -910,14 +945,32 @@ export async function runAgentWorker({
     })) as Call;
     await newCall.start();
 
-    // Slot reserved and the continuation call accepted: the handover will
-    // proceed. Announce it now — before the outgoing session is torn down and
-    // the incoming agent greets — so the transcript marker precedes the new
-    // agent's first turn. A busy rejection throws at newCall.start() above,
-    // before this point, so a failed transfer leaves no marker.
-    sendMessage({
-      inject: `Call transferred to agent ${newAgentDef.name || newAgentDef.id}`,
-    });
+    if (takeover) {
+      // Slot held: commit the takeover — drop the transfer target and end the
+      // bridged record. Belt-and-braces: the hook is best-effort internally,
+      // but if it does throw, release the reserved call and abort with the
+      // bridge in whatever state the hook left it (the humans keep talking).
+      try {
+        await takeover.onReserved();
+      } catch (e) {
+        const error = e instanceof Error ? e : new Error(String(e));
+        await newCall
+          .end(`bridged agent takeover aborted: ${error.message}`)
+          .catch(() => undefined);
+        throw error;
+      }
+    } else {
+      // Slot reserved and the continuation call accepted: the handover will
+      // proceed. Announce it now — before the outgoing session is torn down and
+      // the incoming agent greets — so the transcript marker precedes the new
+      // agent's first turn. A busy rejection throws at newCall.start() above,
+      // before this point, so a failed transfer leaves no marker. (Takeover
+      // mode announces later, onto the NEW call record — the outgoing records
+      // are already ended, so a marker batched onto them would be lost.)
+      sendMessage({
+        inject: `Call transferred to agent ${newAgentDef.name || newAgentDef.id}`,
+      });
+    }
 
     // Cover the dead-air gap: from here until the incoming agent first speaks
     // (or fails) the caller would otherwise hear silence while the old session
@@ -976,12 +1029,19 @@ export async function runAgentWorker({
       resolvedVoiceMode = voiceMode;
       setActiveAgentCall?.(newCall);
 
-      // Hand the records over: the original call ends pointing at its child.
-      await oldCall
-        .end(`transferred to agent ${newAgentDef.id}, continued as call ${newCall.id}`)
-        .catch((e) => {
-          logger.warn({ e }, "agent handover: ending original call failed");
-        });
+      if (takeover) {
+        // The marker lands on the NEW call record (activeAgentCall just
+        // flipped above) — the outgoing agent call and the bridged record
+        // are both already ended.
+        sendMessage({ inject: takeover.announcement });
+      } else {
+        // Hand the records over: the original call ends pointing at its child.
+        await oldCall
+          .end(`transferred to agent ${newAgentDef.id}, continued as call ${newCall.id}`)
+          .catch((e) => {
+            logger.warn({ e }, "agent handover: ending original call failed");
+          });
+      }
 
       if (recordingOptions?.enabled) {
         logger.warn(
@@ -1122,6 +1182,32 @@ export async function runAgentWorker({
       getTransferState,
       onAgentTransfer,
     });
+
+  // ---- Bridged human→agent takeover (options.bridgedTransferToAgent) ----
+  // Expose the live handover machinery to the transfer handler: when a
+  // bridged transfer completes it arms a DTMF watch on the transfer target
+  // (see bridged-transfer-to-agent.ts), and a match re-enters here to start
+  // the mapped agent's stack on the room the caller is still connected to.
+  // The history snapshot is taken by the arming code at bridge time.
+  registerBridgedTakeover?.({
+    getConversationHistoryText: () =>
+      conversationHistory
+        .map(
+          ({ role, text }) => `${role === "user" ? "Caller" : "Agent"}: ${text}`,
+        )
+        .join("\n"),
+    takeover: ({ newAgentDef, instructions, parentCall, parentId, onReserved }) =>
+      restartWithAgent(newAgentDef, instructions, {
+        takeover: {
+          parentCall,
+          parentId,
+          onReserved,
+          announcement: `Human transfer target handed the call back; continuing with agent ${
+            newAgentDef.name || newAgentDef.id
+          }`,
+        },
+      }),
+  });
 
   try {
     // Wrap setup operations with timeout

--- a/agents/livekit/lib/worker.ts
+++ b/agents/livekit/lib/worker.ts
@@ -39,6 +39,7 @@ import {
   type TransferContext,
   destroyInProgressTransfer,
 } from "./transfer-handler.js";
+import type { BridgedTakeoverRuntime } from "./bridged-transfer-to-agent.js";
 import { withTimeout } from "./utils.js";
 import {
   ConfidenceTonePlayer,
@@ -272,6 +273,7 @@ export default defineAgent({
         getTransferState,
         startHandoverTone,
         stopHandoverTone,
+        registerBridgedTakeover,
       } = await setupCallAndUtilities({
         ctx,
         room,
@@ -437,6 +439,7 @@ export default defineAgent({
             setActiveAgentCall,
             startHandoverTone,
             stopHandoverTone,
+            registerBridgedTakeover,
             endTransferActivityIfNeeded: endTransferActivityFn,
             getTransferState,
             recordingOptions: activeRecordingOptions,
@@ -1211,6 +1214,15 @@ async function setupCallAndUtilities({
       )
     : null;
 
+  // Human→agent takeover capability (options.bridgedTransferToAgent): the
+  // voice runtime registers its live handover machinery here once its stack
+  // is up (and clears it on teardown); the transfer handler reads it when a
+  // bridged transfer completes to arm the post-bridge DTMF watch.
+  let bridgedTakeoverRuntime: BridgedTakeoverRuntime | null = null;
+  const registerBridgedTakeover = (rt: BridgedTakeoverRuntime | null) => {
+    bridgedTakeoverRuntime = rt;
+  };
+
   const getTransferState = () => transferState;
   const setTransferState = (
     state: "none" | "dialling" | "talking" | "rejected" | "failed",
@@ -1379,6 +1391,7 @@ async function setupCallAndUtilities({
         setTransferState,
         getTransferState,
         setBridgedCallRecord,
+        getBridgedTakeover: () => bridgedTakeoverRuntime,
       };
 
       return await handleTransfer(transferContext);
@@ -1436,6 +1449,9 @@ async function setupCallAndUtilities({
     checkForHangup,
     modelRef,
     sessionRef,
+    // Registration point for the runtime's bridged human→agent takeover
+    // capability (options.bridgedTransferToAgent).
+    registerBridgedTakeover,
     // expose helper to check the currently active call for logging
     getActiveCall: () => bridgedCallRecord || activeAgentCall,
     // The agent's own call WITHOUT the bridge override — usage attribution must

--- a/agents/livekit/test/bridge-transcription.test.ts
+++ b/agents/livekit/test/bridge-transcription.test.ts
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseBridgedTranscribeOption,
+  BridgeTranscriptCollector,
+  CALLER,
+  TARGET,
+} from "../lib/bridge-transcription.js";
+
+// Option parser + transcript collector for options.bridgedTransferTranscribe.
+// run: node --import tsx --test test/bridge-transcription.test.ts
+
+const makeCall = () =>
+  ({
+    id: "call-1",
+    userId: "user-1",
+    organisationId: "org-1",
+  }) as any;
+
+test("parseBridgedTranscribeOption: absent/false/disabled give null", () => {
+  assert.equal(parseBridgedTranscribeOption(undefined), null);
+  assert.equal(parseBridgedTranscribeOption({}), null);
+  assert.equal(
+    parseBridgedTranscribeOption({ bridgedTransferTranscribe: false }),
+    null,
+  );
+  assert.equal(
+    parseBridgedTranscribeOption({
+      bridgedTransferTranscribe: { enabled: false, provider: "deepgram" },
+    }),
+    null,
+  );
+  // Malformed shapes are off, not errors (lenient like pipecat).
+  assert.equal(
+    parseBridgedTranscribeOption({ bridgedTransferTranscribe: "yes" }),
+    null,
+  );
+  assert.equal(
+    parseBridgedTranscribeOption({ bridgedTransferTranscribe: ["deepgram"] }),
+    null,
+  );
+});
+
+test("parseBridgedTranscribeOption: true and object forms normalise", () => {
+  assert.deepEqual(
+    parseBridgedTranscribeOption({ bridgedTransferTranscribe: true }),
+    { provider: "elevenlabs", language: null },
+  );
+  assert.deepEqual(
+    parseBridgedTranscribeOption({ bridgedTransferTranscribe: {} }),
+    { provider: "elevenlabs", language: null },
+  );
+  assert.deepEqual(
+    parseBridgedTranscribeOption({
+      bridgedTransferTranscribe: { provider: "deepgram", language: "en-GB" },
+    }),
+    { provider: "deepgram", language: "en-GB" },
+  );
+  // enabled: true is the explicit-on idiom.
+  assert.deepEqual(
+    parseBridgedTranscribeOption({
+      bridgedTransferTranscribe: { enabled: true, language: " fr " },
+    }),
+    { provider: "elevenlabs", language: "fr" },
+  );
+});
+
+test("collector: entries are speaker-labelled and batched onto the call record", async () => {
+  const call = makeCall();
+  const collector = new BridgeTranscriptCollector(call, false);
+  await collector.add(CALLER, "  hello there  ");
+  await collector.add(TARGET, "hi, how can I help");
+  await collector.add(CALLER, ""); // empty finals are dropped
+  assert.equal(collector.length, 2);
+
+  const batched = (call as any).batchedTransactionLogs;
+  assert.equal(batched.length, 2);
+  assert.deepEqual(
+    batched.map((e: any) => ({
+      callId: e.callId,
+      type: e.type,
+      data: e.data,
+      isFinal: e.isFinal,
+    })),
+    [
+      { callId: "call-1", type: "user", data: "hello there", isFinal: true },
+      {
+        callId: "call-1",
+        type: "agent",
+        data: "hi, how can I help",
+        isFinal: true,
+      },
+    ],
+  );
+  assert.equal(batched[0].userId, "user-1");
+  assert.equal(batched[0].organisationId, "org-1");
+});
+
+test("collector: render merges chronologically across speakers", async () => {
+  let clock = 0;
+  const collector = new BridgeTranscriptCollector(makeCall(), false, () => clock);
+  clock = 30;
+  await collector.add(TARGET, "who is calling");
+  clock = 10;
+  await collector.add(CALLER, "hello");
+  clock = 20;
+  await collector.add(CALLER, "it's me");
+  assert.equal(
+    collector.render(),
+    "> caller: hello\n> caller: it's me\n> transfer target: who is calling\n",
+  );
+});
+
+test("collector: empty collector renders empty string", () => {
+  const collector = new BridgeTranscriptCollector(makeCall(), false);
+  assert.equal(collector.render(), "");
+  assert.equal(collector.length, 0);
+});

--- a/agents/livekit/test/bridged-transfer-to-agent.test.ts
+++ b/agents/livekit/test/bridged-transfer-to-agent.test.ts
@@ -160,3 +160,58 @@ test("composeTakeoverPrompt: history carried by default, dropped when off", () =
   assert.match(fresh, /Treat this as a fresh conversation/);
   assert.doesNotMatch(fresh, /# Conversation/);
 });
+
+test("composeTakeoverPrompt: bridged-segment transcript carried when present", () => {
+  const agent = { id: "a1", prompt: "You are the booking agent." } as any;
+  const bridge = "> caller: can I book tuesday\n> transfer target: sure\n";
+  const prompt = composeTakeoverPrompt(
+    agent,
+    "Caller: hi\nAgent: hello",
+    true,
+    bridge,
+  );
+  assert.match(prompt, /# Conversation between the caller and the previous agent/);
+  assert.match(prompt, /Caller: hi/);
+  assert.match(
+    prompt,
+    /# Conversation between the caller and the human transfer target/,
+  );
+  assert.match(prompt, /> caller: can I book tuesday/);
+  // With a bridge transcript, the "not recorded" note is replaced by it.
+  assert.doesNotMatch(prompt, /was not recorded/);
+  // Bridge section comes after the pre-transfer history section (pipecat order).
+  assert.ok(
+    prompt.indexOf("# Conversation between the caller and the previous agent") <
+      prompt.indexOf(
+        "# Conversation between the caller and the human transfer target",
+      ),
+  );
+});
+
+test("composeTakeoverPrompt: bridge transcript without pre-transfer history", () => {
+  const agent = { id: "a1", prompt: "You are the booking agent." } as any;
+  const prompt = composeTakeoverPrompt(agent, "", true, "> caller: hello\n");
+  assert.doesNotMatch(
+    prompt,
+    /# Conversation between the caller and the previous agent/,
+  );
+  assert.match(
+    prompt,
+    /# Conversation between the caller and the human transfer target/,
+  );
+  // No history at all → no "not recorded" note either.
+  assert.doesNotMatch(prompt, /was not recorded/);
+});
+
+test("composeTakeoverPrompt: includeHistory false suppresses the bridge transcript too", () => {
+  const agent = { id: "a1", prompt: "You are the booking agent." } as any;
+  const prompt = composeTakeoverPrompt(
+    agent,
+    "Caller: hi",
+    false,
+    "> caller: secret\n",
+  );
+  assert.match(prompt, /Treat this as a fresh conversation/);
+  assert.doesNotMatch(prompt, /# Conversation/);
+  assert.doesNotMatch(prompt, /secret/);
+});

--- a/agents/livekit/test/bridged-transfer-to-agent.test.ts
+++ b/agents/livekit/test/bridged-transfer-to-agent.test.ts
@@ -1,0 +1,162 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseBridgedTransferMap,
+  DtmfSequenceMatcher,
+  composeTakeoverPrompt,
+} from "../lib/bridged-transfer-to-agent.js";
+
+// Map parser + DTMF sequence matcher for options.bridgedTransferToAgent.
+// run: node --import tsx --test test/bridged-transfer-to-agent.test.ts
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+test("parseBridgedTransferMap: absent/empty/invalid options give null", () => {
+  assert.equal(parseBridgedTransferMap(undefined), null);
+  assert.equal(parseBridgedTransferMap({}), null);
+  assert.equal(parseBridgedTransferMap({ bridgedTransferToAgent: {} }), null);
+  assert.equal(parseBridgedTransferMap({ bridgedTransferToAgent: "1" }), null);
+  assert.equal(parseBridgedTransferMap({ bridgedTransferToAgent: ["1"] }), null);
+});
+
+test("parseBridgedTransferMap: normalises string and object values", () => {
+  const map = parseBridgedTransferMap({
+    bridgedTransferToAgent: {
+      "1": "agent-a",
+      "*7": { agent: "agent-b", includeHistory: false, fromLabel: "survey" },
+      "22": { agent: "agent-c", includeHistory: "false" },
+      "#3": { agent: "agent-d", includeHistory: true },
+    },
+  });
+  assert.ok(map);
+  assert.deepEqual(map!.get("1"), {
+    key: "1",
+    agentId: "agent-a",
+    includeHistory: true, // defaults on
+  });
+  assert.deepEqual(map!.get("*7"), {
+    key: "*7",
+    agentId: "agent-b",
+    includeHistory: false, // fromLabel annotation ignored
+  });
+  // Legacy "false" string idiom (cf. transfer_agent includeHistory)
+  assert.equal(map!.get("22")!.includeHistory, false);
+  assert.equal(map!.get("#3")!.includeHistory, true);
+});
+
+test("parseBridgedTransferMap: skips malformed entries, keeps good ones", () => {
+  const map = parseBridgedTransferMap({
+    bridgedTransferToAgent: {
+      "1": "agent-a",
+      ab: "agent-bad-key", // non-keypad chars
+      "123456789": "agent-too-long", // > 8 chars
+      "2": {}, // no agent id
+      "3": { agent: 42 }, // non-string agent id
+    },
+  });
+  assert.ok(map);
+  assert.deepEqual([...map!.keys()], ["1"]);
+});
+
+test("matcher: unambiguous exact key fires immediately", async () => {
+  const fired: string[] = [];
+  const m = new DtmfSequenceMatcher(["1", "*7"], async (k) => {
+    fired.push(k);
+  }, 30);
+  m.feed("1");
+  await sleep(0);
+  assert.deepEqual(fired, ["1"]);
+  // Fires once: further digits are ignored after a successful match.
+  m.feed("1");
+  await sleep(50);
+  assert.deepEqual(fired, ["1"]);
+  m.cancel();
+});
+
+test("matcher: exact-but-extendable waits for the timeout", async () => {
+  const fired: string[] = [];
+  const m = new DtmfSequenceMatcher(["1", "12"], async (k) => {
+    fired.push(k);
+  }, 30);
+  m.feed("1");
+  await sleep(10);
+  assert.deepEqual(fired, []); // still waiting for a possible "12"
+  await sleep(50);
+  assert.deepEqual(fired, ["1"]); // resolved to the exact key on timeout
+  m.cancel();
+});
+
+test("matcher: longer key wins when completed before the timeout", async () => {
+  const fired: string[] = [];
+  const m = new DtmfSequenceMatcher(["1", "12"], async (k) => {
+    fired.push(k);
+  }, 30);
+  m.feed("1");
+  m.feed("2");
+  await sleep(0);
+  assert.deepEqual(fired, ["12"]);
+  m.cancel();
+});
+
+test("matcher: bare prefix resets after the timeout", async () => {
+  const fired: string[] = [];
+  const m = new DtmfSequenceMatcher(["*7"], async (k) => {
+    fired.push(k);
+  }, 30);
+  m.feed("*");
+  await sleep(60);
+  assert.deepEqual(fired, []); // prefix aged out, no match
+  // A fresh full sequence still fires.
+  m.feed("*");
+  m.feed("7");
+  await sleep(0);
+  assert.deepEqual(fired, ["*7"]);
+  m.cancel();
+});
+
+test("matcher: stray digits slide out oldest-first", async () => {
+  const fired: string[] = [];
+  const m = new DtmfSequenceMatcher(["*7"], async (k) => {
+    fired.push(k);
+  }, 30);
+  m.feed("5"); // stray press — must not poison the following sequence
+  m.feed("*");
+  m.feed("7");
+  await sleep(0);
+  assert.deepEqual(fired, ["*7"]);
+  m.cancel();
+});
+
+test("matcher: re-arms when the takeover handler throws", async () => {
+  let attempts = 0;
+  const m = new DtmfSequenceMatcher(["1"], async () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("target agent busy");
+  }, 30);
+  m.feed("1");
+  await sleep(0);
+  assert.equal(attempts, 1);
+  // First attempt failed (bridge still up) — a retry press works.
+  m.feed("1");
+  await sleep(0);
+  assert.equal(attempts, 2);
+  // Second attempt succeeded — matcher stays fired.
+  m.feed("1");
+  await sleep(50);
+  assert.equal(attempts, 2);
+  m.cancel();
+});
+
+test("composeTakeoverPrompt: history carried by default, dropped when off", () => {
+  const agent = { id: "a1", prompt: "You are the booking agent." } as any;
+  const withHistory = composeTakeoverPrompt(agent, "Caller: hi\nAgent: hello", true);
+  assert.match(withHistory, /^You are the booking agent\./);
+  assert.match(withHistory, /taken over a live call/);
+  assert.match(withHistory, /# Conversation between the caller and the previous agent/);
+  assert.match(withHistory, /Caller: hi/);
+  assert.match(withHistory, /was not recorded/);
+
+  const fresh = composeTakeoverPrompt(agent, "Caller: hi", false);
+  assert.match(fresh, /Treat this as a fresh conversation/);
+  assert.doesNotMatch(fresh, /# Conversation/);
+});

--- a/agents/pipecat/pipecat_aplisay/bridge_transcript.py
+++ b/agents/pipecat/pipecat_aplisay/bridge_transcript.py
@@ -1,0 +1,195 @@
+"""Transcription of the human↔human segment of a bridged transfer
+(``options.bridgedTransferTranscribe``).
+
+After a bridged transfer the AI has left the call, so nothing transcribes
+the caller↔transfer-target conversation. When the option is set the worker
+collects a speaker-labelled transcript of that segment without moving the
+media off the gateway fast path:
+
+- **voiceblender** runs its native per-leg STT (``POST /v1/legs/{id}/stt``)
+  and the transcripts arrive as ``stt.text`` VSI events per leg;
+- **sipbridge** streams a decoded stereo *copy* of the bridge on the
+  kept-open monitor WS (``tap_audio`` — left = caller, right = target) and
+  the worker runs one :class:`SttStream` per channel using the agent's
+  configured STT vendor.
+
+Either way the entries land in a :class:`BridgeTranscriptCollector`, which
+posts each final utterance to the bridged-segment call record's transaction
+log as it arrives (``user`` = caller, ``agent`` = transfer target — the
+B-party occupies the agent slot of a two-party transcript) and renders the
+merged history for the takeover agent's prompt. See ``bridged_transfer.py``
+and ``docs/call-transfers.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+from loguru import logger
+
+from . import api_client
+
+CALLER = "caller"
+TARGET = "transfer target"
+
+_SPEAKER_LOG_TYPE = {CALLER: "user", TARGET: "agent"}
+
+
+def parse_transcribe_option(options: Optional[dict]) -> Optional[dict]:
+    """Normalise ``options.bridgedTransferTranscribe`` to ``None`` (off) or
+    ``{"provider": str, "language": Optional[str]}``. Lenient — the server
+    validated the shape at save time."""
+    raw = (options or {}).get("bridgedTransferTranscribe")
+    if raw is None or raw is False:
+        return None
+    if raw is True:
+        return {"provider": "elevenlabs", "language": None}
+    if not isinstance(raw, dict) or raw.get("enabled") is False:
+        return None
+    return {
+        "provider": str(raw.get("provider") or "elevenlabs"),
+        "language": raw.get("language"),
+    }
+
+
+@dataclass
+class BridgeTranscriptCollector:
+    """Accumulates final utterances from the two bridged humans.
+
+    ``call`` is the bridged-segment call record the entries are logged
+    against; ``stream_log`` mirrors the CallSession convention (live POST
+    per entry vs batch flushed by ``end_call``).
+    """
+
+    call: api_client.CallRecord
+    stream_log: bool = False
+    _entries: list[tuple[float, str, str]] = field(default_factory=list)
+
+    async def add(self, speaker: str, text: str) -> None:
+        text = (text or "").strip()
+        if not text:
+            return
+        self._entries.append((time.monotonic(), speaker, text))
+        entry = {
+            "userId": self.call.userId,
+            "organisationId": self.call.organisationId,
+            "callId": self.call.id,
+            "type": _SPEAKER_LOG_TYPE.get(speaker, "user"),
+            "data": text,
+            "isFinal": True,
+        }
+        if self.stream_log:
+            try:
+                await api_client.create_transaction_log(entry)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"bridge transcript log post failed: {e}")
+        else:
+            self.call.batched_transaction_logs.append(entry)
+
+    def render(self) -> str:
+        """Merged, chronologically ordered ``> caller:`` / ``> transfer
+        target:`` lines — same shape as ``${parentTranscript}``."""
+        return "".join(
+            f"> {speaker}: {text}\n" for _, speaker, text in sorted(self._entries)
+        )
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+class _TranscriptionCollector:
+    """Terminal FrameProcessor for an :class:`SttStream` pipeline —
+    forwards each final TranscriptionFrame's text to a callback."""
+
+    def __new__(cls, on_final: Callable[[str], Awaitable[None]]):
+        from pipecat.frames.frames import TranscriptionFrame
+        from pipecat.processors.frame_processor import FrameProcessor
+
+        class _Impl(FrameProcessor):
+            def __init__(self) -> None:
+                super().__init__()
+                self._on_final = on_final
+
+            async def process_frame(self, frame, direction):  # noqa: ANN001
+                await super().process_frame(frame, direction)
+                if isinstance(frame, TranscriptionFrame):
+                    try:
+                        await self._on_final(frame.text)
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning(f"bridge transcript collect failed: {e}")
+                await self.push_frame(frame, direction)
+
+        return _Impl()
+
+
+class SttStream:
+    """A minimal STT-only Pipecat pipeline: feed mono 16 kHz PCM in, get
+    final transcription text out via ``on_final``. One instance per
+    bridged leg on the sipbridge topology."""
+
+    def __init__(self, stt_service: Any, on_final: Callable[[str], Awaitable[None]]) -> None:
+        self._stt = stt_service
+        self._collector = _TranscriptionCollector(on_final)
+        self._task: Optional[Any] = None
+        self._runner_task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        from pipecat.pipeline.pipeline import Pipeline
+        from pipecat.pipeline.runner import PipelineRunner
+        from pipecat.pipeline.task import PipelineParams, PipelineTask
+
+        pipeline = Pipeline([self._stt, self._collector])
+        self._task = PipelineTask(
+            pipeline,
+            params=PipelineParams(
+                audio_in_sample_rate=16000,
+                audio_out_sample_rate=16000,
+            ),
+        )
+        runner = PipelineRunner(handle_sigint=False)
+        self._runner_task = asyncio.create_task(runner.run(self._task))
+
+    async def feed(self, pcm16: bytes) -> None:
+        if self._task is None or not pcm16:
+            return
+        from pipecat.frames.frames import InputAudioRawFrame
+
+        await self._task.queue_frames(
+            [InputAudioRawFrame(audio=pcm16, sample_rate=16000, num_channels=1)]
+        )
+
+    async def stop(self) -> None:
+        task = self._task
+        self._task = None
+        if task is not None:
+            try:
+                await task.cancel()
+            except Exception as e:  # noqa: BLE001
+                logger.debug(f"SttStream cancel raised: {e}")
+        if self._runner_task is not None:
+            try:
+                await asyncio.wait_for(self._runner_task, timeout=5.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                pass
+            except Exception as e:  # noqa: BLE001
+                logger.debug(f"SttStream runner exit raised: {e}")
+            self._runner_task = None
+
+
+def split_stereo(audio: bytes) -> tuple[bytes, bytes]:
+    """De-interleave s16le stereo into (left, right) mono byte strings.
+    Left = caller, right = transfer target (the sipbridge tap contract)."""
+    if len(audio) < 4:
+        return b"", b""
+    usable = len(audio) - (len(audio) % 4)
+    view = memoryview(audio)
+    left = bytearray(usable // 2)
+    right = bytearray(usable // 2)
+    for i in range(0, usable, 4):
+        half = i // 2
+        left[half : half + 2] = view[i : i + 2]
+        right[half : half + 2] = view[i + 2 : i + 4]
+    return bytes(left), bytes(right)

--- a/agents/pipecat/pipecat_aplisay/bridged_transfer.py
+++ b/agents/pipecat/pipecat_aplisay/bridged_transfer.py
@@ -185,7 +185,11 @@ class DtmfSequenceMatcher:
 class BtaContext:
     """Everything the post-bridge watcher needs, captured from the parent
     CallSession at the moment the monitored bridge is installed (the
-    session's pipeline — and its call record — end shortly after)."""
+    session's pipeline — and its call record — end shortly after).
+
+    ``targets`` may be empty when the watch exists only for transcription
+    (``bridgedTransferTranscribe`` without ``bridgedTransferToAgent``).
+    """
 
     targets: dict[str, BtaTarget]
     agent: dict
@@ -199,6 +203,15 @@ class BtaContext:
     transcript: str
     metadata: dict = field(default_factory=dict)
     dtmf_timeout_s: float = 1.5
+    # Bridged-segment transcription (``options.bridgedTransferTranscribe``):
+    # normalised config or None, the transfer destination (the bridged
+    # record's calledId), and — once ``prepare_bridge_monitor`` has run —
+    # the started bridged-segment call record + its transcript collector.
+    transcribe: Optional[dict] = None
+    destination: str = ""
+    stream_log: bool = False
+    bridged_call: Optional[api_client.CallRecord] = None
+    collector: Optional[Any] = None
 
 
 @dataclass
@@ -216,7 +229,13 @@ class TakeoverPayload:
     extra: dict = field(default_factory=dict)
 
 
-def bta_context_from_session(session: Any, targets: dict[str, BtaTarget]) -> BtaContext:
+def bta_context_from_session(
+    session: Any,
+    targets: Optional[dict[str, BtaTarget]],
+    *,
+    transcribe: Optional[dict] = None,
+    destination: str = "",
+) -> BtaContext:
     """Snapshot a parent CallSession into a :class:`BtaContext`."""
     aplisay_meta = dict((session.call.metadata or {}).get("aplisay") or {})
     options = session.agent.get("options") or {}
@@ -226,7 +245,7 @@ def bta_context_from_session(session: Any, targets: dict[str, BtaTarget]) -> Bta
     except (TypeError, ValueError):
         timeout_s = 1.5
     return BtaContext(
-        targets=targets,
+        targets=targets or {},
         agent=session.agent,
         instance=session.instance,
         parent_call_id=session.call.id,
@@ -238,27 +257,97 @@ def bta_context_from_session(session: Any, targets: dict[str, BtaTarget]) -> Bta
         transcript=session.get_parent_transcript(),
         metadata=dict(session.call.metadata or {}),
         dtmf_timeout_s=timeout_s,
+        transcribe=transcribe,
+        destination=destination,
+        stream_log=bool((session.instance or {}).get("streamLog")),
     )
+
+
+async def prepare_bridge_monitor(ctx: BtaContext, *, platform: str) -> BtaContext:
+    """Create + start the bridged-segment call record (child of the
+    original call, ``modelName: "telephony:bridged-call"`` — LiveKit
+    parity) and, when transcription is enabled, its transcript collector.
+    Failures are logged, not raised: the bridge itself must proceed even
+    if the record can't be created."""
+    from .bridge_transcript import BridgeTranscriptCollector
+
+    aplisay_meta = dict((ctx.metadata or {}).get("aplisay") or {})
+    try:
+        call = await api_client.create_call(
+            {
+                "parentId": ctx.parent_call_id,
+                "userId": ctx.user_id,
+                "organisationId": ctx.organisation_id,
+                "instanceId": ctx.instance_id,
+                "agentId": ctx.agent.get("id"),
+                "platform": platform,
+                "platformCallId": f"bridge-{ctx.parent_call_id}",
+                "calledId": ctx.destination or ctx.called_id,
+                "callerId": ctx.caller_id,
+                "modelName": "telephony:bridged-call",
+                "options": {},
+                "metadata": {
+                    **(ctx.metadata or {}),
+                    "aplisay": {
+                        **aplisay_meta,
+                        "model": "telephony:bridged-call",
+                        "bridgeOf": ctx.parent_call_id,
+                    },
+                },
+            }
+        )
+        await api_client.start_call(call)
+        ctx.bridged_call = call
+        if ctx.transcribe:
+            ctx.collector = BridgeTranscriptCollector(
+                call=call, stream_log=ctx.stream_log
+            )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"bridged transfer: bridged call record creation failed: {e}")
+    return ctx
+
+
+async def end_bridged_record(ctx: BtaContext, reason: str) -> None:
+    """End the bridged-segment record (idempotent — ``end_call`` guards
+    re-entry), flushing any batched transcript entries with it."""
+    if ctx.bridged_call is None:
+        return
+    try:
+        await api_client.end_call(ctx.bridged_call, reason=reason)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"bridged transfer: ending bridged record failed: {e}")
 
 
 def compose_takeover_prompt(new_agent: dict, ctx: BtaContext, target: BtaTarget) -> str:
     """Build the incoming agent's system prompt. Mirrors the
-    ``transfer_agent`` builtin's composition (call_session.py)."""
+    ``transfer_agent`` builtin's composition (call_session.py). When the
+    bridged segment was transcribed (``bridgedTransferTranscribe``), the
+    human↔human conversation is carried too."""
     prompt = new_agent.get("prompt") or "You are a helpful assistant."
     prompt += (
         "\n\nYou have just taken over a live call. The caller was previously "
         "speaking with another agent and was then transferred to a human, who "
         "has now handed the call back to you."
     )
-    if target.include_history and ctx.transcript:
+    if not target.include_history:
+        prompt += " Treat this as a fresh conversation: disregard any prior context."
+        return prompt
+    if ctx.transcript:
         prompt += (
             "\n\n# Conversation between the caller and the previous agent\n"
             + ctx.transcript
-            + "\n\n(The conversation the caller had with the human after the "
+        )
+    bridge_transcript = ctx.collector.render() if ctx.collector is not None else ""
+    if bridge_transcript:
+        prompt += (
+            "\n\n# Conversation between the caller and the human transfer target\n"
+            + bridge_transcript
+        )
+    elif ctx.transcript:
+        prompt += (
+            "\n\n(The conversation the caller had with the human after the "
             "transfer was not recorded.)"
         )
-    elif not target.include_history:
-        prompt += " Treat this as a fresh conversation: disregard any prior context."
     return prompt
 
 
@@ -333,12 +422,19 @@ async def _end_call_quiet(call: api_client.CallRecord, reason: str) -> None:
         logger.warning(f"bridgedTransferToAgent: end_call after failure failed: {e}")
 
 
-def arm_voiceblender_bta_watch(gateway: Any, gw_session: Any, ctx: BtaContext, *, platform: str) -> None:
+async def arm_voiceblender_bta_watch(
+    gateway: Any, gw_session: Any, ctx: BtaContext, *, platform: str
+) -> None:
     """Arm the voiceblender post-bridge watch: route the transfer-target
     leg's VSI ``dtmf.received`` events through a sequence matcher; on a
     match, reserve the continuation call, stash the TakeoverPayload, and
     run the gateway-side takeover (drop target, un-room the caller leg,
-    re-attach a Pipecat agent). The watch dies with either bridged leg."""
+    re-attach a Pipecat agent). When transcription is enabled, start the
+    container's native STT on both bridged legs and route the ``stt.text``
+    finals into the transcript collector. The watch — and the bridged-
+    segment call record — die with either bridged leg."""
+    from . import bridge_transcript as bt
+
     target_leg = getattr(gw_session, "bridge_peer_leg_id", None)
     caller_leg = gw_session.leg_id
     if not target_leg:
@@ -363,17 +459,61 @@ def arm_voiceblender_bta_watch(gateway: Any, gw_session: Any, ctx: BtaContext, *
             gateway.clear_takeover_session(session_id)
             await _end_call_quiet(payload.call, "bridged transfer-to-agent takeover failed")
             raise
+        if ctx.transcribe:
+            await gateway.stop_leg_stt(caller_leg)
         gateway.clear_bta_watcher(target_leg, caller_leg)
+        await end_bridged_record(
+            ctx, f"Transfer target handed call back to agent {target.agent_id}"
+        )
 
-    matcher = DtmfSequenceMatcher(
-        list(ctx.targets), on_match, timeout_s=ctx.dtmf_timeout_s
-    )
+    matcher: Optional[DtmfSequenceMatcher] = None
+    if ctx.targets:
+        matcher = DtmfSequenceMatcher(
+            list(ctx.targets), on_match, timeout_s=ctx.dtmf_timeout_s
+        )
 
     def on_gone() -> None:
-        matcher.cancel()
+        if matcher is not None:
+            matcher.cancel()
         gateway.clear_bta_watcher(target_leg, caller_leg)
+        # End the bridged-segment record from a detached task (this
+        # callback runs synchronously inside the VSI event loop).
+        asyncio.ensure_future(end_bridged_record(ctx, "Bridged call ended"))
 
-    gateway.register_bta_watcher(target_leg, caller_leg, matcher.feed, on_gone)
+    async def _drop_digit(_digit: str) -> None:
+        return
+
+    gateway.register_bta_watcher(
+        target_leg,
+        caller_leg,
+        matcher.feed if matcher is not None else _drop_digit,
+        on_gone,
+    )
+
+    # Native per-leg STT for the human↔human transcript. Best-effort: a
+    # failed STT start must not break the bridge (or the DTMF watch).
+    if ctx.transcribe and ctx.collector is not None:
+        collector = ctx.collector
+
+        async def _caller_text(text: str) -> None:
+            await collector.add(bt.CALLER, text)
+
+        async def _target_text(text: str) -> None:
+            await collector.add(bt.TARGET, text)
+
+        gateway.register_stt_watcher(caller_leg, _caller_text)
+        gateway.register_stt_watcher(target_leg, _target_text)
+        for leg_id in (caller_leg, target_leg):
+            try:
+                await gateway.start_leg_stt(
+                    leg_id,
+                    provider=ctx.transcribe.get("provider") or "elevenlabs",
+                    language=ctx.transcribe.get("language"),
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.bind(leg_id=leg_id).warning(
+                    f"bridgedTransferTranscribe: native STT start failed: {e}"
+                )
 
 
 async def run_sipbridge_bta_watch(
@@ -382,13 +522,22 @@ async def run_sipbridge_bta_watch(
     """Post-bridge watch loop for sipbridge, run by the /sipbridge/agent WS
     handler AFTER the pipeline has ended (the bridge kept the WS open in
     control-only mode). Reads Pipecat protobuf frames straight off the
-    socket, feeds ``source: "transfer_target"`` DTMF events through the
-    matcher, and on a match POSTs the unbridge (the bridge then closes this
-    WS and dials a fresh one for the takeover session). Returns when the
-    WS closes — takeover or plain end-of-bridge alike."""
-    from pipecat.frames.frames import InputTransportMessageFrame
+    socket:
+
+    - ``source: "transfer_target"`` DTMF events feed the takeover matcher;
+      a match POSTs the unbridge (the bridge then closes this WS and dials
+      a fresh one for the takeover session).
+    - stereo AudioRawFrames (the ``tap_audio`` transcription tap; L =
+      caller, R = target) are split and fed to one STT stream per side,
+      built from the agent's configured STT vendor.
+
+    Returns when the WS closes — takeover or plain end-of-bridge alike —
+    ending the bridged-segment call record on the way out."""
+    from pipecat.frames.frames import AudioRawFrame, InputTransportMessageFrame
     from pipecat.serializers.protobuf import ProtobufFrameSerializer
     from starlette.websockets import WebSocketDisconnect
+
+    from . import bridge_transcript as bt
 
     async def on_match(key: str) -> None:
         target = ctx.targets[key]
@@ -404,16 +553,47 @@ async def run_sipbridge_bta_watch(
             gateway.clear_takeover_session(session_id)
             await _end_call_quiet(payload.call, "bridged transfer-to-agent takeover failed")
             raise
+        await end_bridged_record(
+            ctx, f"Transfer target handed call back to agent {target.agent_id}"
+        )
         # The bridge tears this monitor WS down as part of the unbridge;
         # the receive loop below unwinds on the disconnect.
 
-    matcher = DtmfSequenceMatcher(
-        list(ctx.targets), on_match, timeout_s=ctx.dtmf_timeout_s
-    )
+    matcher: Optional[DtmfSequenceMatcher] = None
+    if ctx.targets:
+        matcher = DtmfSequenceMatcher(
+            list(ctx.targets), on_match, timeout_s=ctx.dtmf_timeout_s
+        )
+
+    # Transcription tap consumers — one STT stream per bridged human,
+    # using the agent's configured STT vendor. Best-effort: a failed STT
+    # build must not break the DTMF watch.
+    caller_stt: Optional[bt.SttStream] = None
+    target_stt: Optional[bt.SttStream] = None
+    if ctx.transcribe and ctx.collector is not None:
+        collector = ctx.collector
+        try:
+            from .voice_session import build_stt_service
+
+            async def _caller_text(text: str) -> None:
+                await collector.add(bt.CALLER, text)
+
+            async def _target_text(text: str) -> None:
+                await collector.add(bt.TARGET, text)
+
+            caller_stt = bt.SttStream(build_stt_service(ctx.agent), _caller_text)
+            target_stt = bt.SttStream(build_stt_service(ctx.agent), _target_text)
+            await caller_stt.start()
+            await target_stt.start()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"bridgedTransferTranscribe: STT tap setup failed: {e}")
+            caller_stt = target_stt = None
+
     serializer = ProtobufFrameSerializer()
-    logger.bind(keys=sorted(ctx.targets.keys())).info(
-        "bridgedTransferToAgent: sipbridge monitor loop running"
-    )
+    logger.bind(
+        keys=sorted(ctx.targets.keys()),
+        transcribe=bool(caller_stt),
+    ).info("bridged transfer: sipbridge monitor loop running")
     try:
         while True:
             data = await websocket.receive_bytes()
@@ -421,11 +601,18 @@ async def run_sipbridge_bta_watch(
                 frame = await serializer.deserialize(data)
             except Exception:  # noqa: BLE001
                 continue
+            if isinstance(frame, AudioRawFrame):
+                if caller_stt is not None and getattr(frame, "num_channels", 1) == 2:
+                    left, right = bt.split_stereo(frame.audio)
+                    await caller_stt.feed(left)
+                    await target_stt.feed(right)
+                continue
             if not isinstance(frame, InputTransportMessageFrame):
                 continue
             message = frame.message
             if (
-                isinstance(message, dict)
+                matcher is not None
+                and isinstance(message, dict)
                 and message.get("type") == "dtmf"
                 and message.get("source") == "transfer_target"
                 and message.get("digit")
@@ -436,7 +623,13 @@ async def run_sipbridge_bta_watch(
     except asyncio.CancelledError:
         raise
     except Exception as e:  # noqa: BLE001
-        logger.warning(f"bridgedTransferToAgent: sipbridge monitor loop ended: {e}")
+        logger.warning(f"bridged transfer: sipbridge monitor loop ended: {e}")
     finally:
-        matcher.cancel()
-        logger.info("bridgedTransferToAgent: sipbridge monitor loop finished")
+        if matcher is not None:
+            matcher.cancel()
+        for stream in (caller_stt, target_stt):
+            if stream is not None:
+                await stream.stop()
+        # Idempotent — a takeover already ended it with its own reason.
+        await end_bridged_record(ctx, "Bridged call ended")
+        logger.info("bridged transfer: sipbridge monitor loop finished")

--- a/agents/pipecat/pipecat_aplisay/bridged_transfer.py
+++ b/agents/pipecat/pipecat_aplisay/bridged_transfer.py
@@ -1,0 +1,442 @@
+"""Human-to-agent transfers (``options.bridgedTransferToAgent``).
+
+After a **bridged** transfer (blind ``dial_bridge`` or a consultative
+finalise), the caller is talking to a human transfer target and the AI
+has left the call. ``options.bridgedTransferToAgent`` lets the *transfer
+target* hand the caller back to an AI agent by pressing a DTMF sequence:
+
+    "options": {
+      "bridgedTransferToAgent": {
+        "1":  { "agent": "<uuid>" },
+        "*7": { "agent": "<uuid>", "includeHistory": false }
+      }
+    }
+
+While the option is set, transfers are forced onto the bridged path
+(REFER would hand the call off-platform, where no DTMF can be observed)
+and the worker keeps watching DTMF **from the transfer-target leg only**:
+
+- **sipbridge**: the bridge keeps the caller leg's worker WS open as a
+  control channel (``monitor_dtmf: true`` on the transfer) and ships
+  target-leg RFC 4733 presses as ``{"type":"dtmf",...,
+  "source":"transfer_target"}`` MessageFrames. The worker's WS handler
+  watches those after the pipeline ends (see ``worker.py``), and on a
+  match POSTs ``/v1/calls/{id}/unbridge`` — the bridge drops the target
+  and re-dials a fresh agent WS for the caller leg.
+- **voiceblender**: the two legs sit in a room and DTMF arrives on the
+  VSI event stream per leg; the gateway routes target-leg digits to a
+  watcher registered here. On a match the worker deletes the target
+  leg, pulls the caller out of the room, and re-attaches a Pipecat
+  agent to the caller leg (``POST /v1/legs/{id}/agent/pipecat``).
+
+Either way the takeover lands in the per-gateway WS handler as a fresh
+WS whose ``session_id`` maps to a :class:`TakeoverPayload` stashed on
+the gateway — the handler builds a new CallSession for the mapped agent
+on a child call record and runs it. History carry (``includeHistory``,
+default true) mirrors the ``transfer_agent`` builtin: the original
+agent↔caller conversation is embedded in the incoming agent's prompt
+(the human-bridge period itself is untranscribed).
+
+See ``docs/call-transfers.md`` (“Human to agent transfers”).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+from loguru import logger
+
+from . import api_client
+
+# Matches the server-side validation in lib/database.js — 1-8 chars of
+# the keypad symbols RFC 4733 carries (A-D are unsupported end-to-end).
+_DTMF_KEY_CHARS = set("0123456789*#")
+
+
+@dataclass
+class BtaTarget:
+    """One entry of the bridgedTransferToAgent map, normalised."""
+
+    key: str
+    agent_id: str
+    include_history: bool = True
+
+
+def parse_bta_map(options: Optional[dict]) -> Optional[dict[str, BtaTarget]]:
+    """Parse ``options.bridgedTransferToAgent`` into key → :class:`BtaTarget`.
+
+    The server has already validated + normalised the option (values are
+    ``{agent, includeHistory?, fromLabel?}`` objects with UUID agents), but
+    be lenient here: skip malformed entries with a warning rather than
+    failing the call. Returns ``None`` when the option is absent/empty.
+    """
+    raw = (options or {}).get("bridgedTransferToAgent")
+    if not isinstance(raw, dict) or not raw:
+        return None
+    targets: dict[str, BtaTarget] = {}
+    for key, value in raw.items():
+        key = str(key)
+        if not (1 <= len(key) <= 8) or not all(c in _DTMF_KEY_CHARS for c in key):
+            logger.warning(f"bridgedTransferToAgent: ignoring malformed key {key!r}")
+            continue
+        entry = {"agent": value} if isinstance(value, str) else value
+        agent_id = (entry or {}).get("agent") if isinstance(entry, dict) else None
+        if not agent_id:
+            logger.warning(f"bridgedTransferToAgent[{key!r}]: ignoring entry without agent")
+            continue
+        include_history = entry.get("includeHistory")
+        targets[key] = BtaTarget(
+            key=key,
+            agent_id=str(agent_id),
+            include_history=True if include_history is None else bool(include_history),
+        )
+    return targets or None
+
+
+class DtmfSequenceMatcher:
+    """Multi-digit DTMF matcher with inter-digit timeout semantics.
+
+    Feed digits as they arrive; ``on_match(key)`` fires (once) when a
+    configured sequence is recognised:
+
+    - a buffer that exactly matches a key AND cannot be extended into a
+      longer key fires immediately;
+    - a buffer that matches a key but is also a prefix of a longer key
+      fires after ``timeout_s`` of silence (giving the longer key a
+      chance);
+    - a buffer that is only a proper prefix resets after ``timeout_s``;
+    - non-matching digits slide out of the buffer (oldest first), so a
+      stray press doesn't poison a following valid sequence.
+
+    ``timeout_s`` intentionally reuses the platform's DTMF aggregation
+    default (``options.dtmfTimeout``, 1.5 s).
+    """
+
+    def __init__(
+        self,
+        keys: list[str],
+        on_match: Callable[[str], Awaitable[None]],
+        *,
+        timeout_s: float = 1.5,
+    ) -> None:
+        self._keys = list(keys)
+        self._on_match = on_match
+        self._timeout_s = timeout_s
+        self._buffer = ""
+        self._timer: Optional[asyncio.TimerHandle] = None
+        self._fired = False
+        self._lock = asyncio.Lock()
+
+    def cancel(self) -> None:
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
+
+    async def feed(self, digit: str) -> None:
+        async with self._lock:
+            if self._fired:
+                return
+            self.cancel()
+            self._buffer += str(digit)
+            # Slide until the buffer is a prefix of at least one key.
+            while self._buffer and not any(k.startswith(self._buffer) for k in self._keys):
+                self._buffer = self._buffer[1:]
+            if not self._buffer:
+                return
+            exact = self._buffer in self._keys
+            extendable = any(k != self._buffer and k.startswith(self._buffer) for k in self._keys)
+            if exact and not extendable:
+                await self._fire(self._buffer)
+                return
+            # Exact-but-extendable resolves on timeout to the exact key;
+            # a bare prefix resolves on timeout to a reset.
+            loop = asyncio.get_running_loop()
+            self._timer = loop.call_later(
+                self._timeout_s,
+                lambda: asyncio.ensure_future(self._on_timeout(exact)),
+            )
+
+    async def _on_timeout(self, exact: bool) -> None:
+        async with self._lock:
+            if self._fired:
+                return
+            buffer, self._buffer = self._buffer, ""
+            self._timer = None
+            if exact and buffer in self._keys:
+                await self._fire(buffer)
+
+    async def _fire(self, key: str) -> None:
+        self._fired = True
+        self._buffer = ""
+        self.cancel()
+        try:
+            await self._on_match(key)
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"bridgedTransferToAgent: on_match({key!r}) failed: {e}")
+            # Allow another attempt if the takeover errored (e.g. target
+            # agent at concurrency limit) — the bridge is still up.
+            self._fired = False
+
+
+@dataclass
+class BtaContext:
+    """Everything the post-bridge watcher needs, captured from the parent
+    CallSession at the moment the monitored bridge is installed (the
+    session's pipeline — and its call record — end shortly after)."""
+
+    targets: dict[str, BtaTarget]
+    agent: dict
+    instance: dict
+    parent_call_id: str
+    organisation_id: Optional[str]
+    user_id: Optional[str]
+    instance_id: Optional[str]
+    caller_id: str
+    called_id: str
+    transcript: str
+    metadata: dict = field(default_factory=dict)
+    dtmf_timeout_s: float = 1.5
+
+
+@dataclass
+class TakeoverPayload:
+    """Stashed on the gateway between a DTMF match and the fresh agent
+    WS arriving at the worker (mirrors :class:`ConsultPayload`). The
+    ``agent`` dict already carries the composed takeover prompt in its
+    ``prompt`` field, and ``call`` is the started child call record.
+    ``extra`` carries gateway-specific correlation (e.g. voiceblender's
+    caller ``leg_id``)."""
+
+    agent: dict
+    instance: dict
+    call: api_client.CallRecord
+    extra: dict = field(default_factory=dict)
+
+
+def bta_context_from_session(session: Any, targets: dict[str, BtaTarget]) -> BtaContext:
+    """Snapshot a parent CallSession into a :class:`BtaContext`."""
+    aplisay_meta = dict((session.call.metadata or {}).get("aplisay") or {})
+    options = session.agent.get("options") or {}
+    timeout_ms = options.get("dtmfTimeout")
+    try:
+        timeout_s = max(0.25, float(timeout_ms) / 1000.0) if timeout_ms is not None else 1.5
+    except (TypeError, ValueError):
+        timeout_s = 1.5
+    return BtaContext(
+        targets=targets,
+        agent=session.agent,
+        instance=session.instance,
+        parent_call_id=session.call.id,
+        organisation_id=session.call.organisationId,
+        user_id=session.call.userId,
+        instance_id=session.call.instanceId,
+        caller_id=aplisay_meta.get("callerId") or "unknown",
+        called_id=aplisay_meta.get("calledId") or "unknown",
+        transcript=session.get_parent_transcript(),
+        metadata=dict(session.call.metadata or {}),
+        dtmf_timeout_s=timeout_s,
+    )
+
+
+def compose_takeover_prompt(new_agent: dict, ctx: BtaContext, target: BtaTarget) -> str:
+    """Build the incoming agent's system prompt. Mirrors the
+    ``transfer_agent`` builtin's composition (call_session.py)."""
+    prompt = new_agent.get("prompt") or "You are a helpful assistant."
+    prompt += (
+        "\n\nYou have just taken over a live call. The caller was previously "
+        "speaking with another agent and was then transferred to a human, who "
+        "has now handed the call back to you."
+    )
+    if target.include_history and ctx.transcript:
+        prompt += (
+            "\n\n# Conversation between the caller and the previous agent\n"
+            + ctx.transcript
+            + "\n\n(The conversation the caller had with the human after the "
+            "transfer was not recorded.)"
+        )
+    elif not target.include_history:
+        prompt += " Treat this as a fresh conversation: disregard any prior context."
+    return prompt
+
+
+async def prepare_takeover(
+    ctx: BtaContext, target: BtaTarget, *, platform: str, session_id: str
+) -> TakeoverPayload:
+    """Resolve the target agent and reserve the continuation call record.
+
+    Raises on any failure — callers must leave the bridge intact when this
+    throws (the humans are still talking; a failed takeover must not drop
+    their call).
+    """
+    new_agent = await api_client.get_internal_agent_by_id(
+        target.agent_id, expected_organisation_id=ctx.organisation_id
+    )
+    if (new_agent.get("type") or "interactive-audio") != "interactive-audio":
+        raise RuntimeError(
+            f"bridgedTransferToAgent target {target.agent_id} is type "
+            f"{new_agent.get('type')} and cannot take over a live call"
+        )
+    model_name = new_agent.get("modelName") or ""
+    if not model_name.startswith("pipecat:"):
+        raise RuntimeError(
+            f"bridgedTransferToAgent target {target.agent_id} uses {model_name}; "
+            "a pipecat call can only be taken over by a pipecat: agent"
+        )
+
+    prompt = compose_takeover_prompt(new_agent, ctx, target)
+    aplisay_meta = dict((ctx.metadata or {}).get("aplisay") or {})
+    call = await api_client.create_call(
+        {
+            "parentId": ctx.parent_call_id,
+            "userId": ctx.user_id,
+            "organisationId": ctx.organisation_id,
+            "instanceId": ctx.instance_id,
+            "agentId": new_agent.get("id"),
+            "platform": platform,
+            "platformCallId": session_id,
+            "calledId": ctx.called_id,
+            "callerId": ctx.caller_id,
+            "modelName": model_name,
+            "options": new_agent.get("options") or {},
+            "metadata": {
+                **(ctx.metadata or {}),
+                "aplisay": {
+                    **aplisay_meta,
+                    "model": model_name,
+                    "bridgedTransferToAgent": {"key": target.key},
+                },
+            },
+        }
+    )
+    # Reserve the concurrency slot; a busy rejection aborts the takeover
+    # with the human bridge still up.
+    await api_client.start_call(call)
+
+    # The composed prompt rides in the agent dict so the standard
+    # ``_run_session`` entry point (which reads ``agent["prompt"]``) uses it.
+    agent_for_run = dict(new_agent)
+    agent_for_run["prompt"] = prompt
+    return TakeoverPayload(agent=agent_for_run, instance=ctx.instance, call=call)
+
+
+def new_takeover_session_id(prefix: str) -> str:
+    return f"{prefix}-bta-{uuid.uuid4()}"
+
+
+async def _end_call_quiet(call: api_client.CallRecord, reason: str) -> None:
+    try:
+        await api_client.end_call(call, reason=reason)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"bridgedTransferToAgent: end_call after failure failed: {e}")
+
+
+def arm_voiceblender_bta_watch(gateway: Any, gw_session: Any, ctx: BtaContext, *, platform: str) -> None:
+    """Arm the voiceblender post-bridge watch: route the transfer-target
+    leg's VSI ``dtmf.received`` events through a sequence matcher; on a
+    match, reserve the continuation call, stash the TakeoverPayload, and
+    run the gateway-side takeover (drop target, un-room the caller leg,
+    re-attach a Pipecat agent). The watch dies with either bridged leg."""
+    target_leg = getattr(gw_session, "bridge_peer_leg_id", None)
+    caller_leg = gw_session.leg_id
+    if not target_leg:
+        logger.warning(
+            "bridgedTransferToAgent: voiceblender bridge has no recorded "
+            "target leg; watch not armed"
+        )
+        return
+
+    async def on_match(key: str) -> None:
+        target = ctx.targets[key]
+        session_id = new_takeover_session_id("vb")
+        logger.bind(key=key, agent_id=target.agent_id, session_id=session_id).info(
+            "bridgedTransferToAgent: DTMF match — starting takeover"
+        )
+        payload = await prepare_takeover(ctx, target, platform=platform, session_id=session_id)
+        payload.extra["leg_id"] = caller_leg
+        gateway.register_takeover_session(session_id, payload)
+        try:
+            await gw_session.takeover_to_agent(agent_ws_session_id=session_id)
+        except Exception:
+            gateway.clear_takeover_session(session_id)
+            await _end_call_quiet(payload.call, "bridged transfer-to-agent takeover failed")
+            raise
+        gateway.clear_bta_watcher(target_leg, caller_leg)
+
+    matcher = DtmfSequenceMatcher(
+        list(ctx.targets), on_match, timeout_s=ctx.dtmf_timeout_s
+    )
+
+    def on_gone() -> None:
+        matcher.cancel()
+        gateway.clear_bta_watcher(target_leg, caller_leg)
+
+    gateway.register_bta_watcher(target_leg, caller_leg, matcher.feed, on_gone)
+
+
+async def run_sipbridge_bta_watch(
+    websocket: Any, gateway: Any, gw_session: Any, ctx: BtaContext, *, platform: str
+) -> None:
+    """Post-bridge watch loop for sipbridge, run by the /sipbridge/agent WS
+    handler AFTER the pipeline has ended (the bridge kept the WS open in
+    control-only mode). Reads Pipecat protobuf frames straight off the
+    socket, feeds ``source: "transfer_target"`` DTMF events through the
+    matcher, and on a match POSTs the unbridge (the bridge then closes this
+    WS and dials a fresh one for the takeover session). Returns when the
+    WS closes — takeover or plain end-of-bridge alike."""
+    from pipecat.frames.frames import InputTransportMessageFrame
+    from pipecat.serializers.protobuf import ProtobufFrameSerializer
+    from starlette.websockets import WebSocketDisconnect
+
+    async def on_match(key: str) -> None:
+        target = ctx.targets[key]
+        session_id = new_takeover_session_id("sb")
+        logger.bind(key=key, agent_id=target.agent_id, session_id=session_id).info(
+            "bridgedTransferToAgent: DTMF match — starting takeover"
+        )
+        payload = await prepare_takeover(ctx, target, platform=platform, session_id=session_id)
+        gateway.register_takeover_session(session_id, payload)
+        try:
+            await gw_session.unbridge(agent_ws_session_id=session_id)
+        except Exception:
+            gateway.clear_takeover_session(session_id)
+            await _end_call_quiet(payload.call, "bridged transfer-to-agent takeover failed")
+            raise
+        # The bridge tears this monitor WS down as part of the unbridge;
+        # the receive loop below unwinds on the disconnect.
+
+    matcher = DtmfSequenceMatcher(
+        list(ctx.targets), on_match, timeout_s=ctx.dtmf_timeout_s
+    )
+    serializer = ProtobufFrameSerializer()
+    logger.bind(keys=sorted(ctx.targets.keys())).info(
+        "bridgedTransferToAgent: sipbridge monitor loop running"
+    )
+    try:
+        while True:
+            data = await websocket.receive_bytes()
+            try:
+                frame = await serializer.deserialize(data)
+            except Exception:  # noqa: BLE001
+                continue
+            if not isinstance(frame, InputTransportMessageFrame):
+                continue
+            message = frame.message
+            if (
+                isinstance(message, dict)
+                and message.get("type") == "dtmf"
+                and message.get("source") == "transfer_target"
+                and message.get("digit")
+            ):
+                await matcher.feed(str(message["digit"]))
+    except WebSocketDisconnect:
+        pass
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"bridgedTransferToAgent: sipbridge monitor loop ended: {e}")
+    finally:
+        matcher.cancel()
+        logger.info("bridgedTransferToAgent: sipbridge monitor loop finished")

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -168,6 +168,11 @@ class CallSession:
     # transfer, recorded when ``_on_transfer`` starts the consult leg so the
     # accept tool finalises via the same mode (attended REFER vs media bridge).
     _consult_use_refer: bool = False
+    # Parsed ``options.bridgedTransferToAgent`` map (human-to-agent
+    # transfers), recorded when ``_on_transfer`` runs so the consultative
+    # accept tool can arm the post-bridge DTMF watch. ``None`` when the
+    # option is unset. See ``bridged_transfer.py``.
+    _bta_targets: Optional[dict] = None
 
     # ---- WebRTC-origin transfer support (see media_relay.py + docs) ----
     # A browser session sets ``is_webrtc_origin``. Such a session — and any
@@ -1336,6 +1341,18 @@ class CallSession:
         use_refer = self._resolve_use_refer(args) and not legacy_bridged
         force_bridged = legacy_bridged or (not use_refer)
 
+        # Human-to-agent transfers (``options.bridgedTransferToAgent``): the
+        # transfer MUST stay bridged on the platform — a REFER hands the call
+        # off-platform where no transfer-target DTMF can be observed — and the
+        # gateway is asked to keep monitoring the target leg. Overrides any
+        # forceRefer/origin-REFER resolution above.
+        from .bridged_transfer import parse_bta_map
+
+        self._bta_targets = parse_bta_map(self.agent.get("options"))
+        if self._bta_targets:
+            use_refer = False
+            force_bridged = True
+
         # Default the calling number toward the gateway to the registration
         # trunk username (e.g. 8092) when registration-originated, unless the
         # LLM/tool supplied an explicit callerId. Mirrors LiveKit's
@@ -1351,6 +1368,7 @@ class CallSession:
             can_refer=use_refer,  # gateway honours this for the final hop
             force_bridged=force_bridged,
             force_refer=use_refer,
+            monitor_dtmf=bool(self._bta_targets),
         )
 
         if op == "consultative":
@@ -1382,6 +1400,11 @@ class CallSession:
             # / none. For blind, success means we're done.
             if op != "consultative":
                 self.transfer_state = TransferState("talking", "Transfer connected")
+                # Human-to-agent transfers: the bridge is up — arm the
+                # post-bridge target-leg DTMF watch and retire this
+                # pipeline (the call now belongs to the two humans).
+                if self._bta_targets:
+                    await self._arm_bta_monitor()
             return {
                 "ok": True,
                 "status": "OK",
@@ -1401,6 +1424,52 @@ class CallSession:
         ``options.transferTone`` is unset). ``mode``: "blind" | "consult"."""
         if self._tone_injector is not None:
             self._tone_injector.arm(mode)
+
+    async def _arm_bta_monitor(self) -> None:
+        """Arm the human-to-agent transfer watch on a just-installed bridge
+        (``options.bridgedTransferToAgent`` — see ``bridged_transfer.py``).
+
+        Snapshot everything the takeover needs (the pipeline and this
+        session's call record end moments later), then arm the gateway-
+        specific watch:
+
+        - **sipbridge** — stash the context on the gateway session; the
+          /sipbridge/agent WS handler keeps reading the (still open) WS for
+          ``source: "transfer_target"`` DTMF events after the pipeline ends.
+          The transport's disconnect is suppressed so tearing the pipeline
+          down doesn't close the WS the watch depends on.
+        - **voiceblender** — register a VSI watcher for the target leg on
+          the gateway; events arrive out-of-band so nothing keeps the WS.
+
+        Finally the pipeline is cancelled from a detached task: the humans
+        are talking through the gateway now, and the original call record
+        ends just like any other bridged transfer.
+        """
+        from .bridged_transfer import arm_voiceblender_bta_watch, bta_context_from_session
+
+        ctx = bta_context_from_session(self, self._bta_targets)
+        gw = self.gateway_session
+        if hasattr(gw, "unbridge"):  # sipbridge
+            gw.bta_context = ctx
+            self._suppress_transport_disconnect(gw.transport)
+            # Outbound-origin calls: wake the WS handler's wait loop so it
+            # can take over reading the kept-open WS (no-op for inbound).
+            signal = getattr(self.sip_gateway, "signal_bta_armed", None)
+            if signal is not None:
+                signal(self.session_id)
+        elif hasattr(gw, "takeover_to_agent"):  # voiceblender
+            arm_voiceblender_bta_watch(self.sip_gateway, gw, ctx, platform=PLATFORM)
+        else:
+            logger.warning(
+                "bridgedTransferToAgent: gateway "
+                f"{type(gw).__name__} has no takeover support; watch not armed"
+            )
+            return
+        logger.bind(
+            session_id=self.session_id,
+            keys=sorted(ctx.targets.keys()),
+        ).info("bridgedTransferToAgent: post-bridge DTMF watch armed")
+        self._agent_swap_task = asyncio.create_task(self._cancel_for_handover())
 
     # ---- WebRTC-origin transfer (worker-side media relay) ----
 
@@ -1902,7 +1971,14 @@ def _builtin_consult_accept(consult_session: CallSession):
                         consult_session.gateway_session
                     )
             else:
-                await parent.gateway_session.bridge_with(consult_session.gateway_session)
+                # Human-to-agent transfers: keep watching the target leg's
+                # DTMF after the bridge (options.bridgedTransferToAgent).
+                monitor = bool(parent._bta_targets)
+                await parent.gateway_session.bridge_with(
+                    consult_session.gateway_session, monitor_dtmf=monitor
+                )
+                if monitor:
+                    await parent._arm_bta_monitor()
         except NotImplementedError as e:
             # The active gateway doesn't support consultative transfer.
             # Should have been rejected upstream by ``transfer()``; if
@@ -2254,6 +2330,35 @@ async def setup_consult_call(
         gateway_session=gw_session,
         call=call,
         parent_session=parent,
+    )
+
+
+async def setup_takeover_call(
+    sip_gateway: SipGateway,
+    inbound: InboundCallContext,
+    *,
+    payload: Any,
+) -> CallSession:
+    """Build the CallSession for a human-to-agent takeover leg
+    (``options.bridgedTransferToAgent`` — see ``bridged_transfer.py``).
+
+    The heavy lifting already happened at DTMF-match time
+    (``prepare_takeover``): the target agent is resolved, the composed
+    takeover prompt rides in ``payload.agent["prompt"]``, and
+    ``payload.call`` is a started child call record (parentId = the
+    original call). Here we just wire the freshly re-attached media leg
+    to a standard CallSession — the incoming agent gets its own full
+    tool surface, unlike a consult-side TransferAgent.
+    """
+    session_params = GatewaySessionParams(session_id=inbound.session_id)
+    gw_session = await sip_gateway.setup_inbound(inbound, session_params)
+    return CallSession(
+        session_id=inbound.session_id,
+        agent=payload.agent,
+        instance=payload.instance,
+        sip_gateway=sip_gateway,
+        gateway_session=gw_session,
+        call=payload.call,
     )
 
 

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -173,6 +173,12 @@ class CallSession:
     # accept tool can arm the post-bridge DTMF watch. ``None`` when the
     # option is unset. See ``bridged_transfer.py``.
     _bta_targets: Optional[dict] = None
+    # Normalised ``options.bridgedTransferTranscribe`` config (bridged-
+    # segment transcription) and the in-flight transfer destination —
+    # captured alongside ``_bta_targets`` for the post-bridge monitor.
+    # See ``bridge_transcript.py``.
+    _bta_transcribe: Optional[dict] = None
+    _bta_destination: str = ""
 
     # ---- WebRTC-origin transfer support (see media_relay.py + docs) ----
     # A browser session sets ``is_webrtc_origin``. Such a session — and any
@@ -1341,15 +1347,19 @@ class CallSession:
         use_refer = self._resolve_use_refer(args) and not legacy_bridged
         force_bridged = legacy_bridged or (not use_refer)
 
-        # Human-to-agent transfers (``options.bridgedTransferToAgent``): the
-        # transfer MUST stay bridged on the platform — a REFER hands the call
-        # off-platform where no transfer-target DTMF can be observed — and the
-        # gateway is asked to keep monitoring the target leg. Overrides any
-        # forceRefer/origin-REFER resolution above.
+        # Human-to-agent transfers (``options.bridgedTransferToAgent``) and
+        # bridged-segment transcription (``options.bridgedTransferTranscribe``):
+        # the transfer MUST stay bridged on the platform — a REFER hands the
+        # call off-platform where neither transfer-target DTMF nor audio can
+        # be observed — and the gateway is asked to keep monitoring the
+        # bridge. Overrides any forceRefer/origin-REFER resolution above.
+        from .bridge_transcript import parse_transcribe_option
         from .bridged_transfer import parse_bta_map
 
         self._bta_targets = parse_bta_map(self.agent.get("options"))
-        if self._bta_targets:
+        self._bta_transcribe = parse_transcribe_option(self.agent.get("options"))
+        self._bta_destination = str(args.get("number") or "")
+        if self._bta_targets or self._bta_transcribe:
             use_refer = False
             force_bridged = True
 
@@ -1369,6 +1379,7 @@ class CallSession:
             force_bridged=force_bridged,
             force_refer=use_refer,
             monitor_dtmf=bool(self._bta_targets),
+            tap_audio=bool(self._bta_transcribe),
         )
 
         if op == "consultative":
@@ -1400,10 +1411,10 @@ class CallSession:
             # / none. For blind, success means we're done.
             if op != "consultative":
                 self.transfer_state = TransferState("talking", "Transfer connected")
-                # Human-to-agent transfers: the bridge is up — arm the
-                # post-bridge target-leg DTMF watch and retire this
-                # pipeline (the call now belongs to the two humans).
-                if self._bta_targets:
+                # Human-to-agent transfers / bridged-segment transcription:
+                # the bridge is up — arm the post-bridge watch and retire
+                # this pipeline (the call now belongs to the two humans).
+                if self._bta_targets or self._bta_transcribe:
                     await self._arm_bta_monitor()
             return {
                 "ok": True,
@@ -1445,9 +1456,22 @@ class CallSession:
         are talking through the gateway now, and the original call record
         ends just like any other bridged transfer.
         """
-        from .bridged_transfer import arm_voiceblender_bta_watch, bta_context_from_session
+        from .bridged_transfer import (
+            arm_voiceblender_bta_watch,
+            bta_context_from_session,
+            prepare_bridge_monitor,
+        )
 
-        ctx = bta_context_from_session(self, self._bta_targets)
+        ctx = bta_context_from_session(
+            self,
+            self._bta_targets,
+            transcribe=self._bta_transcribe,
+            destination=self._bta_destination,
+        )
+        # Bridged-segment call record (+ transcript collector when
+        # transcription is on) — LiveKit parity for the post-transfer
+        # segment. Best-effort: the bridge proceeds without it.
+        await prepare_bridge_monitor(ctx, platform=PLATFORM)
         gw = self.gateway_session
         if hasattr(gw, "unbridge"):  # sipbridge
             gw.bta_context = ctx
@@ -1458,17 +1482,18 @@ class CallSession:
             if signal is not None:
                 signal(self.session_id)
         elif hasattr(gw, "takeover_to_agent"):  # voiceblender
-            arm_voiceblender_bta_watch(self.sip_gateway, gw, ctx, platform=PLATFORM)
+            await arm_voiceblender_bta_watch(self.sip_gateway, gw, ctx, platform=PLATFORM)
         else:
             logger.warning(
-                "bridgedTransferToAgent: gateway "
+                "bridged transfer: gateway "
                 f"{type(gw).__name__} has no takeover support; watch not armed"
             )
             return
         logger.bind(
             session_id=self.session_id,
             keys=sorted(ctx.targets.keys()),
-        ).info("bridgedTransferToAgent: post-bridge DTMF watch armed")
+            transcribe=bool(ctx.transcribe),
+        ).info("bridged transfer: post-bridge watch armed")
         self._agent_swap_task = asyncio.create_task(self._cancel_for_handover())
 
     # ---- WebRTC-origin transfer (worker-side media relay) ----
@@ -1971,13 +1996,17 @@ def _builtin_consult_accept(consult_session: CallSession):
                         consult_session.gateway_session
                     )
             else:
-                # Human-to-agent transfers: keep watching the target leg's
-                # DTMF after the bridge (options.bridgedTransferToAgent).
+                # Human-to-agent transfers / bridged-segment transcription:
+                # keep watching the target leg after the bridge
+                # (options.bridgedTransferToAgent / bridgedTransferTranscribe).
                 monitor = bool(parent._bta_targets)
+                tap = bool(parent._bta_transcribe)
                 await parent.gateway_session.bridge_with(
-                    consult_session.gateway_session, monitor_dtmf=monitor
+                    consult_session.gateway_session,
+                    monitor_dtmf=monitor,
+                    tap_audio=tap,
                 )
-                if monitor:
+                if monitor or tap:
                     await parent._arm_bta_monitor()
         except NotImplementedError as e:
             # The active gateway doesn't support consultative transfer.

--- a/agents/pipecat/pipecat_aplisay/serializers/dtmf_protobuf.py
+++ b/agents/pipecat/pipecat_aplisay/serializers/dtmf_protobuf.py
@@ -50,6 +50,13 @@ class DtmfProtobufFrameSerializer(ProtobufFrameSerializer):
         if not isinstance(message, dict) or message.get("type") != "dtmf":
             return frame
 
+        # Post-bridge transfer-target presses (``options.bridgedTransferToAgent``,
+        # ``source: "transfer_target"``) belong to the monitor loop in
+        # ``bridged_transfer.py``, not to a live pipeline — a stray one racing
+        # the pipeline teardown must not be mistaken for caller input.
+        if message.get("source") == "transfer_target":
+            return None
+
         # ``digit`` is the field the sipbridge/voiceblender media layer emits;
         # ``dtmf`` is accepted as an alias for parity with the FreeSWITCH path.
         digit = message.get("digit") or message.get("dtmf")

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/base.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/base.py
@@ -164,6 +164,14 @@ class TransferRequest:
     # ``bridged_transfer.py`` and ``docs/call-transfers.md``.
     monitor_dtmf: bool = False
 
+    # Bridged-segment transcription (``options.bridgedTransferTranscribe``):
+    # ask the gateway to keep a transcription path over the bridge. On
+    # sipbridge this streams a stereo audio tap on the kept-open monitor WS;
+    # on voiceblender the worker starts the container's native per-leg STT
+    # instead (this flag still forces the bridged path + monitoring WS/
+    # record lifecycle). See ``bridge_transcript.py``.
+    tap_audio: bool = False
+
 
 class GatewaySession(Protocol):
     """A live media session owned by the gateway.
@@ -182,7 +190,9 @@ class GatewaySession(Protocol):
 
     async def shutdown(self) -> None: ...
 
-    async def bridge_with(self, other: "GatewaySession", *, monitor_dtmf: bool = False) -> None:
+    async def bridge_with(
+        self, other: "GatewaySession", *, monitor_dtmf: bool = False, tap_audio: bool = False
+    ) -> None:
         """Install media relay between this session and ``other``.
 
         Used to finalise consultative transfers — when the TransferAgent

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/base.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/base.py
@@ -156,6 +156,14 @@ class TransferRequest:
     transfer_prompt_template: Optional[str] = None
     parent_transcript: Optional[str] = None
 
+    # Human-to-agent transfers (``options.bridgedTransferToAgent``): ask the
+    # gateway to keep watching the transfer-target leg for DTMF after the
+    # bridge is installed, so the worker can drop the target and hand the
+    # caller to another agent. Only meaningful on the bridged paths — the
+    # caller session forces ``force_bridged`` when the option is set. See
+    # ``bridged_transfer.py`` and ``docs/call-transfers.md``.
+    monitor_dtmf: bool = False
+
 
 class GatewaySession(Protocol):
     """A live media session owned by the gateway.
@@ -174,13 +182,18 @@ class GatewaySession(Protocol):
 
     async def shutdown(self) -> None: ...
 
-    async def bridge_with(self, other: "GatewaySession") -> None:
+    async def bridge_with(self, other: "GatewaySession", *, monitor_dtmf: bool = False) -> None:
         """Install media relay between this session and ``other``.
 
         Used to finalise consultative transfers — when the TransferAgent
         on the consult leg calls ``accept_transfer``, the parent leg
         and the consult leg get bridged together (bot WSes close, A and
         C talk directly through the gateway until either BYEs).
+
+        ``monitor_dtmf`` (human-to-agent transfers,
+        ``options.bridgedTransferToAgent``) asks the gateway to keep
+        surfacing transfer-target DTMF to the worker after the bridge is
+        installed — see ``bridged_transfer.py``.
 
         Default implementation raises ``NotImplementedError`` —
         gateways that support consultative transfer override this with
@@ -265,6 +278,22 @@ class ConsultStateMixin:
     def _init_consult_state(self) -> None:
         self._consult_payloads: dict[str, ConsultPayload] = {}
         self._consult_call_ids: dict[str, str] = {}
+        # Human-to-agent takeovers (``options.bridgedTransferToAgent``):
+        # pending payloads keyed by the fresh agent-WS session id chosen at
+        # DTMF-match time. The per-gateway WS handler reads these to build the
+        # incoming agent's CallSession — mirrors the consult stash above. The
+        # values are ``bridged_transfer.TakeoverPayload`` instances (kept
+        # untyped here to avoid a circular import).
+        self._takeover_payloads: dict[str, Any] = {}
+
+    def register_takeover_session(self, session_id: str, payload: Any) -> None:
+        self._takeover_payloads[session_id] = payload
+
+    def takeover_payload(self, session_id: str) -> Optional[Any]:
+        return self._takeover_payloads.get(session_id)
+
+    def clear_takeover_session(self, session_id: str) -> None:
+        self._takeover_payloads.pop(session_id, None)
 
     def register_consult_session(
         self,

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
@@ -187,6 +187,7 @@ class _SbGatewaySession(GatewaySession):
                     "mode": "dial_bridge",
                     "caller_id": req.caller_id_override or "",
                     "monitor_dtmf": req.monitor_dtmf,
+                    "tap_audio": req.tap_audio,
                 },
             )
             self.bridged = True
@@ -276,7 +277,9 @@ class _SbGatewaySession(GatewaySession):
         ).info("sipbridge consultative: consult leg requested; "
                "TransferAgent will spawn when WS arrives")
 
-    async def bridge_with(self, other: GatewaySession, *, monitor_dtmf: bool = False) -> None:
+    async def bridge_with(
+        self, other: GatewaySession, *, monitor_dtmf: bool = False, tap_audio: bool = False
+    ) -> None:
         """Install a sipbridge media relay between this session's leg
         and ``other``'s leg.
 
@@ -303,6 +306,7 @@ class _SbGatewaySession(GatewaySession):
                 "target": other.bridge_call_id,
                 "mode": "bridged",
                 "monitor_dtmf": monitor_dtmf,
+                "tap_audio": tap_audio,
             },
         )
         self.bridged = True

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
@@ -71,8 +71,25 @@ class _SbGatewaySession(GatewaySession):
     session_id: str
     bridge_call_id: str
     _gateway: "SipBridgeSipGateway"
+    # Set once this leg is one half of an installed media bridge (native
+    # dial_bridge or consultative finalise). From that point the bridged
+    # call belongs to the two humans, not to this worker session — the
+    # session's teardown must NOT delete the bridge call (the bridge tears
+    # both legs down itself when either side BYEs).
+    bridged: bool = False
+    # Post-bridge DTMF watcher context (``options.bridgedTransferToAgent``).
+    # Set by ``CallSession`` when a monitored bridge is installed; consumed
+    # by the /sipbridge/agent WS handler, which keeps reading the (still
+    # open) WS for ``source: "transfer_target"`` DTMF events after the
+    # pipeline ends. See ``bridged_transfer.py``.
+    bta_context: Optional[Any] = None
 
     async def hangup(self, reason: str) -> None:
+        if self.bridged:
+            logger.bind(call_id=self.bridge_call_id, reason=reason).info(
+                "sipbridge hangup skipped — leg is part of a live bridge"
+            )
+            return
         logger.bind(call_id=self.bridge_call_id, reason=reason).info(
             "sipbridge hangup"
         )
@@ -160,6 +177,7 @@ class _SbGatewaySession(GatewaySession):
                 call_id=self.bridge_call_id,
                 target=req.destination,
                 mode="dial_bridge",
+                monitor_dtmf=req.monitor_dtmf,
             ).info("sipbridge transfer (native dial+bridge)")
             await self._gateway._call_api(
                 "POST",
@@ -168,8 +186,10 @@ class _SbGatewaySession(GatewaySession):
                     "target": req.destination,
                     "mode": "dial_bridge",
                     "caller_id": req.caller_id_override or "",
+                    "monitor_dtmf": req.monitor_dtmf,
                 },
             )
+            self.bridged = True
             return
 
         logger.bind(
@@ -256,7 +276,7 @@ class _SbGatewaySession(GatewaySession):
         ).info("sipbridge consultative: consult leg requested; "
                "TransferAgent will spawn when WS arrives")
 
-    async def bridge_with(self, other: GatewaySession) -> None:
+    async def bridge_with(self, other: GatewaySession, *, monitor_dtmf: bool = False) -> None:
         """Install a sipbridge media relay between this session's leg
         and ``other``'s leg.
 
@@ -267,6 +287,9 @@ class _SbGatewaySession(GatewaySession):
         "bridged" }`` on the bridge — same primitive the bridge uses
         internally for ``BridgeRelay`` (see
         ``agents/pipecat/sipbridge/internal/call/manager.go``).
+        ``monitor_dtmf`` keeps this (caller) leg's worker WS open across
+        the bridge so transfer-target DTMF events reach the worker
+        (``options.bridgedTransferToAgent``).
         """
         if not isinstance(other, _SbGatewaySession):
             raise NotImplementedError(
@@ -276,7 +299,25 @@ class _SbGatewaySession(GatewaySession):
         await self._gateway._call_api(
             "POST",
             f"/v1/calls/{self.bridge_call_id}/transfer",
-            {"target": other.bridge_call_id, "mode": "bridged"},
+            {
+                "target": other.bridge_call_id,
+                "mode": "bridged",
+                "monitor_dtmf": monitor_dtmf,
+            },
+        )
+        self.bridged = True
+        other.bridged = True
+
+    async def unbridge(self, *, agent_ws_session_id: str) -> None:
+        """Finalise a human-to-agent takeover: drop the bridged peer
+        (transfer target) and have the bridge re-dial a fresh agent WS
+        for this leg at ``/sipbridge/agent/{agent_ws_session_id}``. The
+        worker must have stashed a TakeoverPayload for that session id
+        before calling this. See ``bridged_transfer.py``."""
+        await self._gateway._call_api(
+            "POST",
+            f"/v1/calls/{self.bridge_call_id}/unbridge",
+            {"agent_ws_session_id": agent_ws_session_id},
         )
 
     async def attended_refer_with(self, other: GatewaySession) -> None:
@@ -364,6 +405,12 @@ class SipBridgeSipGateway(ConsultStateMixin, SipGateway):
         # know which bridge resource to target.
         self._session_to_bridge_call: dict[str, str] = {}
 
+        # Map of worker session_id → live _SbGatewaySession, so the WS
+        # handler's outbound branch can find the session object (and its
+        # ``bta_context``) when a bridged transfer-to-agent watch is armed
+        # on an outbound-origin call.
+        self._sessions: dict[str, _SbGatewaySession] = {}
+
         # Per-session leg-done signals — set when the gateway session's
         # WebSocket close handler fires. The /sipbridge/agent WS handler
         # awaits this for outbound calls (where the dispatch task owns
@@ -405,12 +452,25 @@ class SipBridgeSipGateway(ConsultStateMixin, SipGateway):
             _gateway=self,
         )
         self._session_to_bridge_call[session_id] = bridge_call_id
+        self._sessions[session_id] = session
 
         pending = self._pending_outbound.get(session_id)
         if pending and not pending.done():
             pending.set_result(session)
 
         return session
+
+    def live_session(self, session_id: str) -> Optional[_SbGatewaySession]:
+        return self._sessions.get(session_id)
+
+    def signal_bta_armed(self, session_id: str) -> None:
+        """Wake the WS handler's outbound wait loop when a bridged
+        transfer-to-agent watch is armed mid-call, so it can take over
+        reading the (kept-open) WS for transfer-target DTMF. No-op for
+        inbound calls, where nothing waits on the leg-done event."""
+        ev = self._leg_done_events.get(session_id)
+        if ev is not None:
+            ev.set()
 
     def unregister_session(self, session_id: str) -> None:
         """Called when the WS handler exits, regardless of cause.
@@ -420,6 +480,7 @@ class SipBridgeSipGateway(ConsultStateMixin, SipGateway):
         waiter on the leg-done event.
         """
         self._session_to_bridge_call.pop(session_id, None)
+        self._sessions.pop(session_id, None)
         ev = self._leg_done_events.get(session_id)
         if ev is not None:
             ev.set()

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/voiceblender_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/voiceblender_gateway.py
@@ -309,7 +309,9 @@ class _VbGatewaySession(GatewaySession):
         ).info("voiceblender consultative: consult leg requested; "
                "TransferAgent will spawn when WS arrives")
 
-    async def bridge_with(self, other: GatewaySession, *, monitor_dtmf: bool = False) -> None:
+    async def bridge_with(
+        self, other: GatewaySession, *, monitor_dtmf: bool = False, tap_audio: bool = False
+    ) -> None:
         """Install a media bridge between this leg and ``other``'s leg.
 
         Voiceblender's native bridge primitive is room-based: create a
@@ -504,6 +506,9 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
         # bridged leg disconnects. See ``bridged_transfer.py``.
         self._bta_digit_watchers: dict[str, Callable[[str], Awaitable[None]]] = {}
         self._bta_gone_watchers: dict[str, Callable[[], None]] = {}
+        # Bridged-segment transcription (``options.bridgedTransferTranscribe``):
+        # final stt.text events for a bridged human leg, keyed by leg id.
+        self._bta_stt_watchers: dict[str, Callable[[str], Awaitable[None]]] = {}
 
     # ---- Human-to-agent transfer watchers --------------------------------
 
@@ -521,10 +526,35 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
         # Caller-leg death also ends the watch; map it to the same teardown.
         self._bta_gone_watchers[caller_leg_id] = on_gone
 
+    def register_stt_watcher(
+        self, leg_id: str, on_text: Callable[[str], Awaitable[None]]
+    ) -> None:
+        """Route final ``stt.text`` VSI events for ``leg_id`` (a bridged
+        human leg being transcribed via the container's native STT) to
+        ``on_text``. See ``bridge_transcript.py``."""
+        self._bta_stt_watchers[leg_id] = on_text
+
     def clear_bta_watcher(self, *leg_ids: str) -> None:
         for leg_id in leg_ids:
             self._bta_digit_watchers.pop(leg_id, None)
             self._bta_gone_watchers.pop(leg_id, None)
+            self._bta_stt_watchers.pop(leg_id, None)
+
+    async def start_leg_stt(
+        self, leg_id: str, *, provider: str, language: Optional[str]
+    ) -> None:
+        """Start voiceblender's native real-time STT on a leg
+        (``POST /v1/legs/{id}/stt``). Finals arrive as ``stt.text`` VSI
+        events routed via :meth:`register_stt_watcher`."""
+        body: dict[str, Any] = {"provider": provider, "partial": False}
+        if language:
+            body["language"] = language
+        await self._call_api("POST", f"/v1/legs/{leg_id}/stt", body)
+
+    async def stop_leg_stt(self, leg_id: str) -> None:
+        await self._call_api(
+            "DELETE", f"/v1/legs/{leg_id}/stt", None, raise_on_error=False
+        )
 
     # ---- Injection points used by the worker ----------------------------
 
@@ -831,6 +861,8 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
             await self._on_leg_disconnected(event)
         elif etype == "dtmf.received":
             await self._on_leg_dtmf(event)
+        elif etype == "stt.text":
+            await self._on_stt_text(event)
         elif etype in {
             "leg.transfer_initiated",
             "leg.transfer_requested",
@@ -854,6 +886,26 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
         fut = self._pending_connected.get(leg_id)
         if fut is not None and not fut.done():
             fut.set_result(None)
+
+    async def _on_stt_text(self, event: dict) -> None:
+        """Handle an ``stt.text`` VSI event from the container's native STT
+        (started per bridged leg by ``start_leg_stt``). Only FINAL
+        transcripts are forwarded — partials are noise for a transcript.
+        Envelope: ``{"type": "stt.text", "leg_id": "...", "text": "...",
+        "is_final": true}``."""
+        leg_id = event.get("leg_id") or event.get("id")
+        text = event.get("text")
+        if not leg_id or not text or not event.get("is_final", True):
+            return
+        watcher = self._bta_stt_watchers.get(leg_id)
+        if watcher is None:
+            return
+        try:
+            await watcher(str(text))
+        except Exception as e:  # noqa: BLE001
+            logger.bind(leg_id=leg_id).warning(
+                f"VSI: bridged-transfer STT watcher failed: {e}"
+            )
 
     async def _on_leg_dtmf(self, event: dict) -> None:
         """Handle a ``dtmf.received`` VSI event.

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/voiceblender_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/voiceblender_gateway.py
@@ -107,8 +107,24 @@ class _VbGatewaySession(GatewaySession):
     session_id: str
     leg_id: str
     _gateway: "VoiceblenderSipGateway"
+    # Set once this leg is one half of an installed room bridge (native
+    # dial_bridge or consultative finalise). From then on the bridged call
+    # belongs to the two humans — the worker session's teardown must NOT
+    # delete the leg (the room reaps itself when the legs BYE).
+    bridged: bool = False
+    # The bridge-room id and the peer (transfer-target) leg id, recorded
+    # when this session installs a bridge — needed by the human-to-agent
+    # takeover (``options.bridgedTransferToAgent``) to drop the target and
+    # pull this leg back out of the room.
+    bridge_room_id: Optional[str] = None
+    bridge_peer_leg_id: Optional[str] = None
 
     async def hangup(self, reason: str) -> None:
+        if self.bridged:
+            logger.bind(leg_id=self.leg_id, reason=reason).info(
+                "voiceblender hangup skipped — leg is part of a live bridge"
+            )
+            return
         logger.bind(leg_id=self.leg_id, reason=reason).info("voiceblender hangup")
         await self._gateway._call_api(
             "DELETE",
@@ -203,9 +219,12 @@ class _VbGatewaySession(GatewaySession):
             raise RuntimeError(
                 f"voiceblender dial_bridge: POST /v1/legs did not return a leg id: {resp!r}"
             )
-        await self._bridge_legs(self.leg_id, new_leg_id)
+        room_id = await self._bridge_legs(self.leg_id, new_leg_id)
+        self.bridged = True
+        self.bridge_room_id = room_id
+        self.bridge_peer_leg_id = new_leg_id
         logger.bind(
-            original_leg=self.leg_id, target_leg=new_leg_id
+            original_leg=self.leg_id, target_leg=new_leg_id, room=room_id
         ).info("voiceblender dial_bridge: caller bridged to target leg")
 
     async def _do_consultative(self, req: TransferRequest) -> None:
@@ -290,7 +309,7 @@ class _VbGatewaySession(GatewaySession):
         ).info("voiceblender consultative: consult leg requested; "
                "TransferAgent will spawn when WS arrives")
 
-    async def bridge_with(self, other: GatewaySession) -> None:
+    async def bridge_with(self, other: GatewaySession, *, monitor_dtmf: bool = False) -> None:
         """Install a media bridge between this leg and ``other``'s leg.
 
         Voiceblender's native bridge primitive is room-based: create a
@@ -301,20 +320,29 @@ class _VbGatewaySession(GatewaySession):
         ``POST /v1/rooms`` to create, then ``POST /v1/rooms/{room}/legs``
         with each leg id. The room is reaped automatically when the
         last leg leaves.
+
+        ``monitor_dtmf`` records the bridge topology (room + peer leg) on
+        this session so a human-to-agent takeover watcher can be armed —
+        the DTMF events themselves arrive on the VSI stream regardless.
         """
         if not isinstance(other, _VbGatewaySession):
             raise NotImplementedError(
                 f"voiceblender bridge_with: peer must be _VbGatewaySession, "
                 f"got {type(other).__name__}"
             )
-        await self._bridge_legs(self.leg_id, other.leg_id)
+        room_id = await self._bridge_legs(self.leg_id, other.leg_id)
+        self.bridged = True
+        other.bridged = True
+        self.bridge_room_id = room_id
+        self.bridge_peer_leg_id = other.leg_id
         logger.bind(
-            parent_leg=self.leg_id, consult_leg=other.leg_id
+            parent_leg=self.leg_id, consult_leg=other.leg_id, room=room_id,
+            monitor_dtmf=monitor_dtmf,
         ).info("voiceblender bridge_with: legs joined in consult-bridge room")
 
-    async def _bridge_legs(self, leg_a: str, leg_b: str) -> None:
+    async def _bridge_legs(self, leg_a: str, leg_b: str) -> str:
         """Create a temporary voiceblender room and move both legs into
-        it so the room mixer joins their audio.
+        it so the room mixer joins their audio. Returns the room id.
 
         Shared by :meth:`bridge_with` (consultative finalisation) and
         :meth:`_do_dial_bridge` (native blind bridged transfer). The
@@ -344,6 +372,35 @@ class _VbGatewaySession(GatewaySession):
                 f"/v1/rooms/{room_id}/legs",
                 {"leg_id": leg_id},
             )
+        return room_id
+
+    async def takeover_to_agent(self, *, agent_ws_session_id: str) -> None:
+        """Finalise a human-to-agent takeover on this (caller) leg: hang
+        up the bridged transfer-target leg, pull this leg back out of the
+        bridge room, and re-attach a Pipecat agent so voiceblender dials
+        ``/voiceblender/agent/{agent_ws_session_id}``. The worker must
+        have stashed a TakeoverPayload for that session id first. See
+        ``bridged_transfer.py``."""
+        peer = self.bridge_peer_leg_id
+        room = self.bridge_room_id
+        if peer:
+            await self._gateway._call_api(
+                "DELETE",
+                f"/v1/legs/{peer}",
+                {"reason": "normal"},
+                raise_on_error=False,
+            )
+        if room:
+            await self._gateway._call_api(
+                "DELETE",
+                f"/v1/rooms/{room}/legs/{self.leg_id}",
+                None,
+                raise_on_error=False,
+            )
+        self.bridged = False
+        self.bridge_room_id = None
+        self.bridge_peer_leg_id = None
+        await self._gateway._attach_pipecat(self.leg_id, agent_ws_session_id)
 
     async def shutdown(self) -> None:
         # Best-effort hangup. The VSI ``leg.disconnected`` listener will also
@@ -438,6 +495,36 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
 
         # Warm-transfer state (LiveKit-parity) — shared mixin.
         self._init_consult_state()
+
+        # Human-to-agent transfer watchers (``options.bridgedTransferToAgent``):
+        # async callbacks keyed by the TRANSFER-TARGET leg id. While a
+        # monitored bridge is up, ``dtmf.received`` events for that leg are
+        # routed here (the target leg has no CallSession of its own). A second
+        # map keyed the same way carries teardown callbacks fired when either
+        # bridged leg disconnects. See ``bridged_transfer.py``.
+        self._bta_digit_watchers: dict[str, Callable[[str], Awaitable[None]]] = {}
+        self._bta_gone_watchers: dict[str, Callable[[], None]] = {}
+
+    # ---- Human-to-agent transfer watchers --------------------------------
+
+    def register_bta_watcher(
+        self,
+        target_leg_id: str,
+        caller_leg_id: str,
+        on_digit: Callable[[str], Awaitable[None]],
+        on_gone: Callable[[], None],
+    ) -> None:
+        """Route ``dtmf.received`` for ``target_leg_id`` to ``on_digit`` and
+        fire ``on_gone`` (idempotently) when either bridged leg disconnects."""
+        self._bta_digit_watchers[target_leg_id] = on_digit
+        self._bta_gone_watchers[target_leg_id] = on_gone
+        # Caller-leg death also ends the watch; map it to the same teardown.
+        self._bta_gone_watchers[caller_leg_id] = on_gone
+
+    def clear_bta_watcher(self, *leg_ids: str) -> None:
+        for leg_id in leg_ids:
+            self._bta_digit_watchers.pop(leg_id, None)
+            self._bta_gone_watchers.pop(leg_id, None)
 
     # ---- Injection points used by the worker ----------------------------
 
@@ -788,6 +875,18 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
                 f"dtmf.received without leg_id/digit: {event!r}"
             )
             return
+        # Human-to-agent transfer watch: post-bridge, the transfer-target
+        # leg has no CallSession — its digits go to the registered watcher
+        # (see ``bridged_transfer.py``) instead of a pipeline.
+        watcher = self._bta_digit_watchers.get(leg_id)
+        if watcher is not None:
+            try:
+                await watcher(str(digit))
+            except Exception as e:  # noqa: BLE001
+                logger.bind(leg_id=leg_id, digit=digit).warning(
+                    f"VSI: bridged-transfer DTMF watcher failed: {e}"
+                )
+            return
         session_id = self._leg_to_session.get(leg_id)
         if not session_id or self._session_lookup is None:
             return
@@ -897,6 +996,15 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
         leg_id = event.get("leg_id") or event.get("id")
         if not leg_id:
             return
+        # A bridged-transfer watch ends when either bridged leg drops.
+        gone = self._bta_gone_watchers.get(leg_id)
+        if gone is not None:
+            try:
+                gone()
+            except Exception as e:  # noqa: BLE001
+                logger.bind(leg_id=leg_id).warning(
+                    f"VSI: bridged-transfer gone-watcher failed: {e}"
+                )
         # If an originate/consult is still waiting for this leg to answer, the
         # leg dropping first means the call failed (busy / no-answer / 401).
         # Reason lives under the CDR (``cdr.reason``) on the flattened envelope.

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -216,6 +216,36 @@ def _dtmf_aggregator_for(agent: dict) -> DTMFAggregator:
     )
 
 
+def build_stt_service(agent: dict) -> Any:
+    """Construct a fresh STT service from ``agent.options.stt`` (defaulting
+    to Deepgram). Used by the pipeline build below and by the bridged-
+    transfer transcription tap (``bridged_transfer.py``), which runs extra
+    STT streams over the human↔human segment of a monitored bridge —
+    each call returns a NEW service instance, safe to run alongside the
+    pipeline's own."""
+    stt_opts = (agent.get("options") or {}).get("stt") or {}
+    stt_vendor = (stt_opts.get("vendor") or "deepgram").split("/")[0].lower()
+    if stt_vendor == "deepgram":
+        from pipecat.services.deepgram.stt import DeepgramSTTService
+
+        return DeepgramSTTService(api_key=_require_env("DEEPGRAM_API_KEY"))
+    if stt_vendor == "google":
+        from pipecat.services.google.stt import GoogleSTTService
+
+        # GoogleSTTService accepts credentials JSON or credentials_path. Source
+        # of truth is GOOGLE_APPLICATION_CREDENTIALS_JSON (a JSON string) or
+        # GOOGLE_APPLICATION_CREDENTIALS (a path) — pass through whichever the
+        # operator set.
+        creds_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+        creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        return GoogleSTTService(
+            credentials=creds_json,
+            credentials_path=creds_path,
+            location=os.environ.get("GOOGLE_STT_LOCATION", "global"),
+        )
+    raise RuntimeError(f"Unsupported STT vendor {stt_vendor!r} for pipeline mode")
+
+
 def _require_env(name: str, *aliases: str) -> str:
     """Return the first env var that's set; raise a clear error otherwise.
 
@@ -843,31 +873,10 @@ async def _build_pipeline(
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
-    stt_opts = options.get("stt") or {}
     tts_opts = options.get("tts") or {}
 
     # STT
-    stt_vendor = (stt_opts.get("vendor") or "deepgram").split("/")[0].lower()
-    if stt_vendor == "deepgram":
-        from pipecat.services.deepgram.stt import DeepgramSTTService
-
-        stt = DeepgramSTTService(api_key=_require_env("DEEPGRAM_API_KEY"))
-    elif stt_vendor == "google":
-        from pipecat.services.google.stt import GoogleSTTService
-
-        # GoogleSTTService accepts credentials JSON or credentials_path. Source
-        # of truth is GOOGLE_APPLICATION_CREDENTIALS_JSON (a JSON string) or
-        # GOOGLE_APPLICATION_CREDENTIALS (a path) — pass through whichever the
-        # operator set.
-        creds_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
-        creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-        stt = GoogleSTTService(
-            credentials=creds_json,
-            credentials_path=creds_path,
-            location=os.environ.get("GOOGLE_STT_LOCATION", "global"),
-        )
-    else:
-        raise RuntimeError(f"Unsupported STT vendor {stt_vendor!r} for pipeline mode")
+    stt = build_stt_service(agent)
 
     # LLM
     if model_id.startswith("openai/"):

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -60,6 +60,7 @@ from pipecat.transports.websocket.fastapi import (
 
 from . import api_client
 from .auth import require_dispatch_token, verify_join_token
+from .bridged_transfer import run_sipbridge_bta_watch
 from .call_session import (
     CallSession,
     TransferState,
@@ -67,8 +68,9 @@ from .call_session import (
     setup_consult_call,
     setup_inbound_call,
     setup_outbound_call,
+    setup_takeover_call,
 )
-from .constants import DISCONNECT_REASONS
+from .constants import DISCONNECT_REASONS, PLATFORM
 from .invocation_log import flush_invocation_logs
 from .serializers import DtmfProtobufFrameSerializer, FreeSwitchAudioStreamSerializer
 from .serializers.freeswitch_audio_stream import FreeSwitchAudioStreamStart
@@ -1179,6 +1181,51 @@ async def voiceblender_agent(websocket: WebSocket, session_id: str) -> None:
         await websocket.close(code=1011)
         return
 
+    # Human-to-agent takeover leg (``options.bridgedTransferToAgent``): a
+    # DTMF match on a bridged call dropped the transfer target and re-
+    # attached a Pipecat agent to the caller leg under a fresh session id.
+    # Everything the incoming agent needs was stashed at match time — see
+    # ``bridged_transfer.py``.
+    takeover = sip_gateway.takeover_payload(session_id)
+    if takeover is not None:
+        transport = FastAPIWebsocketTransport(
+            websocket=websocket,
+            params=FastAPIWebsocketParams(
+                audio_in_enabled=True,
+                audio_out_enabled=True,
+                add_wav_header=False,
+                serializer=ProtobufFrameSerializer(),
+            ),
+        )
+        aplisay_meta = (
+            takeover.call.metadata.get("aplisay", {})
+            if isinstance(takeover.call.metadata, dict)
+            else {}
+        )
+        ctx = InboundCallContext(
+            session_id=session_id,
+            called_id=aplisay_meta.get("calledId"),
+            caller_id=aplisay_meta.get("callerId"),
+            raw={"transport": transport, "leg_id": takeover.extra.get("leg_id")},
+        )
+        try:
+            session = await setup_takeover_call(sip_gateway, ctx, payload=takeover)
+        except Exception as e:  # noqa: BLE001
+            logger.bind(session_id=session_id).error(
+                f"voiceblender takeover setup failed: {e}"
+            )
+            await websocket.close(code=1011)
+            sip_gateway.clear_takeover_session(session_id)
+            return
+        websocket.app.state.live_calls[session.call.id] = session
+        try:
+            await _run_session(websocket.app, session, session.call.id)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            sip_gateway.clear_takeover_session(session_id)
+        return
+
     pending = sip_gateway.pending_attaches.get(session_id)
     if pending is None:
         logger.bind(session_id=session_id).warning(
@@ -1377,6 +1424,57 @@ async def sipbridge_agent(websocket: WebSocket, session_id: str) -> None:
         or ""
     )
 
+    # Human-to-agent takeover leg (``options.bridgedTransferToAgent``): a
+    # DTMF match on a monitored bridge POSTed /unbridge, and the bridge has
+    # re-dialled the surviving caller leg to us under a fresh session id.
+    # Everything the incoming agent needs was stashed at match time — see
+    # ``bridged_transfer.py``.
+    takeover = sip_gateway.takeover_payload(session_id)
+    if takeover is not None:
+        await websocket.accept()
+        transport = FastAPIWebsocketTransport(
+            websocket=websocket,
+            params=FastAPIWebsocketParams(
+                audio_in_enabled=True,
+                audio_out_enabled=True,
+                add_wav_header=False,
+                serializer=DtmfProtobufFrameSerializer(),
+                audio_in_sample_rate=16000,
+                audio_out_sample_rate=16000,
+            ),
+        )
+        ctx = InboundCallContext(
+            session_id=session_id,
+            called_id=takeover.call.metadata.get("aplisay", {}).get("calledId")
+            if isinstance(takeover.call.metadata, dict) else None,
+            caller_id=takeover.call.metadata.get("aplisay", {}).get("callerId")
+            if isinstance(takeover.call.metadata, dict) else None,
+            raw={"transport": transport, "bridge_call_id": bridge_call_id},
+        )
+        try:
+            session = await setup_takeover_call(sip_gateway, ctx, payload=takeover)
+        except Exception as e:  # noqa: BLE001
+            logger.bind(session_id=session_id).error(
+                f"sipbridge takeover setup failed: {e}"
+            )
+            await websocket.close(code=1011)
+            sip_gateway.clear_takeover_session(session_id)
+            return
+        sip_gateway.register_inbound_session(
+            session_id=session_id,
+            bridge_call_id=bridge_call_id,
+            transport=transport,
+        )
+        websocket.app.state.live_calls[session.call.id] = session
+        try:
+            await _run_session(websocket.app, session, session.call.id)
+        except WebSocketDisconnect:
+            pass
+        finally:
+            sip_gateway.clear_takeover_session(session_id)
+            sip_gateway.unregister_session(session_id)
+        return
+
     if is_outbound:
         # Two sub-flows here:
         #
@@ -1547,10 +1645,19 @@ async def sipbridge_agent(websocket: WebSocket, session_id: str) -> None:
                 sip_gateway.clear_consult_session(session_id)
             return
 
-        # Plain outbound — just wait for done.
+        # Plain outbound — wait for done. The leg-done event also fires when
+        # a bridged transfer-to-agent watch is armed mid-call
+        # (``signal_bta_armed``); in that case the WS is still open and we
+        # take over reading it for transfer-target DTMF.
         done_event = sip_gateway.wait_for_leg_done(session_id)
         try:
             await done_event.wait()
+            gw_session = sip_gateway.live_session(session_id)
+            bta_ctx = getattr(gw_session, "bta_context", None) if gw_session else None
+            if bta_ctx is not None:
+                await run_sipbridge_bta_watch(
+                    websocket, sip_gateway, gw_session, bta_ctx, platform=PLATFORM
+                )
         except WebSocketDisconnect:
             pass
         except asyncio.CancelledError:
@@ -1645,6 +1752,20 @@ async def sipbridge_agent(websocket: WebSocket, session_id: str) -> None:
 
     try:
         await _run_session(websocket.app, session, session.call.id)
+        # Human-to-agent transfers: when a monitored bridge was installed,
+        # the bridge kept this WS open as a control channel and the
+        # CallSession stashed the watch context on the gateway session.
+        # Keep reading the socket for transfer-target DTMF until the
+        # bridge ends (or an unbridge takeover replaces this WS).
+        bta_ctx = getattr(session.gateway_session, "bta_context", None)
+        if bta_ctx is not None:
+            await run_sipbridge_bta_watch(
+                websocket,
+                sip_gateway,
+                session.gateway_session,
+                bta_ctx,
+                platform=PLATFORM,
+            )
     except WebSocketDisconnect:
         pass
     finally:

--- a/agents/pipecat/sipbridge/internal/api/server.go
+++ b/agents/pipecat/sipbridge/internal/api/server.go
@@ -174,6 +174,13 @@ type transferBody struct {
 	// of a bridged transfer-to-agent (options.bridgedTransferToAgent).
 	// Pair with POST /v1/calls/{id}/unbridge to complete the takeover.
 	MonitorDTMF bool `json:"monitor_dtmf"`
+	// TapAudio (modes "bridged" and "dial_bridge" only) additionally
+	// streams a decoded stereo copy of both bridged legs (L = caller,
+	// R = transfer target; 16 kHz s16le AudioRawFrames) on the same
+	// kept-open WS so the worker can transcribe the human↔human segment
+	// (options.bridgedTransferTranscribe). The RTP relay fast path is
+	// unaffected.
+	TapAudio bool `json:"tap_audio"`
 }
 
 func (s *Server) handleTransfer(w http.ResponseWriter, r *http.Request) {
@@ -205,7 +212,10 @@ func (s *Server) handleTransfer(w http.ResponseWriter, r *http.Request) {
 			CallerID:       body.CallerID,
 			CustomHeaders:  body.CustomHeaders,
 			Metadata:       body.Metadata,
-			MonitorDTMF:    body.MonitorDTMF,
+			Options: call.BridgeOptions{
+				MonitorDTMF: body.MonitorDTMF,
+				TapAudio:    body.TapAudio,
+			},
 		})
 		if err != nil {
 			writeErr(w, http.StatusBadGateway, err.Error())
@@ -220,7 +230,10 @@ func (s *Server) handleTransfer(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := s.mgr.Transfer(ctx, id, body.Target, body.Mode, body.MonitorDTMF); err != nil {
+	if err := s.mgr.Transfer(ctx, id, body.Target, body.Mode, call.BridgeOptions{
+		MonitorDTMF: body.MonitorDTMF,
+		TapAudio:    body.TapAudio,
+	}); err != nil {
 		writeErr(w, http.StatusBadGateway, err.Error())
 		return
 	}

--- a/agents/pipecat/sipbridge/internal/api/server.go
+++ b/agents/pipecat/sipbridge/internal/api/server.go
@@ -41,6 +41,7 @@ func New(mgr *call.Manager, addr, token string) *Server {
 	mux.HandleFunc("POST /v1/calls", s.handleOriginate)
 	mux.HandleFunc("POST /v1/calls/{id}/transfer", s.handleTransfer)
 	mux.HandleFunc("POST /v1/calls/{id}/consult", s.handleConsult)
+	mux.HandleFunc("POST /v1/calls/{id}/unbridge", s.handleUnbridge)
 
 	s.hs = &http.Server{
 		Addr:              addr,
@@ -167,6 +168,12 @@ type transferBody struct {
 	CallerID      string            `json:"caller_id"`
 	CustomHeaders map[string]string `json:"custom_headers"`
 	Metadata      map[string]string `json:"metadata"`
+	// MonitorDTMF (modes "bridged" and "dial_bridge" only) keeps this
+	// call's worker WS open across the bridge as a control channel and
+	// surfaces transfer-target DTMF presses on it — the detection half
+	// of a bridged transfer-to-agent (options.bridgedTransferToAgent).
+	// Pair with POST /v1/calls/{id}/unbridge to complete the takeover.
+	MonitorDTMF bool `json:"monitor_dtmf"`
 }
 
 func (s *Server) handleTransfer(w http.ResponseWriter, r *http.Request) {
@@ -198,6 +205,7 @@ func (s *Server) handleTransfer(w http.ResponseWriter, r *http.Request) {
 			CallerID:       body.CallerID,
 			CustomHeaders:  body.CustomHeaders,
 			Metadata:       body.Metadata,
+			MonitorDTMF:    body.MonitorDTMF,
 		})
 		if err != nil {
 			writeErr(w, http.StatusBadGateway, err.Error())
@@ -212,7 +220,45 @@ func (s *Server) handleTransfer(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := s.mgr.Transfer(ctx, id, body.Target, body.Mode); err != nil {
+	if err := s.mgr.Transfer(ctx, id, body.Target, body.Mode, body.MonitorDTMF); err != nil {
+		writeErr(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// unbridgeBody for POST /v1/calls/{id}/unbridge — the finalise step of
+// a bridged transfer-to-agent. Drops the peer (transfer-target) leg,
+// dismantles the relay, and re-attaches this call to a fresh worker
+// agent WS session (which the worker pre-registered under
+// ``agent_ws_session_id``).
+type unbridgeBody struct {
+	AgentWSSessionID string            `json:"agent_ws_session_id"`
+	CustomHeaders    map[string]string `json:"custom_headers"`
+}
+
+func (s *Server) handleUnbridge(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeErr(w, http.StatusBadRequest, "missing call id")
+		return
+	}
+	var body unbridgeBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if body.AgentWSSessionID == "" {
+		writeErr(w, http.StatusBadRequest, "missing agent_ws_session_id")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := s.mgr.Unbridge(ctx, call.UnbridgeParams{
+		CallID:         id,
+		AgentSessionID: body.AgentWSSessionID,
+		CustomHeaders:  body.CustomHeaders,
+	}); err != nil {
 		writeErr(w, http.StatusBadGateway, err.Error())
 		return
 	}

--- a/agents/pipecat/sipbridge/internal/call/manager.go
+++ b/agents/pipecat/sipbridge/internal/call/manager.go
@@ -445,10 +445,8 @@ func (m *Manager) Originate(ctx context.Context, p OriginateParams) (string, err
 //     ``docs/call-transfers.md``.
 //   - mode "consult": invalid for the transfer endpoint — clients
 //     should call the dedicated /v1/calls/{id}/consult endpoint.
-// ``monitorDTMF`` applies to mode "bridged" only: it keeps the original
-// leg's worker WS open as a control channel and surfaces transfer-target
-// DTMF on it (see BridgeRelay / options.bridgedTransferToAgent).
-func (m *Manager) Transfer(ctx context.Context, callID, target, mode string, monitorDTMF bool) error {
+// ``opts`` applies to mode "bridged" only — see BridgeOptions.
+func (m *Manager) Transfer(ctx context.Context, callID, target, mode string, opts BridgeOptions) error {
 	if m.sip == nil {
 		return errors.New("call: SIP layer not registered")
 	}
@@ -456,7 +454,7 @@ func (m *Manager) Transfer(ctx context.Context, callID, target, mode string, mon
 	case "", "blind":
 		return m.sip.Refer(ctx, callID, target)
 	case "bridged":
-		return m.BridgeRelay(callID, target, monitorDTMF)
+		return m.BridgeRelay(callID, target, opts)
 	case "attended":
 		return m.sip.ReferReplaces(ctx, callID, target)
 	case "consult":
@@ -464,6 +462,22 @@ func (m *Manager) Transfer(ctx context.Context, callID, target, mode string, mon
 	default:
 		return fmt.Errorf("call: unknown transfer mode %q", mode)
 	}
+}
+
+// BridgeOptions tune a media-relay bridge (modes "bridged" and
+// "dial_bridge"):
+//
+//   - MonitorDTMF keeps the original (A) leg's worker WS open as a
+//     control channel and surfaces transfer-target DTMF presses on it
+//     (options.bridgedTransferToAgent).
+//   - TapAudio additionally streams a decoded stereo copy of both legs
+//     (L = caller, R = target) on the same kept-open WS for
+//     transcription (options.bridgedTransferTranscribe). See tap.go.
+//
+// Either flag keeps the A leg's WS open.
+type BridgeOptions struct {
+	MonitorDTMF bool
+	TapAudio    bool
 }
 
 // BridgeRelay puts two existing calls into peer-to-peer media-relay
@@ -475,11 +489,13 @@ func (m *Manager) Transfer(ctx context.Context, callID, target, mode string, mon
 // must be compatible (Phase C v1 supports same-family G.711 only —
 // PCMU↔PCMU or PCMA↔PCMA. Cross-family relay (mu↔A) needs a
 // transcoding step in the codec layer; tracked as follow-up).
-// ``monitorDTMF`` marks the A leg (the original caller) as the
+// ``opts.MonitorDTMF`` marks the A leg (the original caller) as the
 // monitoring side: its worker WS is kept open (control-only) and
 // receives ``source: "transfer_target"`` DTMF events detected on the
 // B leg, so the worker can drive a bridged transfer-to-agent.
-func (m *Manager) BridgeRelay(callA, callB string, monitorDTMF bool) error {
+// ``opts.TapAudio`` additionally arms the stereo transcription tap on
+// the same WS (see tap.go).
+func (m *Manager) BridgeRelay(callA, callB string, opts BridgeOptions) error {
 	m.mu.Lock()
 	a, okA := m.calls[callA]
 	b, okB := m.calls[callB]
@@ -499,15 +515,28 @@ func (m *Manager) BridgeRelay(callA, callB string, monitorDTMF bool) error {
 			a.payload, b.payload,
 		)
 	}
+	keepWS := opts.MonitorDTMF || opts.TapAudio
 	a.mu.Lock()
-	a.dtmfMonitor = monitorDTMF
+	a.dtmfMonitor = opts.MonitorDTMF
 	a.mu.Unlock()
-	a.SetPeer(b, monitorDTMF)
+	if opts.TapAudio && a.ws != nil {
+		mixer := newTapMixer(a.ws)
+		a.mu.Lock()
+		a.tap = mixer
+		a.tapSide = tapSideCaller
+		a.mu.Unlock()
+		b.mu.Lock()
+		b.tap = mixer
+		b.tapSide = tapSideTarget
+		b.mu.Unlock()
+	}
+	a.SetPeer(b, keepWS)
 	b.SetPeer(a, false)
 	log.Info().
 		Str("call_a", callA).
 		Str("call_b", callB).
-		Bool("monitor_dtmf", monitorDTMF).
+		Bool("monitor_dtmf", opts.MonitorDTMF).
+		Bool("tap_audio", opts.TapAudio).
 		Msg("call: media relay installed (bridged transfer)")
 	return nil
 }
@@ -522,10 +551,8 @@ type DialBridgeParams struct {
 	CallerID       string
 	CustomHeaders  map[string]string
 	Metadata       map[string]string
-	// MonitorDTMF keeps the original leg's worker WS open across the
-	// bridge and surfaces transfer-target DTMF on it (bridged
-	// transfer-to-agent support).
-	MonitorDTMF bool
+	// Bridge monitoring/tap flags — see BridgeOptions.
+	Options BridgeOptions
 }
 
 // DialAndBridge is the native (non-REFER) blind bridged transfer: it
@@ -577,9 +604,9 @@ func (m *Manager) DialAndBridge(ctx context.Context, p DialBridgeParams) (string
 	m.mu.Unlock()
 
 	// Install the relay. BridgeRelay closes the original leg's bot WS
-	// (SetPeer) so the agent drops out — unless MonitorDTMF keeps it
-	// open as a control channel; the new leg never had one.
-	if err := m.BridgeRelay(p.OriginalCallID, newID, p.MonitorDTMF); err != nil {
+	// (SetPeer) so the agent drops out — unless MonitorDTMF/TapAudio
+	// keep it open as a control channel; the new leg never had one.
+	if err := m.BridgeRelay(p.OriginalCallID, newID, p.Options); err != nil {
 		// Codec mismatch or the original vanished — tear the new leg
 		// down (SIP BYE + media close) so we don't leak it.
 		_ = m.Hangup(context.Background(), newID)
@@ -1459,6 +1486,14 @@ type Call struct {
 		atNanos  int64
 	}
 
+	// tap / tapSide: transcription tap for a bridged transfer
+	// (``tap_audio`` — options.bridgedTransferTranscribe). Both legs of
+	// the bridge share ONE tapMixer, owned by the monitoring leg's
+	// kept-open WS; each leg pushes its own decoded inbound audio to its
+	// side (caller = left, target = right). Guarded by mu. See tap.go.
+	tap     *tapMixer
+	tapSide int
+
 	// firstRTPLogged: once-flag that gates the "first RTP packet
 	// received" diagnostic log. Useful to confirm whether the upstream
 	// is actually sending media to the port we advertised in the SDP
@@ -1519,7 +1554,12 @@ func (c *Call) ClearPeer() {
 	c.mu.Lock()
 	c.peer = nil
 	c.dtmfMonitor = false
+	tap := c.tap
+	c.tap = nil
 	c.mu.Unlock()
+	if tap != nil {
+		tap.Stop()
+	}
 }
 
 // hasPeer reports whether the call is currently in media-relay mode.
@@ -1592,6 +1632,19 @@ func (c *Call) onRTPPayload(pt rtp.PayloadType, seq uint16, payload []byte, _ bo
 				Str("to", peer.callID).
 				Msg("call: relay forward failed")
 			c.Close()
+			return
+		}
+		// Transcription tap (tap_audio): push a decoded COPY of this
+		// leg's audio to its side of the shared mixer. Purely additive —
+		// the relay write above has already happened.
+		c.mu.Lock()
+		tap := c.tap
+		side := c.tapSide
+		c.mu.Unlock()
+		if tap != nil {
+			if samples := c.decode16k(payload); samples != nil {
+				tap.push(side, samples)
+			}
 		}
 		return
 	}
@@ -1802,7 +1855,12 @@ func (c *Call) Close() {
 	}
 	c.done = true
 	close(c.closed)
+	tap := c.tap
+	c.tap = nil
 	c.mu.Unlock()
+	if tap != nil {
+		tap.Stop()
+	}
 	if c.releaseStop != nil {
 		c.releaseStop()
 	}

--- a/agents/pipecat/sipbridge/internal/call/manager.go
+++ b/agents/pipecat/sipbridge/internal/call/manager.go
@@ -381,6 +381,13 @@ func (m *Manager) Originate(ctx context.Context, p OriginateParams) (string, err
 	c.rtp.SetPayloadHandler(c.onRTPPayload)
 	pc.SetAudioHandler(c.onWSAudio)
 	pc.SetCloseHandler(func(err error) {
+		// In relay mode the worker WS is expected to go away (SetPeer
+		// stops it, or a monitoring worker restarts) — the bridged
+		// call itself must survive until a SIP BYE / media timeout.
+		if c.hasPeer() {
+			log.Info().Str("call_id", outCallID).Err(err).Msg("call: ws closed while bridged — call stays up")
+			return
+		}
 		log.Info().Str("call_id", outCallID).Err(err).Msg("call: ws closed (outbound)")
 		c.Close()
 	})
@@ -438,7 +445,10 @@ func (m *Manager) Originate(ctx context.Context, p OriginateParams) (string, err
 //     ``docs/call-transfers.md``.
 //   - mode "consult": invalid for the transfer endpoint — clients
 //     should call the dedicated /v1/calls/{id}/consult endpoint.
-func (m *Manager) Transfer(ctx context.Context, callID, target, mode string) error {
+// ``monitorDTMF`` applies to mode "bridged" only: it keeps the original
+// leg's worker WS open as a control channel and surfaces transfer-target
+// DTMF on it (see BridgeRelay / options.bridgedTransferToAgent).
+func (m *Manager) Transfer(ctx context.Context, callID, target, mode string, monitorDTMF bool) error {
 	if m.sip == nil {
 		return errors.New("call: SIP layer not registered")
 	}
@@ -446,7 +456,7 @@ func (m *Manager) Transfer(ctx context.Context, callID, target, mode string) err
 	case "", "blind":
 		return m.sip.Refer(ctx, callID, target)
 	case "bridged":
-		return m.BridgeRelay(callID, target)
+		return m.BridgeRelay(callID, target, monitorDTMF)
 	case "attended":
 		return m.sip.ReferReplaces(ctx, callID, target)
 	case "consult":
@@ -465,7 +475,11 @@ func (m *Manager) Transfer(ctx context.Context, callID, target, mode string) err
 // must be compatible (Phase C v1 supports same-family G.711 only —
 // PCMU↔PCMU or PCMA↔PCMA. Cross-family relay (mu↔A) needs a
 // transcoding step in the codec layer; tracked as follow-up).
-func (m *Manager) BridgeRelay(callA, callB string) error {
+// ``monitorDTMF`` marks the A leg (the original caller) as the
+// monitoring side: its worker WS is kept open (control-only) and
+// receives ``source: "transfer_target"`` DTMF events detected on the
+// B leg, so the worker can drive a bridged transfer-to-agent.
+func (m *Manager) BridgeRelay(callA, callB string, monitorDTMF bool) error {
 	m.mu.Lock()
 	a, okA := m.calls[callA]
 	b, okB := m.calls[callB]
@@ -485,11 +499,15 @@ func (m *Manager) BridgeRelay(callA, callB string) error {
 			a.payload, b.payload,
 		)
 	}
-	a.SetPeer(b)
-	b.SetPeer(a)
+	a.mu.Lock()
+	a.dtmfMonitor = monitorDTMF
+	a.mu.Unlock()
+	a.SetPeer(b, monitorDTMF)
+	b.SetPeer(a, false)
 	log.Info().
 		Str("call_a", callA).
 		Str("call_b", callB).
+		Bool("monitor_dtmf", monitorDTMF).
 		Msg("call: media relay installed (bridged transfer)")
 	return nil
 }
@@ -504,6 +522,10 @@ type DialBridgeParams struct {
 	CallerID       string
 	CustomHeaders  map[string]string
 	Metadata       map[string]string
+	// MonitorDTMF keeps the original leg's worker WS open across the
+	// bridge and surfaces transfer-target DTMF on it (bridged
+	// transfer-to-agent support).
+	MonitorDTMF bool
 }
 
 // DialAndBridge is the native (non-REFER) blind bridged transfer: it
@@ -555,8 +577,9 @@ func (m *Manager) DialAndBridge(ctx context.Context, p DialBridgeParams) (string
 	m.mu.Unlock()
 
 	// Install the relay. BridgeRelay closes the original leg's bot WS
-	// (SetPeer) so the agent drops out; the new leg never had one.
-	if err := m.BridgeRelay(p.OriginalCallID, newID); err != nil {
+	// (SetPeer) so the agent drops out — unless MonitorDTMF keeps it
+	// open as a control channel; the new leg never had one.
+	if err := m.BridgeRelay(p.OriginalCallID, newID, p.MonitorDTMF); err != nil {
 		// Codec mismatch or the original vanished — tear the new leg
 		// down (SIP BYE + media close) so we don't leak it.
 		_ = m.Hangup(context.Background(), newID)
@@ -568,6 +591,115 @@ func (m *Manager) DialAndBridge(ctx context.Context, p DialBridgeParams) (string
 		Str("destination", p.Destination).
 		Msg("call: native blind bridged transfer established")
 	return newID, nil
+}
+
+// UnbridgeParams carries the body of POST /v1/calls/{id}/unbridge: tear
+// the media relay down, hang up the peer (transfer-target) leg, and
+// re-attach the surviving leg to a fresh worker agent WS session so a
+// new bot pipeline can take the caller over. This is the finalise step
+// of a bridged transfer-to-agent (options.bridgedTransferToAgent).
+type UnbridgeParams struct {
+	CallID           string
+	AgentSessionID   string
+	CustomHeaders    map[string]string
+}
+
+// Unbridge reverses a bridged transfer on the monitoring leg: the peer
+// leg is BYE'd, the relay is dismantled, and the leg is re-wired into
+// ordinary Pipecat-bot mode with a NEW worker WS (dialled to
+// /sipbridge/agent/{AgentSessionID}, which the worker pre-registered).
+// The old control-only monitor WS, if still up, is closed first.
+//
+// On WS dial failure the whole call is torn down — the target is
+// already gone by then and an agent-less silent leg helps nobody — and
+// the error is returned so the worker can mark the takeover failed.
+func (m *Manager) Unbridge(ctx context.Context, p UnbridgeParams) error {
+	if p.AgentSessionID == "" {
+		return errors.New("call: unbridge: AgentSessionID is required")
+	}
+	m.mu.Lock()
+	c, ok := m.calls[p.CallID]
+	m.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("call: unbridge: unknown call_id %q", p.CallID)
+	}
+	c.mu.Lock()
+	peer := c.peer
+	c.mu.Unlock()
+	if peer == nil {
+		return fmt.Errorf("call: unbridge: call %q is not bridged", p.CallID)
+	}
+
+	// 1. Retire the old monitor WS while the relay guard (hasPeer) is
+	// still active, so its close handler doesn't tear the call down.
+	if old := c.ws; old != nil {
+		old.Stop()
+		select {
+		case <-old.Done():
+		case <-time.After(2 * time.Second):
+			log.Warn().Str("call_id", c.callID).Msg("call: unbridge: old ws slow to close; continuing")
+		}
+	}
+
+	// 2. Dismantle the relay BEFORE hanging the peer up so no packet
+	// forwards into a closing RTP session (which would Close us too).
+	c.ClearPeer()
+	peer.ClearPeer()
+	if err := m.Hangup(ctx, peer.callID); err != nil {
+		log.Warn().Err(err).Str("call_id", peer.callID).Msg("call: unbridge: peer hangup failed (continuing)")
+	}
+
+	// 3. Re-attach a fresh bot WS, exactly like an originate. The worker
+	// chose the session id and is already waiting on it.
+	wsURL, err := joinWSPath(m.cfg.WorkerWSBase, "/sipbridge/agent/"+url.PathEscape(p.AgentSessionID))
+	if err != nil {
+		_ = m.Hangup(context.Background(), c.callID)
+		return fmt.Errorf("call: unbridge: ws url: %w", err)
+	}
+	pc := pcclient.NewClient(wsURL)
+	unbridgedID := c.callID
+	pc.SetAudioHandler(c.onWSAudio)
+	pc.SetCloseHandler(func(err error) {
+		if c.hasPeer() {
+			log.Info().Str("call_id", unbridgedID).Err(err).Msg("call: ws closed while bridged — call stays up")
+			return
+		}
+		log.Info().Str("call_id", unbridgedID).Err(err).Msg("call: ws closed (post-unbridge)")
+		c.Close()
+	})
+	hdr := http.Header{}
+	hdr.Set("X-Sipbridge-Call-ID", c.callID)
+	for k, v := range p.CustomHeaders {
+		hdr.Set(k, v)
+	}
+	dctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := pc.Connect(dctx, hdr); err != nil {
+		_ = m.Hangup(context.Background(), c.callID)
+		return fmt.Errorf("call: unbridge: pipecat ws connect: %w", err)
+	}
+
+	// 4. Swap the WS in and restart the decode path (jitter buffer +
+	// release loop) that SetPeer stopped when the relay engaged.
+	c.mu.Lock()
+	c.ws = pc
+	c.sessionID = p.AgentSessionID
+	if c.jb == nil {
+		c.jb = rtp.NewJitterBuffer(3, 160)
+	} else {
+		c.jb.Reset()
+	}
+	c.mu.Unlock()
+	releaseCtx, releaseCancel := context.WithCancel(context.Background())
+	c.releaseStop = releaseCancel
+	c.startJitterRelease(releaseCtx)
+
+	log.Info().
+		Str("call_id", c.callID).
+		Str("session_id", p.AgentSessionID).
+		Str("dropped_peer", peer.callID).
+		Msg("call: unbridged — agent re-attached")
+	return nil
 }
 
 // ConsultParams is what the REST /v1/calls/{id}/consult endpoint
@@ -706,6 +838,12 @@ func (m *Manager) onInvite(
 	rtpSess.SetPayloadHandler(c.onRTPPayload)
 	pc.SetAudioHandler(c.onWSAudio)
 	pc.SetCloseHandler(func(err error) {
+		// See the outbound handler: a bridged call must survive its
+		// worker WS going away (SetPeer stop or monitor-worker loss).
+		if c.hasPeer() {
+			log.Info().Str("call_id", callID).Err(err).Msg("call: ws closed while bridged — call stays up")
+			return
+		}
 		log.Info().Str("call_id", callID).Err(err).Msg("call: ws closed")
 		c.Close()
 	})
@@ -814,7 +952,18 @@ func (m *Manager) onBye(callID string) {
 	m.mu.Unlock()
 	if ok {
 		log.Info().Str("call_id", callID).Msg("call: tearing down (BYE)")
+		// A bridged pair lives and dies together: when one side BYEs,
+		// hang the peer leg up too (BYE + media close) rather than
+		// leaving it to leak until the dialog/media timeout.
+		c.mu.Lock()
+		peer := c.peer
+		c.peer = nil
+		c.mu.Unlock()
 		c.Close()
+		if peer != nil {
+			peer.ClearPeer()
+			_ = m.Hangup(context.Background(), peer.callID)
+		}
 	} else {
 		log.Warn().Str("call_id", callID).Msg("call: onBye for unknown call — already torn down or never registered")
 	}
@@ -1291,6 +1440,25 @@ type Call struct {
 	// to keep the bridged path minimum-latency).
 	peer *Call
 
+	// dtmfMonitor marks this leg as the DTMF-monitoring side of a
+	// bridged transfer (options.bridgedTransferToAgent). While true and
+	// in relay mode, the leg's Pipecat WS is kept open as a control-only
+	// channel: no audio frames flow, but RFC 4733 end-of-event presses
+	// detected on the PEER (transfer-target) leg are surfaced to the
+	// worker as ``{"type":"dtmf",...,"source":"transfer_target"}``
+	// MessageFrames so it can trigger an unbridge + agent re-attach.
+	dtmfMonitor bool
+
+	// lastMonitorDTMF dedupes RFC 4733 end-of-event retransmissions on
+	// the monitor path (senders repeat the final report ~3 times for
+	// loss resilience; each repeat carries the same symbol + duration).
+	// Guarded by mu.
+	lastMonitorDTMF struct {
+		sym      byte
+		duration uint16
+		atNanos  int64
+	}
+
 	// firstRTPLogged: once-flag that gates the "first RTP packet
 	// received" diagnostic log. Useful to confirm whether the upstream
 	// is actually sending media to the port we advertised in the SDP
@@ -1321,10 +1489,13 @@ type Call struct {
 // before the audio path becomes fully duplex.
 //
 // SetPeer is idempotent and may be called once per call. After SetPeer
-// the call's `ws` is closed — the worker no longer participates in
-// audio — and the jitter-buffer release loop is stopped since the
-// relay path forwards packets immediately without reordering.
-func (c *Call) SetPeer(peer *Call) {
+// the call's `ws` is normally closed — the worker no longer
+// participates in audio — and the jitter-buffer release loop is
+// stopped since the relay path forwards packets immediately without
+// reordering. With ``keepWS`` (DTMF-monitored bridges) the WS is left
+// open as a control-only channel: the release loop still stops, so no
+// audio frames flow, but peer-leg DTMF events can be delivered on it.
+func (c *Call) SetPeer(peer *Call, keepWS bool) {
 	c.mu.Lock()
 	c.peer = peer
 	if c.jb != nil {
@@ -1336,9 +1507,26 @@ func (c *Call) SetPeer(peer *Call) {
 		c.releaseStop()
 		c.releaseStop = nil
 	}
-	if c.ws != nil {
+	if c.ws != nil && !keepWS {
 		c.ws.Stop()
 	}
+}
+
+// ClearPeer takes the call back out of media-relay mode (the unbridge
+// path). The caller is responsible for re-attaching a worker WS and
+// restarting the jitter-release loop — see Manager.Unbridge.
+func (c *Call) ClearPeer() {
+	c.mu.Lock()
+	c.peer = nil
+	c.dtmfMonitor = false
+	c.mu.Unlock()
+}
+
+// hasPeer reports whether the call is currently in media-relay mode.
+func (c *Call) hasPeer() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.peer != nil
 }
 
 // onRTPPayload is called by the RTP read loop for each inbound packet.
@@ -1389,6 +1577,15 @@ func (c *Call) onRTPPayload(pt rtp.PayloadType, seq uint16, payload []byte, _ bo
 	peer := c.peer
 	c.mu.Unlock()
 	if peer != nil {
+		if pt == rtp.PayloadDTMF {
+			// Never forward RFC 4733 packets across the relay —
+			// SendPayload would re-stamp them with the audio payload
+			// type and the far end would hear a noise blip instead of
+			// a keypress. If the peer leg is monitoring (bridged
+			// transfer-to-agent), surface the press to its worker WS.
+			peer.maybeEmitPeerDTMF(c.callID, payload)
+			return
+		}
 		if err := peer.rtp.SendPayload(payload); err != nil {
 			log.Warn().Err(err).
 				Str("from", c.callID).
@@ -1446,6 +1643,53 @@ func (c *Call) handleDTMF(payload []byte) {
 	}
 	if err := c.ws.SendMessage(msg); err != nil {
 		log.Warn().Err(err).Str("call_id", c.callID).Msg("call: dtmf ws send failed")
+	}
+}
+
+// maybeEmitPeerDTMF is called on the MONITORING leg of a DTMF-monitored
+// bridge when an RFC 4733 packet arrives on its peer (the transfer
+// target). On the end-of-event packet it ships a MessageFrame to the
+// monitoring leg's still-open worker WS:
+// ``{"type":"dtmf","digit":"5","duration_ms":120,"call_id":"<this>",
+//    "peer_call_id":"<target>","source":"transfer_target"}``.
+// The ``source`` discriminator lets the worker distinguish these
+// post-bridge target-leg presses from ordinary pre-bridge caller DTMF.
+// No-op unless the leg was bridged with monitor_dtmf.
+func (c *Call) maybeEmitPeerDTMF(peerCallID string, payload []byte) {
+	c.mu.Lock()
+	monitoring := c.dtmfMonitor
+	c.mu.Unlock()
+	if !monitoring || c.ws == nil {
+		return
+	}
+	ev, ok := rtp.ParseDTMF(payload)
+	if !ok || !ev.End {
+		return
+	}
+	sym := ev.Symbol()
+	if sym == 0 {
+		return
+	}
+	// Drop end-of-event retransmissions: same symbol + duration within
+	// 250 ms is the same keypress reported again, not a new press.
+	now := time.Now().UnixNano()
+	c.mu.Lock()
+	last := c.lastMonitorDTMF
+	if last.sym == sym && last.duration == ev.Duration && now-last.atNanos < int64(250*time.Millisecond) {
+		c.mu.Unlock()
+		return
+	}
+	c.lastMonitorDTMF.sym = sym
+	c.lastMonitorDTMF.duration = ev.Duration
+	c.lastMonitorDTMF.atNanos = now
+	c.mu.Unlock()
+	durationMS := int(uint32(ev.Duration) / 8)
+	msg := fmt.Sprintf(
+		`{"type":"dtmf","digit":%q,"duration_ms":%d,"call_id":%q,"peer_call_id":%q,"source":"transfer_target"}`,
+		string(sym), durationMS, c.callID, peerCallID,
+	)
+	if err := c.ws.SendMessage(msg); err != nil {
+		log.Warn().Err(err).Str("call_id", c.callID).Msg("call: monitor dtmf ws send failed")
 	}
 }
 
@@ -1514,6 +1758,12 @@ func (c *Call) startJitterRelease(ctx context.Context) {
 // to match the negotiated ptime — most carriers and SBCs enforce this.
 func (c *Call) onWSAudio(pcm16LEbytes []byte) {
 	if c.isClosed() {
+		return
+	}
+	// In relay mode the two SIP legs own the media path. A monitored
+	// bridge keeps the worker WS open for control/DTMF only — any bot
+	// audio still in flight must not be mixed onto the caller's RTP.
+	if c.hasPeer() {
 		return
 	}
 	samples16k := codec.BytesToPCMS16LE(pcm16LEbytes)

--- a/agents/pipecat/sipbridge/internal/call/tap.go
+++ b/agents/pipecat/sipbridge/internal/call/tap.go
@@ -1,0 +1,157 @@
+package call
+
+// Bridged-transfer transcription tap (options.bridgedTransferTranscribe).
+//
+// When a bridged transfer is installed with ``tap_audio: true``, the two
+// humans' RTP keeps flowing through the in-process relay untouched (the
+// fast path gains no latency and no dependency on the worker), but a COPY
+// of each leg's decoded audio is pushed into a tapMixer, which emits one
+// interleaved stereo PCM frame every 20 ms on the monitoring leg's
+// kept-open worker WS:
+//
+//	left channel  = the original caller leg
+//	right channel = the transfer-target leg
+//
+// The worker splits the channels and runs speech-to-text per side to
+// build a speaker-labelled transcript of the human↔human segment — see
+// pipecat_aplisay/bridged_transfer.py and docs/call-transfers.md.
+//
+// The tap is deliberately lossy in both directions: a slow or dead WS
+// never back-pressures the bridge (SendAudioStereo runs on the mixer
+// goroutine, and per-side backlogs are capped), and silence is
+// substituted for a side that has no pending samples so the two channels
+// stay time-aligned enough for transcription.
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/aplisay/llm-agent/agents/pipecat/sipbridge/internal/codec"
+	pcclient "github.com/aplisay/llm-agent/agents/pipecat/sipbridge/internal/pipecat"
+	"github.com/aplisay/llm-agent/agents/pipecat/sipbridge/internal/rtp"
+)
+
+const (
+	tapChunkSamples = 320   // 20 ms at 16 kHz, per channel
+	tapMaxBacklog   = 16000 // 1 s per side; older samples are dropped
+	tapSideCaller   = 0
+	tapSideTarget   = 1
+)
+
+type tapMixer struct {
+	mu      sync.Mutex
+	pending [2][]int16 // per-side queued 16 kHz mono samples
+	ws      *pcclient.Client
+	cancel  context.CancelFunc
+	stopped bool
+}
+
+// newTapMixer starts the 20 ms emit loop. ``ws`` is the monitoring leg's
+// kept-open worker client.
+func newTapMixer(ws *pcclient.Client) *tapMixer {
+	ctx, cancel := context.WithCancel(context.Background())
+	t := &tapMixer{ws: ws, cancel: cancel}
+	go t.run(ctx)
+	return t
+}
+
+// push queues decoded 16 kHz samples for one side of the bridge. Called
+// from the RTP read loops; must stay cheap.
+func (t *tapMixer) push(side int, samples []int16) {
+	if side != tapSideCaller && side != tapSideTarget {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopped {
+		return
+	}
+	t.pending[side] = append(t.pending[side], samples...)
+	if overflow := len(t.pending[side]) - tapMaxBacklog; overflow > 0 {
+		t.pending[side] = t.pending[side][overflow:]
+	}
+}
+
+// Stop halts the emit loop. Idempotent; safe from any goroutine.
+func (t *tapMixer) Stop() {
+	t.mu.Lock()
+	already := t.stopped
+	t.stopped = true
+	t.mu.Unlock()
+	if !already && t.cancel != nil {
+		t.cancel()
+	}
+}
+
+func (t *tapMixer) run(ctx context.Context) {
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	frame := make([]byte, tapChunkSamples*2*2) // stereo s16le
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		t.mu.Lock()
+		if t.stopped {
+			t.mu.Unlock()
+			return
+		}
+		// Skip the frame entirely while BOTH sides are silent — no point
+		// streaming continuous silence at the worker's STT.
+		if len(t.pending[tapSideCaller]) == 0 && len(t.pending[tapSideTarget]) == 0 {
+			t.mu.Unlock()
+			continue
+		}
+		var sides [2][]int16
+		for side := range t.pending {
+			n := len(t.pending[side])
+			if n >= tapChunkSamples {
+				sides[side] = t.pending[side][:tapChunkSamples]
+				t.pending[side] = t.pending[side][tapChunkSamples:]
+			} else {
+				// Whatever is queued, padded with silence.
+				chunk := make([]int16, tapChunkSamples)
+				copy(chunk, t.pending[side])
+				t.pending[side] = t.pending[side][:0]
+				sides[side] = chunk
+			}
+		}
+		t.mu.Unlock()
+		for i := 0; i < tapChunkSamples; i++ {
+			l := sides[tapSideCaller][i]
+			r := sides[tapSideTarget][i]
+			frame[i*4] = byte(l)
+			frame[i*4+1] = byte(uint16(l) >> 8)
+			frame[i*4+2] = byte(r)
+			frame[i*4+3] = byte(uint16(r) >> 8)
+		}
+		if err := t.ws.SendAudioStereo(frame); err != nil {
+			// Worker gone (or unbridge in flight) — the tap is best-effort;
+			// stop rather than spam errors every 20 ms.
+			log.Debug().Err(err).Msg("call: transcription tap send failed; stopping tap")
+			t.Stop()
+			return
+		}
+	}
+}
+
+// decode16k converts one G.711 RTP payload from this call's negotiated
+// codec into 16 kHz mono samples (same codec path as the bot-mode
+// processDecodedPayload). Returns nil for unknown payload types.
+func (c *Call) decode16k(payload []byte) []int16 {
+	var samples8k []int16
+	switch c.payload {
+	case rtp.PayloadPCMU:
+		samples8k = codec.DecodePCMU(payload)
+	case rtp.PayloadPCMA:
+		samples8k = codec.DecodePCMA(payload)
+	default:
+		return nil
+	}
+	return codec.Upsample8To16(samples8k)
+}

--- a/agents/pipecat/sipbridge/internal/pipecat/client.go
+++ b/agents/pipecat/sipbridge/internal/pipecat/client.go
@@ -189,6 +189,26 @@ func (c *Client) SendAudio(pcm16 []byte) error {
 	return c.conn.Write(wctx, websocket.MessageBinary, frame)
 }
 
+// SendAudioStereo frames a two-channel AudioRawFrame and sends it as one
+// binary message. PCM16 little-endian, 16 kHz, interleaved L/R. Used by
+// the bridged-transfer transcription tap (left = caller leg, right =
+// transfer-target leg) — see internal/call/tap.go.
+func (c *Client) SendAudioStereo(pcm16 []byte) error {
+	if c.conn == nil {
+		return errors.New("pipecat client: not connected")
+	}
+	frame := EncodeAudio(AudioRawFrame{
+		Audio:      pcm16,
+		SampleRate: 16000,
+		NumChans:   2,
+	})
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	wctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return c.conn.Write(wctx, websocket.MessageBinary, frame)
+}
+
 // SendMessage frames a MessageFrame and sends it. The body is a
 // free-form string (the platform's convention is to use small JSON
 // blobs there — see internal/call/manager.go:handleDTMF for the

--- a/agents/pipecat/tests/test_bridged_transfer.py
+++ b/agents/pipecat/tests/test_bridged_transfer.py
@@ -1,0 +1,200 @@
+"""Tests for the human-to-agent transfer helpers (``bridged_transfer.py``).
+
+Covers:
+
+- ``parse_bta_map``: option-shape parsing / lenient rejection.
+- ``DtmfSequenceMatcher``: single-digit fire, multi-digit sequences,
+  prefix-vs-exact disambiguation via the inter-digit timeout, stray-digit
+  sliding, retransmission-safe single fire, and retry after a failed match
+  handler.
+- ``compose_takeover_prompt``: history carry on/off.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pipecat_aplisay.bridged_transfer import (
+    BtaContext,
+    BtaTarget,
+    DtmfSequenceMatcher,
+    compose_takeover_prompt,
+    parse_bta_map,
+)
+
+
+AGENT_A = "11111111-2222-3333-4444-555555555555"
+AGENT_B = "66666666-7777-8888-9999-000000000000"
+
+
+class TestParseBtaMap:
+    def test_absent_or_empty(self):
+        assert parse_bta_map(None) is None
+        assert parse_bta_map({}) is None
+        assert parse_bta_map({"bridgedTransferToAgent": {}}) is None
+
+    def test_string_and_object_forms(self):
+        targets = parse_bta_map(
+            {
+                "bridgedTransferToAgent": {
+                    "1": AGENT_A,
+                    "*7": {"agent": AGENT_B, "includeHistory": False},
+                }
+            }
+        )
+        assert targets["1"].agent_id == AGENT_A
+        assert targets["1"].include_history is True
+        assert targets["*7"].agent_id == AGENT_B
+        assert targets["*7"].include_history is False
+
+    def test_malformed_entries_skipped(self):
+        targets = parse_bta_map(
+            {
+                "bridgedTransferToAgent": {
+                    "abc": AGENT_A,          # bad key chars
+                    "123456789": AGENT_A,    # too long
+                    "2": {},                 # no agent
+                    "3": AGENT_B,            # good
+                }
+            }
+        )
+        assert list(targets) == ["3"]
+
+
+class _Collector:
+    def __init__(self):
+        self.matches: list[str] = []
+        self.fail_next = False
+
+    async def on_match(self, key: str) -> None:
+        if self.fail_next:
+            self.fail_next = False
+            raise RuntimeError("simulated takeover failure")
+        self.matches.append(key)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestDtmfSequenceMatcher:
+    def test_single_digit_fires_immediately(self):
+        async def run():
+            c = _Collector()
+            m = DtmfSequenceMatcher(["1", "2"], c.on_match, timeout_s=0.05)
+            await m.feed("2")
+            return c.matches
+
+        assert _run(run()) == ["2"]
+
+    def test_multi_digit_sequence(self):
+        async def run():
+            c = _Collector()
+            m = DtmfSequenceMatcher(["*7"], c.on_match, timeout_s=0.05)
+            await m.feed("*")
+            await m.feed("7")
+            return c.matches
+
+        assert _run(run()) == ["*7"]
+
+    def test_prefix_key_fires_after_timeout(self):
+        async def run():
+            c = _Collector()
+            # "1" is a key but also a prefix of "12" — a lone press of 1
+            # must fire only after the inter-digit timeout.
+            m = DtmfSequenceMatcher(["1", "12"], c.on_match, timeout_s=0.05)
+            await m.feed("1")
+            assert c.matches == []
+            await asyncio.sleep(0.15)
+            return c.matches
+
+        assert _run(run()) == ["1"]
+
+    def test_longer_key_beats_prefix(self):
+        async def run():
+            c = _Collector()
+            m = DtmfSequenceMatcher(["1", "12"], c.on_match, timeout_s=0.2)
+            await m.feed("1")
+            await m.feed("2")
+            return c.matches
+
+        assert _run(run()) == ["12"]
+
+    def test_stray_digits_slide_out(self):
+        async def run():
+            c = _Collector()
+            m = DtmfSequenceMatcher(["9"], c.on_match, timeout_s=0.05)
+            await m.feed("4")
+            await m.feed("2")
+            await m.feed("9")
+            return c.matches
+
+        assert _run(run()) == ["9"]
+
+    def test_fires_once(self):
+        async def run():
+            c = _Collector()
+            m = DtmfSequenceMatcher(["5"], c.on_match, timeout_s=0.05)
+            await m.feed("5")
+            await m.feed("5")
+            return c.matches
+
+        assert _run(run()) == ["5"]
+
+    def test_retry_after_failed_handler(self):
+        async def run():
+            c = _Collector()
+            c.fail_next = True
+            m = DtmfSequenceMatcher(["5"], c.on_match, timeout_s=0.05)
+            await m.feed("5")  # handler raises; matcher re-arms
+            assert c.matches == []
+            await m.feed("5")
+            return c.matches
+
+        assert _run(run()) == ["5"]
+
+    def test_non_matching_digit_never_fires(self):
+        async def run():
+            c = _Collector()
+            m = DtmfSequenceMatcher(["1"], c.on_match, timeout_s=0.02)
+            await m.feed("3")
+            await asyncio.sleep(0.1)
+            return c.matches
+
+        assert _run(run()) == []
+
+
+def _ctx(transcript: str = "> caller: hi\n> agent: hello\n") -> BtaContext:
+    return BtaContext(
+        targets={},
+        agent={"id": "a", "options": {}},
+        instance={"id": "i"},
+        parent_call_id="call-1",
+        organisation_id="org-1",
+        user_id="user-1",
+        instance_id="i",
+        caller_id="+441234567890",
+        called_id="+441234567891",
+        transcript=transcript,
+    )
+
+
+class TestComposeTakeoverPrompt:
+    def test_history_carried_by_default(self):
+        prompt = compose_takeover_prompt(
+            {"prompt": "You are the billing agent."},
+            _ctx(),
+            BtaTarget(key="1", agent_id=AGENT_A, include_history=True),
+        )
+        assert "You are the billing agent." in prompt
+        assert "> caller: hi" in prompt
+        assert "taken over a live call" in prompt
+
+    def test_history_suppressed(self):
+        prompt = compose_takeover_prompt(
+            {"prompt": "You are the billing agent."},
+            _ctx(),
+            BtaTarget(key="1", agent_id=AGENT_A, include_history=False),
+        )
+        assert "> caller: hi" not in prompt
+        assert "fresh conversation" in prompt

--- a/agents/pipecat/tests/test_bridged_transfer.py
+++ b/agents/pipecat/tests/test_bridged_transfer.py
@@ -198,3 +198,106 @@ class TestComposeTakeoverPrompt:
         )
         assert "> caller: hi" not in prompt
         assert "fresh conversation" in prompt
+
+
+# ---- Bridged-segment transcription (bridge_transcript.py) ----
+
+from pipecat_aplisay.bridge_transcript import (  # noqa: E402
+    CALLER,
+    TARGET,
+    BridgeTranscriptCollector,
+    parse_transcribe_option,
+    split_stereo,
+)
+
+
+class TestParseTranscribeOption:
+    def test_shapes(self):
+        assert parse_transcribe_option(None) is None
+        assert parse_transcribe_option({}) is None
+        assert parse_transcribe_option({"bridgedTransferTranscribe": False}) is None
+        assert parse_transcribe_option({"bridgedTransferTranscribe": True}) == {
+            "provider": "elevenlabs",
+            "language": None,
+        }
+        assert parse_transcribe_option(
+            {"bridgedTransferTranscribe": {"provider": "deepgram", "language": "en"}}
+        ) == {"provider": "deepgram", "language": "en"}
+        assert (
+            parse_transcribe_option({"bridgedTransferTranscribe": {"enabled": False}})
+            is None
+        )
+
+
+class TestSplitStereo:
+    def test_deinterleave(self):
+        import struct
+
+        # L samples 1,2,3; R samples -1,-2,-3
+        stereo = struct.pack("<6h", 1, -1, 2, -2, 3, -3)
+        left, right = split_stereo(stereo)
+        assert struct.unpack("<3h", left) == (1, 2, 3)
+        assert struct.unpack("<3h", right) == (-1, -2, -3)
+
+    def test_odd_lengths(self):
+        assert split_stereo(b"") == (b"", b"")
+        assert split_stereo(b"\x01\x00") == (b"", b"")
+
+
+class _FakeCall:
+    def __init__(self):
+        self.id = "bridged-call-1"
+        self.userId = "u"
+        self.organisationId = "o"
+        self.batched_transaction_logs = []
+
+
+class TestBridgeTranscriptCollector:
+    def test_batched_entries_and_render(self):
+        call = _FakeCall()
+        collector = BridgeTranscriptCollector(call=call, stream_log=False)
+
+        async def run():
+            await collector.add(CALLER, "hello, I need help")
+            await collector.add(TARGET, "sure, what's the account number?")
+            await collector.add(CALLER, "  ")  # blank — dropped
+
+        asyncio.run(run())
+        assert len(collector) == 2
+        assert [e["type"] for e in call.batched_transaction_logs] == ["user", "agent"]
+        rendered = collector.render()
+        assert rendered.index("> caller: hello") < rendered.index(
+            "> transfer target: sure"
+        )
+
+
+class TestTakeoverPromptWithBridgeTranscript:
+    def test_bridge_section_included(self):
+        ctx = _ctx()
+        call = _FakeCall()
+        collector = BridgeTranscriptCollector(call=call, stream_log=False)
+        asyncio.run(collector.add(TARGET, "press one to go back to the bot"))
+        ctx.collector = collector
+        prompt = compose_takeover_prompt(
+            {"prompt": "You are the billing agent."},
+            ctx,
+            BtaTarget(key="1", agent_id=AGENT_A, include_history=True),
+        )
+        assert "# Conversation between the caller and the previous agent" in prompt
+        assert "# Conversation between the caller and the human transfer target" in prompt
+        assert "press one to go back" in prompt
+        assert "was not recorded" not in prompt
+
+    def test_fresh_start_omits_bridge_section(self):
+        ctx = _ctx()
+        call = _FakeCall()
+        collector = BridgeTranscriptCollector(call=call, stream_log=False)
+        asyncio.run(collector.add(TARGET, "press one"))
+        ctx.collector = collector
+        prompt = compose_takeover_prompt(
+            {"prompt": "You are the billing agent."},
+            ctx,
+            BtaTarget(key="1", agent_id=AGENT_A, include_history=False),
+        )
+        assert "transfer target" not in prompt.split("fresh conversation")[1] if "fresh conversation" in prompt else True
+        assert "# Conversation" not in prompt

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -692,6 +692,39 @@ components:
             "*7":
               agent: "9a1b0c2d-7777-8888-9999-000011112222"
               includeHistory: false
+        bridgedTransferTranscribe:
+          description: |-
+            Transcribe the human↔human segment of a bridged transfer (the conversation between the
+            caller and the transfer target after the AI has left the call). When enabled, a
+            speaker-labelled transcript of the bridged segment is stored on the bridged-segment call
+            record, and — when combined with `bridgedTransferToAgent` — is included in the incoming
+            agent's prompt when the transfer target hands the caller back by DTMF.
+
+            Set `true` to enable with defaults, or an object to tune the transcription engine where
+            the gateway runs its own STT (the voiceblender topology; the sipbridge topology taps the
+            bridged audio to the worker and uses the agent's configured STT, ignoring `provider`).
+            Media stays on the gateway fast path in all cases — transcription is a tap, not a detour.
+            See docs/call-transfers.md.
+          oneOf:
+            - type: boolean
+            - type: object
+              properties:
+                enabled:
+                  description: Set `false` to disable without removing the object.
+                  type: boolean
+                  default: true
+                provider:
+                  description: Gateway-native STT provider (voiceblender topology only).
+                  type: string
+                  enum: [elevenlabs, deepgram, azure]
+                  default: elevenlabs
+                language:
+                  description: BCP-47 language tag hint for the transcription engine.
+                  type: string
+                  example: en
+          example:
+            provider: deepgram
+            language: en
         transferPrompt:
           description: |-
             Custom prompt to be used by the TransferAgent during consultative transfers. This allows you to customize

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -652,6 +652,46 @@ components:
             volume: medium
             gapMs: 2750
             graceMs: 1200
+        bridgedTransferToAgent:
+          description: |-
+            Human-to-agent transfers: after a **bridged** transfer, let the transfer target hand the
+            caller back to an AI agent by pressing a DTMF sequence. Keys are DTMF sequences of 1-8
+            characters from `0-9`, `*` and `#`; values name the voice agent the caller is handed to
+            when the sequence is detected **on the transfer-target leg** (caller digits never trigger it).
+
+            Values are an agent UUID string, or an object `{ agent, includeHistory }` where
+            `includeHistory` (default `true`) controls whether the incoming agent's prompt carries the
+            conversation the caller had with the original agent. Inside an agent-set document a value
+            may be a `label:<label>` reference, resolved to the member's UUID on save (recorded as
+            `fromLabel` for round-tripping).
+
+            While this option is set, transfers are forced onto the bridged path (a SIP REFER would
+            take the call off-platform, out of DTMF sight). Multi-digit sequences are matched with the
+            `dtmfTimeout` inter-digit timeout. On a match the target leg is dropped and the mapped
+            agent answers the caller on a new child call record. Not available for WebRTC (browser)
+            origin calls. See docs/call-transfers.md.
+          type: object
+          minProperties: 1
+          additionalProperties:
+            oneOf:
+              - type: string
+                description: Target agent UUID (or `label:<label>` inside an agent-set document).
+              - type: object
+                properties:
+                  agent:
+                    description: Target agent UUID (or `label:<label>` inside an agent-set document).
+                    type: string
+                  includeHistory:
+                    description: Carry the original agent's conversation into the incoming agent's prompt.
+                    type: boolean
+                    default: true
+                required:
+                  - agent
+          example:
+            "1": "5f4c0a9e-1111-2222-3333-444455556666"
+            "*7":
+              agent: "9a1b0c2d-7777-8888-9999-000011112222"
+              includeHistory: false
         transferPrompt:
           description: |-
             Custom prompt to be used by the TransferAgent during consultative transfers. This allows you to customize

--- a/api/paths/agent-sets.js
+++ b/api/paths/agent-sets.js
@@ -115,10 +115,11 @@ export async function reconcileMembers({ set, byLabel, existing = [], user, tran
         agent[field] = field === 'type' ? defaultType(def) : def[field];
       }
     }
-    if (agent.functions) {
-      fixupLabelReferences(agent.functions, labelMap, label);
-      agent.changed('functions', true);
-      await validateAgentTargets(agent.functions, { membersById, lookupAgent, owningLabel: label });
+    if (agent.functions || agent.options?.bridgedTransferToAgent) {
+      fixupLabelReferences(agent.functions || [], labelMap, label, agent.options);
+      agent.functions && agent.changed('functions', true);
+      agent.options?.bridgedTransferToAgent && agent.changed('options', true);
+      await validateAgentTargets(agent.functions || [], { membersById, lookupAgent, owningLabel: label, options: agent.options });
     }
   }
   for (const { agent } of members) {

--- a/api/paths/agents.js
+++ b/api/paths/agents.js
@@ -35,9 +35,11 @@ const agentCreate = (async (req, res) => {
   log.info({ modelName, prompt, options, functions, mcpServers, userId, organisationId, type }, 'create API call');
 
   try {
-    // Static transfer_agent/subagent targets must reference accessible agents of the right type
-    functions && await validateAgentTargets(functions, {
-      lookupAgent: (agentId) => Agent.findOne({ where: { id: agentId, ...scopeWhereForUser(res.locals.user) } })
+    // Static transfer_agent/subagent targets and options.bridgedTransferToAgent
+    // targets must reference accessible agents of the right type
+    (functions || options?.bridgedTransferToAgent) && await validateAgentTargets(functions || [], {
+      lookupAgent: (agentId) => Agent.findOne({ where: { id: agentId, ...scopeWhereForUser(res.locals.user) } }),
+      options
     });
     await agent.save();
     res.send({ ...agent.dataValues, keys: undefined });

--- a/api/paths/agents/{agentId}.js
+++ b/api/paths/agents/{agentId}.js
@@ -170,9 +170,11 @@ const agentUpdate = async (req, res) => {
     if (!agent) {
       throw new Error(`Agent with ID ${agentId} not found`);
     }
-    // Static transfer_agent/subagent targets must reference accessible agents of the right type
-    functions && await validateAgentTargets(functions, {
-      lookupAgent: (targetId) => Agent.findOne({ where: { id: targetId, ...scopeWhereForUser(res.locals.user) } })
+    // Static transfer_agent/subagent targets and options.bridgedTransferToAgent
+    // targets must reference accessible agents of the right type
+    (functions || options?.bridgedTransferToAgent) && await validateAgentTargets(functions || [], {
+      lookupAgent: (targetId) => Agent.findOne({ where: { id: targetId, ...scopeWhereForUser(res.locals.user) } }),
+      options
     });
     await agent.update({ name, description, prompt, options, functions, mcpServers, keys, modelName, type });
     req.log.info({ ...agent.dataValues, keys: undefined }, 'Agent updated');

--- a/docs/call-transfers.md
+++ b/docs/call-transfers.md
@@ -619,6 +619,8 @@ The example below forces bridging; set `forceRefer` instead to force SIP REFER.
 
 After a bridged transfer the caller is talking to a human transfer target and the AI has left the conversation. The `options.bridgedTransferToAgent` agent option lets the **transfer target** hand the caller back to an AI agent by pressing a DTMF key sequence — for example a support engineer who has finished a triage conversation can press `1` to pass the caller to a booking agent and put the phone down.
 
+> **Developer walkthrough:** [human-handback-howto.md](./human-handback-howto.md) builds the complete workflow — consultative transfer to a remote worker, transcribed human↔human conversation, DTMF hand-back, and a follow-up agent that books the agreed appointment in the worker's calendar.
+
 ```json
 {
   "name": "Front desk agent",

--- a/docs/call-transfers.md
+++ b/docs/call-transfers.md
@@ -665,14 +665,47 @@ Inside an `/agent-sets` document, `bridgedTransferToAgent` values participate in
 
 On create/update the platform resolves each label to the member's real agent UUID and records the original label as `fromLabel` alongside it, so set documents round-trip exactly like function targets — see [multi-agent-api.md](./multi-agent-api.md).
 
+### Transcribing the bridged segment (`bridgedTransferTranscribe`)
+
+By default the human↔human conversation after a bridged transfer is not transcribed — the AI has left the call, and a takeover agent only receives the *pre-transfer* conversation history. Setting `options.bridgedTransferTranscribe` closes that gap:
+
+```json
+{
+  "options": {
+    "bridgedTransferToAgent": { "1": "5f4c…-uuid" },
+    "bridgedTransferTranscribe": true
+  }
+}
+```
+
+Or with tuning (fields apply where the gateway runs its own STT — the voiceblender topology; sipbridge uses the agent's configured STT and ignores `provider`):
+
+```json
+"bridgedTransferTranscribe": { "provider": "deepgram", "language": "en" }
+```
+
+| Field | Default | Values | Description |
+|-------|---------|--------|-------------|
+| `enabled` | `true` | boolean | Set `false` to disable without removing the object |
+| `provider` | `"elevenlabs"` | `elevenlabs` \| `deepgram` \| `azure` | Gateway-native STT engine (voiceblender only) |
+| `language` | engine default | BCP-47 tag | Language hint for the transcription engine |
+
+**Behaviour:**
+
+- A speaker-labelled transcript (`> caller:` / `> transfer target:`) of the bridged segment is stored on a **bridged-segment call record** — a child call (`modelName: "telephony:bridged-call"`, `parentId` = the original call) created when the monitored bridge is installed and ended when the bridge ends or a hand-back fires.
+- When combined with `bridgedTransferToAgent`, a DTMF hand-back injects the bridged-segment transcript into the incoming agent's prompt as a `# Conversation between the caller and the human transfer target` section (suppressed together with the rest of the history when the matched entry sets `includeHistory: false`).
+- Like `bridgedTransferToAgent`, the option forces transfers onto the bridged path. It also works standalone (transcript + call record only, no DTMF hand-back).
+- **Media stays on the gateway fast path.** On voiceblender the container's native per-leg real-time STT runs and finals arrive as `stt.text` events; on sipbridge the bridge streams a decoded stereo *copy* (left = caller, right = target) of the relay to the worker, which runs one STT stream per channel — the RTP relay between the humans is untouched in both cases.
+- Transcription is best-effort: an STT failure never disturbs the bridged call or the DTMF watch.
+
 ### Topology support
 
-| Topology | Supported | Mechanism |
-|----------|-----------|-----------|
-| LiveKit | ✅ | The agent participant stays in the room (muted) after the bridge and consumes LiveKit's SIP DTMF room events, filtered to the transfer-target participant. On a match the target participant is removed and the mapped agent's stack starts on the same room. |
-| Pipecat + sipbridge | ✅ | The transfer is placed with `monitor_dtmf: true`; the bridge keeps the caller leg's worker WebSocket open as a control-only channel and ships target-leg RFC 4733 presses as `source: "transfer_target"` events. On a match the worker POSTs `/v1/calls/{id}/unbridge` — the bridge drops the target and re-dials a fresh agent WebSocket for the caller leg. |
-| Pipecat + voiceblender | ✅ | The bridged legs sit in a voiceblender room; `dtmf.received` VSI events for the target leg feed the worker's matcher. On a match the worker deletes the target leg, removes the caller from the room, and re-attaches a Pipecat agent to the caller leg. |
-| WebRTC / browser origin | ❌ | Browser-origin transfers use the worker-side media relay; target-leg DTMF monitoring is not currently wired for that path. |
+| Topology | Hand-back (`bridgedTransferToAgent`) | Transcription (`bridgedTransferTranscribe`) | Mechanism |
+|----------|-----------|-----------|-----------|
+| LiveKit | ✅ | ⏳ follow-up | The agent participant stays in the room (muted) after the bridge and consumes LiveKit's SIP DTMF room events, filtered to the transfer-target participant. On a match the target participant is removed and the mapped agent's stack starts on the same room. |
+| Pipecat + sipbridge | ✅ | ✅ | The transfer is placed with `monitor_dtmf`/`tap_audio`; the bridge keeps the caller leg's worker WebSocket open as a control channel, ships target-leg RFC 4733 presses as `source: "transfer_target"` events, and (when transcribing) a stereo audio tap. On a match the worker POSTs `/v1/calls/{id}/unbridge` — the bridge drops the target and re-dials a fresh agent WebSocket for the caller leg. |
+| Pipecat + voiceblender | ✅ | ✅ | The bridged legs sit in a voiceblender room; `dtmf.received` VSI events for the target leg feed the worker's matcher and the container's native per-leg STT feeds the transcript. On a match the worker deletes the target leg, removes the caller from the room, and re-attaches a Pipecat agent to the caller leg. |
+| WebRTC / browser origin | ❌ | ❌ | Browser-origin transfers use the worker-side media relay; target-leg monitoring is not currently wired for that path. |
 
 ## Outbound Call Filter
 

--- a/docs/call-transfers.md
+++ b/docs/call-transfers.md
@@ -615,6 +615,65 @@ The example below forces bridging; set `forceRefer` instead to force SIP REFER.
 
 **Note:** `forceBridged` and `forceRefer` apply to both blind and consultative transfers — for a consultative transfer they select how the *final hop* is completed (media bridge vs attended SIP REFER with Replaces) once the transfer target accepts. If a gateway can't honour an attended REFER it falls back to bridging automatically.
 
+## Human to agent transfers (`bridgedTransferToAgent`)
+
+After a bridged transfer the caller is talking to a human transfer target and the AI has left the conversation. The `options.bridgedTransferToAgent` agent option lets the **transfer target** hand the caller back to an AI agent by pressing a DTMF key sequence — for example a support engineer who has finished a triage conversation can press `1` to pass the caller to a booking agent and put the phone down.
+
+```json
+{
+  "name": "Front desk agent",
+  "options": {
+    "bridgedTransferToAgent": {
+      "1":  { "agent": "5f4c…-uuid-of-booking-agent" },
+      "*7": { "agent": "9a1b…-uuid-of-survey-agent", "includeHistory": false }
+    }
+  }
+}
+```
+
+Each key is a DTMF sequence of 1–8 characters from `0-9`, `*` and `#`. Each value names the **voice agent** the caller should be handed to when that sequence is detected, either as a bare agent UUID string or as an object:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `agent` | — | The target agent's UUID (or a `label:<label>` reference inside an [agent-set document](./multi-agent-api.md) — see below). Must be an `interactive-audio` agent in your organisation; validated when the agent is saved. |
+| `includeHistory` | `true` | When true, the incoming agent's prompt includes the conversation the caller had with the *original* agent (the conversation with the human after the transfer is not recorded and cannot be carried). When false the incoming agent starts fresh. |
+
+### Behaviour
+
+- **Monitoring is armed only after a bridged transfer completes** (a blind bridged transfer, or the bridged finalise of a consultative transfer), and listens to DTMF **from the transfer-target leg only** — digits pressed by the caller never trigger it.
+- **Transfers are forced onto the bridged path while the option is set.** A SIP REFER hands the call off-platform, where the target's DTMF can no longer be observed, so the option overrides `forceRefer`, `forceReferTransfer`, and the registration-origin REFER default, for both blind transfers and the consultative finalise. The usual bridged-mode consequences apply (the platform continues to carry — and bill — the call).
+- **Multi-digit matching** uses the same inter-digit timeout as ordinary DTMF input (`options.dtmfTimeout`, default 1500 ms): a sequence that exactly matches a key fires immediately unless a longer key could still match, in which case it fires after the timeout; unmatched digits age out and do not poison a following valid sequence.
+- **On a match** the transfer target's leg is dropped, the bridged call segment ends, and the mapped agent answers the caller on a **new child call record** (`parentId` linking back to the original call). The incoming agent's prompt is composed like a `transfer_agent` handover: its own prompt, a note that it has just taken over from a human hand-back, and (by default) the original agent↔caller transcript.
+- **If the takeover cannot start** (target agent at its concurrency limit, misconfigured target, wrong model family), the bridge is left intact — the humans stay connected — and the target can retry.
+- **If the transfer target simply hangs up** without pressing a key, the call ends normally.
+
+### Agent sets and label substitution
+
+Inside an `/agent-sets` document, `bridgedTransferToAgent` values participate in the same `label:` substitution as `transfer_agent` / `subagent` targets:
+
+```json
+{
+  "label": "frontdesk",
+  "options": {
+    "bridgedTransferToAgent": {
+      "1": "label:booking",
+      "2": { "agent": "label:survey", "includeHistory": false }
+    }
+  }
+}
+```
+
+On create/update the platform resolves each label to the member's real agent UUID and records the original label as `fromLabel` alongside it, so set documents round-trip exactly like function targets — see [multi-agent-api.md](./multi-agent-api.md).
+
+### Topology support
+
+| Topology | Supported | Mechanism |
+|----------|-----------|-----------|
+| LiveKit | ✅ | The agent participant stays in the room (muted) after the bridge and consumes LiveKit's SIP DTMF room events, filtered to the transfer-target participant. On a match the target participant is removed and the mapped agent's stack starts on the same room. |
+| Pipecat + sipbridge | ✅ | The transfer is placed with `monitor_dtmf: true`; the bridge keeps the caller leg's worker WebSocket open as a control-only channel and ships target-leg RFC 4733 presses as `source: "transfer_target"` events. On a match the worker POSTs `/v1/calls/{id}/unbridge` — the bridge drops the target and re-dials a fresh agent WebSocket for the caller leg. |
+| Pipecat + voiceblender | ✅ | The bridged legs sit in a voiceblender room; `dtmf.received` VSI events for the target leg feed the worker's matcher. On a match the worker deletes the target leg, removes the caller from the room, and re-attaches a Pipecat agent to the caller leg. |
+| WebRTC / browser origin | ❌ | Browser-origin transfers use the worker-side media relay; target-leg DTMF monitoring is not currently wired for that path. |
+
 ## Outbound Call Filter
 
 The `outboundCallFilter` option provides security by restricting which phone numbers can be called via transfers or the originate endpoint. This prevents abuse, such as transferring calls to premium rate numbers.

--- a/docs/call-transfers.md
+++ b/docs/call-transfers.md
@@ -680,7 +680,7 @@ By default the human↔human conversation after a bridged transfer is not transc
 }
 ```
 
-Or with tuning (fields apply where the gateway runs its own STT — the voiceblender topology; sipbridge uses the agent's configured STT and ignores `provider`):
+Or with tuning (fields apply where the gateway runs its own STT — the voiceblender topology; LiveKit and sipbridge use the agent's configured STT and ignore `provider`):
 
 ```json
 "bridgedTransferTranscribe": { "provider": "deepgram", "language": "en" }
@@ -704,7 +704,7 @@ Or with tuning (fields apply where the gateway runs its own STT — the voiceble
 
 | Topology | Hand-back (`bridgedTransferToAgent`) | Transcription (`bridgedTransferTranscribe`) | Mechanism |
 |----------|-----------|-----------|-----------|
-| LiveKit | ✅ | ⏳ follow-up | The agent participant stays in the room (muted) after the bridge and consumes LiveKit's SIP DTMF room events, filtered to the transfer-target participant. On a match the target participant is removed and the mapped agent's stack starts on the same room. |
+| LiveKit | ✅ | ✅ | The agent participant stays in the room (muted) after the bridge and consumes LiveKit's SIP DTMF room events, filtered to the transfer-target participant. On a match the target participant is removed and the mapped agent's stack starts on the same room. When transcribing, the muted agent participant runs one STT stream per human track (the caller and the transfer target are distinct room participants), using the agent's configured STT vendor. |
 | Pipecat + sipbridge | ✅ | ✅ | The transfer is placed with `monitor_dtmf`/`tap_audio`; the bridge keeps the caller leg's worker WebSocket open as a control channel, ships target-leg RFC 4733 presses as `source: "transfer_target"` events, and (when transcribing) a stereo audio tap. On a match the worker POSTs `/v1/calls/{id}/unbridge` — the bridge drops the target and re-dials a fresh agent WebSocket for the caller leg. |
 | Pipecat + voiceblender | ✅ | ✅ | The bridged legs sit in a voiceblender room; `dtmf.received` VSI events for the target leg feed the worker's matcher and the container's native per-leg STT feeds the transcript. On a match the worker deletes the target leg, removes the caller from the room, and re-attaches a Pipecat agent to the caller leg. |
 | WebRTC / browser origin | ❌ | ❌ | Browser-origin transfers use the worker-side media relay; target-leg monitoring is not currently wired for that path. |

--- a/docs/human-handback-howto.md
+++ b/docs/human-handback-howto.md
@@ -1,0 +1,266 @@
+# How-to: consultative transfer to a remote worker, DTMF hand-back, and automated follow-up
+
+This guide builds a complete workflow around **human-to-agent transfers**
+([`bridgedTransferToAgent`](./call-transfers.md#human-to-agent-transfers-bridgedtransfertoagent))
+and **bridged-segment transcription**
+([`bridgedTransferTranscribe`](./call-transfers.md#transcribing-the-bridged-segment-bridgedtransfertranscribe)):
+
+> A caller reaches your front-desk agent. The agent decides the call needs a
+> human — a remote field engineer — and performs a **consultative transfer**
+> to their mobile. The engineer takes the call, has a brief conversation with
+> the caller ("I can come back Tuesday afternoon to replace the valve"), then
+> **presses `1` and puts the phone down**. The caller is seamlessly handed to
+> a follow-up agent that has **read the transcript of the human conversation**,
+> understands what was agreed, and books the return visit into the engineer's
+> calendar before saying goodbye.
+
+The moving parts, end to end:
+
+```
+Caller ──► Front-desk agent ──consultative──► Engineer's mobile
+                                   │  (TransferAgent briefs the engineer,
+                                   │   engineer accepts)
+Caller ◄────────bridged───────────► Engineer      ← transcribed segment
+                                   │  engineer presses 1, hangs up
+Caller ──► Follow-up agent  ──book_appointment──► Calendar API
+```
+
+## Prerequisites
+
+- A telephone number or registration endpoint routed to your agent, with
+  **outbound calling enabled** on its trunk (transfers dial a new leg).
+- Agents on a stack that supports these options — see the
+  [topology support table](./call-transfers.md#topology-support). Everything
+  below is stack-agnostic; only `modelName` changes.
+- A calendar/booking API the follow-up agent can call (any REST endpoint; an
+  [MCP server](./mcp-servers.md) works too).
+
+## Step 1 — create the agent set
+
+The two agents are members of one [agent set](./multi-agent-api.md), so the
+hand-back target is referenced by **label** rather than UUID and the whole
+workflow ships as one document. `POST /agent-sets`:
+
+```json
+{
+  "name": "Field service front office",
+  "description": "Front desk + post-visit follow-up booking",
+  "agents": [
+    {
+      "label": "frontdesk",
+      "name": "Front desk",
+      "modelName": "pipecat:openai/gpt-4o",
+      "prompt": "You are the assistant for Acme Heating. Greet the caller and find out what they need. If they need to speak to the on-call engineer, tell them you are connecting them and call the transfer function. While the consultation is in progress, call transfer_status periodically and keep the caller informed. If the engineer declines or cannot be reached, take a message instead.",
+      "options": {
+        "transferTone": true,
+        "bridgedTransferToAgent": {
+          "1": "label:followup"
+        },
+        "bridgedTransferTranscribe": true,
+        "transferPrompt": "You are briefing Acme's on-call engineer about an incoming call. Conversation so far: ${parentTranscript}\n\nSummarise the caller's issue in one or two sentences and ask if they can take the call. Tell them: when you are finished with the caller, press 1 and the assistant will take the call back and book any follow-up visit you agreed. If they accept, call accept_transfer; if not, call reject_transfer with a short reason.",
+        "outboundCallFilter": "^\\+447700900123$"
+      },
+      "functions": [
+        {
+          "name": "transfer",
+          "implementation": "builtin",
+          "platform": "transfer",
+          "description": "Connect the caller to the on-call engineer (consultative)",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "number":    { "type": "string", "source": "static", "from": "+447700900123" },
+              "operation": { "type": "string", "source": "static", "from": "consultative" }
+            }
+          }
+        },
+        {
+          "name": "transfer_status",
+          "implementation": "builtin",
+          "platform": "transfer_status",
+          "description": "Check the progress of the transfer",
+          "input_schema": { "type": "object", "properties": {} }
+        }
+      ]
+    },
+    {
+      "label": "followup",
+      "name": "Follow-up booking",
+      "modelName": "pipecat:openai/gpt-4o",
+      "prompt": "You are Acme Heating's booking assistant. You have just taken over a call after the caller finished speaking with our engineer — the transcripts of BOTH earlier conversations are in your context above. Read the section headed 'Conversation between the caller and the human transfer target' and work out what was agreed: usually a return visit, a part to be ordered, or nothing. Confirm your understanding with the caller in one sentence (e.g. 'So Sam is coming back on Tuesday afternoon to replace the valve — shall I book that in?'). If a visit was agreed, call book_appointment with the agreed date and time and a one-line summary of the job, then confirm the booking reference to the caller and say goodbye. If nothing needs booking, thank them and say goodbye.",
+      "options": {},
+      "functions": [
+        {
+          "name": "book_appointment",
+          "implementation": "rest",
+          "method": "post",
+          "url": "https://api.example.com/calendar/sam-field-eng/appointments",
+          "description": "Book a visit in the engineer's calendar. Returns a booking reference.",
+          "input_schema": {
+            "type": "object",
+            "properties": {
+              "start":   { "type": "string", "in": "body", "source": "generated", "required": true,
+                           "description": "Appointment start in ISO 8601, e.g. 2026-07-07T14:00:00+01:00" },
+              "summary": { "type": "string", "in": "body", "source": "generated", "required": true,
+                           "description": "One-line description of the job agreed with the caller" },
+              "callerNumber": { "type": "string", "in": "body", "source": "metadata",
+                                "from": "aplisay.callerId",
+                                "description": "The caller's number, for the calendar entry" }
+            }
+          }
+        },
+        {
+          "name": "hangup",
+          "implementation": "builtin",
+          "platform": "hangup",
+          "description": "End the call once the booking is confirmed",
+          "input_schema": { "type": "object", "properties": {} }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Points worth noting:
+
+- **`"1": "label:followup"`** — the hand-back map. On save the platform
+  resolves the label to the member's UUID (recorded as `fromLabel` so the
+  document round-trips). Multi-digit keys (`"12"`, `"*7"`) and multiple
+  entries mapping different keys to different agents are fine.
+- **`bridgedTransferTranscribe: true`** — without this, the follow-up agent
+  would only see the *pre-transfer* conversation and would have no idea what
+  the caller and the engineer agreed. With it, the human↔human segment is
+  transcribed (speaker-labelled) and injected into the takeover prompt.
+- **The `transferPrompt` is how the engineer learns about the `1` key.** The
+  consultative TransferAgent briefs them privately before they accept, so
+  "press 1 when you're done" arrives naturally as part of that briefing. For
+  blind transfers there is no briefing step — you would need the engineer to
+  know the convention already.
+- **`outboundCallFilter`** pins transfers to exactly the engineer's number.
+  Always set this in production — see the
+  [security notes](./call-transfers.md#outbound-call-filter).
+- The follow-up agent needs **no transfer options at all** — it is an
+  ordinary agent; the platform delivers the context to it.
+
+## Step 2 — what happens on the call
+
+1. **Consultation.** The front-desk agent calls `transfer` with
+   `operation: "consultative"`. The engineer's mobile rings; a TransferAgent
+   briefs them (using your `transferPrompt`, with the live conversation
+   substituted for `${parentTranscript}`) and they accept. Meanwhile the
+   caller hears the front-desk agent (and the comfort tone, since
+   `transferTone` is on).
+2. **Bridge.** On acceptance the caller and engineer are bridged. Because
+   `bridgedTransferToAgent`/`bridgedTransferTranscribe` are set, the
+   transfer is **forced onto the bridged path** (never SIP REFER — a REFER
+   would take the call off-platform where neither DTMF nor audio can be
+   observed). The front-desk agent's call record ends; a **bridged-segment
+   child call record** (`modelName: "telephony:bridged-call"`) starts, and
+   the platform begins transcribing both humans. The two of them talk
+   normally; nothing is in their audio path.
+3. **Hand-back.** The engineer presses `1` (only *their* keypad is watched —
+   the caller pressing digits does nothing) and hangs up or just waits. The
+   platform: reserves the follow-up agent's concurrency slot **first** (if
+   the agent is busy, nothing happens and the humans stay connected — the
+   engineer can retry), drops the engineer's leg, ends the bridged record
+   with `Transfer target handed call back to agent …`, and starts the
+   follow-up agent on the caller's leg under a new child call record.
+4. **Follow-up.** The follow-up agent reads its prompt (below), confirms the
+   arrangement with the caller, calls `book_appointment`, reads back the
+   reference, and hangs up.
+
+Every stage is a linked call record under the original call
+(`parentId` chains), each with its own transcript, so the whole journey is
+auditable from the original call's id.
+
+## Step 3 — what the follow-up agent actually sees
+
+The platform composes the takeover system prompt from the follow-up agent's
+own `prompt` plus the carried context. For the call above it looks like:
+
+```text
+You are Acme Heating's booking assistant. …(your prompt)…
+
+You have just taken over a live call. The caller was previously speaking
+with another agent and was then transferred to a human, who has now handed
+the call back to you.
+
+# Conversation between the caller and the previous agent
+> caller: Hi, my boiler's making a banging noise again.
+> agent: I'm sorry to hear that. Let me get our on-call engineer on the line…
+
+# Conversation between the caller and the human transfer target
+> transfer target: Hi, Sam here — I hear the boiler's playing up again?
+> caller: Yes, same banging as last winter.
+> transfer target: OK, that'll be the fill valve. I can come back Tuesday
+  afternoon and swap it — say two o'clock?
+> caller: Tuesday at two works.
+> transfer target: Great, I'll press one and the assistant will book that in.
+```
+
+The second section is the transcribed bridged segment; `> caller:` /
+`> transfer target:` labels come from per-leg speaker separation, not
+diarisation guesswork. If you set `includeHistory: false` on the map entry
+(`"1": { "agent": "label:followup", "includeHistory": false }`), **both**
+sections are suppressed and the agent starts fresh — for this use case you
+want the default (`true`).
+
+An agent can't reliably be told to ignore injected context it has already
+seen, so treat `includeHistory` as the privacy switch: if the human
+conversation might contain things the follow-up agent must not know, turn
+history off (or leave `bridgedTransferTranscribe` unset, which keeps the
+pre-transfer history but omits the human segment).
+
+## Step 4 — the booking call
+
+`book_appointment` is an ordinary REST function: the LLM generates `start`
+and `summary` from the transcript + its confirmation with the caller, and
+`callerNumber` is sourced from call metadata rather than trusted to the
+model. The engineer's calendar is identified statically in the URL
+(`sam-field-eng`) because this agent-set instance *is* Sam's front office. If
+one follow-up agent serves several workers, pass the worker's id the same way
+the hand-back key is chosen — one map entry per worker
+(`"1": "label:followup-sam"`, `"2": "label:followup-alex"`), or look it up
+from the transcript via your own API.
+
+Prefer tools over prompt-parsing where precision matters: the transcript
+tells the agent *what was agreed*; the confirmation with the caller ("shall I
+book that in?") is what guards against STT errors before anything is
+written to the calendar.
+
+## Testing checklist
+
+1. Create the set, `POST /agents/{frontdeskId}/listen` (or attach a number),
+   and call in.
+2. Ask for the engineer; check `transfer_status` progresses
+   `dialling → talking → none` as the engineer accepts.
+3. While bridged, watch the bridged-segment call record appear
+   (`GET /calls?parentId=…`) and — with `bridgedTransferTranscribe` on — its
+   transcript fill in as you speak.
+4. Press `1` **from the engineer's phone** and confirm the follow-up agent
+   answers with awareness of what was said. Press digits from the caller's
+   phone first to confirm they do nothing.
+5. Check the follow-up agent's booking call hits your API with the agreed
+   slot, and that the final call-record chain is
+   `original → bridged segment → follow-up`.
+
+## Caveats
+
+- **The engineer must press the key while still on the call.** Hanging up
+  without pressing ends the call normally — there is no hand-back after the
+  bridge is gone.
+- **Bridged means billed**: forcing the bridged path keeps the platform (and
+  per-minute charges) in the call for the human↔human segment, unlike a
+  REFER hand-off.
+- **Transcription is best-effort**: an STT failure never disturbs the live
+  bridge; the follow-up agent then sees the "was not recorded" note instead
+  of the second section — prompt it to ask the caller what was agreed as a
+  fallback (the example prompt's confirmation step covers this).
+- **Busy follow-up agent**: the takeover aborts and leaves the humans
+  connected; the engineer can press the key again.
+- **Not available for WebRTC (browser) callers** — see the
+  [topology table](./call-transfers.md#topology-support).
+- Keys are matched with the `dtmfTimeout` inter-digit window (default
+  1500 ms); avoid making one key a prefix of another (`"1"` and `"12"`)
+  unless you understand the [timeout disambiguation](./call-transfers.md#human-to-agent-transfers-bridgedtransfertoagent).

--- a/docs/livekit-pipecat-transfer-parity.md
+++ b/docs/livekit-pipecat-transfer-parity.md
@@ -22,7 +22,7 @@ repo, REST + VSI) — with a focus on call transfers.
 | WebRTC (browser) origin transfers | n/a (LiveKit rooms native) | ✅ worker-side media relay | ✅ worker-side media relay |
 | Bridged call record for the post-transfer segment | ✅ child call, `modelName: "telephony:bridged-call"` | ✅ when the bridge is monitored/transcribed; plain bridges still have no record (no event path) | ✅ same condition |
 | Human-to-agent transfers (`options.bridgedTransferToAgent`) | ✅ (this branch) | ✅ (this branch) | ✅ (this branch) |
-| Bridged-segment transcription (`options.bridgedTransferTranscribe`) | ⏳ follow-up (two-track STT on the room) | ✅ stereo tap on the monitor WS + agent's STT | ✅ container-native per-leg STT via VSI |
+| Bridged-segment transcription (`options.bridgedTransferTranscribe`) | ✅ two-track STT on the room participants (caller + target tracks, agent's STT vendor) | ✅ stereo tap on the monitor WS + agent's STT | ✅ container-native per-leg STT via VSI |
 
 **Conclusion:** bridged warm (consultative) and cold (blind) transfers between
 two SIP endpoints are supported on all three topologies. The remaining

--- a/docs/livekit-pipecat-transfer-parity.md
+++ b/docs/livekit-pipecat-transfer-parity.md
@@ -20,8 +20,9 @@ repo, REST + VSI) — with a focus on call transfers.
 | `transfer_status`, `transferPrompt`, `consultFeedback`, `callerId` override, outboundCallFilter | ✅ | ✅ | ✅ |
 | Confidence tone (`options.transferTone`) | ✅ | ✅ | ✅ |
 | WebRTC (browser) origin transfers | n/a (LiveKit rooms native) | ✅ worker-side media relay | ✅ worker-side media relay |
-| Bridged call record for the post-transfer segment | ✅ child call, `modelName: "telephony:bridged-call"` | ❌ not created (follow-up) | ❌ not created (follow-up) |
+| Bridged call record for the post-transfer segment | ✅ child call, `modelName: "telephony:bridged-call"` | ✅ when the bridge is monitored/transcribed; plain bridges still have no record (no event path) | ✅ same condition |
 | Human-to-agent transfers (`options.bridgedTransferToAgent`) | ✅ (this branch) | ✅ (this branch) | ✅ (this branch) |
+| Bridged-segment transcription (`options.bridgedTransferTranscribe`) | ⏳ follow-up (two-track STT on the room) | ✅ stereo tap on the monitor WS + agent's STT | ✅ container-native per-leg STT via VSI |
 
 **Conclusion:** bridged warm (consultative) and cold (blind) transfers between
 two SIP endpoints are supported on all three topologies. The remaining

--- a/docs/livekit-pipecat-transfer-parity.md
+++ b/docs/livekit-pipecat-transfer-parity.md
@@ -1,0 +1,79 @@
+# LiveKit ↔ Pipecat transfer feature parity
+
+Status as of the `transfer-out` branch (July 2026). This note records the
+feature-compatibility analysis between the LiveKit agent worker
+(`agents/livekit`) and the Pipecat agent worker (`agents/pipecat`) on its two
+production SIP topologies — the **sipbridge** container
+(`agents/pipecat/sipbridge`, Go) and the **voiceblender** container (separate
+repo, REST + VSI) — with a focus on call transfers.
+
+## Parity matrix
+
+| Capability | LiveKit | Pipecat + sipbridge | Pipecat + voiceblender |
+|---|---|---|---|
+| Blind transfer, SIP REFER | ✅ `transferParticipant` (telephony.ts) | ✅ `mode: "blind"` in-dialog REFER | ✅ `POST /v1/legs/{id}/transfer` |
+| Blind transfer, bridged (media stays on platform) | ✅ SIP participant into the caller room | ✅ `mode: "dial_bridge"` (agent-less leg + in-process RTP relay) | ✅ agent-less leg + ephemeral room |
+| Consultative (warm) transfer — TransferAgent consult phase | ✅ | ✅ | ✅ |
+| Consultative finalise, bridged | ✅ `moveParticipant` into caller room | ✅ `mode: "bridged"` relay | ✅ room bridge |
+| Consultative finalise, attended REFER-with-Replaces | ✅ | ✅ `mode: "attended"` | ❌ — falls back to media bridge (voiceblender's transfer API takes `replaces_leg_id`, but the worker integration for the consult finalise is not wired; the bridged fallback is used) |
+| Transfer mode selection (origin defaults + `forceBridged`/`forceRefer` + endpoint options) | ✅ | ✅ | ✅ |
+| `transfer_status`, `transferPrompt`, `consultFeedback`, `callerId` override, outboundCallFilter | ✅ | ✅ | ✅ |
+| Confidence tone (`options.transferTone`) | ✅ | ✅ | ✅ |
+| WebRTC (browser) origin transfers | n/a (LiveKit rooms native) | ✅ worker-side media relay | ✅ worker-side media relay |
+| Bridged call record for the post-transfer segment | ✅ child call, `modelName: "telephony:bridged-call"` | ❌ not created (follow-up) | ❌ not created (follow-up) |
+| Human-to-agent transfers (`options.bridgedTransferToAgent`) | ✅ (this branch) | ✅ (this branch) | ✅ (this branch) |
+
+**Conclusion:** bridged warm (consultative) and cold (blind) transfers between
+two SIP endpoints are supported on all three topologies. The remaining
+genuine deltas are (a) voiceblender's attended-REFER finalise (a REFER
+optimisation, not a bridged-transfer gap) and (b) the missing bridged-segment
+call record on the Pipecat topologies (billing/CDR parity follow-up).
+
+## Defects found and fixed during this analysis
+
+The Pipecat *native bridge* API surface existed on both gateways, but the
+end-to-end semantics had two teardown defects that would have collapsed a
+bridge shortly after it was installed:
+
+1. **sipbridge (Go)** — `SetPeer` stops the leg's worker WebSocket, and the
+   WS close handler unconditionally called `Call.Close()`, tearing down the
+   caller's RTP session the moment a relay was installed. Fixed: the close
+   handler leaves a call alone while it is in relay mode; additionally, when
+   one leg of a bridged pair receives a BYE, the peer leg is now hung up too
+   (previously it leaked until the media timeout), and bot audio arriving on
+   a kept-open WS is never mixed onto a bridged call.
+2. **Pipecat worker** — `_run_session`'s teardown called
+   `gateway_session.shutdown()` unconditionally, which `DELETE`d the caller's
+   gateway leg after the pipeline ended — i.e. immediately after a bridged
+   transfer. Fixed: gateway sessions are marked `bridged` when a relay/room
+   bridge is installed and their `hangup()` becomes a no-op (the bridged call
+   belongs to the two humans and lives until either side BYEs).
+
+Also fixed in passing: RFC 4733 packets are no longer forwarded across the
+sipbridge relay re-stamped with the audio payload type (they were audible as
+a brief noise blip and useless as signalling).
+
+## Human-to-agent transfers
+
+`options.bridgedTransferToAgent` (added on this branch, all three topologies)
+lets the transfer target hand the caller back to an AI agent by DTMF after a
+bridged transfer. Full contract in
+[`call-transfers.md`](call-transfers.md#human-to-agent-transfers-bridgedtransfertoagent);
+per-topology mechanics in
+[`sipbridge-integration.md`](sipbridge-integration.md) and
+[`voiceblender-integration.md`](voiceblender-integration.md). Common design:
+
+- The option forces transfers onto the bridged path (REFER would take the
+  call off-platform, out of DTMF sight).
+- Only the **transfer-target leg's** DTMF is watched; multi-digit sequences
+  use `options.dtmfTimeout` (default 1500 ms) inter-digit semantics.
+- On a match: the continuation child call record is reserved **first**
+  (concurrency-safe — a busy target agent aborts the takeover and leaves the
+  humans connected), then the target leg is dropped and the mapped agent's
+  stack starts on the caller leg with configurable history carry
+  (`includeHistory`, default true).
+- In agent-set documents the map values participate in `label:` substitution
+  (`lib/agent-set-labels.js`).
+
+Known limitation: not available for WebRTC-origin (browser) calls, whose
+transfers ride the worker-side media relay.

--- a/docs/multi-agent-api.md
+++ b/docs/multi-agent-api.md
@@ -368,6 +368,7 @@ Agent sets let you create, version, and delete a whole team in single API calls,
 
 - Because `fromLabel` is preserved, a document read back with `GET /agent-sets/{id}` can be edited and `PUT` straight back: labelled references are always re-resolved against the membership in the incoming document. You never have to manage member UUIDs by hand.
 - References to agents *outside* the set are also allowed — use the plain agent UUID instead of a label.
+- The same substitution applies to the values of `options.bridgedTransferToAgent` ([human-to-agent transfers](./call-transfers.md#human-to-agent-transfers-bridgedtransfertoagent)): a value of `"label:booking"` (or `{ "agent": "label:booking", … }`) is rewritten to `{ "agent": "<resolved-uuid>", "fromLabel": "booking", … }` on save and re-resolved on every round-trip. Targets must be `interactive-audio` agents, in or outside the set.
 
 ### Update and delete semantics
 

--- a/docs/sipbridge-integration.md
+++ b/docs/sipbridge-integration.md
@@ -207,7 +207,7 @@ as the Daily / FreeSWITCH / voiceblender ingresses.
 | GET | `/health` | — | liveness + active-call count |
 | DELETE | `/v1/calls/{id}` | — | BYE + media teardown |
 | POST | `/v1/calls` | `{destination, caller_id, agent_ws_session_id, custom_headers, metadata}` | outbound INVITE; returns `{ok, call_id}` once 200 OK arrives and the worker WS is wired |
-| POST | `/v1/calls/{id}/transfer` | `{target, mode, monitor_dtmf?}` where mode ∈ `"blind"`, `"bridged"`, `"attended"`, `"dial_bridge"` | blind = in-dialog REFER on `id`; bridged = media-relay between `id` and `target` (a previously-consulted call_id); attended = REFER-with-Replaces to the consult dialog; dial_bridge = dial `target` as an agent-less leg and relay. `monitor_dtmf` (bridged/dial_bridge only) keeps `id`'s worker WS open as a control channel and surfaces target-leg DTMF on it — see below |
+| POST | `/v1/calls/{id}/transfer` | `{target, mode, monitor_dtmf?, tap_audio?}` where mode ∈ `"blind"`, `"bridged"`, `"attended"`, `"dial_bridge"` | blind = in-dialog REFER on `id`; bridged = media-relay between `id` and `target` (a previously-consulted call_id); attended = REFER-with-Replaces to the consult dialog; dial_bridge = dial `target` as an agent-less leg and relay. `monitor_dtmf` (bridged/dial_bridge only) keeps `id`'s worker WS open as a control channel and surfaces target-leg DTMF on it; `tap_audio` additionally streams a decoded stereo copy of the bridge for transcription — see below |
 | POST | `/v1/calls/{id}/consult` | `{destination, caller_id, agent_ws_session_id, ...}` | dials a second leg as a consult; returns `{ok, consult_call_id}` once the bot WS is wired |
 | POST | `/v1/calls/{id}/unbridge` | `{agent_ws_session_id, custom_headers?}` | human-to-agent takeover finalise: BYE the bridged peer leg, dismantle the relay, and re-attach `id` to a fresh worker agent WS at `/sipbridge/agent/{agent_ws_session_id}` |
 
@@ -248,6 +248,18 @@ the bridge then closes the monitor WS and dials
 worker WS closing while a call is bridged never tears the call down —
 the bridged pair lives until either side BYEs (at which point the
 bridge BYEs the peer leg too).
+
+**Transcription tap (`tap_audio`).** With
+`options.bridgedTransferTranscribe` set, the transfer additionally
+carries `tap_audio: true` and the bridge streams a decoded stereo copy
+of the relay on the same kept-open WS as two-channel `AudioRawFrame`s
+(16 kHz s16le; **left = caller, right = transfer target** — see
+`internal/call/tap.go`). The RTP fast path between the humans is
+untouched: the tap is a per-packet decode into a 20 ms mixer that drops
+rather than back-pressures when the WS is slow, and frames are skipped
+entirely while both sides are silent. The worker splits the channels
+into one STT stream per human (`pipecat_aplisay/bridge_transcript.py`)
+and logs the labelled finals against the bridged-segment call record.
 
 
 ## Operations

--- a/docs/sipbridge-integration.md
+++ b/docs/sipbridge-integration.md
@@ -207,8 +207,9 @@ as the Daily / FreeSWITCH / voiceblender ingresses.
 | GET | `/health` | — | liveness + active-call count |
 | DELETE | `/v1/calls/{id}` | — | BYE + media teardown |
 | POST | `/v1/calls` | `{destination, caller_id, agent_ws_session_id, custom_headers, metadata}` | outbound INVITE; returns `{ok, call_id}` once 200 OK arrives and the worker WS is wired |
-| POST | `/v1/calls/{id}/transfer` | `{target, mode}` where mode ∈ `"blind"`, `"bridged"` | blind = in-dialog REFER on `id`; bridged = media-relay between `id` and `target` (a previously-consulted call_id) |
+| POST | `/v1/calls/{id}/transfer` | `{target, mode, monitor_dtmf?}` where mode ∈ `"blind"`, `"bridged"`, `"attended"`, `"dial_bridge"` | blind = in-dialog REFER on `id`; bridged = media-relay between `id` and `target` (a previously-consulted call_id); attended = REFER-with-Replaces to the consult dialog; dial_bridge = dial `target` as an agent-less leg and relay. `monitor_dtmf` (bridged/dial_bridge only) keeps `id`'s worker WS open as a control channel and surfaces target-leg DTMF on it — see below |
 | POST | `/v1/calls/{id}/consult` | `{destination, caller_id, agent_ws_session_id, ...}` | dials a second leg as a consult; returns `{ok, consult_call_id}` once the bot WS is wired |
+| POST | `/v1/calls/{id}/unbridge` | `{agent_ws_session_id, custom_headers?}` | human-to-agent takeover finalise: BYE the bridged peer leg, dismantle the relay, and re-attach `id` to a fresh worker agent WS at `/sipbridge/agent/{agent_ws_session_id}` |
 
 A shared `SIPBRIDGE_API_TOKEN` Bearer guards all endpoints except
 `/health`. Empty token disables auth (dev only).
@@ -225,6 +226,28 @@ DTMF events fire once per key-press (the bridge collects RFC 4733
 event packets and emits a single MessageFrame on the end-of-event
 flag). The worker's Pipecat pipeline can consume them via a custom
 processor or by hooking the transport's `MessageFrame` callback.
+
+**Monitored bridges (human-to-agent transfers).** When a bridged
+transfer is placed with `monitor_dtmf: true`
+(`options.bridgedTransferToAgent` — see
+[`call-transfers.md`](call-transfers.md#human-to-agent-transfers-bridgedtransfertoagent)),
+the original leg's worker WS is *kept open* across the bridge as a
+control-only channel: no audio frames flow in either direction (bot
+audio is dropped while a relay is installed), but DTMF detected on the
+**peer (transfer-target) leg** is delivered on it as
+
+```json
+{"type":"dtmf","digit":"1","duration_ms":120,"call_id":"<this leg>","peer_call_id":"<target leg>","source":"transfer_target"}
+```
+
+with end-of-event retransmissions deduplicated. The worker's monitor
+loop (`pipecat_aplisay/bridged_transfer.py`) matches configured
+sequences and POSTs `/v1/calls/{id}/unbridge` to complete the takeover;
+the bridge then closes the monitor WS and dials
+`/sipbridge/agent/{agent_ws_session_id}` for the new agent session. A
+worker WS closing while a call is bridged never tears the call down —
+the bridged pair lives until either side BYEs (at which point the
+bridge BYEs the peer leg too).
 
 
 ## Operations

--- a/docs/voiceblender-integration.md
+++ b/docs/voiceblender-integration.md
@@ -300,6 +300,13 @@ for the user-facing contract. On the voiceblender topology the pieces are:
    → `POST /v1/legs/{caller}/agent/pipecat` — voiceblender dials
    `/voiceblender/agent/{session_id}` and the WS handler builds the
    incoming agent's CallSession from the stash.
+4. With `options.bridgedTransferTranscribe` set, the worker also starts
+   voiceblender's **native per-leg STT** (`POST /v1/legs/{id}/stt`,
+   provider/language from the option) on both bridged legs at bridge
+   time. Final `stt.text` VSI events are routed per leg into a
+   speaker-labelled transcript (`bridge_transcript.py`) logged against
+   the bridged-segment call record and, on a DTMF hand-back, injected
+   into the incoming agent's prompt. Media never leaves the room mixer.
 
 ## Known limitations / follow-ups
 

--- a/docs/voiceblender-integration.md
+++ b/docs/voiceblender-integration.md
@@ -126,11 +126,11 @@ Two long-lived control connections live on the worker side:
 `CallSession.transfer()` (function-tool surface) calls
 `gateway_session.transfer(req)`. The voiceblender gateway maps:
 
-| Aplisay `operation` | Voiceblender `mode` |
+| Aplisay `operation` | Voiceblender primitive |
 |---|---|
-| `blind` | `blind` |
-| `bridged` | `blind` (with our worker driving the second leg — out of scope for v1) |
-| `consult` | `attended` |
+| `blind` (REFER) | `POST /v1/legs/{id}/transfer` (in-dialog REFER) |
+| `blind` + `force_bridged` | agent-less `POST /v1/legs` + ephemeral room bridge (`_do_dial_bridge`) |
+| `consultative` | agent-attached consult leg; finalise via room bridge (`bridge_with`) |
 
 Progress events arrive on VSI:
 `leg.transfer_initiated` → `leg.transfer_progress` (per NOTIFY sipfrag) →
@@ -280,12 +280,33 @@ of ingress.
 | `agents/pipecat/deploy/gcp/env-example-{staging,production}` | `COMPOSE_PROFILES` + `SIP_GATEWAY` + voiceblender knobs |
 
 
+## Human-to-agent transfers (`options.bridgedTransferToAgent`)
+
+See [`call-transfers.md`](call-transfers.md#human-to-agent-transfers-bridgedtransfertoagent)
+for the user-facing contract. On the voiceblender topology the pieces are:
+
+1. A bridged transfer (native dial+bridge, or a consultative finalise)
+   puts the caller and target legs in an ephemeral room; the gateway
+   session records `bridge_room_id` / `bridge_peer_leg_id` and is marked
+   `bridged` so the worker's teardown never deletes a leg that now
+   belongs to the two humans.
+2. `dtmf.received` VSI events for the **target leg** (which has no
+   CallSession) are routed to a watcher registered by
+   `bridged_transfer.arm_voiceblender_bta_watch(...)`; the watch dies
+   with either bridged leg (`leg.disconnected`).
+3. On a sequence match the worker reserves a child call record, stashes
+   a `TakeoverPayload` keyed by a fresh session id, then
+   `DELETE /v1/legs/{target}` → `DELETE /v1/rooms/{room}/legs/{caller}`
+   → `POST /v1/legs/{caller}/agent/pipecat` — voiceblender dials
+   `/voiceblender/agent/{session_id}` and the WS handler builds the
+   incoming agent's CallSession from the stash.
+
 ## Known limitations / follow-ups
 
-- **`bridged` transfers** map onto voiceblender's `blind` mode for now;
-  a true bridged transfer needs the worker to drive a second outbound
-  leg into a voiceblender room and unbridge once the bridge is
-  established. Out of scope for v1.
+- **`bridged` transfers**: the native dial+bridge path
+  (`_do_dial_bridge`) dials the target as an agent-less leg and joins
+  both legs in an ephemeral voiceblender room. Bridged legs are marked
+  on the gateway session so worker teardown leaves them alive.
 - **Voiceblender's native recording** is left disabled; the worker
   handles recording via `AudioBufferProcessor` and the AES-GCM/GCS
   pipeline that ships in `pipecat_aplisay/recording/`.

--- a/lib/agent-set-labels.js
+++ b/lib/agent-set-labels.js
@@ -15,6 +15,7 @@
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const LABEL_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+const DTMF_KEY_REGEX = /^[0-9*#]{1,8}$/;
 
 const AGENT_TARGET_PLATFORMS = ['transfer_agent', 'subagent'];
 
@@ -26,7 +27,7 @@ export class AgentSetValidationError extends Error {
   }
 }
 
-export { UUID_REGEX, LABEL_REGEX };
+export { UUID_REGEX, LABEL_REGEX, DTMF_KEY_REGEX };
 
 /**
  * Iterate every `agent` target parameter in an agent's functions.
@@ -47,16 +48,41 @@ function* agentTargetParams(functions) {
 }
 
 /**
+ * Iterate the entries of an agent's `options.bridgedTransferToAgent` map
+ * (DTMF key → agent reference), normalising each value to its object form
+ * `{ agent, includeHistory?, fromLabel? }` in place so callers can mutate the
+ * `agent` reference. Shorthand string values are rewritten to objects on the
+ * first pass; shape errors are left for model validation to report.
+ */
+function* bridgedTransferEntries(options) {
+  const map = options?.bridgedTransferToAgent;
+  if (!map || typeof map !== 'object' || Array.isArray(map)) {
+    return;
+  }
+  for (const [key, value] of Object.entries(map)) {
+    if (typeof value === 'string') {
+      map[key] = { agent: value };
+    }
+    const entry = map[key];
+    if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+      yield { key, entry };
+    }
+  }
+}
+
+/**
  * Resolve `label:` references (and stale `fromLabel` annotations) in an
- * agent's functions against a label → agentId map, mutating the function
- * definitions in place.
+ * agent's functions — and in `options.bridgedTransferToAgent` values —
+ * against a label → agentId map, mutating the definitions in place.
  *
  * @param {Array} functions agent functions array (mutated)
  * @param {Map<string,string>} labelMap label → agent UUID
  * @param {string} owningLabel label of the agent owning these functions (for error messages)
+ * @param {object} [options] agent options object (mutated); only
+ *   `options.bridgedTransferToAgent` values are touched
  * @throws {AgentSetValidationError} on a reference to a label not in the set
  */
-export function fixupLabelReferences(functions, labelMap, owningLabel = '?') {
+export function fixupLabelReferences(functions, labelMap, owningLabel = '?', options = undefined) {
   for (const { func, param } of agentTargetParams(functions)) {
     if (param.source !== 'static') {
       continue;
@@ -78,6 +104,23 @@ export function fixupLabelReferences(functions, labelMap, owningLabel = '?') {
     param.from = labelMap.get(label);
     param.fromLabel = label;
   }
+  for (const { key, entry } of bridgedTransferEntries(options)) {
+    let label;
+    const agentValue = `${entry.agent ?? ''}`;
+    if (agentValue.startsWith('label:')) {
+      label = agentValue.slice('label:'.length);
+    } else if (entry.fromLabel) {
+      label = `${entry.fromLabel}`;
+    } else {
+      continue;
+    }
+    if (!labelMap.has(label)) {
+      throw new AgentSetValidationError(
+        `Agent "${owningLabel}": options.bridgedTransferToAgent["${key}"] references label "${label}" which is not a member of this agent set`);
+    }
+    entry.agent = labelMap.get(label);
+    entry.fromLabel = label;
+  }
 }
 
 /**
@@ -95,8 +138,25 @@ export function fixupLabelReferences(functions, labelMap, owningLabel = '?') {
  * @param {Map<string,object>} [opts.membersById] agentId → member agent (in-set targets)
  * @param {Function} [opts.lookupAgent] async (agentId) => agent row or null
  * @param {string} [opts.owningLabel] for error messages
+ * @param {object} [opts.options] agent options; `options.bridgedTransferToAgent`
+ *   values are validated as interactive-audio agent targets
  */
-export async function validateAgentTargets(functions, { membersById = new Map(), lookupAgent, owningLabel = '?' } = {}) {
+export async function validateAgentTargets(functions, { membersById = new Map(), lookupAgent, owningLabel = '?', options = undefined } = {}) {
+  const resolveTarget = async (targetId, expectedType, context) => {
+    let target = membersById.get(targetId);
+    if (!target && lookupAgent) {
+      target = await lookupAgent(targetId);
+    }
+    if (!target) {
+      throw new AgentSetValidationError(
+        `Agent "${owningLabel}": ${context} references agent ${targetId} which does not exist or is not accessible`);
+    }
+    const targetType = target.type || 'interactive-audio';
+    if (targetType !== expectedType) {
+      throw new AgentSetValidationError(
+        `Agent "${owningLabel}": ${context} must target a ${expectedType} agent, but ${targetId} is type ${targetType}`);
+    }
+  };
   for (const { func, param } of agentTargetParams(functions)) {
     if (param.source !== 'static') {
       continue;
@@ -107,19 +167,15 @@ export async function validateAgentTargets(functions, { membersById = new Map(),
       continue;
     }
     const expectedType = func.platform === 'subagent' ? 'text' : 'interactive-audio';
-    let target = membersById.get(targetId);
-    if (!target && lookupAgent) {
-      target = await lookupAgent(targetId);
+    await resolveTarget(targetId, expectedType, `function ${func.name} (${func.platform})`);
+  }
+  for (const { key, entry } of bridgedTransferEntries(options)) {
+    const targetId = `${entry.agent ?? ''}`;
+    if (!UUID_REGEX.test(targetId)) {
+      continue;
     }
-    if (!target) {
-      throw new AgentSetValidationError(
-        `Agent "${owningLabel}": function ${func.name} references agent ${targetId} which does not exist or is not accessible`);
-    }
-    const targetType = target.type || 'interactive-audio';
-    if (targetType !== expectedType) {
-      throw new AgentSetValidationError(
-        `Agent "${owningLabel}": function ${func.name} (${func.platform}) must target a ${expectedType} agent, but ${targetId} is type ${targetType}`);
-    }
+    // A caller handed off by DTMF always lands on a voice agent
+    await resolveTarget(targetId, 'interactive-audio', `options.bridgedTransferToAgent["${key}"]`);
   }
 }
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -454,6 +454,39 @@ Agent.init({
             }
           }
         }
+        if (this.options?.bridgedTransferTranscribe !== undefined && this.options?.bridgedTransferTranscribe !== null) {
+          // Transcription of the human↔human bridged segment after a bridged
+          //  transfer: true enables it with defaults, or an object tunes the
+          //  gateway-native STT (provider/language apply where the gateway
+          //  runs its own STT — voiceblender; the sipbridge topology uses the
+          //  agent's configured STT). See docs/call-transfers.md.
+          const transcribe = this.options.bridgedTransferTranscribe;
+          if (transcribe !== true && transcribe !== false
+            && (typeof transcribe !== 'object' || Array.isArray(transcribe))) {
+            throw new Error('options.bridgedTransferTranscribe must be a boolean or an object');
+          }
+          if (!Handler.hasTransfer) {
+            throw new Error(`Model ${this.modelName} does not support transfers, but options.bridgedTransferTranscribe is set`);
+          }
+          if (typeof transcribe === 'object') {
+            const allowedFields = ['enabled', 'provider', 'language'];
+            const unknown = Object.keys(transcribe).filter((field) => !allowedFields.includes(field));
+            if (unknown.length) {
+              throw new Error(`options.bridgedTransferTranscribe has unknown field(s) ${unknown.join(', ')} (allowed: ${allowedFields.join(', ')})`);
+            }
+            if (transcribe.enabled !== undefined && typeof transcribe.enabled !== 'boolean') {
+              throw new Error('options.bridgedTransferTranscribe.enabled must be a boolean');
+            }
+            const providers = ['elevenlabs', 'deepgram', 'azure'];
+            if (transcribe.provider !== undefined && !providers.includes(transcribe.provider)) {
+              throw new Error(`options.bridgedTransferTranscribe.provider must be one of ${providers.map(p => `'${p}'`).join(', ')}`);
+            }
+            if (transcribe.language !== undefined
+              && !/^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(`${transcribe.language}`)) {
+              throw new Error('options.bridgedTransferTranscribe.language must be a BCP-47 language tag (e.g. "en", "en-US")');
+            }
+          }
+        }
         const functions = Object.entries(this.functions || {});
         return functions.every(([name, func]) => {
           if (func.implementation !== 'builtin')

--- a/lib/database.js
+++ b/lib/database.js
@@ -412,6 +412,48 @@ Agent.init({
             }
           }
         }
+        if (this.options?.bridgedTransferToAgent !== undefined && this.options?.bridgedTransferToAgent !== null) {
+          // Human-to-agent transfers: a map of DTMF sequences (dialled by the
+          //  transfer TARGET after a bridged transfer) to the voice agent the
+          //  caller should be handed to when that sequence is detected. Values
+          //  are an agent UUID string or { agent, includeHistory }; `label:`
+          //  shortforms are only legal inside an /agent-sets document and are
+          //  resolved to UUIDs (annotated with fromLabel) before save.
+          const map = this.options.bridgedTransferToAgent;
+          if (typeof map !== 'object' || Array.isArray(map)) {
+            throw new Error('options.bridgedTransferToAgent must be an object mapping DTMF sequences to agent references');
+          }
+          if (!Handler.hasTransfer || !Handler.hasAgentTransfer) {
+            throw new Error(`Model ${this.modelName} does not support bridged transfers to agents, but options.bridgedTransferToAgent is set`);
+          }
+          const entries = Object.entries(map);
+          if (!entries.length) {
+            throw new Error('options.bridgedTransferToAgent must contain at least one DTMF key');
+          }
+          for (const [key, value] of entries) {
+            if (!/^[0-9*#]{1,8}$/.test(key)) {
+              throw new Error(`options.bridgedTransferToAgent key "${key}" must be a DTMF sequence of 1-8 characters from 0-9, * and #`);
+            }
+            const entry = typeof value === 'string' ? { agent: value } : value;
+            if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+              throw new Error(`options.bridgedTransferToAgent["${key}"] must be an agent UUID string or an object with an "agent" property`);
+            }
+            const allowedFields = ['agent', 'includeHistory', 'fromLabel'];
+            const unknown = Object.keys(entry).filter((field) => !allowedFields.includes(field));
+            if (unknown.length) {
+              throw new Error(`options.bridgedTransferToAgent["${key}"] has unknown field(s) ${unknown.join(', ')} (allowed: ${allowedFields.join(', ')})`);
+            }
+            if (!`${entry.agent ?? ''}`.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)) {
+              throw new Error(`options.bridgedTransferToAgent["${key}"].agent must be an agent UUID (labels are only valid within an agent-set document)`);
+            }
+            if (entry.includeHistory !== undefined && typeof entry.includeHistory !== 'boolean') {
+              throw new Error(`options.bridgedTransferToAgent["${key}"].includeHistory must be a boolean`);
+            }
+            if (entry.fromLabel !== undefined && !/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/.test(`${entry.fromLabel}`)) {
+              throw new Error(`options.bridgedTransferToAgent["${key}"].fromLabel must be a valid agent-set label`);
+            }
+          }
+        }
         const functions = Object.entries(this.functions || {});
         return functions.every(([name, func]) => {
           if (func.implementation !== 'builtin')

--- a/tests/agent-sets.test.mjs
+++ b/tests/agent-sets.test.mjs
@@ -398,4 +398,109 @@ describe('Agent sets', () => {
     }), res);
     expect(res.statusCode).toBe(400);
   });
+
+  describe('options.bridgedTransferToAgent', () => {
+    function setWithBridgedMap(map) {
+      const doc = setDocument();
+      doc.agents[0].options = { bridgedTransferToAgent: map };
+      return doc;
+    }
+
+    test('resolves label references (string and object forms) in a set document', async () => {
+      const res = makeRes(user);
+      await createAgentSet(makeReq(setWithBridgedMap({
+        '1': 'label:specialist',
+        '*7': { agent: 'label:specialist', includeHistory: false }
+      })), res);
+      expect(res.statusCode).toBe(200);
+
+      const byLabel = Object.fromEntries(res.body.agents.map((a) => [a.label, a]));
+      const map = byLabel.triage.options.bridgedTransferToAgent;
+      // String shorthand normalised to object form, label resolved, fromLabel kept
+      expect(map['1']).toEqual({ agent: byLabel.specialist.id, fromLabel: 'specialist' });
+      expect(map['*7']).toEqual({ agent: byLabel.specialist.id, includeHistory: false, fromLabel: 'specialist' });
+    });
+
+    test('round-trips: PUT re-resolves fromLabel annotations against the new membership', async () => {
+      const createRes = makeRes(user);
+      await createAgentSet(makeReq(setWithBridgedMap({ '2': 'label:specialist' })), createRes);
+      expect(createRes.statusCode).toBe(200);
+
+      // PUT the document straight back (as returned, with resolved UUID + fromLabel)
+      const updateRes = makeRes(user);
+      const doc = {
+        name: createRes.body.name,
+        agents: createRes.body.agents.map(({ label, name, modelName, prompt, options, functions, type }) =>
+          ({ label, name, modelName, prompt, options, functions, type }))
+      };
+      await updateAgentSet(makeReq(doc, { agentSetId: createRes.body.id }), updateRes);
+      expect(updateRes.statusCode).toBe(200);
+      const byLabel = Object.fromEntries(updateRes.body.agents.map((a) => [a.label, a]));
+      expect(byLabel.triage.options.bridgedTransferToAgent['2'].agent).toBe(byLabel.specialist.id);
+      expect(byLabel.triage.options.bridgedTransferToAgent['2'].fromLabel).toBe('specialist');
+    });
+
+    test('rejects an unknown label in the map, transactionally', async () => {
+      const res = makeRes(user);
+      await createAgentSet(makeReq(setWithBridgedMap({ '1': 'label:nonexistent' })), res);
+      expect(res.statusCode).toBe(400);
+      expect(res.body.message).toMatch(/bridgedTransferToAgent\["1"\].*label "nonexistent"/);
+      expect(await Agent.count({ where: { organisationId: user.organisationId } })).toBe(0);
+    });
+
+    test('rejects a map entry targeting a text agent', async () => {
+      const res = makeRes(user);
+      await createAgentSet(makeReq(setWithBridgedMap({ '1': 'label:researcher' })), res);
+      expect(res.statusCode).toBe(400);
+      expect(res.body.message).toMatch(/must target a interactive-audio agent/);
+    });
+
+    test('rejects malformed DTMF keys and entry shapes', async () => {
+      for (const [map, pattern] of [
+        [{ 'abc': 'label:specialist' }, /DTMF sequence/],
+        [{ '123456789': 'label:specialist' }, /DTMF sequence/],
+        [{ '1': { agent: 'label:specialist', bogus: true } }, /unknown field/],
+        [{ '1': { includeHistory: true } }, /must be an agent UUID/],
+        [{}, /at least one DTMF key/]
+      ]) {
+        const res = makeRes(user);
+        await createAgentSet(makeReq(setWithBridgedMap(map)), res);
+        expect(res.statusCode).toBe(400);
+        expect(res.body.message).toMatch(pattern);
+      }
+    });
+
+    test('plain POST /agents accepts a UUID target and rejects labels', async () => {
+      const targetRes = makeRes(user);
+      await createAgent(makeReq({ modelName: VOICE_MODEL, prompt: 'target' }), targetRes);
+      expect(targetRes.statusCode).toBe(200);
+
+      const okRes = makeRes(user);
+      await createAgent(makeReq({
+        modelName: VOICE_MODEL,
+        prompt: 'front desk',
+        options: { bridgedTransferToAgent: { '0': targetRes.body.id } }
+      }), okRes);
+      expect(okRes.statusCode).toBe(200);
+      // Shorthand normalised to object form on the way through
+      expect(okRes.body.options.bridgedTransferToAgent['0']).toEqual({ agent: targetRes.body.id });
+
+      const labelRes = makeRes(user);
+      await createAgent(makeReq({
+        modelName: VOICE_MODEL,
+        prompt: 'front desk',
+        options: { bridgedTransferToAgent: { '0': 'label:someone' } }
+      }), labelRes);
+      expect(labelRes.statusCode).toBe(400);
+
+      const missingRes = makeRes(user);
+      await createAgent(makeReq({
+        modelName: VOICE_MODEL,
+        prompt: 'front desk',
+        options: { bridgedTransferToAgent: { '0': randomUUID() } }
+      }), missingRes);
+      expect(missingRes.statusCode).toBe(400);
+      expect(missingRes.body.message).toMatch(/does not exist/);
+    });
+  });
 });

--- a/tests/agent-sets.test.mjs
+++ b/tests/agent-sets.test.mjs
@@ -470,6 +470,30 @@ describe('Agent sets', () => {
       }
     });
 
+    test('validates bridgedTransferTranscribe shapes', async () => {
+      for (const [transcribe, ok, pattern] of [
+        [true, true],
+        [{ provider: 'deepgram', language: 'en-US' }, true],
+        [{ provider: 'whisper' }, false, /provider must be one of/],
+        [{ language: 'English!' }, false, /BCP-47/],
+        [{ bogus: 1 }, false, /unknown field/],
+        ['yes', false, /boolean or an object/]
+      ]) {
+        const res = makeRes(user);
+        await createAgent(makeReq({
+          modelName: VOICE_MODEL,
+          prompt: 'front desk',
+          options: { bridgedTransferTranscribe: transcribe }
+        }), res);
+        if (ok) {
+          expect(res.statusCode).toBe(200);
+        } else {
+          expect(res.statusCode).toBe(400);
+          expect(JSON.stringify(res.body)).toMatch(pattern);
+        }
+      }
+    });
+
     test('plain POST /agents accepts a UUID target and rejects labels', async () => {
       const targetRes = makeRes(user);
       await createAgent(makeReq({ modelName: VOICE_MODEL, prompt: 'target' }), targetRes);


### PR DESCRIPTION
Completes the feature across all three topologies. After a bridged
transfer the muted agent participant stays in the room and runs one STT
stream per human — the caller's and transfer-target's own audio tracks
give per-speaker separation for free. STT vendor resolution is identical
to the worker's pipeline path (inference.STT.fromModelString over the
agent's options.stt, Deepgram nova-3 default for realtime models);
transcribe.provider is ignored on this topology, language honoured
best-effort. Labelled finals are logged against the existing
telephony:bridged-call record (streamed or batched per instance
convention); on a bridgedTransferToAgent DTMF hand-back the transcript
is snapshotted at match time and injected into the takeover prompt as
the '# Conversation between the caller and the human transfer target'
section, byte-compatible with the pipecat composition and gated by
includeHistory. The option forces the bridged path, works standalone
(no hand-back map), self-disposes with either participant or the room,
and never lets an STT failure disturb the bridged call.