### PR TITLE
fix(livekit): persist consult-leg transcript to the consult call record (hotfix backport of #128)

### DIFF
--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -792,6 +792,45 @@ Be helpful, informal, but respectful and concise as if talking to a colleague in
     });
     setTransferSession(transferSession);
 
+    // Persist the consultation conversation onto the consult CALL RECORD.
+    // Historically the consult leg had NO transcript wiring at all, so its
+    // transcript was always empty. Mirror the main session's ConversationItemAdded
+    // -> transaction-log capture, but target the consult call: buffer each turn and
+    // attach the buffer as the consult call's batched transaction logs, which
+    // consultCall.end() flushes on every terminal path (accept / reject /
+    // init-fail / destroy). See api-client call.end and the /call/{id}/end handler.
+    const consultTranscriptLogs: Array<{
+      userId: string;
+      organisationId: string;
+      callId: string;
+      type: string;
+      data: string;
+      isFinal: boolean;
+      createdAt: Date;
+    }> = [];
+    transferSession.on(
+      voice.AgentSessionEventTypes.ConversationItemAdded,
+      ({
+        item: { type, role, content },
+        createdAt,
+      }: voice.ConversationItemAddedEvent) => {
+        if (type !== "message") return;
+        const text = content.join("");
+        if (!text) return;
+        consultTranscriptLogs.push({
+          userId: context.agent.userId,
+          organisationId: context.agent.organisationId,
+          // Resolved once the consult call exists; turns captured before the
+          // record is created are back-filled where it is attached below.
+          callId: context.getConsultCall()?.id ?? "",
+          type: role === "user" ? "user" : "agent",
+          data: JSON.stringify(text),
+          isFinal: true,
+          createdAt: createdAt ? new Date(createdAt) : new Date(),
+        });
+      },
+    );
+
     await transferSession.start({
       room: consultRoom,
       agent: transferAgent,
@@ -827,6 +866,12 @@ Be helpful, informal, but respectful and concise as if talking to a colleague in
       },
     });
     context.setConsultCall(consultCallRecord);
+    // Attach the buffered consult transcript so consultCall.end() flushes it, and
+    // back-fill callId for any turns captured before this record existed.
+    for (const consultLog of consultTranscriptLogs) {
+      if (!consultLog.callId) consultLog.callId = consultCallRecord.id;
+    }
+    (consultCallRecord as any).batchedTransactionLogs = consultTranscriptLogs;
     logger.info(
       { consultCallId: consultCallRecord.id, consultRoomName },
       "created consultation call record"


### PR DESCRIPTION
**Minimal backport of #128 (base `next`) onto `main`, for hotfix readiness in case that fix is needed before `next` lands.**

## Problem

The consultation (attended-transfer) **leg's transcript is empty** — on prod and everywhere.

The `TransferAgent` session (`transferSession`) that talks to the transfer target is never given a `ConversationItemAdded` → transaction-log handler (the mechanism that persists the main call's transcript). So the consult `Call` record's conversation is never written and its transcript is always empty. Confirmed the same gap on `main` and `next`; a handler for this never existed.

## Fix

Wire a `ConversationItemAdded` handler on `transferSession` that mirrors the main-session capture but targets the **consult** call: each message turn is buffered and attached as the consult call's `batchedTransactionLogs`, which the enriched `consultCall.end()` flushes. The server `/api/agent-db/call/{id}/end` handler already `bulkCreate`s those logs against the consult call id **and builds the call's transcript from them**.

On `main`, `consultCall.end()` is invoked on the accept path (`"Transfer completed"`), init-fail, and the destroy/cleanup path — all flush the batched logs. The pure-reject path flushes via `main`'s existing consult-call teardown (`destroyInProgressTransfer`); this backport deliberately does **not** pull in next's larger reject-teardown rework, keeping the change minimal.

## Why it's safe

- **Flushes once** — `call.end` is idempotent (`_endCalled` guard) and no consult end-site passes explicit `transactionLogs`, so the batched array flushes exactly once (no double-send).
- **Correct target** — logs carry the consult call id (server also forces the URL call id onto every log); attached to the consult call's own batched array, no interaction with the main transcript.
- **No lost turns** — pre-record turns are buffered and back-filled when the record is attached.

## Verification

- `yarn build` succeeds; `tsc --noEmit` clean for `transfer-handler.ts` (only the pre-existing `UsageVendors` errors remain, unrelated).
- `@livekit/agents ^1.0.25` (main's pin) is satisfied by the installed `1.0.46` used to typecheck; the handler uses the identical `voice.ConversationItemAddedEvent` type already used elsewhere in `main`.
- Not yet exercised against a live consult — smoke test a successful **accept** to confirm the consult call's transcript is populated.

Single file, +45 lines. Peer of #128 (identical intent; `main`-specific anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
