### PR TITLE
Organisation chargeableNumberLimit + number-quota (Buy-number support)

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1537,7 +1537,7 @@ components:
     PhoneEndpointUpdateInput:
       description: |-
         Schema for updating a phone endpoint. All fields are optional.
-        For e164-ddi endpoints, only `outbound` and `handler` can be updated.
+        For e164-ddi endpoints, only `outbound`, `handler` and `provisioned` can be updated.
         For phone-registration endpoints, `name`, `outbound`, `handler`, `registrar`, `username`, `password`, and `options` can be updated.
         When credentials (registrar, username, password) are updated, the registration state is reset to initial.
       type: object
@@ -1548,6 +1548,9 @@ components:
         outbound:
           type: boolean
           description: Supports outbound
+        provisioned:
+          type: boolean
+          description: Carrier-side provisioning complete (e164-ddi only; set by the dashboard Buy-number flow)
         handler:
           type: string
           enum:

--- a/api/paths/number-quota.js
+++ b/api/paths/number-quota.js
@@ -1,0 +1,81 @@
+import { PhoneNumber, Trunk, Organisation, Op } from '../../lib/database.js';
+import { requirePermission } from '../../lib/auth/permissions.js';
+
+/**
+ * /api/number-quota — the caller's organisation allowance for phone numbers on
+ * chargeable (non-owned) trunks. `Organisation.chargeableNumberLimit` caps how
+ * many DDIs an org may hold on carrier trunks the platform pays for; numbers on
+ * the org's own (chargeable=false) trunks never count. Backs the dashboard
+ * "Buy number" flow so it can show remaining allowance before a purchase; the
+ * hard enforcement lives in createPhoneEndpoint.
+ */
+export default function (logger) {
+  const getQuota = async (req, res) => {
+    if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
+    const { organisationId } = res.locals.user || {};
+    if (!organisationId) {
+      return res.status(403).send({ error: 'Requires an organisation membership' });
+    }
+    try {
+      const org = await Organisation.findByPk(organisationId, {
+        attributes: ['id', 'chargeableNumberLimit'],
+      });
+      if (!org) {
+        return res.status(404).send({ error: 'Organisation not found' });
+      }
+      const chargeableTrunks = await Trunk.findAll({
+        where: { chargeable: true },
+        attributes: ['id'],
+      });
+      const used = chargeableTrunks.length
+        ? await PhoneNumber.count({
+            where: {
+              organisationId,
+              aplisayId: { [Op.in]: chargeableTrunks.map((t) => t.id) },
+            },
+          })
+        : 0;
+      const limit = org.chargeableNumberLimit ?? null;
+      return res.send({
+        limit,
+        used,
+        remaining: limit == null ? null : Math.max(0, limit - used),
+      });
+    } catch (err) {
+      req.log?.error(err, 'fetching number quota');
+      return res.status(500).send({ error: 'Internal server error' });
+    }
+  };
+  getQuota.apiDoc = {
+    summary: "The caller's organisation quota for numbers on chargeable (non-owned) trunks.",
+    description: `Returns the organisation's chargeable number limit, how many numbers it
+                  currently holds on chargeable trunks, and the remaining allowance.
+                  A null limit means unlimited (remaining is null). Numbers on trunks the
+                  organisation owns (chargeable=false) are not counted.`,
+    operationId: 'getNumberQuota',
+    tags: ['Phone Endpoints'],
+    responses: {
+      200: {
+        description: 'The organisation number quota',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['limit', 'used', 'remaining'],
+              properties: {
+                limit: { type: 'integer', nullable: true, description: 'Max numbers on chargeable trunks; null = unlimited' },
+                used: { type: 'integer', description: 'Numbers currently held on chargeable trunks' },
+                remaining: { type: 'integer', nullable: true, description: 'Numbers still purchasable; null when unlimited' },
+              },
+            },
+          },
+        },
+      },
+      default: {
+        description: 'An error occurred',
+        content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+      },
+    },
+  };
+  return { GET: getQuota };
+}

--- a/api/paths/organisations.js
+++ b/api/paths/organisations.js
@@ -11,7 +11,7 @@ import { defaultRateHistoryEntry } from '../../lib/rates.js';
  *        admin tab org-filter and the (super-admin-only) org-edit modal.
  *   POST create an organisation — superAdmin only (`organisation:create`).
  */
-const LIST_ATTRS = ['id', 'name', 'status', 'agentLimit', 'role', 'allowedModels', 'permissions'];
+const LIST_ATTRS = ['id', 'name', 'status', 'agentLimit', 'chargeableNumberLimit', 'role', 'allowedModels', 'permissions'];
 
 export default function (logger) {
   const list = async (req, res) => {
@@ -72,6 +72,10 @@ export default function (logger) {
         id: randomUUID(),
         name,
         agentLimit: req.body?.agentLimit ?? null,
+        // undefined → model default (3); explicit null = unlimited
+        ...(req.body?.chargeableNumberLimit !== undefined
+          ? { chargeableNumberLimit: req.body.chargeableNumberLimit }
+          : {}),
         status: req.body?.status || 'active',
         role,
         permissions,
@@ -96,6 +100,7 @@ export default function (logger) {
             properties: {
               name: { type: 'string' },
               agentLimit: { type: 'integer', nullable: true },
+              chargeableNumberLimit: { type: 'integer', nullable: true, default: 3, description: 'Max numbers the org may hold on chargeable (non-owned) trunks; null = unlimited' },
               status: { type: 'string', enum: ['provisional', 'active', 'suspended', 'deactivated'], default: 'active' },
               role: { type: 'string', nullable: true },
               permissions: { type: 'object', nullable: true },

--- a/api/paths/organisations/{organisationId}.js
+++ b/api/paths/organisations/{organisationId}.js
@@ -48,6 +48,13 @@ export default function (logger) {
     if ('agentLimit' in req.body && !can(res.locals.user, 'organisation', 'setLimits')) {
       return res.status(403).json({ message: 'forbidden', detail: 'Requires organisation:setLimits' });
     }
+    // chargeableNumberLimit caps numbers the org holds on trunks WE pay for — a
+    // platform spend policy, not org capacity. orgAdmin holds setLimits for their
+    // own org, so gating it there would let customers raise their own allowance;
+    // gate on the superAdmin-only billing-policy action instead.
+    if ('chargeableNumberLimit' in req.body && !can(res.locals.user, 'organisation', 'setRate')) {
+      return res.status(403).json({ message: 'forbidden', detail: 'Requires organisation:setRate (super admin)' });
+    }
     const baselineKeys = ['role', 'permissions', 'allowedModels'];
     if (baselineKeys.some((k) => k in req.body)) {
       if (!can(res.locals.user, 'organisation', 'setPermissions')) {
@@ -61,7 +68,7 @@ export default function (logger) {
     const rbacErr = validateRbacFields(req.body);
     if (rbacErr) return res.status(400).send({ message: rbacErr });
 
-    const EDITABLE = ['name', 'agentLimit', 'status', 'role', 'permissions', 'allowedModels'];
+    const EDITABLE = ['name', 'agentLimit', 'chargeableNumberLimit', 'status', 'role', 'permissions', 'allowedModels'];
     for (const k of EDITABLE) if (k in req.body) org[k] = req.body[k];
     try {
       await org.save();
@@ -84,6 +91,7 @@ export default function (logger) {
             properties: {
               name: { type: 'string' },
               agentLimit: { type: 'integer', nullable: true },
+              chargeableNumberLimit: { type: 'integer', nullable: true, description: 'Max numbers the org may hold on chargeable (non-owned) trunks; null = unlimited' },
               status: { type: 'string', enum: ['provisional', 'active', 'suspended', 'deactivated'] },
               role: { type: 'string', nullable: true },
               permissions: { type: 'object', nullable: true },

--- a/api/paths/phone-endpoints.js
+++ b/api/paths/phone-endpoints.js
@@ -290,15 +290,70 @@ const createPhoneEndpoint = async (req, res) => {
         });
       }
 
-      const phoneNumber = await PhoneNumber.create({
-        number: normalizedNumber,
-        // Handler is always derived from the trunk (or defaulted) and cannot be chosen by the caller for DDI endpoints
-        handler: trunk.handler || 'livekit',
-        outbound: requestedOutbound,
-        organisationId: organisationId,
-        // Internally store the trunk association using the aplisayId foreign key
-        aplisayId: data.trunkId
-      });
+      // Numbers on chargeable trunks (carrier trunks shared into the org, i.e.
+      // not owned by it) are capped by Organisation.chargeableNumberLimit
+      // (null = unlimited). Count + create share a transaction behind a FOR
+      // UPDATE lock on the organisation row so concurrent claims cannot race
+      // past the limit. Numbers on the org's own trunks are never counted.
+      let phoneNumber;
+      try {
+        phoneNumber = await PhoneNumber.sequelize.transaction(async (transaction) => {
+          if (trunk.chargeable && organisationId) {
+            const org = await Organisation.findByPk(organisationId, {
+              transaction,
+              lock: transaction.LOCK.UPDATE,
+            });
+            const limit = org?.chargeableNumberLimit ?? null;
+            if (limit != null) {
+              const chargeableTrunks = await Trunk.findAll({
+                where: { chargeable: true },
+                attributes: ['id'],
+                transaction,
+              });
+              const used = await PhoneNumber.count({
+                where: {
+                  organisationId,
+                  aplisayId: { [Op.in]: chargeableTrunks.map((t) => t.id) },
+                },
+                transaction,
+              });
+              if (used >= limit) {
+                const err = new Error(`Chargeable number limit reached (${used} of ${limit} in use)`);
+                err.code = 'chargeable_number_limit';
+                err.limit = limit;
+                err.used = used;
+                throw err;
+              }
+            }
+          }
+          return PhoneNumber.create({
+            number: normalizedNumber,
+            // Handler is always derived from the trunk (or defaulted) and cannot be chosen by the caller for DDI endpoints
+            handler: trunk.handler || 'livekit',
+            outbound: requestedOutbound,
+            organisationId: organisationId,
+            // Internally store the trunk association using the aplisayId foreign key
+            aplisayId: data.trunkId
+          }, { transaction });
+        });
+      } catch (err) {
+        if (err.code === 'chargeable_number_limit') {
+          return res.status(403).send({
+            error: err.message,
+            code: err.code,
+            limit: err.limit,
+            used: err.used
+          });
+        }
+        // The pre-check above races exact simultaneous claims; the PK constraint
+        // is the backstop — report it as the same conflict.
+        if (err.name === 'SequelizeUniqueConstraintError') {
+          return res.status(409).send({
+            error: 'Phone number already exists'
+          });
+        }
+        throw err;
+      }
 
       return res.status(201).send({
         success: true,
@@ -582,6 +637,22 @@ createPhoneEndpoint.apiDoc = {
                   type: 'string'
                 }
               }
+            }
+          }
+        }
+      }
+    },
+    403: {
+      description: 'Chargeable number limit reached — the organisation already holds its maximum number of DDIs on chargeable (non-owned) trunks',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              error: { type: 'string' },
+              code: { type: 'string', example: 'chargeable_number_limit' },
+              limit: { type: 'integer', description: 'The organisation\'s chargeable number limit' },
+              used: { type: 'integer', description: 'Numbers currently held on chargeable trunks' }
             }
           }
         }

--- a/api/paths/phone-endpoints/{identifier}.js
+++ b/api/paths/phone-endpoints/{identifier}.js
@@ -193,8 +193,10 @@ const updatePhoneEndpoint = async (req, res) => {
         return res.status(403).send({ error: 'Access denied' });
       }
 
-      // Update allowed fields for numbers
-      const allowedFields = ['outbound', 'handler'];
+      // Update allowed fields for numbers. `provisioned` marks carrier-side
+      // provisioning complete — set by the dashboard Buy-number flow once the
+      // provider has activated and pointed the number at the platform.
+      const allowedFields = ['outbound', 'handler', 'provisioned'];
       const updateFields = {};
       for (const field of allowedFields) {
         if (updateData[field] !== undefined) {
@@ -204,6 +206,9 @@ const updatePhoneEndpoint = async (req, res) => {
       // basic validation for number updates
       if (updateFields.outbound !== undefined && typeof updateFields.outbound !== 'boolean') {
         return res.status(400).send({ error: 'outbound must be a boolean value' });
+      }
+      if (updateFields.provisioned !== undefined && typeof updateFields.provisioned !== 'boolean') {
+        return res.status(400).send({ error: 'provisioned must be a boolean value' });
       }
       if (updateFields.handler !== undefined && !TELEPHONY_HANDLER_NAMES.includes(updateFields.handler)) {
         return res.status(400).send({ error: `handler must be one of: ${TELEPHONY_HANDLER_NAMES.join(', ')}` });

--- a/docs/number-lifecycle-adding-a-number.md
+++ b/docs/number-lifecycle-adding-a-number.md
@@ -14,6 +14,14 @@ To verify success, you should check **both**:
 - The number’s **`provisioned`** flag in Aplisay (internal readiness)
 - The number’s **`callReceived`** timestamp in Aplisay (proof at least one inbound call reached the Aplisay platform)
 
+> **Self-service purchase path:** the polite.ai dashboard's **Buy number** flow automates
+> this whole lifecycle for numbers on the shared chargeable Aplisay trunk — it reserves the
+> number here first (`POST /api/phone-endpoints`, which enforces the organisation's
+> `chargeableNumberLimit`, default 3), then allocates/activates it at the numbering provider
+> (Magrathea) and points it at the platform SIP ingress, then sets `provisioned=true` via
+> PUT. The steps below remain the manual path for BYO trunks and admin range provisioning.
+> See polite-ai `docs/buy-number-design.md`.
+
 ## Lifecycle steps
 
 ### 1) Provision the number (or range) on the external trunk provider

--- a/docs/phone-endpoints-api.md
+++ b/docs/phone-endpoints-api.md
@@ -108,6 +108,13 @@ Creates a new phone endpoint. Supports E.164 DDI (number on a trunk) and phone-r
 
 - **Request body**: `type`, `number` (or legacy `phoneNumber`), `trunkId`, and optionally `name`, `handler`, `outbound`.
 - Handler and outbound are constrained by the trunk: the effective handler is from the trunk, and `outbound` can only be `true` if the trunk has outbound enabled.
+- **Chargeable-number limit**: when the target trunk is **chargeable** (a platform carrier
+  trunk shared into the organisation — i.e. not owned by it), the organisation's
+  `chargeableNumberLimit` applies (default 3, `null` = unlimited; a platform billing policy
+  editable only via the organisations API under `organisation:setRate`). A claim beyond the
+  limit returns `403 { "error": "…", "code": "chargeable_number_limit", "limit": n, "used": n }`.
+  Numbers on the organisation's own (non-chargeable) trunks are never counted or limited.
+  Current allowance is readable at [`GET /api/number-quota`](#get-apinumber-quota).
 - **Response (201)**: `{ "success": true, "number": "1234567890" }` (number without `+`).
 
 **Example:**
@@ -172,7 +179,11 @@ The `options` object carries provider-specific and behavioural settings for the 
 Updates an existing phone endpoint.
 
 - **Path**: `identifier` is the E.164 number (with or without `+`) for DDI, or the registration ID for phone-registration.
-- **Body**: Only send fields you want to change. For E.164 DDI, only `outbound` and `handler` are updatable; for phone-registration, `name`, `outbound`, `handler`, `registrar`, `username`, `password`, and `options` can be updated. Updating credentials resets registration state.
+- **Body**: Only send fields you want to change. For E.164 DDI, `outbound`, `handler` and
+  `provisioned` are updatable (`provisioned` marks carrier-side provisioning complete — the
+  dashboard Buy-number flow sets it once the provider has activated the number and pointed it
+  at the platform); for phone-registration, `name`, `outbound`, `handler`, `registrar`,
+  `username`, `password`, and `options` can be updated. Updating credentials resets registration state.
 - **Response (200)**: `{ "success": true }`.
 
 ---
@@ -182,6 +193,26 @@ Updates an existing phone endpoint.
 Deletes a phone endpoint. `identifier` is the number (E.164) or registration ID.
 
 - **Response (200)**: `{ "success": true, "message": "Phone endpoint deleted successfully" }`.
+- **Purchased numbers**: deleting only removes the platform record — it does NOT deactivate
+  the number at the carrier. The polite-ai dashboard releases purchased numbers at the
+  numbering provider before calling this; API callers deleting a provisioned number on a
+  chargeable trunk must arrange the carrier release themselves (see
+  polite-ai `docs/buy-number-design.md`).
+
+---
+
+### GET /api/number-quota
+
+The caller organisation's allowance for numbers on **chargeable** (non-owned, carrier)
+trunks — backs the dashboard Buy-number flow. Requires `phoneEndpoint:read` and an
+organisation membership.
+
+- **Response (200)**: `{ "limit": 3, "used": 1, "remaining": 2 }` — `limit`/`remaining` are
+  `null` when the organisation is unlimited. Numbers on the organisation's own
+  (non-chargeable) trunks are not counted.
+- The limit itself is `Organisation.chargeableNumberLimit` (default 3), editable via the
+  organisations API under `organisation:setRate` (super admin billing policy — deliberately
+  not orgAdmin's `setLimits`).
 
 ---
 
@@ -230,7 +261,9 @@ Deletes a phone endpoint. `identifier` is the number (E.164) or registration ID.
 - All endpoints require authentication. Results are scoped to the caller’s organisation.
 - **400**: Validation failed, invalid body, or trunk not found / not in organisation.
 - **401**: Unauthorized.
-- **403**: Forbidden.
+- **403**: Forbidden — including `code: "chargeable_number_limit"` on POST when the
+  organisation has used its allowance of numbers on chargeable trunks (body carries
+  `limit` and `used`).
 - **404**: Endpoint not found (PUT/DELETE).
 - **409**: Phone number already exists (POST).
 - **500**: Server error.

--- a/lib/database.js
+++ b/lib/database.js
@@ -10,7 +10,10 @@ import { initPhoneRegistration } from './database-models/phone-registration.js';
 import { encryptSecret, decryptSecret } from './utils/credentials.js';
 import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-limits.js';
 
-const schemaVersion = 53;  // 53: billing Phase D7 — DROP the tariffs period-overlap EXCLUDE constraint;
+const schemaVersion = 54;  // 54: `organisations.chargeable_number_limit` (max numbers an org may hold on
+                           //     chargeable/non-owned trunks; default 3, null = unlimited). Enforced in
+                           //     createPhoneEndpoint for chargeable-trunk DDIs only.
+                           // 53: billing Phase D7 — DROP the tariffs period-overlap EXCLUDE constraint;
                            //     resolveTariff (latest start_date <= billedAt wins) makes overlapping /
                            //     open-ended same-name versions unambiguous, so the constraint was too strict.
                            // 52: billing Phase D5 — `tariff_prefixes.minimum_micros` (minimum carrier charge
@@ -1913,6 +1916,15 @@ Organisation.init({
     type: DataTypes.INTEGER,
     allowNull: true,
     defaultValue: null,
+  },
+  // Max numbers this org may hold on trunks it does not own (chargeable carrier
+  // trunks shared into the org — the trunk⇄org join means "usable by", so
+  // trunk.chargeable is the not-owned case). Enforced at phone-endpoint
+  // creation. null = unlimited (same semantics as agentLimit).
+  chargeableNumberLimit: {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+    defaultValue: 3,
   },
   status: {
     type: DataTypes.ENUM('provisional', 'active', 'suspended', 'deactivated'),

--- a/tests/chargeable-number-limit.test.mjs
+++ b/tests/chargeable-number-limit.test.mjs
@@ -10,6 +10,7 @@ import { randomUUID } from 'crypto';
  */
 describe('Chargeable number limit', () => {
   let createPhoneEndpoint;
+  let updatePhoneEndpoint;
   let getNumberQuota;
   let patchOrganisation;
 
@@ -59,9 +60,11 @@ describe('Chargeable number limit', () => {
   beforeAll(async () => {
     await setupRealDatabase();
     const phoneEndpointsModule = await import('../api/paths/phone-endpoints.js');
+    const identifierModule = await import('../api/paths/phone-endpoints/{identifier}.js');
     const quotaModule = await import('../api/paths/number-quota.js');
     const orgItemModule = await import('../api/paths/organisations/{organisationId}.js');
     createPhoneEndpoint = phoneEndpointsModule.default(mockLogger, {}, {}).POST;
+    updatePhoneEndpoint = identifierModule.default(mockLogger, {}, {}).PUT;
     getNumberQuota = quotaModule.default(mockLogger).GET;
     patchOrganisation = orgItemModule.default(mockLogger).PATCH;
   }, 30000);
@@ -220,6 +223,34 @@ describe('Chargeable number limit', () => {
     }
     const rejected = await claim(chargeableTrunkId);
     expect(rejected._status).toBe(403);
+  });
+
+  test('provisioned is settable via PUT once carrier work completes', async () => {
+    const number = nextNumber();
+    const created = await claim(chargeableTrunkId, { number });
+    expect(created._status).toBe(201);
+
+    const req = createMockRequest({
+      params: { identifier: number },
+      body: { provisioned: true }
+    });
+    const res = createMockResponse();
+    res.locals.user = { role: 'owner', organisationId: orgId };
+    await updatePhoneEndpoint(req, res);
+    expect(res._status).toBe(200);
+
+    const row = await PhoneNumber.findByPk(number.replace(/^\+/, ''));
+    expect(row.provisioned).toBe(true);
+
+    // Bad type is rejected.
+    const badReq = createMockRequest({
+      params: { identifier: number },
+      body: { provisioned: 'yes' }
+    });
+    const badRes = createMockResponse();
+    badRes.locals.user = { role: 'owner', organisationId: orgId };
+    await updatePhoneEndpoint(badReq, badRes);
+    expect(badRes._status).toBe(400);
   });
 
   test('concurrent claims cannot race past the limit', async () => {

--- a/tests/chargeable-number-limit.test.mjs
+++ b/tests/chargeable-number-limit.test.mjs
@@ -1,0 +1,234 @@
+import { setupRealDatabase, teardownRealDatabase, PhoneNumber, Organisation, Trunk } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+/**
+ * Organisation.chargeableNumberLimit — caps how many numbers an org may hold on
+ * chargeable (non-owned, carrier) trunks. Enforced in createPhoneEndpoint;
+ * numbers on the org's own (chargeable=false) trunks are never counted.
+ * Reported by GET /api/number-quota; editable only via the superAdmin billing
+ * policy action (organisation:setRate), NOT orgAdmin's setLimits.
+ */
+describe('Chargeable number limit', () => {
+  let createPhoneEndpoint;
+  let getNumberQuota;
+  let patchOrganisation;
+
+  let orgId;
+  let chargeableTrunkId;
+  let ownTrunkId;
+  let unique;
+  let seq;
+
+  const mockLogger = {
+    info: () => { },
+    error: () => { },
+    warn: () => { },
+    debug: () => { },
+    child: () => mockLogger
+  };
+
+  const createMockRequest = (data = {}) => ({
+    body: data.body || {},
+    params: data.params || {},
+    query: data.query || {},
+    headers: data.headers || {},
+    log: mockLogger,
+    ...data
+  });
+
+  const createMockResponse = () => ({
+    locals: { user: null },
+    _status: null,
+    _body: null,
+    status(code) { this._status = code; return this; },
+    send(body) { this._body = body; this._status = this._status || 200; return this; },
+    json(body) { this._body = body; this._status = this._status || 200; return this; },
+  });
+
+  // Distinct E.164 numbers per test run (PhoneNumber PK is the number itself).
+  const nextNumber = () => `+44${unique}${String(seq++).padStart(3, '0')}`;
+
+  const claim = async (trunkId, { user, number } = {}) => {
+    const req = createMockRequest({ body: { type: 'e164-ddi', number: number || nextNumber(), trunkId } });
+    const res = createMockResponse();
+    res.locals.user = user || { role: 'owner', organisationId: orgId };
+    await createPhoneEndpoint(req, res);
+    return res;
+  };
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    const phoneEndpointsModule = await import('../api/paths/phone-endpoints.js');
+    const quotaModule = await import('../api/paths/number-quota.js');
+    const orgItemModule = await import('../api/paths/organisations/{organisationId}.js');
+    createPhoneEndpoint = phoneEndpointsModule.default(mockLogger, {}, {}).POST;
+    getNumberQuota = quotaModule.default(mockLogger).GET;
+    patchOrganisation = orgItemModule.default(mockLogger).PATCH;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 60000);
+
+  beforeEach(async () => {
+    orgId = randomUUID();
+    // 9 unique digits: 3300 + 5 random; nextNumber appends 3 more (12 digits total).
+    unique = `3300${String(Math.floor(Math.random() * 90000) + 10000)}`;
+    seq = 0;
+    await Organisation.create({ id: orgId, name: 'Chargeable Limit Test Org' });
+
+    chargeableTrunkId = `test-chargeable-${orgId.slice(0, 8)}`;
+    const chargeableTrunk = await Trunk.create({
+      id: chargeableTrunkId,
+      name: 'Shared carrier trunk (we pay)',
+      handler: 'livekit',
+      outbound: false,
+      chargeable: true
+    });
+    await chargeableTrunk.addOrganisation(orgId);
+
+    ownTrunkId = `test-own-${orgId.slice(0, 8)}`;
+    const ownTrunk = await Trunk.create({
+      id: ownTrunkId,
+      name: 'Customer BYO trunk',
+      handler: 'livekit',
+      outbound: false,
+      chargeable: false
+    });
+    await ownTrunk.addOrganisation(orgId);
+  });
+
+  afterEach(async () => {
+    await PhoneNumber.destroy({ where: { organisationId: orgId } });
+    await Trunk.destroy({ where: { id: [chargeableTrunkId, ownTrunkId] } });
+    await Organisation.destroy({ where: { id: orgId } });
+  });
+
+  test('defaults to 3 on new organisations', async () => {
+    const org = await Organisation.findByPk(orgId);
+    expect(org.chargeableNumberLimit).toBe(3);
+  });
+
+  test('allows claims up to the limit on a chargeable trunk, rejects the next', async () => {
+    for (let i = 0; i < 3; i++) {
+      const res = await claim(chargeableTrunkId);
+      expect(res._status).toBe(201);
+      expect(res._body).toHaveProperty('success', true);
+    }
+    const rejected = await claim(chargeableTrunkId);
+    expect(rejected._status).toBe(403);
+    expect(rejected._body).toMatchObject({
+      code: 'chargeable_number_limit',
+      limit: 3,
+      used: 3
+    });
+  });
+
+  test("never counts or limits numbers on the org's own (non-chargeable) trunks", async () => {
+    // Well over the limit on the org's own trunk — all fine.
+    for (let i = 0; i < 5; i++) {
+      const res = await claim(ownTrunkId);
+      expect(res._status).toBe(201);
+    }
+    // The chargeable allowance is untouched by those.
+    for (let i = 0; i < 3; i++) {
+      const res = await claim(chargeableTrunkId);
+      expect(res._status).toBe(201);
+    }
+    const rejected = await claim(chargeableTrunkId);
+    expect(rejected._status).toBe(403);
+    expect(rejected._body.code).toBe('chargeable_number_limit');
+  });
+
+  test('null limit means unlimited', async () => {
+    await Organisation.update({ chargeableNumberLimit: null }, { where: { id: orgId } });
+    for (let i = 0; i < 5; i++) {
+      const res = await claim(chargeableTrunkId);
+      expect(res._status).toBe(201);
+    }
+  });
+
+  test('zero limit blocks all chargeable claims', async () => {
+    await Organisation.update({ chargeableNumberLimit: 0 }, { where: { id: orgId } });
+    const rejected = await claim(chargeableTrunkId);
+    expect(rejected._status).toBe(403);
+    expect(rejected._body).toMatchObject({ code: 'chargeable_number_limit', limit: 0, used: 0 });
+  });
+
+  test('number-quota reports limit / used / remaining for the caller org', async () => {
+    await claim(chargeableTrunkId);
+    // A number on the org's own trunk must not appear in `used`.
+    await claim(ownTrunkId);
+
+    const req = createMockRequest();
+    const res = createMockResponse();
+    res.locals.user = { role: 'owner', organisationId: orgId };
+    await getNumberQuota(req, res);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ limit: 3, used: 1, remaining: 2 });
+  });
+
+  test('number-quota reports unlimited as null limit/remaining', async () => {
+    await Organisation.update({ chargeableNumberLimit: null }, { where: { id: orgId } });
+    const req = createMockRequest();
+    const res = createMockResponse();
+    res.locals.user = { role: 'owner', organisationId: orgId };
+    await getNumberQuota(req, res);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ limit: null, used: 0, remaining: null });
+  });
+
+  test('number-quota requires an organisation', async () => {
+    const req = createMockRequest();
+    const res = createMockResponse();
+    res.locals.user = { role: 'owner' };
+    await getNumberQuota(req, res);
+    expect(res._status).toBe(403);
+  });
+
+  test('orgAdmin cannot raise their own chargeableNumberLimit (spend policy, not capacity)', async () => {
+    const req = createMockRequest({
+      params: { organisationId: orgId },
+      body: { chargeableNumberLimit: 100 }
+    });
+    const res = createMockResponse();
+    res.locals.user = { role: 'orgAdmin', organisationId: orgId };
+    await patchOrganisation(req, res);
+    expect(res._status).toBe(403);
+
+    const org = await Organisation.findByPk(orgId);
+    expect(org.chargeableNumberLimit).toBe(3);
+  });
+
+  test('superAdmin can set chargeableNumberLimit', async () => {
+    const req = createMockRequest({
+      params: { organisationId: orgId },
+      body: { chargeableNumberLimit: 5 }
+    });
+    const res = createMockResponse();
+    res.locals.user = { role: 'superAdmin', organisationId: randomUUID() };
+    await patchOrganisation(req, res);
+    expect(res._status).toBe(200);
+
+    const org = await Organisation.findByPk(orgId);
+    expect(org.chargeableNumberLimit).toBe(5);
+
+    // And the raised limit is live for claims.
+    for (let i = 0; i < 5; i++) {
+      const claimed = await claim(chargeableTrunkId);
+      expect(claimed._status).toBe(201);
+    }
+    const rejected = await claim(chargeableTrunkId);
+    expect(rejected._status).toBe(403);
+  });
+
+  test('concurrent claims cannot race past the limit', async () => {
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => claim(chargeableTrunkId))
+    );
+    const created = results.filter((r) => r._status === 201);
+    const rejected = results.filter((r) => r._status === 403);
+    expect(created.length).toBe(3);
+    expect(rejected.length).toBe(3);
+  });
+});


### PR DESCRIPTION

## What

- **`Organisation.chargeableNumberLimit`** (schema v54): INTEGER, default **3**, `null` = unlimited. Caps how many numbers an org may hold on **chargeable trunks** — carrier trunks shared into the org, i.e. trunks the org does not own (the trunk⇄org join means "usable by", so `chargeable: true` is precisely the non-owned case). Numbers on the org's own BYO/PBX trunks are never counted or limited.
- **Enforcement in `createPhoneEndpoint`**: when the target trunk is chargeable, the count + create run in one transaction behind a `FOR UPDATE` lock on the organisation row, so concurrent claims cannot race past the limit. Rejection: `403 { code: 'chargeable_number_limit', limit, used }`. Unique-PK races map to the existing 409.
- **`GET /api/number-quota`**: `{ limit, used, remaining }` for the caller's org (`phoneEndpoint:read`) — backs the drawer's allowance display.
- **`provisioned` settable via e164-ddi PUT** (boolean-validated): the buy flow marks a number provisioned once the carrier has activated it and pointed it at the platform. Previously the flag was write-only via direct DB access.
- **Org API exposure**: `chargeableNumberLimit` in list attrs / create / PATCH, gated on **`organisation:setRate`** (superAdmin billing policy) — deliberately NOT `setLimits`, which orgAdmin holds for their own org and could otherwise use to raise their own spend allowance. `agentLimit` keeps its existing `setLimits` gate.

## Tests

`tests/chargeable-number-limit.test.mjs` — 12 cases: default 3, allow-to-limit/reject-next, own-trunk numbers never counted, null unlimited, zero blocks, quota shapes, RBAC (orgAdmin cannot raise own limit; superAdmin can), provisioned PUT, and a 6-way concurrent-claim race (3 created / 3 rejected). Full suite: **466/466 pass** (42 suites).

