### PR TITLE
fix(livekit): dial consult transfer target with the raw requested number

### DIFF
--- a/agents/livekit/lib/telephony.ts
+++ b/agents/livekit/lib/telephony.ts
@@ -337,14 +337,11 @@ export async function dialTransferTargetToConsultation(
       aLegEncrypted,
     );
     
-    // Format destination number
-    const destinationFormatted = destination.replace(/^0/, "44").replace(/^(?!\+)/, "+");
-
     // For registration endpoints, we dial the destination number directly
     // The trunk is configured to route to the registrar, and we include the registration endpoint ID in headers
     const transferTargetParticipant = await sipClient.createSipParticipant(
       registrationTrunkId,
-      destinationFormatted, // Use phone number, trunk routes to registrar
+      destination, // Dial exactly as specified in the transfer request; trunk routes to the registrar
       consultRoomName,
       {
         participantIdentity: transferTargetIdentity,
@@ -365,7 +362,7 @@ export async function dialTransferTargetToConsultation(
       }
     );
 
-    logger.info({ transferTargetParticipant, consultRoomName, destinationFormatted, registrationEndpointId, registrationTrunkId, registrationUsername }, "transfer target dialed through registrar trunk with registration endpoint ID");
+    logger.info({ transferTargetParticipant, consultRoomName, destination, registrationEndpointId, registrationTrunkId, registrationUsername }, "transfer target dialed through registrar trunk with registration endpoint ID");
     return transferTargetParticipant;
   }
 
@@ -379,11 +376,9 @@ export async function dialTransferTargetToConsultation(
     throw new Error("No livekit outbound SIP trunk found");
   }
 
-  const destinationFormatted = destination.replace(/^0/, "44").replace(/^(?!\+)/, "+");
-
   const transferTargetParticipant = await sipClient.createSipParticipant(
     outboundSipTrunk.sipTrunkId,
-    destinationFormatted,
+    destination,
     consultRoomName,
     {
       participantIdentity: transferTargetIdentity,


### PR DESCRIPTION
## What

Dial the consultative (warm) transfer target using the **raw number from the transfer tool call's `number` field**, instead of normalising it to UK E.164 first.

`dialTransferTargetToConsultation` previously ran the destination through `destination.replace(/^0/, "44").replace(/^(?!\+)/, "+")` before `createSipParticipant`, on both the registration/B2BUA path and the outbound-trunk path. A tool call of `500` was therefore dialled as `+500`, and short / extension-style targets could not be reached.

This drops that normalisation so the consult path dials `destination` verbatim. The blind-bridge path (`bridgeParticipant`) already dials the raw `bridgeTo`, so this brings the two transfer paths into line.

## Why

Enables warm transfer to extensions / short codes (e.g. `500`) when the agent's `outboundCallFilter` permits them and the call egresses via a registration/B2BUA trunk to the customer PBX. Previously the unconditional `+` prefix broke extension matching on the PBX.

## Behaviour change to note

Callers that relied on the consult path auto-normalising national-format UK numbers (`07…`, `01…`, `0…`) to E.164 will now have the number passed through exactly as supplied in the tool call. The outbound SBC already receives raw numbers on the blind-bridge path today, so this is consistent with existing production behaviour — but transfer numbers should now be supplied in the form the target trunk expects.

Note: the transfer-number **validation** gate (default UK regex, or the agent's `outboundCallFilter`) is unchanged; short codes still require a suitable `outboundCallFilter` on the agent to pass validation.

## Scope

- `agents/livekit/lib/telephony.ts` — `dialTransferTargetToConsultation` only (both the registration/B2BUA and outbound-trunk branches, plus the corresponding log field). No other paths touched.

Not merged — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
