### PR TITLE
feat: allocate numbers onto global (non-org-owned) chargeable trunks

### DIFF
--- a/api/paths/phone-endpoints.js
+++ b/api/paths/phone-endpoints.js
@@ -267,19 +267,26 @@ const createPhoneEndpoint = async (req, res) => {
         });
       }
 
-      // Validate that the trunk exists and is associated with the organisation
-      const trunk = await Trunk.findByPk(data.trunkId, {
-        include: [{
-          model: Organisation,
-          where: { id: organisationId },
-          required: true
-        }]
-      });
-      
+      // Resolve the trunk. Chargeable trunks are shared platform carrier trunks
+      // (our public inbound/outbound trunks) that organisations consume but do
+      // not own — any org may allocate a number onto one (capped downstream by
+      // chargeableNumberLimit). Non-chargeable trunks are customer BYO/PBX/
+      // registration trunks and MUST be associated with the caller's org.
+      const trunk = await Trunk.findByPk(data.trunkId);
       if (!trunk) {
         return res.status(400).send({
-          error: 'Trunk not found or not associated with your organisation'
+          error: 'Trunk not found'
         });
+      }
+      if (!trunk.chargeable) {
+        const ownedByOrg = organisationId
+          ? await trunk.hasOrganisation(organisationId)
+          : false;
+        if (!ownedByOrg) {
+          return res.status(400).send({
+            error: 'Trunk not found or not associated with your organisation'
+          });
+        }
       }
 
       // Determine outbound behaviour: cannot exceed trunk's outbound capability

--- a/api/paths/trunks.js
+++ b/api/paths/trunks.js
@@ -13,23 +13,37 @@ export default function (logger) {
 const listTrunks = async (req, res) => {
   if (!requirePermission(res, 'trunk', 'read')) return;
   const { organisationId } = res.locals.user || {};
-  const { offset, pageSize } = req.query || {};
+  const { offset, pageSize, chargeable } = req.query || {};
+  const chargeableOnly = chargeable === 'true' || chargeable === '1';
   try {
     const startOffset = Math.max(0, parseInt(offset || '0', 10) || 0);
     const size = Math.min(200, Math.max(1, parseInt(pageSize || '50', 10) || 50));
-    
-    // Find trunks associated with the organisation through the many-to-many relationship
-    const rows = await Trunk.findAll({
-      include: [{
-        model: Organisation,
-        where: { id: organisationId },
-        required: true
-      }],
-      attributes: ['id', 'name', 'handler', 'outbound', 'chargeable', 'flags'],
-      limit: size,
-      offset: startOffset
-    });
-    
+
+    // Chargeable trunks are shared platform carrier trunks that organisations
+    // consume but do not own, so `chargeable=true` returns them GLOBALLY (no
+    // TrunkOrganisation filter) — this is how a caller finds a buy target for a
+    // number when their org owns no trunks. The default (unfiltered) listing
+    // stays org-scoped: it answers "which trunks are MINE to route with".
+    const rows = chargeableOnly
+      ? await Trunk.findAll({
+          where: { chargeable: true },
+          attributes: ['id', 'name', 'handler', 'outbound', 'chargeable', 'flags'],
+          order: [['id', 'ASC']],
+          limit: size,
+          offset: startOffset
+        })
+      : await Trunk.findAll({
+          // Find trunks associated with the organisation through the many-to-many relationship
+          include: [{
+            model: Organisation,
+            where: { id: organisationId },
+            required: true
+          }],
+          attributes: ['id', 'name', 'handler', 'outbound', 'chargeable', 'flags'],
+          limit: size,
+          offset: startOffset
+        });
+
     const nextOffset = rows.length === size ? startOffset + size : null;
     res.send({ items: rows, nextOffset });
   }
@@ -57,6 +71,14 @@ listTrunks.apiDoc = {
       name: 'pageSize', in: 'query', required: false,
       schema: { type: 'integer', minimum: 1, maximum: 200, default: 50 },
       description: 'Page size (max 200)'
+    },
+    {
+      name: 'chargeable', in: 'query', required: false,
+      schema: { type: 'boolean' },
+      description: 'When true, return the platform chargeable (carrier) trunks GLOBALLY, ignoring '
+        + 'organisation assignment. These are shared trunks any organisation may allocate numbers '
+        + 'onto (e.g. for the Buy-number flow); a chargeable trunk\'s flags.provider names the '
+        + 'numbering provider it fronts. Omit for the default org-scoped listing.'
     }
   ],
   responses: {

--- a/api/paths/trunks/{trunkId}.js
+++ b/api/paths/trunks/{trunkId}.js
@@ -51,7 +51,11 @@ export default function (logger) {
     const trunk = await Trunk.findByPk(req.params.trunkId, withOrgs);
     if (!trunk) return res.status(404).send({ message: `Trunk ${req.params.trunkId} not found` });
 
-    const { name, chargeable, organisationIds } = req.body || {};
+    const { name, chargeable, organisationIds, provider } = req.body || {};
+
+    if (provider !== undefined && provider !== null && typeof provider !== 'string') {
+      return res.status(400).send({ message: 'provider must be a string, or null to clear it' });
+    }
 
     // Validate the assignment set up-front (before any write) so a bad org id
     // fails cleanly rather than part-applying the trunk field edits.
@@ -72,6 +76,15 @@ export default function (logger) {
         // name is nullable in the model; treat an empty string as "clear it".
         if (name !== undefined) trunk.name = typeof name === 'string' && name.trim() ? name.trim() : null;
         if (chargeable !== undefined) trunk.chargeable = !!chargeable;
+        // provider is stored under flags.provider (the numbering provider this
+        // chargeable trunk fronts, e.g. "magrathea"); reassign flags so the
+        // JSONB column is marked dirty. Empty/null clears it.
+        if (provider !== undefined) {
+          const flags = { ...(trunk.flags || {}) };
+          if (provider && provider.trim()) flags.provider = provider.trim();
+          else delete flags.provider;
+          trunk.flags = Object.keys(flags).length ? flags : null;
+        }
         await trunk.save({ transaction });
         // setOrganisations reconciles the TrunkOrganisation join table to exactly
         // `orgs` (adds/removes rows); only touch it when the caller sent the field.
@@ -97,6 +110,7 @@ export default function (logger) {
             properties: {
               name: { type: 'string', nullable: true, description: 'Free-form human name; empty clears it' },
               chargeable: { type: 'boolean', description: 'Whether outbound minutes are destination-billed to the org' },
+              provider: { type: 'string', nullable: true, description: 'Numbering provider this chargeable trunk fronts (stored under flags.provider, e.g. "magrathea"); the Buy-number flow lands a bought number on the chargeable trunk whose provider matches the carrier it was bought from. Empty/null clears it.' },
               organisationIds: {
                 type: 'array',
                 items: { type: 'string' },

--- a/docs/phone-endpoints-api.md
+++ b/docs/phone-endpoints-api.md
@@ -108,8 +108,15 @@ Creates a new phone endpoint. Supports E.164 DDI (number on a trunk) and phone-r
 
 - **Request body**: `type`, `number` (or legacy `phoneNumber`), `trunkId`, and optionally `name`, `handler`, `outbound`.
 - Handler and outbound are constrained by the trunk: the effective handler is from the trunk, and `outbound` can only be `true` if the trunk has outbound enabled.
-- **Chargeable-number limit**: when the target trunk is **chargeable** (a platform carrier
-  trunk shared into the organisation — i.e. not owned by it), the organisation's
+- **Trunk eligibility**: a **chargeable** trunk is a shared platform carrier trunk that
+  organisations consume but do not own — **any** organisation may allocate a number onto one
+  (there is no `TrunkOrganisation` association to satisfy). A **non-chargeable** trunk is a
+  customer BYO/PBX/registration trunk and MUST be associated with the caller's organisation.
+  A missing trunk id returns `400 "Trunk not found"`; a real but unowned non-chargeable trunk
+  returns `400 "Trunk not found or not associated with your organisation"`. Discover the
+  platform chargeable trunks with [`GET /api/trunks?chargeable=true`](#get-apitrunks) (global,
+  each carrying `flags.provider`).
+- **Chargeable-number limit**: on a chargeable trunk the organisation's
   `chargeableNumberLimit` applies (default 3, `null` = unlimited; a platform billing policy
   editable only via the organisations API under `organisation:setRate`). A claim beyond the
   limit returns `403 { "error": "…", "code": "chargeable_number_limit", "limit": n, "used": n }`.

--- a/tests/chargeable-trunk-global.test.mjs
+++ b/tests/chargeable-trunk-global.test.mjs
@@ -1,0 +1,185 @@
+import { setupRealDatabase, teardownRealDatabase, PhoneNumber, Organisation, Trunk } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+/**
+ * Chargeable trunks are shared PLATFORM carrier trunks: organisations consume
+ * but do not own them (no TrunkOrganisation row). So createPhoneEndpoint must
+ * let any org allocate onto a chargeable trunk regardless of association, while
+ * still requiring ownership for non-chargeable BYO trunks. The Buy-number flow
+ * discovers them via GET /api/trunks?chargeable=true (global) and matches the
+ * carrier by flags.provider, which superAdmin sets via PATCH /api/trunks/{id}.
+ */
+describe('Chargeable trunks are global (not org-owned)', () => {
+  let createPhoneEndpoint;
+  let listTrunks;
+  let patchTrunk;
+
+  let orgId;
+  let otherOrgId;
+  let chargeableTrunkId;
+  let byoTrunkId;
+  let unique;
+  let seq;
+
+  const mockLogger = {
+    info: () => { }, error: () => { }, warn: () => { }, debug: () => { }, child: () => mockLogger,
+  };
+
+  const req = (data = {}) => ({ body: data.body || {}, params: data.params || {}, query: data.query || {}, headers: {}, log: mockLogger, ...data });
+  const res = () => ({
+    locals: { user: null },
+    _status: null,
+    _body: null,
+    status(c) { this._status = c; return this; },
+    send(b) { this._body = b; this._status = this._status || 200; return this; },
+    json(b) { this._body = b; this._status = this._status || 200; return this; },
+  });
+
+  const nextNumber = () => `+44${unique}${String(seq++).padStart(3, '0')}`;
+
+  const claim = async (trunkId, { user, number } = {}) => {
+    const r = req({ body: { type: 'e164-ddi', number: number || nextNumber(), trunkId } });
+    const s = res();
+    s.locals.user = user || { role: 'owner', organisationId: orgId };
+    await createPhoneEndpoint(r, s);
+    return s;
+  };
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    const phoneEndpointsModule = await import('../api/paths/phone-endpoints.js');
+    const trunksModule = await import('../api/paths/trunks.js');
+    const trunkItemModule = await import('../api/paths/trunks/{trunkId}.js');
+    createPhoneEndpoint = phoneEndpointsModule.default(mockLogger, {}, {}).POST;
+    listTrunks = trunksModule.default(mockLogger).GET;
+    patchTrunk = trunkItemModule.default(mockLogger).PATCH;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 60000);
+
+  beforeEach(async () => {
+    orgId = randomUUID();
+    otherOrgId = randomUUID();
+    unique = `3301${String(Math.floor(Math.random() * 90000) + 10000)}`;
+    seq = 0;
+    await Organisation.create({ id: orgId, name: 'Consuming Org' });
+    await Organisation.create({ id: otherOrgId, name: 'Other Org' });
+
+    // A GLOBAL chargeable trunk — deliberately NOT associated with any org.
+    chargeableTrunkId = `test-global-chargeable-${orgId.slice(0, 8)}`;
+    await Trunk.create({
+      id: chargeableTrunkId,
+      name: 'Aplisay carrier (Magrathea)',
+      handler: 'jambonz',
+      outbound: false,
+      chargeable: true,
+      flags: { provider: 'magrathea' },
+    });
+
+    // A non-chargeable BYO trunk owned by `otherOrgId` (NOT our org).
+    byoTrunkId = `test-byo-${orgId.slice(0, 8)}`;
+    const byo = await Trunk.create({
+      id: byoTrunkId, name: 'Someone else PBX', handler: 'livekit', outbound: false, chargeable: false,
+    });
+    await byo.addOrganisation(otherOrgId);
+  });
+
+  afterEach(async () => {
+    await PhoneNumber.destroy({ where: { organisationId: [orgId, otherOrgId] } });
+    await Trunk.destroy({ where: { id: [chargeableTrunkId, byoTrunkId] } });
+    await Organisation.destroy({ where: { id: [orgId, otherOrgId] } });
+  });
+
+  test('an org with NO trunk assignments can allocate onto a global chargeable trunk', async () => {
+    const s = await claim(chargeableTrunkId);
+    expect(s._status).toBe(201);
+    expect(s._body).toMatchObject({ success: true, trunkId: chargeableTrunkId });
+    const row = await PhoneNumber.findByPk(s._body.number);
+    expect(row.organisationId).toBe(orgId);
+    expect(row.aplisayId).toBe(chargeableTrunkId);
+    // Handler is derived from the trunk (routes the number to the right ingress).
+    expect(row.handler).toBe('jambonz');
+  });
+
+  test('a non-chargeable trunk the org does NOT own is still rejected', async () => {
+    const s = await claim(byoTrunkId);
+    expect(s._status).toBe(400);
+    expect(s._body.error).toMatch(/not associated with your organisation/i);
+  });
+
+  test('an unknown trunk is rejected as not found', async () => {
+    const s = await claim(`no-such-trunk-${orgId.slice(0, 8)}`);
+    expect(s._status).toBe(400);
+    expect(s._body.error).toMatch(/not found/i);
+  });
+
+  test('a non-chargeable trunk the org DOES own still works (regression)', async () => {
+    const ownTrunkId = `test-own-${orgId.slice(0, 8)}`;
+    const own = await Trunk.create({ id: ownTrunkId, name: 'My PBX', handler: 'livekit', outbound: false, chargeable: false });
+    await own.addOrganisation(orgId);
+    try {
+      const s = await claim(ownTrunkId);
+      expect(s._status).toBe(201);
+    } finally {
+      await PhoneNumber.destroy({ where: { aplisayId: ownTrunkId } });
+      await Trunk.destroy({ where: { id: ownTrunkId } });
+    }
+  });
+
+  test('GET /trunks?chargeable=true returns the global chargeable trunk with its provider, for an org that owns nothing', async () => {
+    const r = req({ query: { chargeable: 'true' } });
+    const s = res();
+    s.locals.user = { role: 'owner', organisationId: orgId };
+    await listTrunks(r, s);
+    expect(s._status).toBe(200);
+    const mine = s._body.items.find((t) => t.id === chargeableTrunkId);
+    expect(mine).toBeTruthy();
+    expect(mine.chargeable).toBe(true);
+    expect(mine.flags?.provider).toBe('magrathea');
+    // The default org-scoped listing must NOT surface it (org owns no trunks).
+    const r2 = req({ query: {} });
+    const s2 = res();
+    s2.locals.user = { role: 'owner', organisationId: orgId };
+    await listTrunks(r2, s2);
+    expect(s2._body.items.find((t) => t.id === chargeableTrunkId)).toBeFalsy();
+  });
+
+  test('superAdmin can set and clear flags.provider on a trunk', async () => {
+    const set = res();
+    set.locals.user = { role: 'superAdmin' };
+    await patchTrunk(req({ params: { trunkId: chargeableTrunkId }, body: { provider: 'gamma' } }), set);
+    expect(set._status).toBe(200);
+    expect(set._body.flags.provider).toBe('gamma');
+
+    const cleared = res();
+    cleared.locals.user = { role: 'superAdmin' };
+    await patchTrunk(req({ params: { trunkId: chargeableTrunkId }, body: { provider: null } }), cleared);
+    expect(cleared._status).toBe(200);
+    expect(cleared._body.flags?.provider ?? null).toBeNull();
+  });
+
+  test('setting provider does not disturb other flags', async () => {
+    await Trunk.update({ flags: { host: 'sbc.aplisay.net', provider: 'magrathea' } }, { where: { id: chargeableTrunkId } });
+    const s = res();
+    s.locals.user = { role: 'superAdmin' };
+    await patchTrunk(req({ params: { trunkId: chargeableTrunkId }, body: { provider: 'twilio' } }), s);
+    expect(s._status).toBe(200);
+    expect(s._body.flags).toMatchObject({ host: 'sbc.aplisay.net', provider: 'twilio' });
+  });
+
+  test('a non-super caller cannot set provider', async () => {
+    const s = res();
+    s.locals.user = { role: 'owner', organisationId: orgId };
+    await patchTrunk(req({ params: { trunkId: chargeableTrunkId }, body: { provider: 'x' } }), s);
+    expect(s._status).toBe(403);
+  });
+
+  test('provider of the wrong type is rejected', async () => {
+    const s = res();
+    s.locals.user = { role: 'superAdmin' };
+    await patchTrunk(req({ params: { trunkId: chargeableTrunkId }, body: { provider: 123 } }), s);
+    expect(s._status).toBe(400);
+  });
+});

--- a/tests/phone-endpoints-comprehensive.test.mjs
+++ b/tests/phone-endpoints-comprehensive.test.mjs
@@ -714,7 +714,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
 
       // Since trunk validation is implemented, this should fail with trunk not found
       expect(res._status).toBe(400);
-      expect(res._body).toHaveProperty('error', 'Trunk not found or not associated with your organisation');
+      expect(res._body).toHaveProperty('error', 'Trunk not found');
     });
 
     test('should create phone registration endpoint', async () => {
@@ -996,7 +996,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
       await createPhoneEndpoint(req, res);
 
       expect(res._status).toBe(400);
-      expect(res._body).toHaveProperty('error', 'Trunk not found or not associated with your organisation');
+      expect(res._body).toHaveProperty('error', 'Trunk not found');
     });
 
     test('should return 409 for duplicate phone registration (same registrar and username)', async () => {
@@ -2593,7 +2593,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
 
       await createPhoneEndpoint(invalidDdiReq, invalidDdiRes);
       expect(invalidDdiRes._status).toBe(400);
-      expect(invalidDdiRes._body).toHaveProperty('error', 'Trunk not found or not associated with your organisation');
+      expect(invalidDdiRes._body).toHaveProperty('error', 'Trunk not found');
     });
   });
 


### PR DESCRIPTION
Fixes the Buy-number flow for the real trunk topology: **chargeable trunks are shared platform carrier trunks that organisations consume but do not own** (no `TrunkOrganisation` row). The original implementation assumed they were shared *into* each org, so both number-creation and trunk-listing org-scoped them out of reach — an org that owns no trunk (the normal case) got *"No chargeable trunk is available."*

## Changes

- **`createPhoneEndpoint`**: a **chargeable** trunk is usable by any org without association (still capped by `chargeableNumberLimit`); a **non-chargeable** BYO/PBX trunk still requires org ownership (via `hasOrganisation`). A missing trunk now returns the precise `"Trunk not found"`; a real-but-unowned non-chargeable trunk keeps `"Trunk not found or not associated with your organisation"`.
- **`GET /api/trunks?chargeable=true`**: returns the platform chargeable trunks **globally** (ignoring `TrunkOrganisation`) so a caller whose org owns no trunk can still find a buy target. The default listing stays org-scoped.
- **`PATCH /api/trunks/{id}`**: superAdmin can set `flags.provider` (the numbering provider a chargeable trunk fronts, e.g. `"magrathea"`); the buy flow lands a bought number on the chargeable trunk whose provider matches the carrier it came from.

## Tests

`tests/chargeable-trunk-global.test.mjs` (9): an org owning nothing can allocate onto a global chargeable trunk; a non-chargeable unowned trunk is still rejected; missing vs unowned error messages; the `?chargeable=true` global scope vs the org-scoped default; superAdmin set/clear `flags.provider` without disturbing other flags; RBAC + type validation. Updated 3 comprehensive assertions for the now-precise not-found message. **Full suite 479/479 green.**

