### PR TITLE
feat: superAdmin all-trunks list (scope=all) + trunk create

### DIFF
--- a/api/paths/trunks.js
+++ b/api/paths/trunks.js
@@ -1,55 +1,156 @@
 import { Trunk, Organisation, Op } from '../../lib/database.js';
 import { requirePermission } from '../../lib/auth/permissions.js';
+import { TELEPHONY_HANDLER_NAMES } from '../../lib/handlers/index.js';
+
+const TRUNK_ATTRS = ['id', 'name', 'handler', 'outbound', 'chargeable', 'flags'];
+const withOrgs = { include: [{ model: Organisation, attributes: ['id'], through: { attributes: [] } }] };
+const projectWithOrgs = (t) => ({
+  id: t.id,
+  name: t.name ?? null,
+  handler: t.handler ?? null,
+  outbound: !!t.outbound,
+  chargeable: !!t.chargeable,
+  flags: t.flags ?? null,
+  organisationIds: (t.Organisations || []).map((o) => o.id),
+});
 
 let log;
 
 export default function (logger) {
   log = logger;
   return {
-    GET: listTrunks
+    GET: listTrunks,
+    POST: createTrunk
   };
 };
 
 const listTrunks = async (req, res) => {
   if (!requirePermission(res, 'trunk', 'read')) return;
   const { organisationId } = res.locals.user || {};
-  const { offset, pageSize, chargeable } = req.query || {};
+  const { offset, pageSize, chargeable, scope } = req.query || {};
   const chargeableOnly = chargeable === 'true' || chargeable === '1';
+  const allScope = scope === 'all';
+  // The cross-tenant "every trunk" view is a super-admin administration surface
+  // (see + edit + assign to any org), so it needs `trunk:assign`, not just read.
+  if (allScope && !requirePermission(res, 'trunk', 'assign')) return;
   try {
     const startOffset = Math.max(0, parseInt(offset || '0', 10) || 0);
     const size = Math.min(200, Math.max(1, parseInt(pageSize || '50', 10) || 50));
 
-    // Chargeable trunks are shared platform carrier trunks that organisations
-    // consume but do not own, so `chargeable=true` returns them GLOBALLY (no
-    // TrunkOrganisation filter) — this is how a caller finds a buy target for a
-    // number when their org owns no trunks. The default (unfiltered) listing
-    // stays org-scoped: it answers "which trunks are MINE to route with".
-    const rows = chargeableOnly
-      ? await Trunk.findAll({
-          where: { chargeable: true },
-          attributes: ['id', 'name', 'handler', 'outbound', 'chargeable', 'flags'],
-          order: [['id', 'ASC']],
-          limit: size,
-          offset: startOffset
-        })
-      : await Trunk.findAll({
-          // Find trunks associated with the organisation through the many-to-many relationship
-          include: [{
-            model: Organisation,
-            where: { id: organisationId },
-            required: true
-          }],
-          attributes: ['id', 'name', 'handler', 'outbound', 'chargeable', 'flags'],
-          limit: size,
-          offset: startOffset
-        });
+    // Three listing modes:
+    //  - scope=all (super): EVERY trunk, each with its organisationIds, for the
+    //    admin trunk manager.
+    //  - chargeable=true: the shared platform carrier trunks GLOBALLY (orgs
+    //    consume but don't own them) — how a caller finds a buy target.
+    //  - default: org-scoped — "which trunks are MINE to route with".
+    let rows;
+    let mapped;
+    if (allScope) {
+      rows = await Trunk.findAll({ ...withOrgs, order: [['id', 'ASC']], limit: size, offset: startOffset });
+      mapped = rows.map(projectWithOrgs);
+    } else if (chargeableOnly) {
+      rows = await Trunk.findAll({
+        where: { chargeable: true },
+        attributes: TRUNK_ATTRS,
+        order: [['id', 'ASC']],
+        limit: size,
+        offset: startOffset
+      });
+      mapped = rows;
+    } else {
+      rows = await Trunk.findAll({
+        // Find trunks associated with the organisation through the many-to-many relationship
+        include: [{ model: Organisation, where: { id: organisationId }, required: true }],
+        attributes: TRUNK_ATTRS,
+        limit: size,
+        offset: startOffset
+      });
+      mapped = rows;
+    }
 
     const nextOffset = rows.length === size ? startOffset + size : null;
-    res.send({ items: rows, nextOffset });
+    res.send({ items: mapped, nextOffset });
   }
   catch (err) {
     req.log?.error(err, 'listing trunks');
     res.status(500).send({ error: 'Internal server error' });
+  }
+};
+
+const TRUNK_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+/**
+ * Create a trunk (super admin, `trunk:create`). Trunks are a curated platform
+ * resource; the `id` is an admin-supplied stable identifier (it is what numbers
+ * reference via aplisayId and typically mirrors the carrier/telephony platform
+ * trunk), NOT generated. Optionally chargeable (a shared carrier trunk) with a
+ * `provider` tag, and assigned to organisations up-front.
+ */
+const createTrunk = async (req, res) => {
+  if (!requirePermission(res, 'trunk', 'create')) return;
+  const { id, name, handler, outbound, chargeable, provider, organisationIds } = req.body || {};
+
+  const trunkId = typeof id === 'string' ? id.trim() : '';
+  if (!TRUNK_ID_RE.test(trunkId)) {
+    return res.status(400).send({ message: 'id is required: 1–128 chars, letters/digits/._- and must start alphanumeric' });
+  }
+  if (handler !== undefined && handler !== null && !TELEPHONY_HANDLER_NAMES.includes(handler)) {
+    return res.status(400).send({ message: `handler must be one of: ${TELEPHONY_HANDLER_NAMES.join(', ')}` });
+  }
+  if (provider !== undefined && provider !== null && typeof provider !== 'string') {
+    return res.status(400).send({ message: 'provider must be a string, or null' });
+  }
+  if (outbound !== undefined && typeof outbound !== 'boolean') {
+    return res.status(400).send({ message: 'outbound must be a boolean' });
+  }
+  if (chargeable !== undefined && typeof chargeable !== 'boolean') {
+    return res.status(400).send({ message: 'chargeable must be a boolean' });
+  }
+
+  // Validate the org-assignment set up-front so a bad id fails cleanly.
+  let orgs = null;
+  if (organisationIds !== undefined) {
+    if (!Array.isArray(organisationIds) || organisationIds.some((o) => typeof o !== 'string')) {
+      return res.status(400).send({ message: 'organisationIds must be an array of organisation ids' });
+    }
+    const unique = [...new Set(organisationIds)];
+    orgs = await Organisation.findAll({ where: { id: unique }, attributes: ['id'] });
+    if (orgs.length !== unique.length) {
+      return res.status(400).send({ message: 'One or more organisationIds do not exist' });
+    }
+  }
+
+  try {
+    const existing = await Trunk.findByPk(trunkId);
+    if (existing) {
+      return res.status(409).send({ message: `Trunk ${trunkId} already exists` });
+    }
+
+    const flags = {};
+    if (typeof provider === 'string' && provider.trim()) flags.provider = provider.trim();
+
+    await Trunk.sequelize.transaction(async (transaction) => {
+      const trunk = await Trunk.create({
+        id: trunkId,
+        name: typeof name === 'string' && name.trim() ? name.trim() : null,
+        handler: handler ?? null,
+        outbound: !!outbound,
+        chargeable: !!chargeable,
+        flags: Object.keys(flags).length ? flags : null,
+      }, { transaction });
+      if (orgs && orgs.length) await trunk.setOrganisations(orgs, { transaction });
+    });
+
+    const fresh = await Trunk.findByPk(trunkId, withOrgs);
+    return res.status(201).send(projectWithOrgs(fresh));
+  }
+  catch (err) {
+    // Unique-violation backstop for a race between the pre-check and create.
+    if (err?.name === 'SequelizeUniqueConstraintError') {
+      return res.status(409).send({ message: `Trunk ${trunkId} already exists` });
+    }
+    log?.error({ err: err?.message }, 'creating trunk');
+    return res.status(400).send({ message: err?.message || 'Failed to create trunk' });
   }
 };
 
@@ -79,6 +180,13 @@ listTrunks.apiDoc = {
         + 'organisation assignment. These are shared trunks any organisation may allocate numbers '
         + 'onto (e.g. for the Buy-number flow); a chargeable trunk\'s flags.provider names the '
         + 'numbering provider it fronts. Omit for the default org-scoped listing.'
+    },
+    {
+      name: 'scope', in: 'query', required: false,
+      schema: { type: 'string', enum: ['all'] },
+      description: 'scope=all (super admin, `trunk:assign`) returns EVERY trunk on the platform, '
+        + 'each with its organisationIds, for the admin trunk manager (see + edit + assign to any '
+        + 'org). Ignored/forbidden for non-super callers.'
     }
   ],
   responses: {
@@ -101,7 +209,8 @@ listTrunks.apiDoc = {
                     handler: { type: 'string', nullable: true, description: 'Telephony handler for this trunk (e.g. livekit, jambonz)' },
                     outbound: { type: 'boolean', description: 'Whether this trunk can be used for outbound calls' },
                     chargeable: { type: 'boolean', description: 'Whether outbound minutes on this trunk are destination-billed to the org (our carrier trunks); false for BYO/inbound/registration trunks' },
-                    flags: { type: 'object', nullable: true, description: 'JSON object containing trunk flags (e.g., canRefer)' }
+                    flags: { type: 'object', nullable: true, description: 'JSON object containing trunk flags (e.g., canRefer, provider)' },
+                    organisationIds: { type: 'array', items: { type: 'string' }, description: 'Organisations this trunk is assigned to (only present for scope=all)' }
                   }
                 }
               },
@@ -117,6 +226,44 @@ listTrunks.apiDoc = {
         'application/json': { schema: { $ref: '#/components/schemas/Error' } }
       }
     }
+  }
+};
+
+createTrunk.apiDoc = {
+  summary: 'Create a trunk (super admin).',
+  description: `Create a platform trunk. Trunks are a curated resource; the id is an
+                admin-supplied stable identifier (it is what phone numbers reference and
+                typically mirrors the carrier / telephony platform trunk), not generated.
+                A chargeable trunk is a shared carrier trunk (any org may allocate numbers
+                onto it) and may carry a numbering provider tag; it can be assigned to
+                organisations up-front.`,
+  operationId: 'createTrunk',
+  tags: ['Phone Endpoints'],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string', description: 'Stable trunk identifier (1–128 chars, letters/digits/._- , starts alphanumeric)' },
+            name: { type: 'string', nullable: true, description: 'Free-form human name' },
+            handler: { type: 'string', enum: TELEPHONY_HANDLER_NAMES, nullable: true, description: 'Telephony handler this trunk routes via' },
+            outbound: { type: 'boolean', default: false, description: 'Whether the trunk supports outbound calls' },
+            chargeable: { type: 'boolean', default: false, description: 'Shared carrier trunk whose outbound minutes are destination-billed' },
+            provider: { type: 'string', nullable: true, description: 'Numbering provider a chargeable trunk fronts (stored under flags.provider)' },
+            organisationIds: { type: 'array', items: { type: 'string' }, description: 'Organisations to assign this trunk to' }
+          }
+        }
+      }
+    }
+  },
+  responses: {
+    201: { description: 'Created trunk (with organisationIds)' },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    409: { description: 'A trunk with this id already exists', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    default: { description: 'An error occurred', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
   }
 };
 

--- a/docs/phone-endpoints-api.md
+++ b/docs/phone-endpoints-api.md
@@ -223,6 +223,24 @@ organisation membership.
 
 ---
 
+### Trunk administration (super admin)
+
+Trunks are a curated platform resource. Ordinary callers get the org-scoped listing
+(`GET /api/trunks`) and `chargeable=true` (global carrier trunks); super admins additionally get:
+
+- **`GET /api/trunks?scope=all`** (`trunk:assign`): EVERY trunk on the platform, each with its
+  `organisationIds`, for the admin trunk manager (see + edit + assign to any org). A non-super
+  caller passing `scope=all` gets `403`.
+- **`POST /api/trunks`** (`trunk:create`): create a trunk. Body: `id` (**required, admin-supplied**
+  stable identifier — 1–128 chars `[A-Za-z0-9][A-Za-z0-9._-]*`; it is what numbers reference via
+  `aplisayId` and typically mirrors the carrier/telephony trunk, so it is not generated), plus
+  optional `name`, `handler` (`jambonz`/`livekit`/`pipecat`), `outbound`, `chargeable`, `provider`
+  (→ `flags.provider`), and `organisationIds`. Duplicate `id` → `409`; returns `201` with the
+  created trunk incl. `organisationIds`.
+- Editing name / chargeable / provider / org assignments is `PATCH /api/trunks/{id}` (`trunk:assign`).
+
+---
+
 ## Using the API for managing telephone numbers
 
 ### Listing and filtering

--- a/lib/auth/permissions.js
+++ b/lib/auth/permissions.js
@@ -32,7 +32,7 @@ export const statements = {
 
   // Telephony / calls / billing
   phoneEndpoint: ['claim', 'read', 'update', 'release'],
-  trunk: ['read', 'assign'],
+  trunk: ['read', 'assign', 'create'],
   call: ['read', 'listen'],
   recording: ['read', 'download', 'delete'],
   usage: ['read', 'readAll'], // readAll = cross-tenant
@@ -143,7 +143,7 @@ export const roles = {
       usage: ['read', 'readAll'],
       rate: ['read', 'readAll', 'create', 'update', 'delete'],
       tariff: ['read', 'readAll', 'create', 'update', 'delete'],
-      trunk: ['read', 'assign'],
+      trunk: ['read', 'assign', 'create'],
       system: ['readConfig', 'manage'],
       user: ['create', 'read', 'readAll', 'update', 'delete', 'ban', 'setRole', 'setLimits', 'setPermissions', 'impersonate'],
       organisation: ['create', 'read', 'readAll', 'update', 'delete', 'verify', 'setLimits', 'setRate', 'credit', 'billing', 'setPermissions'],

--- a/tests/trunk-admin.test.mjs
+++ b/tests/trunk-admin.test.mjs
@@ -1,0 +1,125 @@
+import { setupRealDatabase, teardownRealDatabase, Trunk, Organisation, Op } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+/**
+ * SuperAdmin trunk administration:
+ *  - GET /api/trunks?scope=all → EVERY trunk with organisationIds (trunk:assign).
+ *  - POST /api/trunks → create a trunk with an admin-supplied id (trunk:create).
+ * Both are super-only; ordinary callers keep the org-scoped list and no create.
+ */
+describe('SuperAdmin trunk administration', () => {
+  let listTrunks;
+  let createTrunk;
+
+  let orgId;
+  let tag;
+
+  const mockLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, child: () => mockLogger };
+  const req = (data = {}) => ({ body: data.body || {}, params: data.params || {}, query: data.query || {}, headers: {}, log: mockLogger, ...data });
+  const res = () => ({
+    locals: { user: null },
+    _status: null,
+    _body: null,
+    status(c) { this._status = c; return this; },
+    send(b) { this._body = b; this._status = this._status || 200; return this; },
+    json(b) { this._body = b; this._status = this._status || 200; return this; },
+  });
+
+  const superUser = () => ({ role: 'superAdmin' });
+  const ownerUser = () => ({ role: 'owner', organisationId: orgId });
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    const trunksModule = await import('../api/paths/trunks.js');
+    listTrunks = trunksModule.default(mockLogger).GET;
+    createTrunk = trunksModule.default(mockLogger).POST;
+  }, 30000);
+
+  afterAll(async () => { await teardownRealDatabase(); }, 60000);
+
+  beforeEach(async () => {
+    orgId = randomUUID();
+    tag = orgId.slice(0, 8);
+    await Organisation.create({ id: orgId, name: 'Trunk Admin Test Org' });
+  });
+
+  afterEach(async () => {
+    await Trunk.destroy({ where: { id: { [Op.like]: `ta-${tag}-%` } } }).catch(() => {});
+    await Organisation.destroy({ where: { id: orgId } });
+  });
+
+  const create = async (body, user = superUser()) => {
+    const r = req({ body }); const s = res(); s.locals.user = user;
+    await createTrunk(r, s); return s;
+  };
+
+  test('superAdmin creates a trunk with an admin-supplied id, provider and org assignment', async () => {
+    const id = `ta-${tag}-carrier`;
+    const s = await create({ id, name: 'Carrier', handler: 'jambonz', outbound: true, chargeable: true, provider: 'magrathea', organisationIds: [orgId] });
+    expect(s._status).toBe(201);
+    expect(s._body).toMatchObject({ id, name: 'Carrier', handler: 'jambonz', outbound: true, chargeable: true });
+    expect(s._body.flags.provider).toBe('magrathea');
+    expect(s._body.organisationIds).toEqual([orgId]);
+    const row = await Trunk.findByPk(id);
+    expect(row).toBeTruthy();
+  });
+
+  test('duplicate id is a 409', async () => {
+    const id = `ta-${tag}-dup`;
+    expect((await create({ id })). _status).toBe(201);
+    expect((await create({ id })). _status).toBe(409);
+  });
+
+  test('a bad id is rejected', async () => {
+    for (const id of ['', '   ', 'has space', '.startsdot', 'x'.repeat(129)]) {
+      expect((await create({ id })). _status).toBe(400);
+    }
+  });
+
+  test('an unknown handler is rejected', async () => {
+    expect((await create({ id: `ta-${tag}-h`, handler: 'nope' })). _status).toBe(400);
+  });
+
+  test('a non-existent organisationId is rejected before any create', async () => {
+    const id = `ta-${tag}-badorg`;
+    const s = await create({ id, organisationIds: ['no-such-org'] });
+    expect(s._status).toBe(400);
+    expect(await Trunk.findByPk(id)).toBeNull();
+  });
+
+  test('a non-super caller cannot create a trunk', async () => {
+    const s = await create({ id: `ta-${tag}-x` }, ownerUser());
+    expect(s._status).toBe(403);
+  });
+
+  test('scope=all returns every trunk with organisationIds (superAdmin)', async () => {
+    const a = `ta-${tag}-a`, b = `ta-${tag}-b`;
+    await create({ id: a, chargeable: true, provider: 'magrathea' });
+    await create({ id: b, organisationIds: [orgId] });
+
+    const r = req({ query: { scope: 'all', pageSize: '200' } }); const s = res(); s.locals.user = superUser();
+    await listTrunks(r, s);
+    expect(s._status).toBe(200);
+    const ids = s._body.items.map((t) => t.id);
+    expect(ids).toEqual(expect.arrayContaining([a, b]));
+    const bRow = s._body.items.find((t) => t.id === b);
+    expect(bRow.organisationIds).toEqual([orgId]);
+  });
+
+  test('a non-super caller cannot use scope=all', async () => {
+    const r = req({ query: { scope: 'all' } }); const s = res(); s.locals.user = ownerUser();
+    await listTrunks(r, s);
+    expect(s._status).toBe(403);
+  });
+
+  test('the default listing stays org-scoped (no cross-tenant leak)', async () => {
+    const mine = `ta-${tag}-mine`, other = `ta-${tag}-other`;
+    await create({ id: mine, organisationIds: [orgId] });
+    await create({ id: other }); // assigned to nobody
+    const r = req({ query: { pageSize: '200' } }); const s = res(); s.locals.user = ownerUser();
+    await listTrunks(r, s);
+    const ids = s._body.items.map((t) => t.id);
+    expect(ids).toContain(mine);
+    expect(ids).not.toContain(other);
+  });
+});


### PR DESCRIPTION
Two superAdmin trunk-administration capabilities. Trunks are a curated platform resource with **no application create path** (they were seeded manually), and the list was **org-scoped only** — so a superAdmin couldn't see trunks owned by *other* orgs to edit/assign them, nor create new ones.

## Changes

- **`GET /api/trunks?scope=all`** (`trunk:assign`): returns **every** trunk on the platform, each with its `organisationIds`, for the admin trunk manager (see + edit + assign to any org). A non-super caller passing `scope=all` gets `403`; the default listing stays org-scoped (no cross-tenant leak).
- **`POST /api/trunks`** (new **`trunk:create`**, superAdmin): create a trunk with an **admin-supplied `id`** (it's what numbers reference via `aplisayId` and mirrors the carrier/telephony trunk, so it is *not* generated) plus `name` / `handler` (`jambonz`/`livekit`/`pipecat`) / `outbound` / `chargeable` / `provider` (→ `flags.provider`) / `organisationIds`. Duplicate id → `409`; validation on id, handler, provider, orgs.
- **RBAC**: add `trunk:create`, granted to superAdmin.

## Tests

`tests/trunk-admin.test.mjs` (9): create with id/provider/org assignment; duplicate → 409; bad id / handler / non-existent org rejected; non-super cannot create or use `scope=all`; `scope=all` returns every trunk with `organisationIds`; the default list stays org-scoped. **Full suite 488/488 green.**

