### PR TITLE
fix(trunks): honour coerced boolean for ?chargeable=true (buy-number staging bug)

### DIFF
--- a/api/paths/trunks.js
+++ b/api/paths/trunks.js
@@ -28,7 +28,12 @@ const listTrunks = async (req, res) => {
   if (!requirePermission(res, 'trunk', 'read')) return;
   const { organisationId } = res.locals.user || {};
   const { offset, pageSize, chargeable, scope } = req.query || {};
-  const chargeableOnly = chargeable === 'true' || chargeable === '1';
+  // NB: the `chargeable` query param is declared `type: boolean` in the apiDoc,
+  // so express-openapi COERCES it to a real boolean (`true`) in the running app
+  // — it only arrives as the string 'true' from raw/direct callers and tests.
+  // Accept both, or the coerced boolean silently falls through to the org-scoped
+  // branch (the same truthy convention the `originate` param relies on).
+  const chargeableOnly = chargeable === true || chargeable === 'true' || chargeable === '1';
   const allScope = scope === 'all';
   // The cross-tenant "every trunk" view is a super-admin administration surface
   // (see + edit + assign to any org), so it needs `trunk:assign`, not just read.

--- a/tests/chargeable-trunk-global.test.mjs
+++ b/tests/chargeable-trunk-global.test.mjs
@@ -146,6 +146,19 @@ describe('Chargeable trunks are global (not org-owned)', () => {
     expect(s2._body.items.find((t) => t.id === chargeableTrunkId)).toBeFalsy();
   });
 
+  test('chargeable is honoured as a COERCED boolean (as express-openapi delivers it), not just the string', async () => {
+    // In the running app the `chargeable` query param is declared type:boolean,
+    // so it arrives as the boolean `true`, not the string 'true'. A non-super
+    // org owning nothing must STILL get the global chargeable trunk — otherwise
+    // it silently falls through to the empty org-scoped list (the staging bug).
+    const r = req({ query: { chargeable: true } });
+    const s = res();
+    s.locals.user = { role: 'owner', organisationId: otherOrgId }; // owns nothing chargeable
+    await listTrunks(r, s);
+    expect(s._status).toBe(200);
+    expect(s._body.items.find((t) => t.id === chargeableTrunkId)).toBeTruthy();
+  });
+
   test('superAdmin can set and clear flags.provider on a trunk', async () => {
     const set = res();
     set.locals.user = { role: 'superAdmin' };


### PR DESCRIPTION
## The bug
On staging, buying a number failed with *"Number purchasing isn't configured — the platform has no chargeable carrier trunk"* even though a correctly-configured chargeable `magrathea` trunk existed.

Root cause: the `chargeable` query param on `GET /api/trunks` is declared `type: boolean` in the apiDoc, so **express-openapi coerces it to a real boolean** at runtime. The handler checked `chargeable === 'true'` (string), so `chargeableOnly` was **always false** in the deployed app and every `?chargeable=true` request silently fell through to the **org-scoped** branch.

That's why it looked non-deterministic: a superAdmin (whose org owns the trunk) saw it via the org-scoped fallback, while a buyer whose org owns nothing got an empty list. `scope=all` was fine (`type: string`, not coerced away). The global chargeable-trunk listing (from #139) **never actually worked in deployment**.

## Diagnosis (staging)
Confirmed the deployed image's `trunks.js` is byte-identical to `next` (no revert), single DB `llmvoicestaging`, correct trunk row — then traced the runtime split to the coercion via the codebase's own `originate` param, which is `type: boolean` and read with a truthy `if (originate)`.

## Fix
`chargeable === true || chargeable === 'true' || chargeable === '1'` — accept the coerced boolean and raw strings, matching the `originate` convention.

Regression test passes `chargeable: true` **as a boolean** (as express-openapi delivers it): it fails on the old check, passes on the fix. The prior tests + stub all used the raw string `'true'`, which is why this slipped through. Full suite **489/489**.

Should be merged and **staging redeployed** to unblock buy-number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)