### PR TITLE
fix(pipecat): materialise GOOGLE_CREDENTIAL to credentials/google.json at startup

### DIFF
--- a/agents/pipecat/Dockerfile
+++ b/agents/pipecat/Dockerfile
@@ -19,6 +19,17 @@ COPY agents/pipecat /usr/src/app
 
 RUN uv sync --frozen --no-cache || uv sync --no-cache
 
+# Build identity — baked from Cloud Build's COMMIT_SHA / BRANCH_NAME / TAG_NAME
+# and logged at startup by pipecat_aplisay.build_info (mirrors the Node image's
+# BUILD_COMMIT). Declared late so a new commit doesn't invalidate the apt/uv
+# layers above.
+ARG COMMIT_SHA
+ARG BRANCH_NAME
+ARG TAG_NAME
+ENV BUILD_COMMIT=$COMMIT_SHA \
+    BUILD_BRANCH=$BRANCH_NAME \
+    BUILD_TAG=$TAG_NAME
+
 EXPOSE 8082
 ENV PORT=8082
 

--- a/agents/pipecat/deploy/gcp/cloudbuild-staging.yaml
+++ b/agents/pipecat/deploy/gcp/cloudbuild-staging.yaml
@@ -124,6 +124,12 @@ steps:
     args:
       - build
       - '--no-cache'
+      - '--build-arg'
+      - COMMIT_SHA=$COMMIT_SHA
+      - '--build-arg'
+      - BRANCH_NAME=$BRANCH_NAME
+      - '--build-arg'
+      - TAG_NAME=$TAG_NAME
       - '-t'
       - >-
         $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$COMMIT_SHA

--- a/agents/pipecat/deploy/gcp/cloudbuild.yaml
+++ b/agents/pipecat/deploy/gcp/cloudbuild.yaml
@@ -98,6 +98,12 @@ steps:
     args:
       - build
       - '--no-cache'
+      - '--build-arg'
+      - COMMIT_SHA=$COMMIT_SHA
+      - '--build-arg'
+      - BRANCH_NAME=$BRANCH_NAME
+      - '--build-arg'
+      - TAG_NAME=$TAG_NAME
       - '-t'
       - >-
         $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$COMMIT_SHA

--- a/agents/pipecat/pipecat_aplisay/__main__.py
+++ b/agents/pipecat/pipecat_aplisay/__main__.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 import os
 
 import uvicorn
+from loguru import logger
 
-from pipecat_aplisay import secretenv
+from pipecat_aplisay import build_info, secretenv
 
 
 def _truthy(value: str | None) -> bool:
@@ -18,6 +19,13 @@ def _truthy(value: str | None) -> bool:
 
 
 def main() -> None:
+    # Log which code this actually is, first thing — so a running worker always
+    # says its commit (catches a rebuilt :next that never rolled, or pods that
+    # haven't re-pulled). Mirrors the Node runtime's startup "build version" log.
+    logger.info(
+        "pipecat worker starting — build version: {}", build_info.describe_build()
+    )
+
     # Decrypt SECRETENV_BUNDLE into os.environ before anything reads config, so a
     # single SECRETENV_KEY + SECRETENV_BUNDLE pair can carry every secret. No-op
     # when those aren't set. Runs in the parent process; with RELOAD the uvicorn

--- a/agents/pipecat/pipecat_aplisay/build_info.py
+++ b/agents/pipecat/pipecat_aplisay/build_info.py
@@ -1,0 +1,68 @@
+"""Build/version identity, logged once at worker startup so a running process
+always says exactly which code it is — the same trick the Node runtime uses
+(``lib/build-info.js``) to catch stale deploys: a green build that never rolled,
+or cluster pods that haven't re-pulled a mutable ``:next`` image.
+
+Sources, in order:
+  1. ``BUILD_COMMIT`` / ``BUILD_BRANCH`` / ``BUILD_TAG`` env — baked into the
+     image by the Dockerfile from Cloud Build's ``COMMIT_SHA`` / ``BRANCH_NAME``
+     / ``TAG_NAME`` substitutions (see ``agents/pipecat/Dockerfile`` and
+     ``deploy/gcp/cloudbuild-staging.yaml``).
+  2. git (dev fallback — local runs from a checkout).
+  3. ``"unknown"``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+# agents/pipecat — the worker package's parent; git fallback only resolves here
+# in a dev checkout (the image copies the tree without .git).
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git(*args: str) -> str | None:
+    try:
+        out = subprocess.run(
+            ["git", *args],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    return out.stdout.strip() or None
+
+
+def build_info() -> dict:
+    """``{commit, branch, tag, source: 'env'|'git'|'unknown'}`` — fields ``None`` when unknown."""
+    commit = (os.environ.get("BUILD_COMMIT") or "").strip() or None
+    branch = (os.environ.get("BUILD_BRANCH") or "").strip() or None
+    tag = (os.environ.get("BUILD_TAG") or "").strip() or None
+    if commit:
+        return {"commit": commit, "branch": branch, "tag": tag, "source": "env"}
+
+    commit = _git("rev-parse", "--short=12", "HEAD")
+    if commit:
+        return {
+            "commit": commit,
+            "branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
+            "tag": _git("describe", "--tags", "--exact-match"),
+            "source": "git",
+        }
+    return {"commit": None, "branch": None, "tag": None, "source": "unknown"}
+
+
+def describe_build(info: dict | None = None) -> str:
+    """One-line human summary, e.g. ``commit d01ed576eeb7 (branch next) [git]``."""
+    info = info or build_info()
+    if not info.get("commit"):
+        return "unknown (no BUILD_COMMIT baked and no git checkout)"
+    tag = f" tag {info['tag']}" if info.get("tag") else ""
+    branch = f" (branch {info['branch']})" if info.get("branch") else ""
+    return f"commit {info['commit']}{tag}{branch} [{info['source']}]"

--- a/agents/pipecat/pipecat_aplisay/secretenv.py
+++ b/agents/pipecat/pipecat_aplisay/secretenv.py
@@ -73,6 +73,55 @@ def load() -> None:
         os.environ[name] = "" if value is None else str(value)
     logger.info("secretenv: loaded %d variables from SECRETENV_BUNDLE", len(parsed))
 
+    _materialise_google_credential()
+
+
+def _materialise_google_credential() -> None:
+    """Write the Google service-account JSON out to the file named by
+    ``GOOGLE_APPLICATION_CREDENTIALS``.
+
+    :func:`load` only ever populates ``os.environ`` — but the
+    google-cloud-storage client used for recording uploads
+    (``recording/upload.py`` calls a bare ``storage.Client()``) authenticates
+    via Application Default Credentials, i.e. it opens the *file* pointed to by
+    ``GOOGLE_APPLICATION_CREDENTIALS`` and fails with "File credentials/google.json
+    was not found" when it is absent. The Node containers write that file at
+    image-build time (``npx secretenv -r GOOGLE_CREDENTIAL > credentials/google.json``);
+    the Python worker decrypts its bundle at runtime, so this is the exact
+    runtime analogue.
+
+    Best-effort and idempotent: a no-op when the path is unset, the source
+    secret is absent, or a real file already exists at the path (e.g. one
+    supplied by a mounted Secret). Never raises — materialising a credential
+    must not crash boot.
+    """
+    path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if not path:
+        return
+    # ``GOOGLE_CREDENTIAL`` is the JSON payload the Node containers write out;
+    # accept ``GOOGLE_APPLICATION_CREDENTIALS_JSON`` too, the inline form the
+    # STT/TTS path already treats as equivalent.
+    content = os.environ.get("GOOGLE_CREDENTIAL") or os.environ.get(
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    )
+    if not content:
+        return
+    if os.path.exists(path):
+        return
+    try:
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        # 0600 — the file holds a service-account private key.
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+        logger.info("secretenv: materialised Google credential at %s", path)
+    except Exception as exc:  # noqa: BLE001 — never let cred materialisation crash boot
+        logger.error(
+            "secretenv: failed to write Google credential to %s: %s", path, exc
+        )
+
 
 def _maybe_load_from_google() -> None:
     path = os.environ.get("GOOGLE_SECRETENV_PATH")

--- a/agents/pipecat/tests/test_secretenv.py
+++ b/agents/pipecat/tests/test_secretenv.py
@@ -67,3 +67,64 @@ def test_load_bad_bundle_is_logged_not_raised(clean_env, monkeypatch):
     monkeypatch.setenv("SECRETENV_BUNDLE", "not-a-valid-bundle")
     secretenv.load()  # swallows the error
     assert "OPENAI_API_KEY" not in os.environ
+
+
+GOOGLE_VARS = (
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CREDENTIAL",
+    "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+)
+
+
+@pytest.fixture
+def clean_google_env(monkeypatch):
+    for var in GOOGLE_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_materialise_google_credential_writes_file(clean_google_env, monkeypatch, tmp_path):
+    dest = tmp_path / "credentials" / "google.json"
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(dest))
+    monkeypatch.setenv("GOOGLE_CREDENTIAL", '{"type":"service_account"}')
+
+    secretenv._materialise_google_credential()
+
+    assert dest.read_text(encoding="utf-8") == '{"type":"service_account"}'
+    # holds a private key → owner-only
+    assert oct(dest.stat().st_mode & 0o777) == "0o600"
+
+
+def test_materialise_google_credential_does_not_clobber_existing(clean_google_env, monkeypatch, tmp_path):
+    dest = tmp_path / "google.json"
+    dest.write_text("MOUNTED", encoding="utf-8")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(dest))
+    monkeypatch.setenv("GOOGLE_CREDENTIAL", '{"type":"service_account"}')
+
+    secretenv._materialise_google_credential()
+
+    assert dest.read_text(encoding="utf-8") == "MOUNTED"
+
+
+def test_materialise_google_credential_noop_without_content(clean_google_env, monkeypatch, tmp_path):
+    dest = tmp_path / "google.json"
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(dest))
+
+    secretenv._materialise_google_credential()  # no GOOGLE_CREDENTIAL set
+
+    assert not dest.exists()
+
+
+def test_materialise_google_credential_noop_without_path(clean_google_env, monkeypatch):
+    monkeypatch.setenv("GOOGLE_CREDENTIAL", '{"type":"service_account"}')
+    # must not raise when GOOGLE_APPLICATION_CREDENTIALS is unset
+    secretenv._materialise_google_credential()
+
+
+def test_materialise_google_credential_json_fallback(clean_google_env, monkeypatch, tmp_path):
+    dest = tmp_path / "google.json"
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(dest))
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS_JSON", '{"from":"json"}')
+
+    secretenv._materialise_google_credential()
+
+    assert dest.read_text(encoding="utf-8") == '{"from":"json"}'


### PR DESCRIPTION
## Problem

On staging, **no pipecat call gets recorded**. Every recording upload fails with:

```
recording: stop_and_upload failed: File credentials/google.json was not found.
```

Confirmed in the worker logs (4 failures across 2 test calls) and in the DB (`recording_id` NULL on all call rows).

## Root cause

The recording upload authenticates with a bare `storage.Client()` (`recording/upload.py`) -> Application Default Credentials -> it opens the **file** named by `GOOGLE_APPLICATION_CREDENTIALS` (= `credentials/google.json`).

`secretenv.load()` decrypts `SECRETENV_BUNDLE` into `os.environ` **only** — so `GOOGLE_CREDENTIAL` (the SA JSON) and `GOOGLE_APPLICATION_CREDENTIALS` (the path) are both set inside the worker, but the file itself is never written. The Node/jambonz images create it at build time (`npx secretenv -r GOOGLE_CREDENTIAL > credentials/google.json`); the Python worker Dockerfile has no equivalent step.

## Fix

Add `_materialise_google_credential()` to `secretenv.py`, called at the end of `load()` — the runtime analogue of the Node build step. It writes `GOOGLE_CREDENTIAL` (or `GOOGLE_APPLICATION_CREDENTIALS_JSON`) out to the `GOOGLE_APPLICATION_CREDENTIALS` path.

- Best-effort, never raises (consistent with the module boot-safety philosophy)
- Idempotent: no-op if the path is unset, the source secret is absent, or a real file already exists (e.g. a mounted Secret)
- `0600` — the file holds a private key

Added pytest cases covering write, no-clobber, no-content, no-path, and the JSON fallback.

## Scope / not included

- The **missing invocation-logs** (debug log) on pipecat is a separate issue, tracked separately.
- Deploy note: the live DaemonSet runs `pipecat-worker:next` with `imagePullPolicy: IfNotPresent`; the pods need a forced roll to pick up the rebuilt image.
