### PR TITLE
fix(pipecat): capture & persist per-call invocation logs (debug log)

### DIFF
--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -27,6 +27,7 @@ from loguru import logger
 from pipecat.pipeline.runner import PipelineRunner
 
 from . import api_client
+from . import invocation_log
 from .agent_tools import build_agent_tools
 from .mcp_tools import close_mcp_servers, connect_mcp_servers
 from .constants import DISCONNECT_REASONS, PLATFORM
@@ -630,50 +631,68 @@ class CallSession:
 
     async def _run_prepared_once(self, task, max_duration_secs: Optional[int]) -> None:
         """One pipeline execution (see :meth:`run_prepared`)."""
-        runner = PipelineRunner(handle_sigint=False)
-        self._runner = runner
-        self._task = task
+        # Bind this segment's callId into loguru's context for the whole run, so
+        # every log emitted while the pipeline runs (ours and Pipecat's own) is
+        # captured into the per-call InvocationLog buffer and flushed below.
+        # self.call is only swapped to the continuation in run_prepared, AFTER
+        # this returns, so it's stable for this segment — capture it up front.
+        seg_call = self.call
+        with logger.contextualize(callId=seg_call.id):
+            runner = PipelineRunner(handle_sigint=False)
+            self._runner = runner
+            self._task = task
 
-        timeout_task: Optional[asyncio.Task] = None
-        if max_duration_secs:
-            timeout_task = asyncio.create_task(self._timeout_watchdog(max_duration_secs))
+            timeout_task: Optional[asyncio.Task] = None
+            if max_duration_secs:
+                timeout_task = asyncio.create_task(self._timeout_watchdog(max_duration_secs))
 
-        kick_transport = self._handover_webrtc_kick
-        self._handover_webrtc_kick = None
-        kick_task: Optional[asyncio.Task] = None
-        if kick_transport is not None:
-            kick_task = asyncio.create_task(
-                self._fire_rebuilt_webrtc_connected(kick_transport)
-            )
-
-        try:
-            await runner.run(task)
-            if self._pending_agent_handover is not None:
-                # Full agent-stack handover: the old pipeline was cancelled on
-                # purpose, the old call record is already ended with a pointer
-                # to its continuation, and run() restarts on the live transport.
-                logger.bind(call_id=self.call.id).info(
-                    "pipeline ended for agent handover; not ending the call"
+            kick_transport = self._handover_webrtc_kick
+            self._handover_webrtc_kick = None
+            kick_task: Optional[asyncio.Task] = None
+            if kick_transport is not None:
+                kick_task = asyncio.create_task(
+                    self._fire_rebuilt_webrtc_connected(kick_transport)
                 )
-            else:
-                # Normal completion when transport disconnects or pipeline ends.
-                await self._end(DISCONNECT_REASONS["ORIGINAL_PARTICIPANT"])
-        finally:
-            if kick_task and not kick_task.done():
-                kick_task.cancel()
-            if timeout_task and not timeout_task.done():
-                timeout_task.cancel()
-            # Tear down any WebRTC-origin relay leg / consult leg this session
-            # was bridged to, so the telephony side and its Call record don't
-            # outlive the browser caller.
-            await self._teardown_relay()
-            # Finalise the recording once the runner has stopped. The
-            # AudioBufferProcessor has already drained any in-flight frames by
-            # this point, so no more ``on_audio_data`` events will fire.
-            await self._finalise_recording()
-            # Release any MCP server connections opened in prepare_run.
-            await close_mcp_servers(self._mcp_closers, log=logger)
-            self._mcp_closers = []
+
+            try:
+                await runner.run(task)
+                if self._pending_agent_handover is not None:
+                    # Full agent-stack handover: the old pipeline was cancelled on
+                    # purpose, the old call record is already ended with a pointer
+                    # to its continuation, and run() restarts on the live transport.
+                    logger.bind(call_id=self.call.id).info(
+                        "pipeline ended for agent handover; not ending the call"
+                    )
+                else:
+                    # Normal completion when transport disconnects or pipeline ends.
+                    await self._end(DISCONNECT_REASONS["ORIGINAL_PARTICIPANT"])
+            finally:
+                if kick_task and not kick_task.done():
+                    kick_task.cancel()
+                if timeout_task and not timeout_task.done():
+                    timeout_task.cancel()
+                # Tear down any WebRTC-origin relay leg / consult leg this session
+                # was bridged to, so the telephony side and its Call record don't
+                # outlive the browser caller.
+                await self._teardown_relay()
+                # Finalise the recording once the runner has stopped. The
+                # AudioBufferProcessor has already drained any in-flight frames by
+                # this point, so no more ``on_audio_data`` events will fire.
+                await self._finalise_recording()
+                # Persist this segment's captured logs as its InvocationLog (the
+                # UI "debug log"), keyed to this segment's own Call record — the
+                # per-call analogue of the LiveKit agent's job-shutdown persist.
+                try:
+                    await invocation_log.flush_invocation_logs(
+                        call_id=seg_call.id,
+                        user_id=seg_call.userId,
+                        org_id=seg_call.organisationId,
+                    )
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(f"invocation log flush failed: {e}")
+                # Release any MCP server connections opened in prepare_run.
+                await close_mcp_servers(self._mcp_closers, log=logger)
+                self._mcp_closers = []
 
     async def inject_dtmf(self, digit: str) -> bool:
         """Inject a DTMF keypress into the running pipeline as an

--- a/agents/pipecat/pipecat_aplisay/invocation_log.py
+++ b/agents/pipecat/pipecat_aplisay/invocation_log.py
@@ -1,56 +1,159 @@
-"""Invocation-log buffer — section 9.3 of docs/livekit-agent-architecture.md.
+"""Invocation-log capture — the per-call "debug log" surfaced in the UI.
 
-Buffer is process-wide, callId-tagged. The contract is structured logging with a
-flush at shutdown via ``POST /api/agent-db/invocation-log``. Specific log shapes
-are implementation choice — we use loguru entries serialised as dicts.
+A loguru sink (installed by :func:`install_capture`) buffers every *call-scoped*
+log record — one emitted while ``callId`` is bound into loguru's context via
+``logger.contextualize(callId=...)`` in :class:`CallSession` — keyed by that
+callId. At the end of each call segment the session drains its own entries and
+POSTs them to ``POST /api/agent-db/invocation-log`` (see
+:func:`flush_invocation_logs`), mirroring how the LiveKit agent persists an
+InvocationLog at job shutdown (``agents/livekit/lib/voice-agent-runtime.ts``).
+
+Only call-scoped records are buffered, so on a long-running worker the buffer
+stays bounded to the logs of in-flight calls — idle/system logging is dropped
+rather than accumulated forever.
 """
 
 from __future__ import annotations
 
-import asyncio
 import os
+import threading
 from typing import Any
 
 from loguru import logger
 
 from . import api_client
 
+# Process-wide, callId-tagged. Guarded by a threading.Lock: the loguru sink runs
+# synchronously in whatever thread emitted the log (possibly a worker thread,
+# e.g. ``asyncio.to_thread``), while flush runs on the event loop.
 _BUFFER: list[dict[str, Any]] = []
-_LOCK = asyncio.Lock()
+_LOCK = threading.Lock()
+_installed = False
+
+# Soft cap so a pathologically long / verbose call can't grow the buffer without
+# bound; when exceeded we drop the oldest entry (the server prunes anyway).
+_MAX_ENTRIES = 20_000
 
 
-async def append(entry: dict[str, Any]) -> None:
-    async with _LOCK:
+def _record_to_entry(record: dict) -> dict[str, Any]:
+    extra = dict(record.get("extra") or {})
+    call_id = extra.pop("callId", None)
+    entry: dict[str, Any] = {
+        "callId": call_id,
+        "ts": record["time"].isoformat(),
+        "level": record["level"].name,
+        "logger": record["name"],
+        "function": record["function"],
+        "line": record["line"],
+        "message": record["message"],
+    }
+    if extra:
+        entry["extra"] = extra
+    exc = record.get("exception")
+    if exc is not None:
+        entry["exception"] = repr(exc)
+    return entry
+
+
+def _capture_sink(message) -> None:
+    """loguru sink: buffer call-scoped records (those with a bound ``callId``)."""
+    record = message.record
+    if not (record.get("extra") or {}).get("callId"):
+        return  # only capture logs emitted within a call's context
+    try:
+        entry = _record_to_entry(record)
+    except Exception:  # noqa: BLE001 — logging must never raise
+        return
+    with _LOCK:
         _BUFFER.append(entry)
+        if len(_BUFFER) > _MAX_ENTRIES:
+            del _BUFFER[0]
 
 
-async def flush_invocation_logs(subsystem: str = "pipecat-agent") -> None:
-    """Drain the buffer and POST it to llm-agent."""
-    async with _LOCK:
-        batch = list(_BUFFER)
-        _BUFFER.clear()
+def install_capture(level: str | None = None) -> None:
+    """Register the buffering sink on the shared loguru logger (idempotent).
 
+    Call once at worker startup, after all imports, so nothing later resets the
+    handler set out from under us. Adds a handler; the existing stderr sink is
+    left untouched, so console output is unchanged.
+    """
+    global _installed
+    if _installed:
+        return
+    logger.add(
+        _capture_sink,
+        level=(level or os.environ.get("LOGLEVEL", "INFO")).upper(),
+        enqueue=False,
+        backtrace=False,
+        diagnose=False,
+    )
+    _installed = True
+
+
+def _drain(call_id: str | None) -> list[dict[str, Any]]:
+    """Remove and return buffered entries — one call's, or all when ``call_id`` is None."""
+    with _LOCK:
+        if call_id is None:
+            batch = list(_BUFFER)
+            _BUFFER.clear()
+            return batch
+        keep: list[dict[str, Any]] = []
+        batch: list[dict[str, Any]] = []
+        for entry in _BUFFER:
+            (batch if (entry.get("callId") or "system") == call_id else keep).append(entry)
+        if batch:
+            _BUFFER[:] = keep
+        return batch
+
+
+async def _post(
+    call_id: str, entries: list[dict], user_id: str, org_id: str, subsystem: str
+) -> None:
+    try:
+        await api_client.save_invocation_log(
+            {
+                "userId": user_id,
+                "organisationId": org_id,
+                "callId": call_id,
+                "subsystem": subsystem,
+                "log": entries,
+            }
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"invocation log POST failed for {call_id}: {e}")
+
+
+async def flush_invocation_logs(
+    call_id: str | None = None,
+    user_id: str | None = None,
+    org_id: str | None = None,
+    subsystem: str = "pipecat-agent",
+) -> None:
+    """Drain buffered logs and POST them to llm-agent.
+
+    With ``call_id`` (the per-call path — ``CallSession`` at segment end): drain
+    only that call's entries and attribute them to the call's own ``user_id`` /
+    ``org_id``. Without ``call_id`` (the shutdown safety net): drain everything,
+    grouped by callId, falling back to the worker's env identity for stragglers.
+    """
+    batch = _drain(call_id)
     if not batch:
         return
 
-    user_id = os.environ.get("WORKER_USER_ID", "")
-    org_id = os.environ.get("WORKER_ORGANISATION_ID", "")
+    if call_id is not None:
+        await _post(
+            call_id,
+            batch,
+            user_id or os.environ.get("WORKER_USER_ID", ""),
+            org_id or os.environ.get("WORKER_ORGANISATION_ID", ""),
+            subsystem,
+        )
+        return
 
+    env_user = os.environ.get("WORKER_USER_ID", "")
+    env_org = os.environ.get("WORKER_ORGANISATION_ID", "")
     by_call: dict[str, list[dict]] = {}
     for entry in batch:
-        call_id = entry.get("callId") or "system"
-        by_call.setdefault(call_id, []).append(entry)
-
-    for call_id, entries in by_call.items():
-        try:
-            await api_client.save_invocation_log(
-                {
-                    "userId": user_id,
-                    "organisationId": org_id,
-                    "callId": call_id,
-                    "subsystem": subsystem,
-                    "log": entries,
-                }
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.warning(f"invocation log POST failed for {call_id}: {e}")
+        by_call.setdefault(entry.get("callId") or "system", []).append(entry)
+    for cid, entries in by_call.items():
+        await _post(cid, entries, env_user, env_org, subsystem)

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -71,7 +71,7 @@ from .call_session import (
     setup_takeover_call,
 )
 from .constants import DISCONNECT_REASONS, PLATFORM
-from .invocation_log import flush_invocation_logs
+from .invocation_log import flush_invocation_logs, install_capture
 from .serializers import DtmfProtobufFrameSerializer, FreeSwitchAudioStreamSerializer
 from .serializers.freeswitch_audio_stream import FreeSwitchAudioStreamStart
 from .sip_gateway import (
@@ -105,6 +105,10 @@ WEBRTC_ICE_SERVERS = [
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Capture call-scoped logs into the InvocationLog buffer. Installed here (at
+    # runtime, after all imports) so nothing resets loguru's handlers on us.
+    install_capture()
+
     # SIP gateway is selected at startup. SIP_GATEWAY=daily|freeswitch|voiceblender.
     gateway_name = os.environ.get("SIP_GATEWAY", "freeswitch").lower()
     if gateway_name == "daily":

--- a/agents/pipecat/tests/test_invocation_log.py
+++ b/agents/pipecat/tests/test_invocation_log.py
@@ -1,0 +1,109 @@
+"""Tests for invocation-log capture (loguru sink) + per-call flush."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import types
+
+import pytest
+
+from pipecat_aplisay import invocation_log
+
+
+def _msg(call_id, message="hi", level="INFO"):
+    """A stand-in for a loguru Message (only ``.record`` is used by the sink)."""
+    record = {
+        "extra": {"callId": call_id} if call_id else {},
+        "time": dt.datetime(2026, 7, 9, 0, 0, 0),
+        "level": types.SimpleNamespace(name=level),
+        "name": "pipecat_aplisay.test",
+        "function": "f",
+        "line": 1,
+        "message": message,
+        "exception": None,
+    }
+    return types.SimpleNamespace(record=record)
+
+
+@pytest.fixture(autouse=True)
+def _clear_buffer():
+    with invocation_log._LOCK:
+        invocation_log._BUFFER.clear()
+    yield
+    with invocation_log._LOCK:
+        invocation_log._BUFFER.clear()
+
+
+def test_sink_buffers_only_call_scoped():
+    invocation_log._capture_sink(_msg("call-A", "a1"))
+    invocation_log._capture_sink(_msg(None, "orphan"))  # no callId -> dropped
+    invocation_log._capture_sink(_msg("call-A", "a2"))
+    invocation_log._capture_sink(_msg("call-B", "b1"))
+    assert [e["callId"] for e in invocation_log._BUFFER] == ["call-A", "call-A", "call-B"]
+
+
+def test_flush_drains_only_that_call(monkeypatch):
+    posted = []
+
+    async def fake_save(payload):
+        posted.append(payload)
+
+    monkeypatch.setattr(invocation_log.api_client, "save_invocation_log", fake_save)
+    for m in (_msg("call-A", "a1"), _msg("call-B", "b1"), _msg("call-A", "a2")):
+        invocation_log._capture_sink(m)
+
+    asyncio.run(
+        invocation_log.flush_invocation_logs(call_id="call-A", user_id="U", org_id="O")
+    )
+
+    assert len(posted) == 1
+    p = posted[0]
+    assert p["callId"] == "call-A"
+    assert p["userId"] == "U" and p["organisationId"] == "O"
+    assert p["subsystem"] == "pipecat-agent"
+    assert [e["message"] for e in p["log"]] == ["a1", "a2"]
+    # call-B's entry survives for its own flush
+    assert [e["callId"] for e in invocation_log._BUFFER] == ["call-B"]
+
+
+def test_flush_noop_when_no_entries_for_call(monkeypatch):
+    posted = []
+
+    async def fake_save(payload):
+        posted.append(payload)
+
+    monkeypatch.setattr(invocation_log.api_client, "save_invocation_log", fake_save)
+    asyncio.run(
+        invocation_log.flush_invocation_logs(call_id="absent", user_id="U", org_id="O")
+    )
+    assert posted == []
+
+
+def test_shutdown_flush_groups_by_call(monkeypatch):
+    posted = []
+
+    async def fake_save(payload):
+        posted.append(payload)
+
+    monkeypatch.setattr(invocation_log.api_client, "save_invocation_log", fake_save)
+    monkeypatch.setenv("WORKER_USER_ID", "envU")
+    monkeypatch.setenv("WORKER_ORGANISATION_ID", "envO")
+    for m in (_msg("call-A", "a1"), _msg("call-B", "b1"), _msg("call-A", "a2")):
+        invocation_log._capture_sink(m)
+
+    asyncio.run(invocation_log.flush_invocation_logs())  # no call_id -> drain all
+
+    by_call = {p["callId"]: p for p in posted}
+    assert set(by_call) == {"call-A", "call-B"}
+    assert by_call["call-A"]["userId"] == "envU"
+    assert [e["message"] for e in by_call["call-A"]["log"]] == ["a1", "a2"]
+    assert invocation_log._BUFFER == []
+
+
+def test_max_entries_cap(monkeypatch):
+    monkeypatch.setattr(invocation_log, "_MAX_ENTRIES", 3)
+    for i in range(5):
+        invocation_log._capture_sink(_msg("call-A", f"m{i}"))
+    # oldest dropped, newest kept
+    assert [e["message"] for e in invocation_log._BUFFER] == ["m2", "m3", "m4"]


### PR DESCRIPTION
## Problem

Pipecat calls have **no debug log** in the UI — `invocation_logs` is always empty (confirmed: 0 rows for every recent call; worker logs show zero invocation-log POSTs).

## Root cause

`invocation_log.py` was scaffolded but never wired:
- Nothing fed the buffer — `append()` was dead code, so `flush_invocation_logs()` always hit `if not batch: return`.
- `flush_invocation_logs()` was only called at **process shutdown** (`worker.py` lifespan). For a long-lived worker handling many calls, per-call logs are never persisted.
- It attributed logs to process-level `WORKER_USER_ID`/`WORKER_ORGANISATION_ID` env — wrong for a multi-tenant worker.

(Recordings work per-call because they use a per-call finalise; invocation logs never got the equivalent.)

## Fix

Complete the feature, mirroring the LiveKit agent (which persists an InvocationLog at job = call shutdown):

- **`invocation_log.py`** — add a loguru **sink** (`install_capture`) that buffers only *call-scoped* records (those emitted while `callId` is bound via `logger.contextualize`), keyed by callId, with a soft cap so the buffer stays bounded to in-flight calls. `flush_invocation_logs(call_id, user_id, org_id)` drains just that call's entries and attributes them to the call's **own** user/org; the no-arg shutdown path still drains everything as a safety net.
- **`worker.py`** — `install_capture()` at lifespan startup (after imports, so nothing resets loguru's handlers).
- **`call_session.py`** — wrap each pipeline segment in `logger.contextualize(callId=…)` and flush that segment's InvocationLog in the **same `finally` that finalises its recording**, keyed to the segment's own Call record. So each Call record (parent + each transfer child) gets its own debug log, exactly like recordings.

## Tests

`tests/test_invocation_log.py`: sink captures call-scoped only, per-call drain isolation, per-call vs shutdown attribution, buffer cap. 15/15 pipecat unit tests pass locally.

## Verify after deploy

Live call → confirm worker logs show an invocation-log POST, and the `invocation_logs` table gets a row for the call (and the UI debug log renders).
