### PR TITLE
fix(pipecat): pino-shaped invocation-log entries (fix call-panel cursor)

### DIFF
--- a/agents/pipecat/pipecat_aplisay/invocation_log.py
+++ b/agents/pipecat/pipecat_aplisay/invocation_log.py
@@ -35,23 +35,48 @@ _installed = False
 _MAX_ENTRIES = 20_000
 
 
+# loguru level name -> pino numeric level. The Calls UI (polite-ai
+# ``dashboard.calls.tsx`` / ``api.call-diagnostics.tsx``) was built for the
+# LiveKit agent's pino logs, so it keys off pino fields: ``time`` (epoch ms —
+# projected onto the recording timeline so the playhead follows each entry),
+# numeric ``level`` (>=40 = warn/error) and ``msg``. pino ladder:
+# trace10 debug20 info30 warn40 error50 fatal60.
+_PINO_LEVELS = {
+    "TRACE": 10,
+    "DEBUG": 20,
+    "INFO": 30,
+    "SUCCESS": 30,
+    "WARNING": 40,
+    "ERROR": 50,
+    "CRITICAL": 60,
+}
+
+
 def _record_to_entry(record: dict) -> dict[str, Any]:
+    """Serialise a loguru record as a **pino-shaped** entry, so pipecat and
+    LiveKit invocation logs render identically in the UI. ``time`` is epoch
+    milliseconds via ``datetime.timestamp()`` — an absolute (UTC) instant
+    regardless of the record's tzinfo, which is what the timeline maths expects.
+    """
     extra = dict(record.get("extra") or {})
     call_id = extra.pop("callId", None)
+    level_name = record["level"].name
     entry: dict[str, Any] = {
-        "callId": call_id,
-        "ts": record["time"].isoformat(),
-        "level": record["level"].name,
+        "callId": call_id,  # internal: groups/drains per call (the UI ignores it)
+        "time": int(record["time"].timestamp() * 1000),
+        "level": _PINO_LEVELS.get(level_name.upper(), 30),
+        "levelName": level_name,
+        "msg": record["message"],
         "logger": record["name"],
         "function": record["function"],
         "line": record["line"],
-        "message": record["message"],
     }
     if extra:
         entry["extra"] = extra
     exc = record.get("exception")
     if exc is not None:
-        entry["exception"] = repr(exc)
+        value = getattr(exc, "value", None)
+        entry["err"] = {"message": str(value) if value is not None else repr(exc)}
     return entry
 
 

--- a/agents/pipecat/tests/test_invocation_log.py
+++ b/agents/pipecat/tests/test_invocation_log.py
@@ -43,6 +43,15 @@ def test_sink_buffers_only_call_scoped():
     assert [e["callId"] for e in invocation_log._BUFFER] == ["call-A", "call-A", "call-B"]
 
 
+def test_entries_are_pino_shaped():
+    invocation_log._capture_sink(_msg("call-A", "hello", level="WARNING"))
+    e = invocation_log._BUFFER[0]
+    assert isinstance(e["time"], int)  # epoch ms, for the UI timeline/playhead
+    assert e["level"] == 40  # pino numeric: WARNING -> 40 (>=40 = notable)
+    assert e["msg"] == "hello"
+    assert e["levelName"] == "WARNING"
+
+
 def test_flush_drains_only_that_call(monkeypatch):
     posted = []
 
@@ -62,7 +71,7 @@ def test_flush_drains_only_that_call(monkeypatch):
     assert p["callId"] == "call-A"
     assert p["userId"] == "U" and p["organisationId"] == "O"
     assert p["subsystem"] == "pipecat-agent"
-    assert [e["message"] for e in p["log"]] == ["a1", "a2"]
+    assert [e["msg"] for e in p["log"]] == ["a1", "a2"]
     # call-B's entry survives for its own flush
     assert [e["callId"] for e in invocation_log._BUFFER] == ["call-B"]
 
@@ -97,7 +106,7 @@ def test_shutdown_flush_groups_by_call(monkeypatch):
     by_call = {p["callId"]: p for p in posted}
     assert set(by_call) == {"call-A", "call-B"}
     assert by_call["call-A"]["userId"] == "envU"
-    assert [e["message"] for e in by_call["call-A"]["log"]] == ["a1", "a2"]
+    assert [e["msg"] for e in by_call["call-A"]["log"]] == ["a1", "a2"]
     assert invocation_log._BUFFER == []
 
 
@@ -106,4 +115,4 @@ def test_max_entries_cap(monkeypatch):
     for i in range(5):
         invocation_log._capture_sink(_msg("call-A", f"m{i}"))
     # oldest dropped, newest kept
-    assert [e["message"] for e in invocation_log._BUFFER] == ["m2", "m3", "m4"]
+    assert [e["msg"] for e in invocation_log._BUFFER] == ["m2", "m3", "m4"]


### PR DESCRIPTION
## Problem

On the call panel, the debug-log **cursor/playhead is always stuck at the end** — it doesn't follow playback to the entry for the current moment.

## Root cause (worker-side data shape)

The Calls UI projects each invocation-log entry onto the recording timeline:

```
debugOffsets = debug.map(item => (callStartMs && item.timeMs) ? (item.timeMs - callStartMs)/1000 : 0)
activeDebugIndex(currentOffset) = last item whose offset <= currentOffset
```

`item.timeMs` comes from `entryTimeMs(entry)`, which reads pino/OTLP fields — `time` (epoch-ms number), `timeUnixNano`, or a `timestamp` string. But the pipecat loguru entries used **`ts`** (ISO string) + **`message`** + a level **name**. `entryTimeMs` didn't recognise `ts`, so **every entry got `timeMs = 0` → offset 0**, and the "last entry at/≤ playhead" was therefore always the final one → cursor pinned to the end. (Not a UTC/localtime bug — both `call.startedAt` and a proper epoch-ms `time` are absolute.)

The diagnostics route (`api.call-diagnostics.tsx`) similarly needs a **numeric** pino `level` (>=40 = warn/error) and `msg`, which the name-string level didn't satisfy.

## Fix

Emit the **same shape the LiveKit agent's pino logger produces**, so both agents' invocation logs render identically:

- `time` — epoch **milliseconds** (`datetime.timestamp()`, an absolute/UTC instant → no tz skew), the field `entryTimeMs` reads;
- `level` — **numeric** pino level (loguru name → pino ladder: info30/warn40/error50…);
- `msg` — the message; plus `levelName`, `logger`, `function`, `line`, and `err.message` for exceptions.

## Tests

`tests/test_invocation_log.py` updated (`msg`, numeric `level`) + a `test_entries_are_pino_shaped`. 6/6 pass.

## Note

This fixes all **new** calls. Invocation-log rows already stored in the old loguru shape will still mis-position (they lack `time`); if you want those to render too, the alternative/additive UI tweak is to teach `entryTimeMs` to also parse a `ts` ISO string — happy to do that separately.
