### PR TITLE
feat(agents): list armed key names via GET /agents/{id}/keys

### DIFF
--- a/api/paths/agents/{agentId}/keys.js
+++ b/api/paths/agents/{agentId}/keys.js
@@ -8,9 +8,80 @@ let log;
 export default function (logger) {
   log = logger;
   return {
+    GET: agentKeysList,
     PUT: agentKeysUpsert,
   };
 }
+
+/**
+ * GET /agents/{agentId}/keys — list the NAMES of the credential keys armed on
+ * the agent (values are write-only and never returned).
+ *
+ * Key values can never be read back, so a trusted BFF that pushed a key has no
+ * way to confirm it actually landed: a desync (datastore restore, a full
+ * PUT /agents/{agentId} that dropped `keys`, a partial push) leaves the agent
+ * with no key while the pusher still believes it is armed — and any MCP server
+ * that references the missing key is then silently dropped from every chat.
+ * Exposing the names (not the values) lets the pusher detect and self-heal that
+ * wedge. Scoped to the caller's own agents, like GET /agents/{agentId}.
+ */
+const agentKeysList = async (req, res) => {
+  const { agentId } = req.params;
+  if (isBuiltinAgentId(agentId)) {
+    return res.status(404).send({ message: `Agent with ID ${agentId} not found` });
+  }
+  try {
+    const agent = await Agent.findOne({ where: { id: agentId, ...scopeWhereForUser(res.locals.user) } });
+    if (!agent) {
+      return res.status(404).send({ message: `Agent with ID ${agentId} not found` });
+    }
+    const keyNames = (Array.isArray(agent.keys) ? agent.keys : []).map((k) => k?.name).filter(Boolean);
+    res.send({ id: agent.id, keyNames });
+  } catch (err) {
+    req.log.error(err);
+    res.status(400).send({ message: err.message });
+  }
+};
+
+agentKeysList.apiDoc = {
+  summary: 'List the names of credential keys armed on an agent',
+  description:
+    'Returns the NAMES of the credential keys currently stored on the agent; key values are write-only and '
+    + 'never returned. Lets a trusted caller confirm a key it pushed is actually present — values cannot be '
+    + 'read back, so a push/restore desync is otherwise undetectable and silently strips any MCP server that '
+    + 'references the missing key.',
+  operationId: 'listAgentKeys',
+  tags: ['Agent'],
+  parameters: [
+    {
+      description: 'ID of the agent to inspect',
+      in: 'path',
+      name: 'agentId',
+      required: true,
+      schema: { type: 'string' },
+    },
+  ],
+  responses: {
+    200: {
+      description: 'The agent id and the names of its stored keys (values are never returned).',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              id: { type: 'string', format: 'uuid' },
+              keyNames: { type: 'array', items: { type: 'string' } },
+            },
+          },
+        },
+      },
+    },
+    default: {
+      description: 'An error occurred',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+    },
+  },
+};
 
 /**
  * PUT /agents/{agentId}/keys — MERGE credential keys by name.

--- a/tests/agent-keys-endpoint.test.mjs
+++ b/tests/agent-keys-endpoint.test.mjs
@@ -1,0 +1,164 @@
+import { setupRealDatabase, teardownRealDatabase, Organisation, User } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+// GET /agents/{agentId}/keys must expose only key NAMES (never values), so a
+// trusted BFF can confirm a write-only key it pushed is actually armed on the
+// agent — the fix for the silent "MCP server dropped because its key is
+// missing" wedge. PUT /keys must still merge (never clobber a sibling key).
+describe('Agent keys endpoint (names-only visibility + merge)', () => {
+  let createAgent;
+  let listKeys;
+  let upsertKeys;
+
+  let testOrgId;
+  let testUserId;
+  let createdAgentId;
+
+  const mockLogger = {
+    info: () => {},
+    error: () => {},
+    warn: () => {},
+    debug: () => {},
+    child: () => mockLogger,
+  };
+
+  const createMockRequest = (overrides = {}) => ({
+    body: {},
+    params: {},
+    query: {},
+    headers: {},
+    log: mockLogger,
+    ...overrides,
+  });
+
+  const createMockResponse = (locals = {}) => ({
+    _status: null,
+    _body: null,
+    locals,
+    status(code) {
+      this._status = code;
+      return this;
+    },
+    send(data) {
+      this._body = data;
+      return this;
+    },
+    json(data) {
+      this._body = data;
+      return this;
+    },
+  });
+
+  const asUser = () => ({ user: { id: testUserId, role: 'owner', organisationId: testOrgId } });
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+
+    const agentsModule = await import('../api/paths/agents.js');
+    const keysModule = await import('../api/paths/agents/{agentId}/keys.js');
+
+    createAgent = agentsModule.default(mockLogger, {}, { emit: () => {}, on: () => {}, off: () => {} }).POST;
+    listKeys = keysModule.default(mockLogger).GET;
+    upsertKeys = keysModule.default(mockLogger).PUT;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 60000);
+
+  beforeEach(async () => {
+    testOrgId = randomUUID();
+    testUserId = randomUUID();
+    createdAgentId = null;
+
+    await Organisation.create({ id: testOrgId, name: 'Test Org (keys)' });
+    await User.create({
+      id: testUserId,
+      organisationId: testOrgId,
+      name: 'Test User',
+      email: 'test-keys@example.com',
+    });
+  }, 30000);
+
+  afterEach(async () => {
+    try {
+      if (testUserId) await User.destroy({ where: { id: testUserId } });
+      if (testOrgId) await Organisation.destroy({ where: { id: testOrgId } });
+    } catch {}
+  });
+
+  const makeAgentWithKeys = async (keys) => {
+    const req = createMockRequest({
+      body: {
+        name: 'Keys test agent',
+        modelName: 'livekit:ultravox/ultravox-v0.7',
+        prompt: 'You are a helpful assistant.',
+        keys,
+      },
+    });
+    const res = createMockResponse(asUser());
+    await createAgent(req, res);
+    expect(res._body).toHaveProperty('id');
+    // The create response itself must never echo key values back.
+    expect(JSON.stringify(res._body)).not.toContain('pik_secret');
+    return res._body.id;
+  };
+
+  test('GET /keys returns key NAMES and never values', async () => {
+    createdAgentId = await makeAgentWithKeys([
+      { name: 'POLITE_DISCOVERY', in: 'bearer', value: 'pik_secret_discovery' },
+      { name: 'OTHER_KEY', in: 'header', value: 'pik_secret_other' },
+    ]);
+
+    const res = createMockResponse(asUser());
+    await listKeys(createMockRequest({ params: { agentId: createdAgentId } }), res);
+
+    expect(res._status === 200 || res._status === null).toBe(true);
+    expect(res._body).toHaveProperty('id', createdAgentId);
+    expect([...res._body.keyNames].sort()).toEqual(['OTHER_KEY', 'POLITE_DISCOVERY']);
+    // The whole point: values stay write-only.
+    expect(JSON.stringify(res._body)).not.toContain('pik_secret');
+  });
+
+  test('GET /keys returns an empty list for an agent with no keys', async () => {
+    createdAgentId = await makeAgentWithKeys(undefined);
+
+    const res = createMockResponse(asUser());
+    await listKeys(createMockRequest({ params: { agentId: createdAgentId } }), res);
+
+    expect(res._body.keyNames).toEqual([]);
+  });
+
+  test('PUT /keys merges by name without clobbering siblings; GET reflects it', async () => {
+    createdAgentId = await makeAgentWithKeys([
+      { name: 'POLITE_DISCOVERY', in: 'bearer', value: 'pik_secret_old' },
+    ]);
+
+    // Arm a fresh discovery bearer AND a new sibling key in one merge.
+    const putRes = createMockResponse(asUser());
+    await upsertKeys(
+      createMockRequest({
+        params: { agentId: createdAgentId },
+        body: {
+          keys: [
+            { name: 'POLITE_DISCOVERY', in: 'bearer', value: 'pik_secret_new' },
+            { name: 'POLITE_KNOWLEDGE', in: 'bearer', value: 'pik_secret_knowledge' },
+          ],
+        },
+      }),
+      putRes,
+    );
+    expect([...putRes._body.keyNames].sort()).toEqual(['POLITE_DISCOVERY', 'POLITE_KNOWLEDGE']);
+    expect(JSON.stringify(putRes._body)).not.toContain('pik_secret');
+
+    const getRes = createMockResponse(asUser());
+    await listKeys(createMockRequest({ params: { agentId: createdAgentId } }), getRes);
+    expect([...getRes._body.keyNames].sort()).toEqual(['POLITE_DISCOVERY', 'POLITE_KNOWLEDGE']);
+  });
+
+  test('GET /keys 404s for an unknown agent', async () => {
+    const res = createMockResponse(asUser());
+    await listKeys(createMockRequest({ params: { agentId: randomUUID() } }), res);
+    expect(res._status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Why

Agent credential key **values** are write-only and never returned by the API. So a client has **no way to confirm it actually landed**. If the agent's `keys` later drift out of sync with what the pusher recorded (a datastore restore, a stray full `PUT /agents/{id}` that dropped `keys`, a partial push), the agent ends up with **no key** while the pusher still believes it is armed.

The Anthropic connector path then drops **any `mcpServer` that references the missing key on every chat**, with only a `debug` line ([`anthropic.js` `serverAuthToken`/`activeMcpServers`](lib/models/anthropic.js)). 

Add **`GET /agents/{agentId}/keys` → `{ id, keyNames }`** — exposes the key **names** (never the values) so a pusher can detect and self-heal the desync. Scoped to the caller's own agents like `GET /agents/{agentId}`; mirrors the existing `PUT /keys` merge response.

## Tests

`tests/agent-keys-endpoint.test.mjs` (4/4 pass against the test DB):
- returns key names; **never** leaks values
- empty list for a keyless agent
- merge `PUT /keys` preserves sibling keys; `GET` reflects it
- 404 on unknown agent


