### PR TITLE
feat(chat): explicit test_result frame + claim-at-enqueue pending resolution

### DIFF
--- a/lib/set-builder-agent.js
+++ b/lib/set-builder-agent.js
@@ -123,6 +123,8 @@ TESTING & TROUBLESHOOTING
   (voice/interactive-audio members only; call it ALONE and then wait). The user runs the call in their
   browser and you receive the result back: a "legs" array with one entry per call leg, each carrying its own
   agentLabel, transcript, function calls and invocation log.
+- The user may decline or skip the test — the result is then { "ok": false, "reason": ... }. Acknowledge
+  briefly and carry on; don't re-offer the same test straight away.
 - If the call transferred (more than one leg / transferred:true), the result includes a separate leg for EACH
   agent the call passed through — e.g. testing reception that hands off to sales gives you both the reception
   leg AND the sales leg. You do NOT need to test the transferred-to agent separately to see its behaviour.

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -118,6 +118,8 @@ class TextChatSession {
       try { msg = JSON.parse(data.toString()); } catch { return; }
       if (msg.type === 'user' && typeof msg.text === 'string') {
         await this.turn(msg.text, send);
+      } else if (msg.type === 'test_result' && typeof msg.result === 'string') {
+        await this.testResult(msg, send);
       }
     });
     ws.on('close', () => { this.finaliseUsage(); sessions.delete(this.id); });
@@ -195,16 +197,22 @@ class TextChatSession {
    * the shared conversation state.
    */
   turn(userText, send, hidden = false) {
+    // Claim any pending tool call at ENQUEUE (frame arrival), not when the
+    // queued turn eventually runs: a pending created by an intervening turn
+    // (the model pausing again while this message waited in the queue) must
+    // never capture a message that predates it.
+    const claimed = this.pending;
+    this.pending = null;
     this.queue = (this.queue || Promise.resolve())
-      .then(() => this.runTurn(userText, send, hidden))
+      .then(() => this.runTurn(userText, send, hidden, claimed))
       .catch((e) => this.logger.error(e, 'chat turn chain error'));
     return this.queue;
   }
 
-  async runTurn(userText, send, hidden = false) {
+  async runTurn(userText, send, hidden = false, claimed = null) {
     if (!hidden) send({ type: 'user_echo', text: userText });
     send({ type: 'status', state: 'thinking' });
-    this.logger.info({ id: this.id, hidden, resume: !!this.pending }, 'chat turn started');
+    this.logger.info({ id: this.id, hidden, resume: !!claimed }, 'chat turn started');
     // Surface server-side MCP tool calls (the builder reading the Aplisay
     // docs/API) so the user sees progress during the slow connector round trips.
     const onLlmEvent = (ev) => {
@@ -213,13 +221,29 @@ class TextChatSession {
       }
     };
     try {
-      let round;
-      if (this.pending) {
-        // This message answers a pending ask_user; resume the agent's tool loop
-        // by returning the answer (plus any sibling tool results) as tool_results.
-        const { toolUseId, otherResults } = this.pending;
+      // A pending created AFTER this message was queued (the model paused again
+      // while this turn waited in the queue) must still be answered — the LLM
+      // API rejects a plain user message while a tool call dangles. ask_user
+      // keeps its legacy semantics (the user's text IS the answer); a test
+      // pause is declined, with the user's message carried inside the result.
+      let pending = claimed;
+      if (!pending && this.pending) {
+        pending = this.pending;
         this.pending = null;
-        round = await this.llm.callResult([...otherResults, { id: toolUseId, result: userText }], onLlmEvent);
+        if (pending.platform === 'test_agent') {
+          userText = JSON.stringify({
+            ok: false,
+            reason: 'The user continued the conversation instead of running the test. Their message follows.',
+            userMessage: userText,
+          });
+        }
+      }
+      let round;
+      if (pending) {
+        // This message answers the pending tool call; resume the agent's tool
+        // loop by returning the answer (plus any sibling results) as tool_results.
+        const { toolUseId, otherResults } = pending;
+        round = await this.llm.callResult([...(otherResults || []), { id: toolUseId, result: userText }], onLlmEvent);
       } else {
         round = await this.llm.rawCompletion(userText, onLlmEvent);
       }
@@ -269,7 +293,7 @@ class TextChatSession {
                 (m) => this.onToolResults(m, send), {}, {}, this.functionOptions);
               otherResults = res.function_results || [];
             }
-            this.pending = { toolUseId: pause.id, otherResults };
+            this.pending = { toolUseId: pause.id, otherResults, platform: this.platformOf(pause.name) };
             if (this.platformOf(pause.name) === 'test_agent') {
               const label = pause.input?.label;
               const member = (this.latestSet?.agents || []).find((a) => a.label === label);
@@ -306,6 +330,24 @@ class TextChatSession {
     } finally {
       send({ type: 'turn_complete' });
     }
+  }
+
+  /**
+   * Resolve a pending test_agent call from an explicit `test_result` frame
+   * ({type:'test_result', id, result}) — the unambiguous channel for clients
+   * that drive their own in-browser test flow (polite-ai). The id must match
+   * the pending tool-use id so a stale or duplicate frame can't hijack an
+   * unrelated turn. The legacy protocol — the next plain `user` message
+   * resumes the pending call (llm-frontend) — is unchanged; a client using
+   * this frame must send it BEFORE any queued user text so the paused turn
+   * consumes the result, not the chat message.
+   */
+  testResult(msg, send) {
+    if (!this.pending || msg.id !== this.pending.toolUseId) {
+      this.logger.warn({ id: this.id, frameId: msg.id }, 'test_result without a matching pending tool call — ignored');
+      return Promise.resolve();
+    }
+    return this.turn(msg.result, send, true);
   }
 
   /** Record this round's LLM token usage against the chat session (best-effort). */

--- a/tests/text-chat-test-result.test.mjs
+++ b/tests/text-chat-test-result.test.mjs
@@ -1,0 +1,112 @@
+// database-test-wrapper sets the POSTGRES_* env for the standard test container
+// BEFORE lib/database.js is imported (text-chat.js pulls it in transitively),
+// and its teardown closes the import-time connections so jest can exit.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+
+const { createChatSession } = await import('../lib/text-chat.js');
+
+// The explicit `test_result` websocket frame ({type:'test_result', id, result})
+// that resolves a pending test_agent tool call — the unambiguous channel used
+// by clients that drive their own in-browser test flow (polite-ai). The legacy
+// protocol (next plain `user` message resumes the pending call) is untouched.
+// These tests pin the guard rails: strict id match, no-op without a pending
+// call, claim-at-ENQUEUE semantics (a pending is consumed when its answering
+// frame arrives, so a pending created by an intervening turn can never capture
+// a message that predates it), and resumption as a hidden turn.
+
+const logger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const agent = {
+  id: 'agent-1',
+  organisationId: 'org-1',
+  userId: 'user-1',
+  modelName: 'text:anthropic/claude-sonnet-5',
+  functions: [],
+  keys: [],
+  options: {},
+  mcpServers: [],
+};
+
+beforeAll(async () => {
+  await setupRealDatabase();
+});
+
+afterAll(async () => {
+  await teardownRealDatabase();
+});
+
+function makeSession() {
+  const session = createChatSession({ agent, logger });
+  const turns = [];
+  // turn() claims the pending and enqueues runTurn — stub the run itself so
+  // the claim semantics are exercised without an LLM.
+  session.runTurn = (text, send, hidden = false, claimed = null) => {
+    turns.push({ text, hidden, claimed });
+    return Promise.resolve();
+  };
+  return { session, turns };
+}
+
+describe('text-chat test_result frame', () => {
+  test('matching id claims the pending at enqueue and resumes as a hidden turn', async () => {
+    const { session, turns } = makeSession();
+    session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' };
+    await session.testResult({ type: 'test_result', id: 'toolu_1', result: '{"ok":true,"legs":[]}' }, () => {});
+    expect(turns).toEqual([
+      {
+        text: '{"ok":true,"legs":[]}',
+        hidden: true,
+        claimed: { toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' },
+      },
+    ]);
+    // Claimed at enqueue: a duplicate frame or a later user message can no
+    // longer capture this pending.
+    expect(session.pending).toBeNull();
+  });
+
+  test('mismatched id is ignored (a stale frame cannot hijack another turn)', async () => {
+    const { session, turns } = makeSession();
+    session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' };
+    await session.testResult({ type: 'test_result', id: 'toolu_2', result: '{"ok":true}' }, () => {});
+    expect(turns).toEqual([]);
+    expect(session.pending).toEqual({ toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' });
+  });
+
+  test('missing id is ignored', async () => {
+    const { session, turns } = makeSession();
+    session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' };
+    await session.testResult({ type: 'test_result', result: '{"ok":true}' }, () => {});
+    expect(turns).toEqual([]);
+  });
+
+  test('no pending tool call is a no-op', async () => {
+    const { session, turns } = makeSession();
+    await session.testResult({ type: 'test_result', id: 'toolu_1', result: '{"ok":false}' }, () => {});
+    expect(turns).toEqual([]);
+  });
+
+  test('duplicate frame after the claim is ignored', async () => {
+    const { session, turns } = makeSession();
+    session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' };
+    await session.testResult({ type: 'test_result', id: 'toolu_1', result: '{"ok":true}' }, () => {});
+    await session.testResult({ type: 'test_result', id: 'toolu_1', result: '{"ok":true}' }, () => {});
+    expect(turns).toHaveLength(1);
+  });
+
+  test('legacy protocol: a plain user turn claims the pending at enqueue', async () => {
+    const { session, turns } = makeSession();
+    session.pending = { toolUseId: 'toolu_9', otherResults: [], platform: 'ask_user' };
+    await session.turn('the answer', () => {});
+    expect(turns).toEqual([
+      {
+        text: 'the answer',
+        hidden: false,
+        claimed: { toolUseId: 'toolu_9', otherResults: [], platform: 'ask_user' },
+      },
+    ]);
+    expect(session.pending).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds an unambiguous websocket channel for resolving a paused `test_agent` tool call — `{type:'test_result', id, result}` with a strict tool-use-id match — and fixes the pending-resolution race the review found.

## Why

The legacy protocol (next plain user message consumed verbatim as the tool result) stays intact for llm-frontend, but is unusable for a client whose users can type freely while a test is pending.

## Changes

- `test_result` inbound frame: resolves the pending call only when `id` matches the paused tool-use id; stale/duplicate frames are logged and ignored.
- **Claim-at-enqueue** (review, HIGH): `turn()` now snapshots and clears `this.pending` when the answering frame *arrives*, so a pending created by an intervening turn can never capture a message that predates it.
- Run-time pendings are still answered (the API rejects a plain user message while a tool_use dangles): `ask_user` keeps text-is-the-answer semantics; a `test_agent` pause is declined with the user's message carried inside the structured result (`pending.platform` is now recorded for this).
- Builtin set-builder prompt: decline-shape guidance ({ok:false, reason}).
- Tests: `tests/text-chat-test-result.test.mjs` (6 cases — id match, stale/duplicate/missing-id, claim semantics for both protocols), using the standard database-test-wrapper setup/teardown so jest exits cleanly.

## Verification

Full db suite: 45 suites / 498 tests green.
