### PR TITLE
feat(chat): builder token efficiency — cache TTL, walk-back breakpoint, effort, slim save echoes, subjectAgent seed

### DIFF
--- a/api/paths/agents/{agentId}/chat.js
+++ b/api/paths/agents/{agentId}/chat.js
@@ -37,11 +37,15 @@ const agentChat = async (req, res) => {
       });
     }
     // Optional seed: an existing set to edit, a prior test result to diagnose,
-    // and/or a caller-formatted context block (e.g. website-knowledge state)
-    // appended verbatim to the opening turn.
-    const { set, testResult, knowledge } = req.body || {};
-    const session = createChatSession({ agent, set, testResult, knowledge, logger: req.log });
-    log.info({ agentId, sessionId: session.id, edit: !!set, diagnose: !!testResult, knowledge: !!knowledge }, 'agent chat session started');
+    // the diagnosed agent's own definition (a SET-LESS troubleshoot — without
+    // it the builder root-causes prompt/function bugs blind), and/or a
+    // caller-formatted context block (e.g. website-knowledge state) appended
+    // verbatim to the opening turn.
+    const { set, testResult, subjectAgent, knowledge } = req.body || {};
+    const session = createChatSession({ agent, set, testResult, subjectAgent, knowledge, logger: req.log });
+    log.info(
+      { agentId, sessionId: session.id, edit: !!set, diagnose: !!testResult, subjectAgent: !!subjectAgent, knowledge: !!knowledge },
+      'agent chat session started');
     res.send({ id: session.id, socket: `/chat/${session.id}` });
   }
   catch (err) {
@@ -77,6 +81,10 @@ agentChat.apiDoc = {
           properties: {
             set: { type: 'object', nullable: true, description: 'An existing agent-set document to edit (seeds the builder).' },
             testResult: { type: 'object', nullable: true, description: 'A prior test run (transcript/functions/invocation log) to diagnose.' },
+            // No `type`: a single definition object, or an array of them (one
+            // per distinct agent on a transferred call) — typed loosely so the
+            // request validator accepts both shapes.
+            subjectAgent: { nullable: true, description: 'For a set-less troubleshoot: the diagnosed agent\'s own definition (prompt/functions/options) — or an array of definitions, one per distinct agent on the call — so fixes are grounded in what the agent actually says and does.' },
             knowledge: { type: 'string', nullable: true, description: 'A caller-formatted context block appended verbatim to the opening turn (e.g. website-knowledge state).' },
           },
         },

--- a/lib/function-handler.js
+++ b/lib/function-handler.js
@@ -106,11 +106,46 @@ const hardwiredBuiltins = {
       import('./voices/index.js'),
     ]);
     const voicesInstance = new Voices();
-    return locale
+    const result = locale
       ? await getModelVoicesForLocale({ modelName, locale, voicesInstance })
       : await getModelVoiceLocales({ modelName, voicesInstance });
+    return trimVoicesResult(result);
   }
 };
+
+// Bound the list_voices payload for the LLM: the raw catalogue for a big
+// vendor set (ultravox realtime: ~25KB / ~6k tokens) rides the conversation
+// for the rest of the session once fetched. Voice choice needs name, gender
+// and a short description — cap the description and the per-vendor list, with
+// an explicit trailing note so the model knows more exist and can narrow by
+// locale or ask the user rather than assume the list is complete. The REST
+// endpoint (GET /models/:modelName/voices) is untouched.
+const VOICES_PER_VENDOR = 60;
+const VOICE_DESCRIPTION_CHARS = 100;
+// Exported for tests only — not part of the module's public surface.
+export function trimVoicesResult(result) {
+  if (!result || !result.vendors || typeof result.vendors !== 'object') return result;
+  const vendors = {};
+  for (const [vendor, voices] of Object.entries(result.vendors)) {
+    if (!Array.isArray(voices)) {
+      vendors[vendor] = voices;
+      continue;
+    }
+    const kept = voices.slice(0, VOICES_PER_VENDOR).map((v) => (
+      v && typeof v.description === 'string' && v.description.length > VOICE_DESCRIPTION_CHARS
+        ? { ...v, description: `${v.description.slice(0, VOICE_DESCRIPTION_CHARS)}…` }
+        : v
+    ));
+    vendors[vendor] = voices.length > kept.length
+      ? [...kept, {
+        note: `…and ${voices.length - kept.length} more ${vendor} voices not shown. If the user names a `
+          + 'specific voice, use that name verbatim — creation validates against the FULL catalogue, '
+          + 'not this trimmed list.',
+      }]
+      : kept;
+  }
+  return { ...result, vendors };
+}
 
 async function functionHandler(function_calls, functions, keys, messageHandler, metadata, specficBuiltins, options = {}) {
   let builtins = { ...hardwiredBuiltins, ...specficBuiltins };

--- a/lib/models/anthropic.js
+++ b/lib/models/anthropic.js
@@ -18,6 +18,27 @@ const MCP_BETA = 'mcp-client-2025-11-20';
 const MAX_SERVER_HOPS = 6;
 const DEFAULT_MAX_TOKENS = 4096;
 
+// TTL for the prompt-cache breakpoints of INTERACTIVE sessions. Chats are
+// human-paced — a think-pause or an in-browser test call routinely outlives
+// the default 5-minute TTL, and every lapse re-WRITES the whole accumulated
+// prefix at the write premium instead of re-reading it at 0.1x (staging
+// showed 2-4 lapses per builder session). The 1-hour TTL doubles the write
+// premium (2x vs 1.25x base input) but keeps the prefix warm across pauses —
+// net cheaper on any session with a pause. Headless one-shot paths (invoke,
+// subagent) never pause, so they stay on the default 5m (see the constructor's
+// `interactive` flag). Env-tunable for A/B via the metered cacheWriteTokens:
+// set ANTHROPIC_CACHE_TTL=5m to revert. The API accepts exactly '5m' | '1h' —
+// anything else would 400 EVERY request process-wide, so validate.
+const CACHE_TTL_RAW = process.env.ANTHROPIC_CACHE_TTL;
+const CACHE_TTL = ['5m', '1h'].includes(CACHE_TTL_RAW) ? CACHE_TTL_RAW : '1h';
+if (CACHE_TTL_RAW && CACHE_TTL_RAW !== CACHE_TTL) {
+  console.warn(`ANTHROPIC_CACHE_TTL="${CACHE_TTL_RAW}" is not a valid cache TTL ('5m'|'1h') — using '1h'`);
+}
+const INTERACTIVE_CACHE_CONTROL = CACHE_TTL === '5m'
+  ? { type: 'ephemeral' }
+  : { type: 'ephemeral', ttl: CACHE_TTL };
+const DEFAULT_CACHE_CONTROL = { type: 'ephemeral' };
+
 /**
  * Implements the LLM class against current Anthropic Claude models via the
  * Messages API. Used by `text:anthropic/...` agents (text-agent invoke,
@@ -63,10 +84,49 @@ class Anthropic extends Llm {
   // Vendor label for usage metering (see lib/usage.js).
   static provider = 'anthropic';
 
-  constructor({ logger, prompt, options, model, mcpServers }) {
+  // Values the GA `output_config.effort` parameter accepts. Anything else in
+  // options.effort is ignored (with a warning) rather than 400ing every turn.
+  static EFFORT_LEVELS = new Set(['low', 'medium', 'high', 'xhigh', 'max']);
+  // Effort support varies BY MODEL among the models we offer: these two reject
+  // output_config.effort outright, and 'xhigh' only exists from Opus 4.7 —
+  // sending an unsupported combo 400s every turn, so gate per model too.
+  static EFFORT_UNSUPPORTED = new Set(['claude-sonnet-4-5', 'claude-haiku-4-5']);
+  static EFFORT_NO_XHIGH = new Set(['claude-opus-4-6', 'claude-sonnet-4-6']);
+
+  /** The effort value safe to send for this model, or undefined to omit. */
+  static effortFor(model, requested, logger) {
+    if (!requested) return undefined;
+    if (!Anthropic.EFFORT_LEVELS.has(requested)) {
+      logger.warn({ effort: requested }, 'ignoring unknown options.effort value');
+      return undefined;
+    }
+    const bare = String(model).split('/').pop();
+    if (Anthropic.EFFORT_UNSUPPORTED.has(bare)) {
+      logger.warn({ model, effort: requested }, 'model rejects output_config.effort — ignoring');
+      return undefined;
+    }
+    if (requested === 'xhigh' && Anthropic.EFFORT_NO_XHIGH.has(bare)) {
+      logger.warn({ model, effort: requested }, "model has no 'xhigh' effort — using 'high'");
+      return 'high';
+    }
+    return requested;
+  }
+
+  constructor({ logger, prompt, options, model, mcpServers, interactive }) {
     super(...arguments);
     this.mcpServers = Array.isArray(mcpServers) ? mcpServers : [];
     this.model = model || Anthropic.allModels[0][0];
+    // Interactive (human-paced chat) sessions use the long cache TTL; headless
+    // one-shots (invoke/subagent) never pause, so the doubled 1h write premium
+    // would be a pure cost increase there — they keep the 5m default.
+    this.cacheControl = interactive ? INTERACTIVE_CACHE_CONTROL : DEFAULT_CACHE_CONTROL;
+    // Optional reasoning-effort hint (options.effort): current models default
+    // to effort 'high'. Note this driver never sends a `thinking` param, so
+    // whether thinking runs is per-model default behaviour — implicit adaptive
+    // on Sonnet 5 (and always-on on Fable), OFF-when-omitted on Opus 4.7/4.8 —
+    // and effort here mainly bounds output verbosity (plus thinking depth
+    // where thinking runs). Only sent when set AND supported by the model.
+    this.effort = Anthropic.effortFor(this.model, options?.effort, logger);
     this.gpt = {
       ...(this.gpt || {}),
       // Note: temperature/top_p are intentionally omitted — current Claude
@@ -75,7 +135,7 @@ class Anthropic extends Llm {
       system: prompt,
       messages: [],
     };
-    logger.debug({ prompt, model: this.gpt.model, mcpServers: this.mcpServers.length }, 'NEW Anthropic agent');
+    logger.debug({ prompt, model: this.gpt.model, effort: this.effort, mcpServers: this.mcpServers.length }, 'NEW Anthropic agent');
   }
 
   set prompt(newPrompt) {
@@ -129,29 +189,37 @@ class Anthropic extends Llm {
 
   /**
    * Return a COPY of the messages array with a single `cache_control` breakpoint
-   * on the last cacheable block of the last message. Anthropic caches the whole
-   * prefix up to a breakpoint, so this makes each round re-read the (large,
-   * ever-growing) conversation — MCP doc-reads especially — at ~0.1x instead of
-   * re-billing it in full every turn. Applied to a copy so the stored history
-   * stays clean and we never accrue past the 4-breakpoint limit; the 5-minute
-   * cache TTL keeps interactive chats warm.
+   * on the most recent cacheable block. Anthropic caches the whole prefix up to
+   * a breakpoint, so this makes each round re-read the (large, ever-growing)
+   * conversation — MCP doc-reads especially — at ~0.1x instead of re-billing it
+   * in full every turn. Applied to a copy so the stored history stays clean and
+   * we never accrue past the 4-breakpoint limit.
+   *
+   * Walks BACK from the last message: a pause_turn continuation can end on a
+   * message that is entirely connector (mcp_tool_use/mcp_tool_result) or
+   * thinking blocks, and a breakpoint may only attach to a cacheable type —
+   * skipping the breakpoint there (the old behaviour) billed the whole
+   * conversation uncached for that call. (Residual caveat: a breakpoint finds
+   * its prior cache entry within a 20-content-block lookback, so a single hop
+   * adding more than ~20 blocks can still miss — rare enough to accept.)
    */
   withMessageCacheBreakpoint(messages) {
-    if (!messages.length) return messages;
     const copy = messages.slice();
-    const last = copy[copy.length - 1];
-    const blocks = typeof last.content === 'string'
-      ? [{ type: 'text', text: last.content }]
-      : Array.isArray(last.content) ? last.content.map((b) => ({ ...b })) : null;
-    if (!blocks) return messages;
-    let idx = -1;
-    for (let i = blocks.length - 1; i >= 0; i -= 1) {
-      if (Anthropic.CACHEABLE_BLOCKS.has(blocks[i].type)) { idx = i; break; }
+    for (let m = copy.length - 1; m >= 0; m -= 1) {
+      const msg = copy[m];
+      const blocks = typeof msg.content === 'string'
+        ? [{ type: 'text', text: msg.content }]
+        : Array.isArray(msg.content) ? msg.content.map((b) => ({ ...b })) : null;
+      if (!blocks) continue;
+      for (let i = blocks.length - 1; i >= 0; i -= 1) {
+        if (Anthropic.CACHEABLE_BLOCKS.has(blocks[i].type)) {
+          blocks[i] = { ...blocks[i], cache_control: this.cacheControl };
+          copy[m] = { ...msg, content: blocks };
+          return copy;
+        }
+      }
     }
-    if (idx < 0) return messages;
-    blocks[idx] = { ...blocks[idx], cache_control: { type: 'ephemeral' } };
-    copy[copy.length - 1] = { ...last, content: blocks };
-    return copy;
+    return messages;
   }
 
   /**
@@ -176,10 +244,10 @@ class Anthropic extends Llm {
     const mcpServers = this.activeMcpServers();
     const tools = this.toolsParam(mcpServers);
     // Send the (static, re-sent every round) system prompt as a content block
-    //  with an ephemeral cache_control breakpoint so successive rounds of the
-    //  same conversation hit the prompt cache rather than re-billing it in full.
+    //  with a cache_control breakpoint so successive rounds of the same
+    //  conversation hit the prompt cache rather than re-billing it in full.
     const system = this.gpt.system
-      ? [{ type: 'text', text: this.gpt.system, cache_control: { type: 'ephemeral' } }]
+      ? [{ type: 'text', text: this.gpt.system, cache_control: this.cacheControl }]
       : undefined;
     // Two cache breakpoints (well under Anthropic's limit of 4): the static
     //  system prompt, and a rolling one on the last message so system + tools +
@@ -188,6 +256,7 @@ class Anthropic extends Llm {
     const request = {
       model: this.gpt.model,
       max_tokens: this.gpt.max_tokens,
+      ...(this.effort ? { output_config: { effort: this.effort } } : {}),
       ...(system ? { system } : {}),
       messages,
       ...(tools.length ? { tools } : {}),

--- a/lib/set-builder-agent.js
+++ b/lib/set-builder-agent.js
@@ -21,7 +21,9 @@ const MCP_URL = process.env.SET_BUILDER_MCP_URL || 'https://mcp-next.aplisay.com
 // built-in agent to every tenant (see lib/builtin-agents.js).
 export const SET_BUILDER_AGENT_ID = 'builtin:set-builder';
 
-const SYSTEM_PROMPT = `You are the Aplisay Set Builder. You help a user design and create an "agent set" — a
+// Exported for the prompt↔registry consistency test (every model id the
+// prompt quotes as an example must exist in its handler's registry).
+export const SYSTEM_PROMPT = `You are the Aplisay Set Builder. You help a user design and create an "agent set" — a
 team of voice and text agents that work together on phone/WebRTC calls — and then create it for them
 via your tools. Be concise and collaborative: understand the goal, agree a name, propose a design, save it
 early, then refine. Persist work as you go so nothing is lost if the session is interrupted.
@@ -36,7 +38,7 @@ AGENT SET DOCUMENT
 Each member is an ordinary agent definition plus a set-unique "label":
   { "label": "sales", "name": "Sales", "modelName": "...", "prompt": "...", "functions": [ ... ] }
 - label: unique within the set, matching ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$ — used for intra-set references.
-- modelName: a handler-prefixed model, e.g. "livekit:ultravox/ultravox-70b" or "pipecat:openai/gpt-4o-realtime"
+- modelName: a handler-prefixed model, e.g. "livekit:ultravox/ultravox-70b" or "pipecat:openai/gpt-realtime"
   for VOICE (interactive-audio) agents, or "text:anthropic/..." / "text:openai/..." for TEXT agents.
   The type is inferred from the prefix ("text:" → a text agent).
 - prompt: the agent's own system prompt. Write it so the agent introduces itself when it takes a call.

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -37,9 +37,9 @@ export function getChatSession(id) {
  * and register it. Returns the session; read `session.id` / `/chat/${id}` for
  * the websocket path.
  */
-export function createChatSession({ agent, set, testResult, knowledge, logger = defaultLogger }) {
+export function createChatSession({ agent, set, testResult, subjectAgent, knowledge, logger = defaultLogger }) {
   const id = crypto.randomUUID();
-  const session = new TextChatSession({ id, agent, set, testResult, knowledge, logger });
+  const session = new TextChatSession({ id, agent, set, testResult, subjectAgent, knowledge, logger });
   sessions.set(id, session);
   session.expiry = setTimeout(() => {
     if (!session.connected) sessions.delete(id);
@@ -57,7 +57,7 @@ function interactiveSystemPrompt(agent) {
 }
 
 class TextChatSession {
-  constructor({ id, agent, set, testResult, knowledge, logger }) {
+  constructor({ id, agent, set, testResult, subjectAgent, knowledge, logger }) {
     Object.assign(this, { id, agent, logger });
     // Billing anchor for this text session: the interaction start. Stamped on
     // every usage row (metadata.startedAt) so cost resolution has a billing
@@ -68,6 +68,10 @@ class TextChatSession {
     // It also lets `test_agent` resolve a member label to a real agent id.
     this.latestSet = set || null;
     this.seedTestResult = testResult || null;
+    // The diagnosed agent's own definition, for a SET-LESS troubleshoot: the
+    // builder is asked to propose fixes to the agent, which is guesswork
+    // without its prompt/functions/options in front of it.
+    this.seedSubjectAgent = subjectAgent || null;
     // Optional pre-formatted context block (e.g. the org's website-knowledge
     // state) supplied by the caller and appended to the hidden opening turn.
     // Opaque to this service — relayed verbatim, never parsed.
@@ -149,9 +153,18 @@ class TextChatSession {
         ? 'propose specific fixes, then apply them with patch_agent_set (using the set id) once the user agrees.'
         : 'propose specific fixes the user can make to the agent (there is no saved agent set for this agent, '
           + 'so describe the changes rather than calling patch_agent_set).';
+      // Set-less troubleshoot: ground the diagnosis in the agent's own
+      // definition — without it, prompt/function root-causing is guesswork
+      // against half the evidence. An array means one definition per distinct
+      // agent on the call (a transfer chain between standalone agents).
+      const subject = !setJson && this.seedSubjectAgent
+        ? (Array.isArray(this.seedSubjectAgent)
+          ? `\n\nCURRENT AGENT DEFINITIONS (JSON — one per distinct agent on the call, root first):\n${JSON.stringify(this.seedSubjectAgent)}`
+          : `\n\nCURRENT AGENT DEFINITION (JSON):\n${JSON.stringify(this.seedSubjectAgent)}`)
+        : '';
       const context = setJson
         ? `\n\nCURRENT SET (JSON):\n${setJson}\n\nTEST RESULT (JSON):\n${JSON.stringify(this.seedTestResult)}`
-        : `\n\nTEST RESULT (JSON):\n${JSON.stringify(this.seedTestResult)}`;
+        : `${subject}\n\nTEST RESULT (JSON):\n${JSON.stringify(this.seedTestResult)}`;
       return intro
         + 'Greet very briefly, then analyse the test result below. The result has a `legs` array with ONE '
         + 'entry per call leg — each with its own agentLabel/agentName, transcript, functions and invocationLog. '
@@ -188,6 +201,9 @@ class TextChatSession {
       modelName: this.agent.modelName,
       model: this.agent.modelName,
       mcpServers: this.agent.mcpServers,
+      // Human-paced session: drivers that cache the prompt prefix may use a
+      // long TTL (a think-pause or test call outlives the 5m default).
+      interactive: true,
     });
   }
 
@@ -291,7 +307,7 @@ class TextChatSession {
               const res = await functionHandler(
                 others, this.functions, this.agent.keys || [],
                 (m) => this.onToolResults(m, send), {}, {}, this.functionOptions);
-              otherResults = res.function_results || [];
+              otherResults = this.slimResults(res.function_results || []);
             }
             this.pending = { toolUseId: pause.id, otherResults, platform: this.platformOf(pause.name) };
             if (this.platformOf(pause.name) === 'test_agent') {
@@ -314,7 +330,7 @@ class TextChatSession {
             round.calls, this.functions, this.agent.keys || [],
             (m) => this.onToolResults(m, send),
             {}, {}, this.functionOptions);
-          round = await this.llm.callResult(function_results, onLlmEvent);
+          round = await this.llm.callResult(this.slimResults(function_results), onLlmEvent);
           this.recordRoundUsage(round);
           continue;
         }
@@ -382,6 +398,41 @@ class TextChatSession {
   platformOf(name) {
     const fn = this.functions.find((f) => f.name === name);
     return fn && fn.platform;
+  }
+
+  /**
+   * Shrink set-mutation tool results before they enter the LLM conversation.
+   * A save's full rendered set (2-15KB) is only needed by the ws `set` frame
+   * and latestSet — both fed the full result via onToolResults BEFORE this
+   * runs. The model gets a confirmation stub instead: it already holds what it
+   * just sent as the tool_use arguments, and the stub carries the post-save
+   * identities (set id, member ids) that label resolution produced. Without
+   * this, every save echo rides the conversation for the rest of the session —
+   * an iterative build carries ~20-25k tokens of near-duplicate set snapshots.
+   * Save FAILURES (an `{ error }` result) pass through untouched — the model
+   * must read those verbatim to correct the payload.
+   */
+  static SET_PLATFORMS = new Set(['create_agent_set', 'update_agent_set', 'patch_agent_set']);
+
+  slimResults(results) {
+    return (results || []).map((r) => {
+      if (!TextChatSession.SET_PLATFORMS.has(this.platformOf(r.name))) return r;
+      try {
+        const parsed = JSON.parse(r.result);
+        if (!parsed || !Array.isArray(parsed.agents)) return r;
+        return {
+          ...r,
+          result: JSON.stringify({
+            saved: true,
+            id: parsed.id,
+            name: parsed.name,
+            members: parsed.agents.map((a) => ({ label: a.label, id: a.id, name: a.name })),
+          }),
+        };
+      } catch {
+        return r; // non-JSON result — pass through
+      }
+    });
   }
 
   /** Forward tool results, and surface a created/updated set as a typed event. */

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -27,6 +27,15 @@ const sessions = new Map();
 const PENDING_TTL_MS = Number(process.env.TEXT_CHAT_PENDING_TTL_MS || 120000);
 // Hard ceiling on tool round-trips within a single user turn.
 const MAX_TOOL_HOPS = Number(process.env.TEXT_CHAT_MAX_TOOL_HOPS || 16);
+// After the websocket drops, the session (and its whole LLM conversation)
+// survives for this long so a page reload or navigation RE-ATTACHES to it
+// instead of starting over — a fresh session re-pays the entire opening seed
+// + playbook fetch (15-22k tokens; restart clusters were a top cost in the
+// staging usage data) and forgets the conversation.
+const REATTACH_GRACE_MS = Number(process.env.TEXT_CHAT_REATTACH_GRACE_MS || 15 * 60 * 1000);
+// Frames produced while no socket is attached (a turn finishing across a
+// reload) are buffered and flushed on re-attach, so nothing said is lost.
+const OUTBOX_CAP = 200;
 
 export function getChatSession(id) {
   return sessions.get(id);
@@ -100,21 +109,61 @@ class TextChatSession {
     };
   }
 
-  /** Attach a websocket and run the chat for its lifetime. */
+  /**
+   * Attach a websocket and run the chat for its lifetime. Called again on
+   * RE-ATTACH: after a socket drop the session lingers for REATTACH_GRACE_MS,
+   * and a new socket for the same id rebinds to the live conversation — no
+   * new seed, no replayed opening turn; buffered frames flush, and a pending
+   * interactive ask (ask_user / test) is re-emitted so a freshly loaded UI
+   * can answer it. The `attached` frame tells the client which case it got.
+   */
   async handleChat(ws) {
+    // Single consumer, NEWEST socket wins: an existing socket is closed and
+    // the session rebinds to the new one. Rejecting the newcomer instead would
+    // strand the user in exactly the case the grace window exists for — after
+    // an ungraceful drop (laptop sleep, network switch) the dead socket can
+    // read as OPEN for minutes, and there is no heartbeat to prove otherwise.
+    // The superseded socket's close handler is a no-op (guarded on
+    // `this.ws !== ws`), so takeover can't tear the session down.
+    if (this.ws && this.ws !== ws && this.ws.readyState === this.ws.OPEN) {
+      const old = this.ws;
+      try { old.send(JSON.stringify({ type: 'error', message: 'This session was reconnected elsewhere.' })); } catch { /* dead socket */ }
+      try { old.close(); } catch { /* dead socket */ }
+    }
+    const firstAttach = !this.everConnected;
+    this.ws = ws;
     this.connected = true;
+    this.everConnected = true;
     clearTimeout(this.expiry);
-    const send = (msg) => {
-      try { ws.send(JSON.stringify(msg)); } catch (e) { this.logger.error(e, 'chat send failed'); }
-    };
+    clearTimeout(this.graceTimer);
+    if (!this.send) {
+      this.outbox = [];
+      // One canonical sender for the session's lifetime: every turn closure
+      // routes through it, so output from a turn that spans a reconnect lands
+      // on the CURRENT socket (or the outbox) instead of a dead one.
+      this.send = (msg) => {
+        if (!this.connected || !this.ws || this.ws.readyState !== this.ws.OPEN) {
+          this.outbox.push(msg);
+          if (this.outbox.length > OUTBOX_CAP) this.outbox.shift();
+          return;
+        }
+        try { this.ws.send(JSON.stringify(msg)); } catch (e) { this.logger.error(e, 'chat send failed'); }
+      };
+    }
+    const send = this.send;
 
-    try {
-      await this.buildLlm();
-    } catch (e) {
-      this.logger.error(e, 'chat agent init failed');
-      send({ type: 'error', message: `Could not start agent: ${e.message}` });
-      ws.close();
-      return;
+    if (firstAttach) {
+      try {
+        await this.buildLlm();
+      } catch (e) {
+        this.logger.error(e, 'chat agent init failed');
+        send({ type: 'error', message: `Could not start agent: ${e.message}` });
+        ws.close();
+        // No LLM was ever built — nothing to re-attach to. Tear down now
+        // rather than leaving an llm-less zombie in the registry forever.
+        this.teardown();
+        return;
+      }
     }
 
     ws.on('message', async (data) => {
@@ -126,8 +175,30 @@ class TextChatSession {
         await this.testResult(msg, send);
       }
     });
-    ws.on('close', () => { this.finaliseUsage(); sessions.delete(this.id); });
+    ws.on('close', () => {
+      if (this.ws !== ws) return; // superseded by a newer socket
+      this.connected = false;
+      this.graceTimer = setTimeout(() => this.teardown(), REATTACH_GRACE_MS);
+      if (this.graceTimer.unref) this.graceTimer.unref();
+    });
     ws.on('error', (e) => this.logger.error(e, 'chat ws error'));
+
+    // `busy` lets a re-attaching client restore its thinking indicator when a
+    // turn is still running from before the drop.
+    send({ type: 'attached', resumed: !firstAttach, busy: !!this.busy });
+    if (!firstAttach) {
+      // A pause reached while detached puts its frame in the outbox AND on
+      // this.pending — skip it in the flush (same object) so it arrives once.
+      const queued = this.outbox;
+      this.outbox = [];
+      for (const msg of queued) {
+        if (msg !== this.pending?.frame) send(msg);
+      }
+      // A paused interactive ask was emitted to the old socket — re-emit it so
+      // the restored UI shows the question/test card again.
+      if (this.pending?.frame) send(this.pending.frame);
+      return;
+    }
 
     // Open with a hidden turn whose prompt depends on how the session was seeded
     // (build from scratch / edit an existing set / diagnose a test result). Any
@@ -136,6 +207,18 @@ class TextChatSession {
       ? `${this.openingPrompt()}\n\n${this.seedKnowledge}`
       : this.openingPrompt();
     await this.turn(opening, send, true);
+  }
+
+  /**
+   * Final teardown once the re-attach grace lapses. Usage finalisation
+   * (cost-at-finalisation) therefore lags a dropped session by the grace
+   * window, and a process exit during grace skips it entirely — both are
+   * covered by the nightly uncosted-row sweep (lib/rates.js), which exists as
+   * the backstop for exactly this class of exit.
+   */
+  teardown() {
+    this.finaliseUsage();
+    sessions.delete(this.id);
   }
 
   /** The hidden opening-turn prompt — build, edit, or diagnose depending on the seed. */
@@ -226,6 +309,7 @@ class TextChatSession {
   }
 
   async runTurn(userText, send, hidden = false, claimed = null) {
+    this.busy = true;
     if (!hidden) send({ type: 'user_echo', text: userText });
     send({ type: 'status', state: 'thinking' });
     this.logger.info({ id: this.id, hidden, resume: !!claimed }, 'chat turn started');
@@ -309,20 +393,24 @@ class TextChatSession {
                 (m) => this.onToolResults(m, send), {}, {}, this.functionOptions);
               otherResults = this.slimResults(res.function_results || []);
             }
-            this.pending = { toolUseId: pause.id, otherResults, platform: this.platformOf(pause.name) };
+            // The pause frame is kept on the pending record so a client that
+            // re-attaches after a drop can be shown the ask again.
+            let frame;
             if (this.platformOf(pause.name) === 'test_agent') {
               const label = pause.input?.label;
               const member = (this.latestSet?.agents || []).find((a) => a.label === label);
-              send({ type: 'test', id: pause.id, label, agentId: member?.id || null, name: member?.name || label });
+              frame = { type: 'test', id: pause.id, label, agentId: member?.id || null, name: member?.name || label };
             } else {
-              send({
+              frame = {
                 type: 'question',
                 id: pause.id,
                 question: pause.input?.question || '',
                 options: Array.isArray(pause.input?.options) ? pause.input.options : [],
                 multiSelect: !!pause.input?.multiSelect,
-              });
+              };
             }
+            this.pending = { toolUseId: pause.id, otherResults, platform: this.platformOf(pause.name), frame };
+            send(frame);
             return; // paused — the next user message resumes this turn
           }
           send({ type: 'tool_call', calls: round.calls.map(({ name, input }) => ({ name, input })) });
@@ -344,6 +432,7 @@ class TextChatSession {
       this.logger.error(e, 'chat turn failed');
       send({ type: 'error', message: e.message });
     } finally {
+      this.busy = false;
       send({ type: 'turn_complete' });
     }
   }

--- a/lib/ws-handler.js
+++ b/lib/ws-handler.js
@@ -21,7 +21,13 @@ const createWsServer = ({ server, logger }, restrict) => {
         wss.on('connection', (ws) => session.handleChat(ws));
         wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req));
       } else {
+        // Refuse the upgrade OUTRIGHT: leaving it unanswered parks the browser
+        // WebSocket in CONNECTING, so a client probing a lapsed session (the
+        // re-attach flow after the grace window) would burn its whole fallback
+        // timeout instead of failing over immediately.
         logger.debug({ id }, `WS chat request but no session for ${url.path}`);
+        socket.write('HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n');
+        socket.destroy();
       }
       return;
     }

--- a/tests/set-builder-prompt-models.test.mjs
+++ b/tests/set-builder-prompt-models.test.mjs
@@ -1,0 +1,45 @@
+import { SYSTEM_PROMPT } from '../lib/set-builder-agent.js';
+import { pipecatModelIdFlags } from '../lib/models/pipecat.js';
+import { livekitModelIdFlags } from '../agents/livekit/dist/lib/livekit-model-registry.js';
+import Anthropic from '../lib/models/anthropic.js';
+
+// The builder prompt tells the model "Never invent a model name" and then
+// quotes example model ids — so every id the prompt quotes must actually exist
+// in the corresponding handler registry. A phantom example (this caught
+// "pipecat:openai/gpt-4o-realtime") is worse than a rejected save: model ids
+// are not validated at create time, so an agent copying the example saves
+// fine and then fails at call time. Placeholder ids ending "..." are skipped —
+// they illustrate a prefix, not a model.
+
+describe('set-builder prompt model examples', () => {
+  const quoted = [...SYSTEM_PROMPT.matchAll(/"(pipecat|livekit|text|jambonz|ultravox):([a-z0-9_-]+)\/([A-Za-z0-9._-]+)"/g)]
+    .map(([, handler, provider, model]) => ({ handler, id: `${provider}/${model}` }))
+    .filter((q) => !q.id.endsWith('...'));
+
+  test('the prompt quotes at least one handler-prefixed example', () => {
+    expect(quoted.length).toBeGreaterThan(0);
+  });
+
+  test('every pipecat: example exists in the pipecat model registry', () => {
+    for (const { handler, id } of quoted.filter((q) => q.handler === 'pipecat')) {
+      expect({ handler, id, known: !!pipecatModelIdFlags[id] }).toEqual({ handler, id, known: true });
+    }
+  });
+
+  test('every livekit: example exists in the livekit model registry', () => {
+    for (const { handler, id } of quoted.filter((q) => q.handler === 'livekit')) {
+      expect({ handler, id, known: !!livekitModelIdFlags[id] }).toEqual({ handler, id, known: true });
+    }
+  });
+
+  test('every text: example exists in a text-driver model list', () => {
+    const known = new Set(Anthropic.allModels.map(([id]) => id));
+    for (const { handler, id } of quoted.filter((q) => q.handler === 'text')) {
+      expect({ handler, id, known: known.has(id) }).toEqual({ handler, id, known: true });
+    }
+  });
+
+  test('the retired gpt-4o-realtime example is gone', () => {
+    expect(SYSTEM_PROMPT).not.toContain('gpt-4o-realtime');
+  });
+});

--- a/tests/text-chat-reattach.test.mjs
+++ b/tests/text-chat-reattach.test.mjs
@@ -1,0 +1,177 @@
+// database-test-wrapper sets the POSTGRES_* env for the standard test container
+// BEFORE lib/database.js is imported (text-chat.js pulls it in transitively),
+// and its teardown closes the import-time connections so jest can exit.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+
+const { createChatSession, getChatSession } = await import('../lib/text-chat.js');
+const { trimVoicesResult } = await import('../lib/function-handler.js');
+
+// Session re-attach: after the websocket drops, the session (and its whole LLM
+// conversation) lingers for a grace window; a new socket for the same id
+// rebinds instead of the client re-paying the full seed + playbook in a fresh
+// session. These tests pin the lifecycle: first attach runs the opening turn,
+// re-attach doesn't; frames produced while detached flush from the outbox; a
+// pending interactive ask is re-emitted; and a second concurrent socket is
+// rejected.
+
+const logger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const agent = {
+  id: 'agent-1',
+  organisationId: 'org-1',
+  userId: 'user-1',
+  modelName: 'text:anthropic/claude-sonnet-5',
+  functions: [],
+  keys: [],
+  options: {},
+  mcpServers: [],
+};
+
+beforeAll(async () => {
+  await setupRealDatabase();
+});
+
+afterAll(async () => {
+  await teardownRealDatabase();
+});
+
+/** Minimal ws double: records sent frames, exposes its handlers. */
+function makeWs() {
+  const ws = {
+    OPEN: 1,
+    readyState: 1,
+    sent: [],
+    handlers: {},
+    send(raw) { this.sent.push(JSON.parse(raw)); },
+    on(ev, fn) { this.handlers[ev] = fn; },
+    close() { this.readyState = 3; },
+  };
+  return ws;
+}
+
+function makeSession() {
+  const session = createChatSession({ agent, logger });
+  const turns = [];
+  session.buildLlm = async () => {}; // no LLM in these tests
+  session.runTurn = (text, send, hidden = false, claimed = null) => {
+    turns.push({ text, hidden, claimed });
+    return Promise.resolve();
+  };
+  return { session, turns };
+}
+
+describe('text-chat session re-attach', () => {
+  test('first attach announces itself and runs the opening turn once', async () => {
+    const { session, turns } = makeSession();
+    const ws = makeWs();
+    await session.handleChat(ws);
+    expect(ws.sent[0]).toEqual({ type: 'attached', resumed: false, busy: false });
+    expect(turns).toHaveLength(1);
+    expect(turns[0].hidden).toBe(true);
+  });
+
+  test('re-attach after a drop rebinds without a new opening turn and flushes the outbox', async () => {
+    const { session, turns } = makeSession();
+    const ws1 = makeWs();
+    await session.handleChat(ws1);
+    expect(turns).toHaveLength(1);
+
+    // Drop the socket: the session lingers (grace) rather than being deleted.
+    ws1.readyState = 3;
+    ws1.handlers.close();
+    expect(getChatSession(session.id)).toBe(session);
+
+    // A frame produced while detached is buffered, not lost.
+    session.send({ type: 'agent', text: 'finished while you were away' });
+
+    const ws2 = makeWs();
+    await session.handleChat(ws2);
+    expect(turns).toHaveLength(1); // no second opening turn
+    expect(ws2.sent[0]).toEqual({ type: 'attached', resumed: true, busy: false });
+    expect(ws2.sent[1]).toEqual({ type: 'agent', text: 'finished while you were away' });
+  });
+
+  test('re-attach re-emits a pending interactive ask', async () => {
+    const { session } = makeSession();
+    const ws1 = makeWs();
+    await session.handleChat(ws1);
+    const frame = { type: 'question', id: 'toolu_q', question: 'Which channel?', options: [], multiSelect: false };
+    session.pending = { toolUseId: 'toolu_q', otherResults: [], platform: 'ask_user', frame };
+
+    ws1.readyState = 3;
+    ws1.handlers.close();
+    const ws2 = makeWs();
+    await session.handleChat(ws2);
+    expect(ws2.sent).toContainEqual(frame);
+  });
+
+  test('a second concurrent socket TAKES OVER (newest wins; half-open old sockets must not block)', async () => {
+    const { session, turns } = makeSession();
+    const ws1 = makeWs();
+    await session.handleChat(ws1);
+    const ws2 = makeWs();
+    await session.handleChat(ws2);
+    // The old socket is told and closed; the session now speaks to the new one.
+    expect(ws1.sent.at(-1)?.type).toBe('error');
+    expect(ws1.readyState).toBe(3); // closed
+    expect(session.ws).toBe(ws2);
+    expect(ws2.sent[0]).toEqual({ type: 'attached', resumed: true, busy: false });
+    expect(turns).toHaveLength(1); // still no second opening turn
+  });
+
+  test('a pause reached while detached is delivered exactly once on re-attach', async () => {
+    const { session } = makeSession();
+    const ws1 = makeWs();
+    await session.handleChat(ws1);
+    ws1.readyState = 3;
+    ws1.handlers.close();
+    // The pause frame goes through send() while detached (outbox) AND onto
+    // this.pending — re-attach must not deliver it twice.
+    const frame = { type: 'question', id: 'toolu_q', question: 'Which?', options: [], multiSelect: false };
+    session.pending = { toolUseId: 'toolu_q', otherResults: [], platform: 'ask_user', frame };
+    session.send(frame);
+    const ws2 = makeWs();
+    await session.handleChat(ws2);
+    expect(ws2.sent.filter((f) => f.type === 'question')).toHaveLength(1);
+  });
+
+  test('buildLlm failure tears the session down instead of leaving a zombie', async () => {
+    const { session } = makeSession();
+    session.buildLlm = async () => { throw new Error('no such model'); };
+    const ws = makeWs();
+    await session.handleChat(ws);
+    expect(getChatSession(session.id)).toBeUndefined();
+  });
+
+  test('teardown finalises and removes the session', async () => {
+    const { session } = makeSession();
+    const ws = makeWs();
+    await session.handleChat(ws);
+    session.teardown();
+    expect(getChatSession(session.id)).toBeUndefined();
+  });
+});
+
+describe('list_voices payload bound', () => {
+  test('long descriptions are capped and oversized vendor lists truncated with a note', () => {
+    const voices = Array.from({ length: 70 }, (_, i) => ({
+      name: `voice-${i}`,
+      gender: 'female',
+      description: 'd'.repeat(300),
+    }));
+    const out = trimVoicesResult({ vendors: { elevenlabs: voices, cartesia: voices.slice(0, 3) }, voiceStack: 'pipeline' });
+    expect(out.vendors.elevenlabs).toHaveLength(61); // 60 + trailing note
+    expect(out.vendors.elevenlabs[60].note).toMatch(/10 more elevenlabs voices/);
+    expect(out.vendors.elevenlabs[0].description.length).toBeLessThanOrEqual(101);
+    expect(out.vendors.cartesia).toHaveLength(3);
+    expect(out.voiceStack).toBe('pipeline');
+  });
+
+  test('locale-list results (no vendors) pass through untouched', () => {
+    const result = { locales: ['en-GB', 'any'], voiceStack: 'realtime' };
+    expect(trimVoicesResult(result)).toBe(result);
+  });
+});

--- a/tests/text-chat-test-result.test.mjs
+++ b/tests/text-chat-test-result.test.mjs
@@ -110,3 +110,52 @@ describe('text-chat test_result frame', () => {
     expect(session.pending).toBeNull();
   });
 });
+
+describe('text-chat slimResults', () => {
+  const setAgent = {
+    ...agent,
+    functions: [
+      { name: 'create_agent_set', platform: 'create_agent_set' },
+      { name: 'list_voices', platform: 'list_voices' },
+    ],
+  };
+  const fullSet = JSON.stringify({
+    id: 'set-1',
+    name: 'Team',
+    description: 'a team',
+    agents: [
+      { id: 'a-1', label: 'main', name: 'Main', prompt: 'x'.repeat(4000), functions: [] },
+      { id: 'a-2', label: 'sales', name: 'Sales', prompt: 'y'.repeat(4000), functions: [] },
+    ],
+  });
+
+  test('a save result is replaced with a stub carrying the post-save identities', () => {
+    const session = createChatSession({ agent: setAgent, logger });
+    const [slim] = session.slimResults([{ name: 'create_agent_set', result: fullSet }]);
+    const parsed = JSON.parse(slim.result);
+    expect(parsed).toEqual({
+      saved: true,
+      id: 'set-1',
+      name: 'Team',
+      members: [
+        { label: 'main', id: 'a-1', name: 'Main' },
+        { label: 'sales', id: 'a-2', name: 'Sales' },
+      ],
+    });
+    expect(slim.result.length).toBeLessThan(fullSet.length / 10);
+  });
+
+  test('save FAILURES and non-set tools pass through verbatim', () => {
+    const session = createChatSession({ agent: setAgent, logger });
+    const error = JSON.stringify({ error: 'validation failed: agents[0].functions[0] …' });
+    const voices = JSON.stringify({ locales: ['en-GB'] });
+    const results = session.slimResults([
+      { name: 'create_agent_set', result: error },
+      { name: 'list_voices', result: voices },
+      { name: 'create_agent_set', result: 'not json' },
+    ]);
+    expect(results[0].result).toBe(error);
+    expect(results[1].result).toBe(voices);
+    expect(results[2].result).toBe('not json');
+  });
+});


### PR DESCRIPTION
## Token efficiency
- **1h cache TTL for interactive sessions** (`ANTHROPIC_CACHE_TTL` env, validated `5m|1h`): think-pauses and in-browser test calls outlive the 5-minute TTL, and every lapse re-writes the whole 30–50k prefix at the write premium — 2–4 lapses/session on staging. Headless invoke/subagent one-shots keep 5m (nothing pauses there; 2× write premium would be pure cost).
- **Walk-back rolling breakpoint**: a pause_turn continuation ending on all-MCP/thinking blocks used to skip the message breakpoint silently, billing the conversation uncached that call.
- **Slim save echoes**: create/patch/update_agent_set results reach the LLM as a ~100-token stub (post-save ids included); the ws `set` frame + `latestSet` still get the full render. Save errors and truncation notices pass through verbatim.
- **options.effort** → `output_config.effort`, gated per model (rejected models omit; `xhigh`→`high` on 4.6-family) so a mis-set option can't 400 every turn.

## Coverage / correctness
- `subjectAgent` seed on POST /agents/{id}/chat: set-less troubleshoots now ground the diagnosis in the agent definition(s) — array-per-leg for transfer chains.
- Phantom `pipecat:openai/gpt-4o-realtime` prompt example fixed (model ids aren't validated at create — agents saved fine and failed at call time) + a prompt↔registry consistency test (pipecat/livekit/text ids).
- Builtin prompt: decline-shape guidance for skipped tests.

## Verification
Full db suite 46/46 suites, 505 tests. 