### PR TITLE
feat(chat): persisted session history + builder eval harness

### DIFF
--- a/api/paths/chat-sessions.js
+++ b/api/paths/chat-sessions.js
@@ -1,0 +1,162 @@
+import { fn, col, Op } from 'sequelize';
+import { ChatSession, UsageRecord } from '../../lib/database.js';
+import { scopeWhereForUser } from '../../lib/scope.js';
+import { requirePermission } from '../../lib/auth/permissions.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    GET: listChatSessions,
+  };
+}
+
+/**
+ * Aggregate LLM token usage (and any resolved cost) for a page of chat
+ * sessions in one query — usage_records keys on the same session id.
+ */
+async function usageBySession(ids) {
+  if (!ids.length) return {};
+  const rows = await UsageRecord.findAll({
+    attributes: [
+      [col('session_id'), 'sessionId'],
+      [col('unit'), 'unit'],
+      [fn('SUM', col('quantity')), 'quantity'],
+      [fn('SUM', col('cost_micros')), 'costMicros'],
+      [fn('MAX', col('currency')), 'currency'],
+    ],
+    where: { sessionId: { [Op.in]: ids }, technology: 'llm' },
+    group: [col('session_id'), col('unit')],
+    raw: true,
+  });
+  const UNIT_KEYS = {
+    input_tokens: 'inputTokens',
+    output_tokens: 'outputTokens',
+    cache_read_tokens: 'cacheReadTokens',
+    cache_write_tokens: 'cacheWriteTokens',
+  };
+  const out = {};
+  for (const r of rows) {
+    const key = UNIT_KEYS[r.unit];
+    if (!key) continue;
+    const entry = (out[r.sessionId] = out[r.sessionId] || {
+      inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costMicros: 0, currency: null,
+    });
+    entry[key] = Number(r.quantity) || 0;
+    entry.costMicros += Number(r.costMicros) || 0;
+    entry.currency = entry.currency || r.currency || null;
+  }
+  return out;
+}
+
+/**
+ * GET /chat-sessions — the builder session history: persisted interactive
+ * chat sessions in the caller's scope, newest first, each with its aggregated
+ * LLM token usage. Filter by the agent set worked on (`setId`) or the chat
+ * agent itself (`agentId`). Transcripts are NOT included here — fetch one
+ * session for its transcript.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const listChatSessions = async (req, res) => {
+  if (!requirePermission(res, 'agent', 'read')) return;
+  try {
+    const { setId, agentId } = req.query;
+    // set_id is a uuid column — a malformed value would 500 on the Postgres
+    // cast; reject it as the client error it is. (agentId is a string column.)
+    if (setId && !UUID_RE.test(String(setId))) {
+      return res.status(400).send({ message: 'setId must be a UUID' });
+    }
+    const limit = Math.max(1, Math.min(parseInt(req.query.limit) || 20, 100));
+    const offset = Math.max(0, parseInt(req.query.offset) || 0);
+    const where = {
+      ...scopeWhereForUser(res.locals.user),
+      ...(setId ? { setId } : {}),
+      ...(agentId ? { agentId } : {}),
+    };
+    const { count, rows } = await ChatSession.findAndCountAll({
+      attributes: ['id', 'agentId', 'setId', 'mode', 'title', 'modelName', 'startedAt', 'endedAt', 'turns'],
+      where,
+      order: [['startedAt', 'DESC']],
+      limit,
+      offset,
+    });
+    const usage = await usageBySession(rows.map((r) => r.id));
+    res.send({
+      sessions: rows.map((r) => ({ ...r.get({ plain: true }), usage: usage[r.id] || null })),
+      total: count,
+    });
+  } catch (error) {
+    req.log.error(error);
+    res.status(500).send({ error: error.message });
+  }
+};
+
+listChatSessions.apiDoc = {
+  summary: 'List persisted interactive chat sessions (builder session history)',
+  description:
+    'Returns the caller\'s persisted text-agent chat sessions, newest first, each with aggregated LLM '
+    + 'token usage joined from the usage ledger. Filter by the agent set the session worked on (`setId`) '
+    + 'or by the chat agent (`agentId`). Transcripts are returned by GET /chat-sessions/{sessionId} only.',
+  operationId: 'listChatSessions',
+  tags: ['Agent'],
+  parameters: [
+    { in: 'query', name: 'setId', required: false, schema: { type: 'string' }, description: 'Only sessions that worked on this agent set' },
+    { in: 'query', name: 'agentId', required: false, schema: { type: 'string' }, description: 'Only sessions chatted with this agent (e.g. the org builder)' },
+    { in: 'query', name: 'limit', required: false, schema: { type: 'integer', default: 20, maximum: 100 } },
+    { in: 'query', name: 'offset', required: false, schema: { type: 'integer', default: 0 } },
+  ],
+  responses: {
+    200: {
+      description: 'Sessions in scope, newest first.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              total: { type: 'integer' },
+              sessions: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'string' },
+                    agentId: { type: 'string', nullable: true },
+                    setId: { type: 'string', nullable: true },
+                    mode: { type: 'string', nullable: true, description: "'new' | 'edit' | 'troubleshoot'" },
+                    title: { type: 'string', nullable: true },
+                    modelName: { type: 'string', nullable: true },
+                    startedAt: { type: 'string', format: 'date-time' },
+                    endedAt: { type: 'string', format: 'date-time', nullable: true },
+                    turns: { type: 'integer' },
+                    usage: {
+                      type: 'object',
+                      nullable: true,
+                      properties: {
+                        inputTokens: { type: 'integer' },
+                        outputTokens: { type: 'integer' },
+                        cacheReadTokens: { type: 'integer' },
+                        cacheWriteTokens: { type: 'integer' },
+                        costMicros: { type: 'integer' },
+                        currency: { type: 'string', nullable: true },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    default: {
+      description: 'Error',
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/Error' },
+        },
+      },
+    },
+  },
+};

--- a/api/paths/chat-sessions/{sessionId}.js
+++ b/api/paths/chat-sessions/{sessionId}.js
@@ -1,0 +1,140 @@
+import { fn, col } from 'sequelize';
+import { ChatSession, UsageRecord } from '../../../lib/database.js';
+import { scopeWhereForUser } from '../../../lib/scope.js';
+import { requirePermission } from '../../../lib/auth/permissions.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    GET: getChatSession,
+  };
+}
+
+/**
+ * GET /chat-sessions/{sessionId} — one persisted chat session, including its
+ * transcript and aggregated LLM token usage. Scoped to the caller.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const getChatSession = async (req, res) => {
+  if (!requirePermission(res, 'agent', 'read')) return;
+  const { sessionId } = req.params;
+  // id is a uuid column — a malformed value would 500 on the Postgres cast;
+  // for a GET-by-id that's simply "no such session".
+  if (!UUID_RE.test(String(sessionId))) {
+    return res.status(404).send({ message: `Chat session ${sessionId} not found` });
+  }
+  try {
+    const session = await ChatSession.findOne({
+      where: { id: sessionId, ...scopeWhereForUser(res.locals.user) },
+    });
+    if (!session) {
+      return res.status(404).send({ message: `Chat session ${sessionId} not found` });
+    }
+    const rows = await UsageRecord.findAll({
+      attributes: [
+        [col('unit'), 'unit'],
+        [fn('SUM', col('quantity')), 'quantity'],
+        [fn('SUM', col('cost_micros')), 'costMicros'],
+        [fn('MAX', col('currency')), 'currency'],
+      ],
+      where: { sessionId, technology: 'llm' },
+      group: [col('unit')],
+      raw: true,
+    });
+    const UNIT_KEYS = {
+      input_tokens: 'inputTokens',
+      output_tokens: 'outputTokens',
+      cache_read_tokens: 'cacheReadTokens',
+      cache_write_tokens: 'cacheWriteTokens',
+    };
+    const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, costMicros: 0, currency: null };
+    for (const r of rows) {
+      const key = UNIT_KEYS[r.unit];
+      if (!key) continue;
+      usage[key] = Number(r.quantity) || 0;
+      usage.costMicros += Number(r.costMicros) || 0;
+      usage.currency = usage.currency || r.currency || null;
+    }
+    res.send({ ...session.get({ plain: true }), usage });
+  } catch (error) {
+    req.log.error(error);
+    res.status(500).send({ error: error.message });
+  }
+};
+
+getChatSession.apiDoc = {
+  summary: 'Fetch one persisted chat session, including its transcript',
+  description:
+    'Returns a single persisted text-agent chat session in the caller\'s scope, with the recorded '
+    + 'transcript ([{role, text, at}]) and aggregated LLM token usage from the usage ledger.',
+  operationId: 'getChatSession',
+  tags: ['Agent'],
+  parameters: [
+    { in: 'path', name: 'sessionId', required: true, schema: { type: 'string' } },
+  ],
+  responses: {
+    200: {
+      description: 'The chat session.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+              agentId: { type: 'string', nullable: true },
+              setId: { type: 'string', nullable: true },
+              mode: { type: 'string', nullable: true },
+              title: { type: 'string', nullable: true },
+              modelName: { type: 'string', nullable: true },
+              startedAt: { type: 'string', format: 'date-time' },
+              endedAt: { type: 'string', format: 'date-time', nullable: true },
+              turns: { type: 'integer' },
+              transcript: {
+                type: 'array',
+                nullable: true,
+                items: {
+                  type: 'object',
+                  properties: {
+                    role: { type: 'string' },
+                    text: { type: 'string' },
+                    at: { type: 'string' },
+                  },
+                },
+              },
+              usage: {
+                type: 'object',
+                properties: {
+                  inputTokens: { type: 'integer' },
+                  outputTokens: { type: 'integer' },
+                  cacheReadTokens: { type: 'integer' },
+                  cacheWriteTokens: { type: 'integer' },
+                  costMicros: { type: 'integer' },
+                  currency: { type: 'string', nullable: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    404: {
+      description: 'No such session in the caller\'s scope.',
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/Error' },
+        },
+      },
+    },
+    default: {
+      description: 'Error',
+      content: {
+        'application/json': {
+          schema: { $ref: '#/components/schemas/Error' },
+        },
+      },
+    },
+  },
+};

--- a/lib/database.js
+++ b/lib/database.js
@@ -10,7 +10,10 @@ import { initPhoneRegistration } from './database-models/phone-registration.js';
 import { encryptSecret, decryptSecret } from './utils/credentials.js';
 import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-limits.js';
 
-const schemaVersion = 54;  // 54: `organisations.chargeable_number_limit` (max numbers an org may hold on
+const schemaVersion = 55;  // 55: `chat_sessions` — persisted interactive text-agent chat sessions
+                           //     (transcript, set linkage, mode, usage joins on usage_records.session_id)
+                           //     backing the builder session-history API (GET /chat-sessions).
+                           // 54: `organisations.chargeable_number_limit` (max numbers an org may hold on
                            //     chargeable/non-owned trunks; default 3, null = unlimited). Enforced in
                            //     createPhoneEndpoint for chargeable-trunk DDIs only.
                            // 53: billing Phase D7 — DROP the tariffs period-overlap EXCLUDE constraint;
@@ -1470,6 +1473,89 @@ UsageRecord.init({
 });
 
 /**
+ * A persisted interactive text-agent chat session (schema v55) — the durable
+ * record behind the builder's session history. The in-memory TextChatSession
+ * (lib/text-chat.js) creates a row on first attach and best-effort updates it
+ * per turn; the id IS the chat session id, so token usage joins directly on
+ * usage_records.session_id. `setId` is a plain (un-FK'd) column on purpose:
+ * history must survive the set being deleted. `agentId` is a STRING, not a
+ * UUID — built-in agents ('builtin:set-builder') chat too.
+ *
+ * @class ChatSession
+ */
+class ChatSession extends Model {}
+
+ChatSession.init({
+  id: {
+    type: DataTypes.UUID,
+    primaryKey: true,
+  },
+  agentId: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  organisationId: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  userId: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  // The agent set the session was working on: seeded from an edit/troubleshoot
+  // opener, or stamped at the first save of a new-team session.
+  setId: {
+    type: DataTypes.UUID,
+    allowNull: true,
+  },
+  // How the session was seeded: 'new' | 'edit' | 'troubleshoot'.
+  mode: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  // Display title — the set's name where known.
+  title: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  modelName: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  startedAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+  },
+  endedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
+  turns: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    defaultValue: 0,
+  },
+  // [{ role: 'user'|'agent'|'system', text, at }] — capped by the writer.
+  transcript: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  },
+},
+  {
+    sequelize,
+    timestamps: true,
+    underscored: true,
+    indexes: [
+      { fields: ['organisation_id', 'set_id'] },
+      { fields: ['organisation_id', 'agent_id'] },
+      { fields: ['organisation_id', 'started_at'] },
+      // The list endpoint scopes by userId OR organisationId then orders by
+      // started_at — cover the user side too.
+      { fields: ['user_id', 'started_at'] },
+    ],
+  });
+
+/**
  * Named, date-ranged rate card — the per-component price definitions that value
  * UsageRecords at transaction end (schema v44). Identified by (name, startDate);
  * the effective interval is [startDate, endDate) where a null endDate is open
@@ -2414,6 +2500,7 @@ const databaseStarted = sequelize.authenticate()
     .then(() => TransactionLog.sync({ alter: true }))
     .then(() => InvocationLog.sync({ alter: true }))
     .then(() => UsageRecord.sync({ alter: true }))
+    .then(() => ChatSession.sync({ alter: true }))
     .then(() => RateCard.sync({ alter: true }))
     .then(() => addRateCardOverlapConstraint())
     .then(() => BalanceCredit.sync({ alter: true }))
@@ -2430,6 +2517,24 @@ const databaseStarted = sequelize.authenticate()
       return Metadata.upsert({ key: 'dbVersion', value: schemaVersion }, { returning: true });
     })) || Promise.resolve())
   .then(async () => {
+    // chat_sessions is ensured UNCONDITIONALLY (plain sync: create-if-missing,
+    // no alter), outside the DB_FORCE_SYNC-gated upgrade chain. This class of
+    // gated table creation has silently failed to reach staging/prod twice
+    // before (better-auth satellite tables; see schema-history notes) and this
+    // feature's failure mode is the quietest yet: chats keep working, history
+    // just never records, and the UI shows an innocuous empty state.
+    await ChatSession.sync();
+    // Boot sweep: sessions live only in THIS process's memory, so any row
+    // still open (ended_at IS NULL) at boot belongs to a previous process and
+    // is by definition dead — close it at its last write, or the history UI
+    // shows phantom LIVE sessions forever. (Single-instance assumption; use a
+    // started_at cutoff if the API layer ever scales out.)
+    const swept = await sequelize.query(
+      `UPDATE "chat_sessions" SET "ended_at" = "updated_at" WHERE "ended_at" IS NULL`,
+    );
+    const closed = swept?.[1]?.rowCount ?? 0;
+    if (closed) logger.info({ closed }, 'Closed orphaned chat sessions from a previous process');
+
     // Domain-column defaults for Better-Auth's direct inserts (parallel-auth phase).
     await setColumnDefault('users', 'role', `'owner'`);
     await setColumnDefault('users', 'signup_method', `'better-auth'`);
@@ -2487,6 +2592,7 @@ export {
   InvocationLog,
   CallRecordingDownload,
   UsageRecord,
+  ChatSession,
   RateCard,
   BalanceCredit,
   Tariff,

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -20,6 +20,11 @@ import { functionHandler } from './function-handler.js';
 import { llmFunctions, runSubagentById } from './subagent.js';
 import { createAgentSetForAgent, updateAgentSetForAgent, patchAgentSetForAgent } from './agent-set-service.js';
 import { recordLlmTokens, recordSubagentUsage, finaliseSession } from './usage.js';
+import { ChatSession } from './database.js';
+
+// Persisted transcripts are capped: keep the newest entries (with an elision
+// marker) so a marathon session can't grow a row without bound.
+const TRANSCRIPT_MAX_ENTRIES = 500;
 
 const sessions = new Map();
 // A session is created when the chat is opened and consumed when the client's
@@ -152,20 +157,10 @@ class TextChatSession {
     }
     const send = this.send;
 
-    if (firstAttach) {
-      try {
-        await this.buildLlm();
-      } catch (e) {
-        this.logger.error(e, 'chat agent init failed');
-        send({ type: 'error', message: `Could not start agent: ${e.message}` });
-        ws.close();
-        // No LLM was ever built — nothing to re-attach to. Tear down now
-        // rather than leaving an llm-less zombie in the registry forever.
-        this.teardown();
-        return;
-      }
-    }
-
+    // Handlers are registered BEFORE the awaits below: a socket that drops
+    // while buildLlm/persist are in flight would otherwise emit 'close' with
+    // no listener, so the grace timer would never arm and the session would
+    // leak in memory forever.
     ws.on('message', async (data) => {
       let msg;
       try { msg = JSON.parse(data.toString()); } catch { return; }
@@ -182,6 +177,52 @@ class TextChatSession {
       if (this.graceTimer.unref) this.graceTimer.unref();
     });
     ws.on('error', (e) => this.logger.error(e, 'chat ws error'));
+
+    if (firstAttach) {
+      try {
+        await this.buildLlm();
+      } catch (e) {
+        this.logger.error(e, 'chat agent init failed');
+        send({ type: 'error', message: `Could not start agent: ${e.message}` });
+        ws.close();
+        // No LLM was ever built — nothing to re-attach to. Tear down now
+        // rather than leaving an llm-less zombie in the registry forever.
+        this.teardown();
+        return;
+      }
+      // Durable record of the session (best-effort — persistence must never
+      // block the chat): backs the builder's session-history API, and joins
+      // token usage on usage_records.session_id. ONLY builder sessions are
+      // persisted: this endpoint also serves a tenant's own text agents, and
+      // their end-user conversations must not be silently retained (there is
+      // no TTL or deletion surface yet). The builder is the builtin, or an
+      // org row polite-ai pushes (courtesy marker in the description — the
+      // polite-ai dashboard resolves builders by id, but for retention gating
+      // the marker + builtin id cover the intended scope).
+      const isBuilder =
+        this.agent.id === 'builtin:set-builder' ||
+        String(this.agent.description || '').includes('[polite:agent-builder]');
+      this.transcript = isBuilder ? [] : null;
+      if (isBuilder) {
+        try {
+          await ChatSession.create({
+            id: this.id,
+            agentId: this.agent.id ?? null,
+            organisationId: this.agent.organisationId ?? null,
+            userId: this.agent.userId ?? null,
+            setId: this.latestSet?.id ?? null,
+            mode: this.seedTestResult ? 'troubleshoot' : this.latestSet ? 'edit' : 'new',
+            title: this.latestSet?.name ?? null,
+            modelName: this.agent.modelName ?? null,
+            startedAt: this.startedAt,
+            transcript: [],
+          });
+          this.persisted = true;
+        } catch (e) {
+          this.logger.error(e, 'chat session persist (create) failed — history disabled for this session');
+        }
+      }
+    }
 
     // `busy` lets a re-attaching client restore its thinking indicator when a
     // turn is still running from before the drop.
@@ -217,7 +258,15 @@ class TextChatSession {
    * the backstop for exactly this class of exit.
    */
   teardown() {
+    if (this.torndown) return; // idempotent — close-after-failed-init double-fires
+    this.torndown = true;
     this.finaliseUsage();
+    if (this.persisted) {
+      ChatSession.update(
+        { endedAt: new Date(), transcript: this.transcript, turns: this.turnsCount || 0 },
+        { where: { id: this.id } },
+      ).catch((e) => this.logger.error(e, 'chat session persist (end) failed'));
+    }
     sessions.delete(this.id);
   }
 
@@ -310,7 +359,11 @@ class TextChatSession {
 
   async runTurn(userText, send, hidden = false, claimed = null) {
     this.busy = true;
-    if (!hidden) send({ type: 'user_echo', text: userText });
+    if (!hidden) {
+      this.turnsCount = (this.turnsCount || 0) + 1;
+      this.record('user', userText);
+      send({ type: 'user_echo', text: userText });
+    }
     send({ type: 'status', state: 'thinking' });
     this.logger.info({ id: this.id, hidden, resume: !!claimed }, 'chat turn started');
     // Surface server-side MCP tool calls (the builder reading the Aplisay
@@ -349,7 +402,10 @@ class TextChatSession {
       }
       this.recordRoundUsage(round);
       for (let hop = 0; hop < MAX_TOOL_HOPS; hop += 1) {
-        if (round.text) send({ type: 'agent', text: round.text });
+        if (round.text) {
+          this.record('agent', round.text);
+          send({ type: 'agent', text: round.text });
+        }
         if (round.calls && round.calls.length) {
           // A tool call truncated at the output-token limit (stop_reason
           // "max_tokens") has incomplete arguments — a large field such as the
@@ -410,6 +466,14 @@ class TextChatSession {
               };
             }
             this.pending = { toolUseId: pause.id, otherResults, platform: this.platformOf(pause.name), frame };
+            // The ask is part of the conversation — without it, the persisted
+            // transcript shows answers to invisible questions.
+            this.record(
+              'agent',
+              frame.type === 'question'
+                ? `${frame.question}${frame.options?.length ? ` (options: ${frame.options.join(' / ')})` : ''}`
+                : `[offered a live in-browser test of “${frame.name}”]`,
+            );
             send(frame);
             return; // paused — the next user message resumes this turn
           }
@@ -430,11 +494,43 @@ class TextChatSession {
       // turn that no longer exists.
       this.pending = null;
       this.logger.error(e, 'chat turn failed');
+      this.record('system', `Turn failed: ${e.message}`);
       send({ type: 'error', message: e.message });
     } finally {
       this.busy = false;
       send({ type: 'turn_complete' });
+      this.persistTurn(); // fire-and-forget — history must never block the chat
     }
+  }
+
+  /** Append a transcript entry for the durable session record (capped). */
+  record(role, text) {
+    if (!this.transcript || typeof text !== 'string' || !text) return;
+    this.transcript.push({ role, text, at: new Date().toISOString() });
+    const excess = this.transcript.length - TRANSCRIPT_MAX_ENTRIES;
+    if (excess > 0) {
+      this.transcript.splice(0, excess + 1, {
+        role: 'system',
+        text: '[… earlier conversation trimmed …]',
+        at: this.transcript[excess]?.at,
+      });
+    }
+  }
+
+  /** Best-effort per-turn flush of the durable session record. */
+  persistTurn() {
+    if (!this.persisted) return;
+    ChatSession.update(
+      {
+        transcript: this.transcript,
+        turns: this.turnsCount || 0,
+        // A new-team session gains its set at the first save; keep the row
+        // pointing at the latest identity the canvas is showing.
+        setId: this.latestSet?.id ?? null,
+        title: this.latestSet?.name ?? null,
+      },
+      { where: { id: this.id } },
+    ).catch((e) => this.logger.error(e, 'chat session persist (update) failed'));
   }
 
   /**

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -18,6 +18,9 @@ import { UsageRecord, Sequelize } from './database.js';
 import { costUsageRow } from './rates.js';
 import defaultLogger from './logger.js';
 
+/** usage_records.agent_id is a UUID column; anything else is unattributable. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /**
  * Record (or update) a single usage meter for a session.
  *
@@ -64,6 +67,12 @@ export async function recordUsage({
     log.warn({ sessionId, technology, unit }, 'recordUsage: missing sessionId/technology/unit; skipping');
     return null;
   }
+  // usage_records.agent_id is a UUID column, but BUILTIN agents chat too
+  // ('builtin:set-builder') — a non-UUID id must degrade to an unattributed
+  // row, not throw the whole meter reading away (builtin builder sessions
+  // metered NOTHING before this). The original id still discriminates the
+  // meterKey below, so per-agent meters within a session stay distinct.
+  const agentIdColumn = agentId && UUID_RE.test(String(agentId)) ? agentId : null;
   const meterKey = UsageRecord.meterKey({ agentId, technology, provider, detail, unit });
   const qty = Math.trunc(Number(quantity) || 0);
 
@@ -71,7 +80,8 @@ export async function recordUsage({
     const [record, created] = await UsageRecord.findOrCreate({
       where: { sessionId, meterKey },
       defaults: {
-        sessionId, meterKey, callId, organisationId, userId, agentId,
+        sessionId, meterKey, callId, organisationId, userId,
+        agentId: agentIdColumn,
         technology, provider, detail, unit,
         quantity: qty,
         finalised: !!finalised,
@@ -93,7 +103,7 @@ export async function recordUsage({
     if (callId && !record.callId) updates.callId = callId;
     if (organisationId && !record.organisationId) updates.organisationId = organisationId;
     if (userId && !record.userId) updates.userId = userId;
-    if (agentId && !record.agentId) updates.agentId = agentId;
+    if (agentIdColumn && !record.agentId) updates.agentId = agentIdColumn;
     if (metadata) updates.metadata = metadata;
     if (Object.keys(updates).length) {
       await record.update(updates, { transaction });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:setup": "docker-compose -f tests/docker-compose.test.yml up -d",
     "livekit-dev": "NODE_ENV=development LOGLEVEL=debug nodemon -e js,mjs,json,yaml agents/livekit/realtime.mjs dev",
     "auth:generate": "better-auth generate --config scripts/better-auth-config.mjs",
-    "auth:migrate": "better-auth migrate --config scripts/better-auth-config.mjs"
+    "auth:migrate": "better-auth migrate --config scripts/better-auth-config.mjs",
+    "eval:builder": "node tools/builder-eval/run.mjs"
   },
   "author": "",
   "license": "MIT",

--- a/tests/chat-sessions-endpoint.test.mjs
+++ b/tests/chat-sessions-endpoint.test.mjs
@@ -1,0 +1,135 @@
+import { setupRealDatabase, teardownRealDatabase, Organisation, User } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+// Persisted chat sessions (schema v55) back the builder's session history:
+// text-chat writes a row per session (transcript, set linkage, mode) and the
+// /chat-sessions endpoints list/fetch them org-scoped with LLM token usage
+// joined from usage_records on the shared session id.
+describe('Chat session persistence + history endpoints', () => {
+  let ChatSession;
+  let recordLlmTokens;
+  let listSessions;
+  let getSession;
+
+  let testOrgId;
+  let testUserId;
+
+  const mockLogger = {
+    info: () => {}, error: () => {}, warn: () => {}, debug: () => {},
+    child: () => mockLogger,
+  };
+
+  const createMockRequest = (overrides = {}) => ({
+    body: {}, params: {}, query: {}, headers: {}, log: mockLogger, ...overrides,
+  });
+
+  const createMockResponse = (locals = {}) => ({
+    _status: null,
+    _body: null,
+    locals,
+    status(code) { this._status = code; return this; },
+    send(data) { this._body = data; return this; },
+    json(data) { this._body = data; return this; },
+  });
+
+  const asUser = () => ({ user: { id: testUserId, role: 'owner', organisationId: testOrgId } });
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    ({ ChatSession } = await import('../lib/database.js'));
+    ({ recordLlmTokens } = await import('../lib/usage.js'));
+    listSessions = (await import('../api/paths/chat-sessions.js')).default(mockLogger).GET;
+    getSession = (await import('../api/paths/chat-sessions/{sessionId}.js')).default(mockLogger).GET;
+    await ChatSession.sync({ alter: true });
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 60000);
+
+  beforeEach(async () => {
+    testOrgId = randomUUID();
+    testUserId = randomUUID();
+    await Organisation.create({ id: testOrgId, name: 'Test Org (chat sessions)' });
+    await User.create({
+      id: testUserId, organisationId: testOrgId,
+      name: 'Test User', email: 'chat-sessions@example.com',
+    });
+  }, 30000);
+
+  afterEach(async () => {
+    try {
+      await ChatSession.destroy({ where: { organisationId: testOrgId } });
+      await User.destroy({ where: { id: testUserId } });
+      await Organisation.destroy({ where: { id: testOrgId } });
+    } catch { /* best-effort */ }
+  });
+
+  const makeSessionRow = async (over = {}) => {
+    const id = randomUUID();
+    await ChatSession.create({
+      id,
+      agentId: 'builtin:set-builder',
+      organisationId: testOrgId,
+      userId: testUserId,
+      setId: over.setId ?? null,
+      mode: over.mode ?? 'new',
+      title: over.title ?? null,
+      modelName: 'text:anthropic/claude-sonnet-5',
+      startedAt: over.startedAt ?? new Date(),
+      turns: over.turns ?? 3,
+      transcript: over.transcript ?? [{ role: 'user', text: 'build me a team', at: new Date().toISOString() }],
+      ...over,
+    });
+    return id;
+  };
+
+  test('list is org-scoped, newest first, filters by setId and joins usage', async () => {
+    const setId = randomUUID();
+    const s1 = await makeSessionRow({ setId, startedAt: new Date(Date.now() - 60_000), mode: 'edit', title: 'Team A' });
+    const s2 = await makeSessionRow({ setId, startedAt: new Date(), mode: 'troubleshoot', title: 'Team A' });
+    await makeSessionRow({}); // different (no) set — filtered out
+    // Another org's session must never appear.
+    const otherOrg = randomUUID();
+    await Organisation.create({ id: otherOrg, name: 'Other Org' });
+    await ChatSession.create({
+      id: randomUUID(), agentId: 'builtin:set-builder', organisationId: otherOrg,
+      setId, startedAt: new Date(), transcript: [],
+    });
+
+    await recordLlmTokens({
+      sessionId: s2, organisationId: testOrgId, userId: testUserId,
+      provider: 'anthropic', model: 'claude-sonnet-5',
+      inputTokens: 100, outputTokens: 200, cacheReadTokens: 3000, cacheWriteTokens: 400,
+      log: mockLogger,
+    });
+
+    const res = createMockResponse(asUser());
+    await listSessions(createMockRequest({ query: { setId } }), res);
+    expect(res._body.sessions).toHaveLength(2);
+    expect(res._body.sessions.map((s) => s.id)).toEqual([s2, s1]); // newest first
+    expect(res._body.sessions[0].usage).toMatchObject({
+      inputTokens: 100, outputTokens: 200, cacheReadTokens: 3000, cacheWriteTokens: 400,
+    });
+    expect(res._body.sessions[1].usage).toBeNull();
+    // List responses stay light: no transcript field.
+    expect(res._body.sessions[0]).not.toHaveProperty('transcript');
+  });
+
+  test('detail returns the transcript and 404s outside the caller scope', async () => {
+    const transcript = [
+      { role: 'user', text: 'hello', at: new Date().toISOString() },
+      { role: 'agent', text: 'hi — what shall we build?', at: new Date().toISOString() },
+    ];
+    const id = await makeSessionRow({ transcript, title: 'Team B' });
+
+    const res = createMockResponse(asUser());
+    await getSession(createMockRequest({ params: { sessionId: id } }), res);
+    expect(res._body.transcript).toEqual(transcript);
+    expect(res._body.usage).toMatchObject({ inputTokens: 0, outputTokens: 0 });
+
+    const stranger = createMockResponse({ user: { id: randomUUID(), role: 'owner', organisationId: randomUUID() } });
+    await getSession(createMockRequest({ params: { sessionId: id } }), stranger);
+    expect(stranger._status).toBe(404);
+  });
+});

--- a/tools/builder-eval/README.md
+++ b/tools/builder-eval/README.md
@@ -1,0 +1,64 @@
+# Builder eval harness
+
+Phase 3 of the builder cost/quality programme (see polite-ai
+`docs/builder-efficiency-review.md`): a repeatable benchmark that runs
+scripted build / edit / troubleshoot scenarios through the **real chat loop**
+(`lib/text-chat.js` — LLM driver, tool dispatch, MCP connector, usage
+metering) in-process, once per candidate model, and reports hard-check
+pass/fail, LLM-judge scores, token usage, estimated cost and latency.
+
+## What a run does
+
+For each `model × scenario`:
+
+1. Builds the builtin set-builder definition (`lib/set-builder-agent.js`) with
+   the candidate `modelName`, under a disposable org/user created for the run.
+2. Drives a chat session through a fake websocket: scripted user turns,
+   scripted answers to `ask_user` questions, test offers declined. Exactly the
+   production code path — including the aplisay docs MCP connector.
+3. Hard checks the saved artefacts (set membership, link wiring, voice
+   options, patch discipline, …) — deterministic pass/fail per scenario.
+4. Has a fixed judge model (Claude Opus by default, `EVAL_JUDGE_MODEL` to
+   override) score prompt quality / faithfulness / efficiency out of 10.
+5. Reads the session's token usage straight from `usage_records` (the chat
+   loop meters it exactly as production does) and prices it from the table in
+   `run.mjs`.
+
+## Running
+
+Point `POSTGRES_*` at a **disposable** database — the tests container works:
+
+```sh
+yarn test:setup    # starts the throwaway Postgres on :5433
+
+POSTGRES_HOST=localhost POSTGRES_PORT=5433 POSTGRES_DB=llmvoicetest \
+POSTGRES_USER=testuser POSTGRES_PASSWORD=testpass \
+node tools/builder-eval/run.mjs \
+  --models text:anthropic/claude-sonnet-5,text:anthropic/claude-haiku-4-5 \
+  --scenarios faq-single,receptionist-transfer \
+  --json /tmp/builder-eval.json
+```
+
+`ANTHROPIC_API_KEY` must be set (plus any other provider keys for their
+models). **Runs spend real provider tokens** — a full 6-scenario pass on one
+model is very roughly $0.5–1.5 depending on the model.
+
+Omit `--models` for the current default (Sonnet 5); omit `--scenarios` for
+all of them. Exit code is non-zero when any run fails its hard check.
+
+## Comparing models (Phase 4)
+
+Non-Anthropic candidates need their driver brought up to scratch first — see
+the task list: the OpenAI driver caps output at 1024 tokens and lists no 5.x
+models; Gemini's driver mangles nested tool schemas; Kimi has no driver; and
+only the Anthropic driver supports the MCP connector the builder's docs
+lookups ride on. Until then, cross-vendor rows will fail their hard checks
+for reasons that are the DRIVER's fault, not the model's — fix the driver,
+then trust the numbers.
+
+## Adding scenarios
+
+Add an entry to `scenarios.mjs`: scripted `turns`, `qa` answers for expected
+questions, optional `seed` (set / testResult), a deterministic `check()` and
+a `rubric` for the judge. Keep checks about the ARTEFACTS (what got saved),
+and leave style judgements to the rubric.

--- a/tools/builder-eval/driver.mjs
+++ b/tools/builder-eval/driver.mjs
@@ -1,0 +1,154 @@
+/**
+ * Drives one in-process builder chat session against a scenario: a fake
+ * websocket pair feeds scripted user turns into lib/text-chat.js — the exact
+ * production chat loop (LLM driver, tool dispatch, MCP connector, usage
+ * metering) with no HTTP or auth in the way.
+ */
+import { createChatSession } from '../../lib/text-chat.js';
+import { DEFAULT_ANSWER } from './scenarios.mjs';
+
+const TURN_TIMEOUT_MS = Number(process.env.EVAL_TURN_TIMEOUT_MS || 240_000);
+const MAX_QUESTIONS = 12; // runaway ask_user loops fail the run rather than hang it
+
+/** Minimal ws double the session binds to; the driver is the "browser". */
+function fakeWs() {
+  const ws = {
+    OPEN: 1,
+    readyState: 1,
+    handlers: {},
+    onFrame: null,
+    send(raw) {
+      const frame = JSON.parse(raw);
+      ws.onFrame?.(frame);
+    },
+    on(ev, fn) {
+      ws.handlers[ev] = fn;
+    },
+    close() {
+      ws.readyState = 3;
+      ws.handlers.close?.();
+    },
+  };
+  return ws;
+}
+
+/**
+ * Run one scenario against one model. Returns everything the reporter and
+ * judge need: the final saved set, all frames, the visible transcript,
+ * per-turn latencies and any errors.
+ */
+export async function runScenario({ scenario, agent, logger }) {
+  const session = createChatSession({
+    agent,
+    set: scenario.seed?.set,
+    testResult: scenario.seed?.testResult,
+    logger,
+  });
+
+  const frames = [];
+  const transcript = [];
+  const turnLatencies = [];
+  const errors = [];
+  let latestSet = null;
+  let questionCount = 0;
+  let turnIndex = 0;
+  let turnStartedAt = Date.now();
+
+  const ws = fakeWs();
+  const sendToSession = (msg) => ws.handlers.message?.(JSON.stringify(msg));
+
+  const done = new Promise((resolve, reject) => {
+    let timer;
+    const armTimeout = () => {
+      clearTimeout(timer);
+      timer = setTimeout(
+        () => reject(new Error(`turn timed out after ${TURN_TIMEOUT_MS}ms (turn ${turnIndex})`)),
+        TURN_TIMEOUT_MS,
+      );
+    };
+    armTimeout();
+
+    ws.onFrame = (frame) => {
+      frames.push(frame);
+      switch (frame.type) {
+        case 'agent':
+          transcript.push({ role: 'agent', text: frame.text });
+          break;
+        case 'user_echo':
+          transcript.push({ role: 'user', text: frame.text });
+          break;
+        case 'set':
+          latestSet = frame.set;
+          break;
+        case 'error':
+          errors.push(frame.message);
+          break;
+        case 'question': {
+          questionCount += 1;
+          if (questionCount > MAX_QUESTIONS) {
+            reject(new Error('runaway ask_user loop'));
+            return;
+          }
+          const qa = (scenario.qa || []).find((q) => q.match.test(frame.question || ''));
+          armTimeout();
+          // Answer on the next tick — never re-enter the session mid-frame.
+          setTimeout(() => sendToSession({ type: 'user', text: qa?.reply || DEFAULT_ANSWER }), 0);
+          break;
+        }
+        case 'test':
+          // The harness never runs a live call — decline so the turn resumes.
+          armTimeout();
+          setTimeout(
+            () =>
+              sendToSession({
+                type: 'test_result',
+                id: frame.id,
+                result: JSON.stringify({ ok: false, reason: 'The user skipped the test.' }),
+              }),
+            0,
+          );
+          break;
+        case 'turn_complete': {
+          turnLatencies.push(Date.now() - turnStartedAt);
+          // A pending question/test resumes the SAME logical exchange — its
+          // handlers above continue the flow; only advance the script when
+          // nothing is pending.
+          if (session.pending) return;
+          const next = scenario.turns[turnIndex];
+          if (next === undefined) {
+            clearTimeout(timer);
+            resolve();
+            return;
+          }
+          turnIndex += 1;
+          turnStartedAt = Date.now();
+          armTimeout();
+          setTimeout(() => sendToSession({ type: 'user', text: next }), 0);
+          break;
+        }
+        default:
+          break;
+      }
+    };
+  });
+
+  const startedAt = Date.now();
+  await session.handleChat(ws);
+  try {
+    await done;
+  } finally {
+    ws.close();
+    // Don't wait out the re-attach grace in a harness run.
+    session.teardown();
+  }
+
+  return {
+    sessionId: session.id,
+    latestSet,
+    frames,
+    transcript,
+    turnLatencies,
+    errors,
+    wallMs: Date.now() - startedAt,
+  };
+}

--- a/tools/builder-eval/judge.mjs
+++ b/tools/builder-eval/judge.mjs
@@ -1,0 +1,42 @@
+/**
+ * LLM judge: scores what the hard checks can't — prompt quality, faithfulness
+ * to the brief, conversational efficiency — from the saved set + transcript.
+ * Uses Claude Opus as the judge regardless of the candidate model under test,
+ * so every candidate is marked by the same examiner.
+ */
+import { Anthropic as AnthropicSdk } from '@anthropic-ai/sdk';
+
+const JUDGE_MODEL = process.env.EVAL_JUDGE_MODEL || 'claude-opus-4-8';
+
+const anthropic = new AnthropicSdk();
+
+export async function judge({ scenario, result }) {
+  const payload = {
+    brief: scenario.turns.join('\n---\n'),
+    rubric: scenario.rubric,
+    finalSet: result.latestSet,
+    transcript: result.transcript,
+    hardCheckNotes: result.check?.notes ?? [],
+  };
+  const response = await anthropic.messages.create({
+    model: JUDGE_MODEL,
+    max_tokens: 2048,
+    thinking: { type: 'adaptive' },
+    system:
+      'You are grading an AI "agent builder" on one build session. Score STRICTLY against the '
+      + 'rubric and the user\'s brief — not against what a bigger build could have been. '
+      + 'Respond with ONLY a JSON object: {"promptQuality": 0-10, "faithfulness": 0-10, '
+      + '"efficiency": 0-10, "overall": 0-10, "summary": "<one paragraph>"} — '
+      + 'promptQuality = quality of the produced member prompts; faithfulness = did it build '
+      + 'exactly what was asked, grounded only in given facts; efficiency = fewest turns/'
+      + 'questions/detours to a correct result. No markdown, no prose outside the JSON.',
+    messages: [{ role: 'user', content: JSON.stringify(payload) }],
+  });
+  const text = response.content.filter((b) => b.type === 'text').map((b) => b.text).join('');
+  try {
+    const parsed = JSON.parse(text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1));
+    return { ...parsed, judgeModel: JUDGE_MODEL };
+  } catch {
+    return { promptQuality: null, faithfulness: null, efficiency: null, overall: null, summary: `unparseable judge output: ${text.slice(0, 200)}`, judgeModel: JUDGE_MODEL };
+  }
+}

--- a/tools/builder-eval/run.mjs
+++ b/tools/builder-eval/run.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Builder eval harness (Phase 3 of the builder cost/quality programme — see
+ * polite-ai docs/builder-efficiency-review.md).
+ *
+ * Runs scripted build/edit/troubleshoot scenarios through the REAL chat loop
+ * (lib/text-chat.js — LLM driver, tool dispatch, MCP connector, usage
+ * metering) in-process against a disposable org, for each candidate model,
+ * and reports: hard-check pass/fail, judge scores, tokens, estimated cost and
+ * latency per scenario.
+ *
+ *   node tools/builder-eval/run.mjs [--models a,b] [--scenarios x,y] [--json out.json]
+ *
+ * Requirements: POSTGRES_* env pointing at a DISPOSABLE database (the tests
+ * container works: tests/docker-compose.test.yml), ANTHROPIC_API_KEY (and any
+ * other provider keys for their models). Spends real provider tokens.
+ */
+import { parseArgs } from 'node:util';
+import { writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const { values: args } = parseArgs({
+  options: {
+    models: { type: 'string' },
+    scenarios: { type: 'string' },
+    json: { type: 'string' },
+  },
+});
+
+// Import AFTER dotenv so database.js sees the env (same rule as index.mjs).
+const { Organisation, User, databaseStarted, UsageRecord, stopDatabase } = await import('../../lib/database.js');
+const { createAgentSetForAgent } = await import('../../lib/agent-set-service.js');
+const { setBuilderAgent } = await import('../../lib/set-builder-agent.js');
+const { scenarios } = await import('./scenarios.mjs');
+const { runScenario } = await import('./driver.mjs');
+const { judge } = await import('./judge.mjs');
+
+const DEFAULT_MODELS = ['text:anthropic/claude-sonnet-5'];
+
+// $/MTok — used for the per-run cost estimate in the report. Update as prices
+// move; unknown models report tokens only.
+const PRICES = {
+  'anthropic/claude-sonnet-5': { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'anthropic/claude-sonnet-4-5': { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  'anthropic/claude-haiku-4-5': { in: 1, out: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+  'anthropic/claude-opus-4-8': { in: 5, out: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+};
+
+const quietLogger = {
+  fatal: () => {}, error: (...a) => console.error('[session]', a[0]?.message ?? a[1] ?? a[0]),
+  warn: () => {}, info: () => {}, debug: () => {}, trace: () => {},
+  child: () => quietLogger,
+};
+
+function costOf(model, usage) {
+  const bare = String(model).replace(/^text:/, '');
+  const p = PRICES[bare];
+  if (!p || !usage) return null;
+  return (
+    (usage.inputTokens * p.in +
+      usage.outputTokens * p.out +
+      usage.cacheReadTokens * p.cacheRead +
+      usage.cacheWriteTokens * p.cacheWrite) /
+    1_000_000
+  );
+}
+
+async function usageFor(sessionId) {
+  const rows = await UsageRecord.findAll({ where: { sessionId, technology: 'llm' }, raw: true });
+  const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+  const KEYS = {
+    input_tokens: 'inputTokens', output_tokens: 'outputTokens',
+    cache_read_tokens: 'cacheReadTokens', cache_write_tokens: 'cacheWriteTokens',
+  };
+  for (const r of rows) if (KEYS[r.unit]) usage[KEYS[r.unit]] += Number(r.quantity) || 0;
+  return usage;
+}
+
+async function main() {
+  await databaseStarted;
+
+  const modelIds = (args.models?.split(',') ?? DEFAULT_MODELS).map((m) => m.trim()).filter(Boolean);
+  const wanted = args.scenarios?.split(',').map((s) => s.trim());
+  const picked = wanted ? scenarios.filter((s) => wanted.includes(s.id)) : scenarios;
+  if (!picked.length) throw new Error(`no scenarios matched: ${args.scenarios}`);
+
+  // Disposable tenant per run — everything the builder creates lands here.
+  const orgId = randomUUID();
+  const userId = randomUUID();
+  await Organisation.create({ id: orgId, name: `builder-eval ${new Date().toISOString()}` });
+  await User.create({ id: userId, organisationId: orgId, name: 'builder-eval', email: `eval-${orgId}@example.invalid` });
+
+  const results = [];
+  for (const modelName of modelIds) {
+    for (const scenario of picked) {
+      process.stderr.write(`\n▶ ${modelName} × ${scenario.id} … `);
+      const agent = { ...setBuilderAgent({ id: userId, organisationId: orgId }), modelName };
+      const entry = { model: modelName, scenario: scenario.id, brief: scenario.brief };
+      try {
+        // A seeded set must be a SAVED set (that's the only shape production
+        // ever seeds — polite-ai forwards a stored draft, ids and all). Create
+        // it for real so the builder has an id to patch, then hand the
+        // RENDERED doc to the session exactly as the chat API would.
+        let runScenarioDef = scenario;
+        if (scenario.seed?.set && !scenario.seed.set.id) {
+          const rendered = await createAgentSetForAgent(scenario.seed.set, {
+            userId,
+            organisationId: orgId,
+          });
+          runScenarioDef = { ...scenario, seed: { ...scenario.seed, set: rendered } };
+        }
+        const result = await runScenario({ scenario: runScenarioDef, agent, logger: quietLogger });
+        result.check = scenario.check({
+          set: result.latestSet,
+          frames: result.frames,
+          transcript: result.transcript,
+        });
+        entry.hardCheck = result.check;
+        entry.errors = result.errors;
+        entry.turns = result.turnLatencies.length;
+        entry.turnLatenciesMs = result.turnLatencies;
+        entry.wallMs = result.wallMs;
+        entry.usage = await usageFor(result.sessionId);
+        entry.estCostUsd = costOf(modelName, entry.usage);
+        entry.finalSet = result.latestSet; // keep the artefact for debugging
+        entry.judge = await judge({ scenario, result });
+        process.stderr.write(entry.hardCheck.ok ? 'hard-check PASS' : 'hard-check FAIL');
+      } catch (e) {
+        entry.failed = e.message;
+        process.stderr.write(`RUN FAILED: ${e.message}`);
+      }
+      results.push(entry);
+    }
+  }
+
+  // ---- report ---------------------------------------------------------------
+  const fmtTok = (n) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n ?? 0));
+  console.log('\n\n| model | scenario | hard | judge | out tok | in+cache tok | est $ | wall s |');
+  console.log('|---|---|---|---|---|---|---|---|');
+  for (const r of results) {
+    if (r.failed) {
+      console.log(`| ${r.model} | ${r.scenario} | RUN FAILED | — | — | — | — | — |`);
+      continue;
+    }
+    const u = r.usage;
+    console.log(
+      `| ${r.model} | ${r.scenario} | ${r.hardCheck.ok ? '✅' : '❌'} | ${r.judge.overall ?? '?'} / 10 | ` +
+        `${fmtTok(u.outputTokens)} | ${fmtTok(u.inputTokens + u.cacheReadTokens + u.cacheWriteTokens)} | ` +
+        `${r.estCostUsd != null ? r.estCostUsd.toFixed(3) : '—'} | ${(r.wallMs / 1000).toFixed(0)} |`,
+    );
+  }
+  for (const r of results) {
+    if (r.failed) continue;
+    console.log(`\n### ${r.model} × ${r.scenario}`);
+    for (const n of r.hardCheck.notes) console.log(`- ${n}`);
+    if (r.judge?.summary) console.log(`- judge: ${r.judge.summary}`);
+    if (r.errors?.length) console.log(`- session errors: ${r.errors.join(' | ')}`);
+  }
+
+  if (args.json) {
+    writeFileSync(args.json, JSON.stringify({ ranAt: new Date().toISOString(), orgId, results }, null, 2));
+    console.log(`\nJSON written to ${args.json}`);
+  }
+
+  await stopDatabase?.();
+  // The MCP connector / grace timers are unref'd; exit cleanly regardless.
+  process.exit(results.some((r) => r.failed || (r.hardCheck && !r.hardCheck.ok)) ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/tools/builder-eval/scenarios.mjs
+++ b/tools/builder-eval/scenarios.mjs
@@ -1,0 +1,273 @@
+/**
+ * Builder-eval scenarios: scripted briefs a user might bring to the set
+ * builder, each with hard checks against the saved artefacts and a judge
+ * rubric for the qualities hard checks can't measure.
+ *
+ * Shape:
+ *  - turns: user inputs sent in order, one per completed builder turn.
+ *  - qa: [{ match, reply }] — answers for ask_user questions (first match
+ *    wins); unmatched questions get DEFAULT_ANSWER so no run wedges.
+ *  - seed: optional { set, testResult } opening seeds (edit / troubleshoot).
+ *  - check({ set, frames, transcript }): hard, deterministic pass/fail
+ *    assertions — set is the FINAL saved set doc (null when never saved).
+ *  - rubric: what the judge should reward for this scenario.
+ */
+
+export const DEFAULT_ANSWER =
+  "You choose — pick whatever is most sensible for a small business and carry on.";
+
+const assert = (notes, cond, label) => {
+  notes.push(`${cond ? "PASS" : "FAIL"}: ${label}`);
+  return !!cond;
+};
+
+const memberFns = (m) => (Array.isArray(m?.functions) ? m.functions : []);
+const findPlatform = (m, platform) => memberFns(m).find((f) => f?.platform === platform);
+const isVoice = (m) => (m?.type || "interactive-audio") !== "text" && !String(m?.modelName || "").startsWith("text:");
+
+/**
+ * A link target is valid when it's a static reference to a sibling member —
+ * either the `label:<x>` form the builder writes, or the resolved member id
+ * the platform renders it as after save.
+ */
+const staticTargetsMember = (fn, set, label) => {
+  const target = fn?.input_schema?.properties?.agent;
+  if (target?.source !== "static") return false;
+  const from = String(target?.from || "");
+  if (label) {
+    const member = (set?.agents || []).find((m) => m.label === label);
+    return from === `label:${label}` || (member?.id && from === String(member.id));
+  }
+  const ids = new Set((set?.agents || []).map((m) => String(m.id)));
+  return /^label:/.test(from) || ids.has(from);
+};
+
+export const scenarios = [
+  {
+    id: "faq-single",
+    brief: "Single-agent FAQ voice line",
+    turns: [
+      "Build me a phone agent for my bakery, Crusty's of Leeds. It should answer common questions: opening hours (8am-4pm Tue-Sun), where we are (14 Bridge End, Leeds), and whether we take custom cake orders (yes, with 1 week notice). Keep it to one agent, call the team \"Bakery FAQ\".",
+      "That's great — make sure it politely says it can't help with anything else and suggests calling back during opening hours for complex questions.",
+    ],
+    qa: [
+      { match: /name|call (the|this)/i, reply: "Bakery FAQ" },
+      { match: /model|voice|channel/i, reply: DEFAULT_ANSWER },
+    ],
+    check({ set }) {
+      const notes = [];
+      let ok = assert(notes, !!set?.id, "set was saved");
+      ok = assert(notes, (set?.agents || []).length === 1, "exactly one member") && ok;
+      const m = set?.agents?.[0];
+      ok = assert(notes, isVoice(m), "member is a voice agent") && ok;
+      const p = String(m?.prompt || "");
+      ok = assert(notes, /8\s*am|8:00/i.test(p) && /leeds/i.test(p), "prompt carries the real hours and location") && ok;
+      return { ok, notes };
+    },
+    rubric:
+      "Reward: a warm, complete FAQ prompt grounded ONLY in the facts given (hours, address, cake orders with 1 week notice); an explicit scope limit with the call-back suggestion; sensible model/voice defaults; no invented facts (no made-up phone numbers, prices or services). Penalise: bloated prompts, unasked-for extra agents or functions.",
+  },
+  {
+    id: "receptionist-transfer",
+    brief: "Reception + sales, live transfer",
+    turns: [
+      "I want a phone team for Gadget Traders: a receptionist that answers, finds out what the caller wants, and hands over to a sales agent for anything about buying our refurbished laptops. Call it \"Gadget Traders front desk\".",
+      "Yes, build it and save it.",
+    ],
+    qa: [{ match: /.*/i, reply: DEFAULT_ANSWER }],
+    check({ set }) {
+      const notes = [];
+      let ok = assert(notes, !!set?.id, "set was saved");
+      const members = set?.agents || [];
+      ok = assert(notes, members.length === 2, "two members") && ok;
+      const withTransfer = members.find((m) => findPlatform(m, "transfer_agent"));
+      ok = assert(notes, !!withTransfer, "a member carries a transfer_agent link") && ok;
+      ok = assert(
+        notes,
+        staticTargetsMember(findPlatform(withTransfer || {}, "transfer_agent"), set),
+        "transfer target is a static member reference (never model-generated)",
+      ) && ok;
+      ok = assert(notes, members.every(isVoice), "both members are voice agents (transfer needs voice→voice)") && ok;
+      return { ok, notes };
+    },
+    rubric:
+      "Reward: a receptionist prompt that triages before transferring, a sales prompt that continues naturally after handover, correct one-way transfer wiring, concise prompts. Penalise: transfer target left model-generated, sales agent that re-asks everything the receptionist learned (no handover summary), unnecessary members.",
+  },
+  {
+    id: "booking-subagent",
+    brief: "Voice booker + text availability subagent",
+    turns: [
+      "Build a booking line for Salon Aura. A voice agent takes appointment requests, and I want the availability logic in a separate text agent it can call like a tool — the text agent should just reason over these rules: open Mon-Sat 9-6, each appointment is 45 minutes, no double bookings before noon on Saturdays. Call the team \"Salon Aura bookings\".",
+      "Save it as-is, that's everything.",
+    ],
+    qa: [{ match: /.*/i, reply: DEFAULT_ANSWER }],
+    check({ set }) {
+      const notes = [];
+      let ok = assert(notes, !!set?.id, "set was saved");
+      const members = set?.agents || [];
+      const text = members.find((m) => !isVoice(m));
+      const voice = members.find(isVoice);
+      ok = assert(notes, !!text && !!voice, "one voice member and one text member") && ok;
+      ok = assert(notes, !!findPlatform(voice || {}, "subagent"), "voice member calls the text member via subagent") && ok;
+      ok = assert(notes, !!findPlatform(text || {}, "result"), "text member has the result output contract") && ok;
+      const sub = findPlatform(voice || {}, "subagent")?.input_schema?.properties?.agent;
+      ok = assert(notes, sub?.source === "static", "subagent target is static") && ok;
+      return { ok, notes };
+    },
+    rubric:
+      "Reward: clean separation (voice UX vs availability reasoning), the salon's actual rules encoded in the TEXT agent's prompt, the voice agent covering subagent latency conversationally, correct result contract. Penalise: rules duplicated or placed on the wrong member, missing latency handling, invented booking systems/integrations.",
+  },
+  {
+    id: "voice-locale",
+    brief: "Specific voice: UK female on a pipeline model",
+    turns: [
+      "One voice agent for Harrogate Wines: a friendly UK-accented female voice, and I specifically want a pipeline model (separate speech pieces), not a realtime one. It just takes messages for the owner. Name the team \"Harrogate Wines line\".",
+      "Perfect, save it.",
+    ],
+    qa: [
+      { match: /locale|accent|language/i, reply: "en-GB please" },
+      { match: /.*/i, reply: DEFAULT_ANSWER },
+    ],
+    check({ set, frames }) {
+      const notes = [];
+      let ok = assert(notes, !!set?.id, "set was saved");
+      const m = (set?.agents || [])[0];
+      const listVoicesCalls = frames.filter(
+        (f) => f.type === "tool_call" && (f.calls || []).some((c) => c.name === "list_voices"),
+      );
+      ok = assert(notes, listVoicesCalls.length >= 1, "list_voices was consulted (never invent a voice)") && ok;
+      ok = assert(notes, !!m?.options?.tts?.vendor && !!m?.options?.tts?.voice, "options.tts carries a real vendor + voice") && ok;
+      ok = assert(
+        notes,
+        !/unknown|default|placeholder/i.test(String(m?.options?.tts?.voice || "")),
+        "voice is not a placeholder value",
+      ) && ok;
+      return { ok, notes };
+    },
+    rubric:
+      "Reward: correct pipeline (not realtime) model choice; a voice actually drawn from list_voices output matching UK/female; options.stt handled as the platform requires; a tight message-taking prompt. Penalise: realtime model despite the explicit ask, invented voice names, skipping the locale step.",
+  },
+  {
+    id: "edit-existing",
+    brief: "Edit a seeded set with patch discipline",
+    seed: {
+      set: {
+        name: "Clinic front desk",
+        description: "Reception for a physio clinic",
+        agents: [
+          {
+            label: "reception",
+            name: "Reception",
+            modelName: "livekit:ultravox/ultravox-70b",
+            prompt:
+              "You are the receptionist for Motion Physio. Greet callers, answer questions about opening hours (Mon-Fri 8-6) and prices (£55 initial, £45 follow-up), and take a message with the caller's name and number if they want a callback.",
+            functions: [],
+          },
+        ],
+      },
+    },
+    turns: [
+      "Two changes: tighten the greeting so it's one short warm sentence, and add a second voice agent 'triage' that reception can transfer to when a caller describes an injury — triage should ask about the injury and recommend booking an initial assessment.",
+      "Yes apply both changes.",
+    ],
+    qa: [{ match: /.*/i, reply: DEFAULT_ANSWER }],
+    check({ set, frames }) {
+      const notes = [];
+      let ok = assert(notes, (set?.agents || []).length === 2, "triage member added (2 members)");
+      const patchUsed = frames.some(
+        (f) => f.type === "tool_call" && (f.calls || []).some((c) => c.name === "patch_agent_set"),
+      );
+      ok = assert(notes, patchUsed, "patch_agent_set used for the routine edit (not a wholesale update)") && ok;
+      const reception = (set?.agents || []).find((m) => m.label === "reception");
+      ok = assert(notes, !!findPlatform(reception || {}, "transfer_agent"), "reception gained the transfer to triage") && ok;
+      ok = assert(notes, /£55|£45/.test(String(reception?.prompt || "")), "unrelated prompt content (prices) survived the edit") && ok;
+      return { ok, notes };
+    },
+    rubric:
+      "Reward: minimal, surgical edits (greeting genuinely tightened, everything else preserved), a triage prompt that does what was asked and no more, correct transfer wiring, patch (not update) for the change. Penalise: rewriting the whole reception prompt, dropping the prices/hours, wholesale update_agent_set for a two-line change.",
+  },
+  {
+    id: "troubleshoot",
+    brief: "Diagnose a failed transfer from a test-call bundle",
+    // The fault: the reception PROMPT promises a transfer, but the member has
+    // no transfer_agent function at all — a saveable, realistic builder miss
+    // (an unsaveable fault like a broken label reference could never have
+    // become a stored set in the first place).
+    seed: {
+      set: {
+        name: "Gadget Traders front desk",
+        description: "Reception + sales",
+        agents: [
+          {
+            label: "reception",
+            name: "Reception",
+            modelName: "livekit:ultravox/ultravox-70b",
+            prompt:
+              "You are the Gadget Traders receptionist. Find out what the caller wants; for anything about buying laptops, use your to_sales function to transfer the call to the sales agent with a short summary.",
+            functions: [],
+          },
+          {
+            label: "sales",
+            name: "Sales",
+            modelName: "livekit:ultravox/ultravox-70b",
+            prompt: "You are the Gadget Traders sales agent. Help callers buy refurbished laptops.",
+            functions: [],
+          },
+        ],
+      },
+      testResult: {
+        ok: true,
+        transferred: false,
+        legCount: 1,
+        legs: [
+          {
+            callId: "eval-call-1",
+            agentLabel: "reception",
+            agentName: "Reception",
+            transcript: [
+              { role: "agent", text: "Thanks for calling Gadget Traders, how can I help?" },
+              { role: "user", text: "I want to buy one of your refurbished ThinkPads." },
+              { role: "agent", text: "Let me put you through to sales." },
+              { role: "hangup", text: "call ended without a transfer" },
+            ],
+            functions: [
+              {
+                type: "function_calls",
+                data: [{ name: "to_sales", input: { summary: "wants a refurbished ThinkPad" } }],
+              },
+              {
+                type: "function_results",
+                data: [{ name: "to_sales", result: "ERROR: no such function 'to_sales' is defined on this agent" }],
+              },
+            ],
+            invocationLog: {
+              total: 3,
+              notable: 1,
+              entries: [{ level: 50, msg: "model attempted call to undefined function 'to_sales'" }],
+            },
+          },
+        ],
+      },
+    },
+    turns: [
+      "Yes please fix whatever went wrong with that call.",
+    ],
+    qa: [{ match: /.*/i, reply: "Yes, apply the fix." }],
+    check({ set, transcript }) {
+      const notes = [];
+      const saidWhy = transcript.some(
+        (m) => m.role === "agent" && /to_sales|function|tool|missing|undefined|not (defined|wired|configured)/i.test(m.text),
+      );
+      let ok = assert(notes, saidWhy, "diagnosis names the missing transfer function");
+      const reception = (set?.agents || []).find((m) => m.label === "reception");
+      ok = assert(
+        notes,
+        staticTargetsMember(findPlatform(reception || {}, "transfer_agent"), set, "sales"),
+        "reception gained a transfer_agent targeting the sales member",
+      ) && ok;
+      return { ok, notes };
+    },
+    rubric:
+      "Reward: reading the invocation log, pinpointing that the prompt references a to_sales function that was never defined on the member, a one-line patch that adds exactly that transfer link, offering a re-test. Penalise: guessing at prompt changes, rebuilding members, missing the log evidence, verbose non-diagnosis.",
+  },
+];


### PR DESCRIPTION
Two related deliverables, one adversarially-reviewed branch (24-agent review; all confirmed findings addressed):

## 1. Persisted chat sessions + history API (schema v55)

- `ChatSession` model — transcript (capped), set linkage, mode/title/model, timings; the row id IS the chat session id so `usage_records.session_id` joins directly. **Persistence is gated to builder agents only** (builtin id push marker) — tenants' own text-agent conversations must not be silently retained.
- Best-effort writes from the live chat loop (never blocks chat); `ask_user`/test offers recorded; ws handlers bound before init awaits (session-leak window).
- `GET /chat-sessions` (org-scoped, setId/agentId filters, usage+cost+currency aggregated) and `GET /chat-sessions/{id}` (incl. transcript); UUID params validated.
- **Deploy-safety, learned the hard way twice**: the table is ensured UNCONDITIONALLY outside the `DB_FORCE_SYNC` gate, and a boot sweep closes orphaned rows so a deploy can't leave phantom-LIVE sessions.

## 2. Builder eval harness (`tools/builder-eval/`, Phase 3)

Scripted build/edit/troubleshoot scenarios through the **real chat loop** in-process, per candidate model: deterministic hard checks on saved artefacts + a fixed Opus judge + tokens/cost from production metering. Validated **6/6 hard-check green on Sonnet 5** (~$0.65/pass). First runs already caught: builtin-agent sessions metered nothing (UUID cast discarded the rows — fixed in `recordUsage`), and Sonnet 5 burning ~5 turns second-guessing transfer wiring post-save (a Phase-4 tuning signal).

## Verification
Full suite 46 suites / 516 tests green. 