### PR TITLE
Per-session model override on agent chat (builder model preference)

### DIFF
--- a/api/paths/agents/{agentId}/chat.js
+++ b/api/paths/agents/{agentId}/chat.js
@@ -2,6 +2,7 @@ import { createChatSession } from '../../../../lib/text-chat.js';
 import { resolveAgentForUser } from '../../../../lib/builtin-agents.js';
 import { requirePermission } from '../../../../lib/auth/permissions.js';
 import { isModelAllowed } from '../../../../lib/auth/model-access.js';
+import TextHandler from '../../../../lib/handlers/text.js';
 
 let log;
 
@@ -41,10 +42,25 @@ const agentChat = async (req, res) => {
     // it the builder root-causes prompt/function bugs blind), and/or a
     // caller-formatted context block (e.g. website-knowledge state) appended
     // verbatim to the opening turn.
-    const { set, testResult, subjectAgent, knowledge } = req.body || {};
+    const { set, testResult, subjectAgent, knowledge, model } = req.body || {};
+    // Optional per-SESSION model override (e.g. a user's builder-model
+    // preference). Two gates: the id must be a loadable `text:` catalogue
+    // model, and the caller must be allowed to use it. The override is set
+    // in-memory on the resolved agent (never saved) so the LLM build and the
+    // persisted ChatSession.modelName both reflect the model that actually ran.
+    if (model) {
+      const known = TextHandler.availableModels.some((m) => m.name === model);
+      if (!known) {
+        return res.status(400).send({ message: `Unknown text model: ${model}` });
+      }
+      if (!isModelAllowed(model, res.locals.user?._allowedModels)) {
+        return res.status(403).send({ message: `Model not permitted: ${model}` });
+      }
+      agent.modelName = model;
+    }
     const session = createChatSession({ agent, set, testResult, subjectAgent, knowledge, logger: req.log });
     log.info(
-      { agentId, sessionId: session.id, edit: !!set, diagnose: !!testResult, subjectAgent: !!subjectAgent, knowledge: !!knowledge },
+      { agentId, sessionId: session.id, edit: !!set, diagnose: !!testResult, subjectAgent: !!subjectAgent, knowledge: !!knowledge, model: model || undefined },
       'agent chat session started');
     res.send({ id: session.id, socket: `/chat/${session.id}` });
   }
@@ -86,6 +102,7 @@ agentChat.apiDoc = {
             // request validator accepts both shapes.
             subjectAgent: { nullable: true, description: 'For a set-less troubleshoot: the diagnosed agent\'s own definition (prompt/functions/options) — or an array of definitions, one per distinct agent on the call — so fixes are grounded in what the agent actually says and does.' },
             knowledge: { type: 'string', nullable: true, description: 'A caller-formatted context block appended verbatim to the opening turn (e.g. website-knowledge state).' },
+            model: { type: 'string', nullable: true, description: 'Per-session model override (a `text:` catalogue model the caller is allowed to use, e.g. from a user preference). 400 if unknown, 403 if not permitted.' },
           },
         },
       },

--- a/lib/set-builder-agent.js
+++ b/lib/set-builder-agent.js
@@ -77,12 +77,13 @@ Reference other members with { "source": "static", "from": "label:<label>" } in 
 the platform resolves labels to real IDs on create. transfer_agent must target a voice agent; subagent a text agent.
 
 MCP KNOWLEDGEBASES (giving the team access to a knowledge/docs MCP server)
-- mcpServers is honoured by text:anthropic/… text agents (via the Anthropic MCP connector, server-side) AND by
-  pipecat: voice models. It is NOT honoured by livekit:/jambonz:/ultravox: voice models (they store but ignore it).
-- So the right way to give a team an MCP knowledgebase is a text:anthropic/… (e.g. claude-sonnet-4-6) "knowledge"
-  subagent with the MCP server in its mcpServers, which the other agents consult via a subagent function. Do NOT
-  make the design depend on a pipecat voice agent just to reach an MCP — route knowledge through a text:anthropic
-  subagent, which works no matter what runtime the voice agents use.
+- mcpServers is honoured by ALL text:… agents (every text provider — anthropic, openai, gemini, kimi, groq,
+  openrouter) AND by pipecat: voice models. It is NOT honoured by livekit:/jambonz:/ultravox: voice models
+  (they store but ignore it).
+- So the right way to give a team an MCP knowledgebase is a text:… "knowledge" subagent (e.g.
+  text:anthropic/claude-sonnet-5) with the MCP server in its mcpServers, which the other agents consult via a
+  subagent function. Do NOT make the design depend on a pipecat voice agent just to reach an MCP — route
+  knowledge through a text subagent, which works no matter what runtime the voice agents use.
 
 OTHER FUNCTIONS — look up exact parameters on the MCP before using; DON'T guess
 The platform supports more function types than the links above, and you do NOT know their exact schemas by heart.

--- a/tests/agent-chat-model-override.test.mjs
+++ b/tests/agent-chat-model-override.test.mjs
@@ -1,0 +1,137 @@
+// POST /agents/{agentId}/chat `model` override: a per-SESSION model choice
+// (e.g. a user's builder-model preference) validated against the text
+// catalogue and the caller's model allow-list, then applied in-memory to the
+// resolved agent so the LLM build and the persisted session both reflect it.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+
+// Provider keys must exist BEFORE the endpoint (and its driver imports)
+// load: the catalogue filters on canLoad.ok, and anthropic.js reads its key
+// at module scope.
+process.env.ANTHROPIC_API_KEY ||= 'test-key';
+process.env.OPENAI_API_KEY ||= 'test-key';
+process.env.GROQ_API_KEY ||= 'test-key';
+process.env.GOOGLE_API_KEY ||= 'test-key';
+process.env.KIMI_KEY ||= 'test-key';
+process.env.OPENROUTER_KEY ||= 'test-key';
+
+import { randomUUID } from 'node:crypto';
+
+const chatModule = (await import('../api/paths/agents/{agentId}/chat.js')).default;
+const { getChatSession } = await import('../lib/text-chat.js');
+const { Agent, Organisation } = await import('../lib/database.js');
+
+const mockLogger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const agentChat = chatModule(mockLogger).POST;
+
+const createMockRequest = (overrides = {}) => ({
+  body: {},
+  params: {},
+  query: {},
+  headers: {},
+  log: mockLogger,
+  ...overrides,
+});
+
+const createMockResponse = (locals = {}) => ({
+  _status: null,
+  _body: null,
+  locals,
+  status(code) { this._status = code; return this; },
+  send(data) { this._body = data; return this; },
+  json(data) { this._body = data; return this; },
+});
+
+const asUser = (extra = {}) => ({
+  user: { id: 'user-mo-1', role: 'owner', organisationId: 'org-mo-1', ...extra },
+});
+
+beforeAll(async () => {
+  await setupRealDatabase();
+});
+
+afterAll(async () => {
+  await teardownRealDatabase();
+});
+
+describe('POST /agents/{agentId}/chat model override', () => {
+  test('unknown model is rejected with 400', async () => {
+    const res = createMockResponse(asUser());
+    await agentChat(createMockRequest({
+      params: { agentId: 'builtin:set-builder' },
+      body: { model: 'text:openai/not-a-model' },
+    }), res);
+    expect(res._status).toBe(400);
+    expect(res._body.message).toMatch(/Unknown text model/);
+  });
+
+  test('a model outside the caller allow-list is rejected with 403', async () => {
+    const res = createMockResponse(asUser({
+      _allowedModels: ['builtin:set-builder', 'text:anthropic/claude-sonnet-5'],
+    }));
+    await agentChat(createMockRequest({
+      params: { agentId: 'builtin:set-builder' },
+      body: { model: 'text:openai/gpt-5.6-terra' },
+    }), res);
+    expect(res._status).toBe(403);
+    expect(res._body.message).toMatch(/not permitted/);
+  });
+
+  test('an allowed catalogue model overrides the session model', async () => {
+    const res = createMockResponse(asUser());
+    await agentChat(createMockRequest({
+      params: { agentId: 'builtin:set-builder' },
+      body: { model: 'text:kimi/kimi-k2.6' },
+    }), res);
+    expect(res._status).toBeNull(); // 200 via plain send
+    expect(res._body.id).toBeDefined();
+    const session = getChatSession(res._body.id);
+    expect(session.agent.modelName).toBe('text:kimi/kimi-k2.6');
+    session.teardown();
+  });
+
+  test('no model key leaves the builder default untouched', async () => {
+    const res = createMockResponse(asUser());
+    await agentChat(createMockRequest({
+      params: { agentId: 'builtin:set-builder' },
+      body: {},
+    }), res);
+    expect(res._body.id).toBeDefined();
+    const session = getChatSession(res._body.id);
+    expect(session.agent.modelName).toMatch(/^text:anthropic\//);
+    session.teardown();
+  });
+
+  test('a stored (DB-row) agent takes the override in-memory and the ROW is never saved', async () => {
+    const orgId = randomUUID();
+    await Organisation.create({ id: orgId, name: 'model-override-org' });
+    const row = await Agent.create({
+      name: 'stored text agent',
+      type: 'text',
+      modelName: 'text:anthropic/claude-sonnet-5',
+      prompt: 'You are a test agent.',
+      organisationId: orgId,
+    });
+    try {
+      const res = createMockResponse(asUser({ organisationId: orgId }));
+      await agentChat(createMockRequest({
+        params: { agentId: row.id },
+        body: { model: 'text:kimi/kimi-k2.6' },
+      }), res);
+      expect(res._body.id).toBeDefined();
+      const session = getChatSession(res._body.id);
+      // The session runs the override…
+      expect(session.agent.modelName).toBe('text:kimi/kimi-k2.6');
+      session.teardown();
+      // …but the stored definition is untouched (the mutation is in-memory only).
+      const reloaded = await Agent.findByPk(row.id);
+      expect(reloaded.modelName).toBe('text:anthropic/claude-sonnet-5');
+    } finally {
+      await Agent.destroy({ where: { id: row.id } });
+      await Organisation.destroy({ where: { id: orgId } });
+    }
+  });
+});

--- a/tools/builder-eval/judge.mjs
+++ b/tools/builder-eval/judge.mjs
@@ -36,6 +36,13 @@ export async function judge({ scenario, result }) {
     .replace(/```(json)?/g, ''); // some judgments arrive fenced despite the instruction
   try {
     const parsed = JSON.parse(text.slice(text.indexOf('{'), text.lastIndexOf('}') + 1));
+    // The judge sometimes omits `overall` despite the instruction — derive it
+    // from the subscores rather than losing the row's headline number.
+    if (typeof parsed.overall !== 'number') {
+      const subs = ['promptQuality', 'faithfulness', 'efficiency']
+        .map((k) => parsed[k]).filter((v) => typeof v === 'number');
+      if (subs.length) parsed.overall = Math.round((subs.reduce((a, b) => a + b, 0) / subs.length) * 10) / 10;
+    }
     return { ...parsed, judgeModel: JUDGE_MODEL };
   } catch {
     return { promptQuality: null, faithfulness: null, efficiency: null, overall: null, summary: `unparseable judge output: ${text.slice(0, 200)}`, judgeModel: JUDGE_MODEL };

--- a/tools/builder-eval/run.mjs
+++ b/tools/builder-eval/run.mjs
@@ -41,12 +41,24 @@ const { judge } = await import('./judge.mjs');
 const DEFAULT_MODELS = ['text:anthropic/claude-sonnet-5'];
 
 // $/MTok — used for the per-run cost estimate in the report. Update as prices
-// move; unknown models report tokens only.
+// move; unknown models report tokens only. Verified July 2026 list prices
+// (sonnet-5 has intro $2/$10 to 2026-08-31 — list price used for fairness).
+// NOTE: the OpenAI Responses usage API doesn't split cache WRITES out of
+// input_tokens (writes bill at 1.25x input on gpt-5.6+), so OpenAI costs are
+// slightly underestimated on cache-miss-heavy runs.
 const PRICES = {
   'anthropic/claude-sonnet-5': { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   'anthropic/claude-sonnet-4-5': { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
   'anthropic/claude-haiku-4-5': { in: 1, out: 5, cacheRead: 0.1, cacheWrite: 1.25 },
   'anthropic/claude-opus-4-8': { in: 5, out: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+  'openai/gpt-5.6-sol': { in: 5, out: 30, cacheRead: 0.5, cacheWrite: 0 },
+  'openai/gpt-5.6-terra': { in: 2.5, out: 15, cacheRead: 0.25, cacheWrite: 0 },
+  'openai/gpt-5.6-luna': { in: 1, out: 6, cacheRead: 0.1, cacheWrite: 0 },
+  'openai/gpt-5.5': { in: 5, out: 30, cacheRead: 0.5, cacheWrite: 0 },
+  'gemini/gemini-3.5-flash': { in: 1.5, out: 9, cacheRead: 0.15, cacheWrite: 0 },
+  'kimi/kimi-k2.6': { in: 0.95, out: 4, cacheRead: 0.16, cacheWrite: 0 },
+  // OpenRouter passes Moonshot pricing through (its fee is on credit top-ups).
+  'openrouter/moonshotai/kimi-k2.6': { in: 0.95, out: 4, cacheRead: 0.16, cacheWrite: 0 },
 };
 
 const quietLogger = {


### PR DESCRIPTION
Optional `model` on POST /agents/{agentId}/chat — validated against the text catalogue (400) and the caller's allow-list (403), applied in-memory to the resolved agent so the LLM build and the ChatSession history row both record the model that actually ran. Feeds per-user builder-model preference (companion PR). Also: builder prompt MCP guidance updated for the new cross-provider drivers; eval-harness judge hardening + July-2026 price table. 5 new endpoint tests incl. the stored-DB-row never-saved invariant; suite 538/538 green. Known pre-existing gap (flagged, tracked separately): stored agents' own modelName is not allow-list-gated on chat/invoke.