### PR TITLE
Builtin set-builder default to GPT-5.6 Terra (bake-off)

### DIFF
--- a/lib/set-builder-agent.js
+++ b/lib/set-builder-agent.js
@@ -11,7 +11,11 @@
  * read the live Aplisay API reference and docs at call time.
  */
 
-const MODEL = process.env.SET_BUILDER_MODEL || 'text:anthropic/claude-opus-4-8';
+// Default flipped from claude-opus-4-8 on the 2026-07-12 bake-off (polite-ai
+// docs/builder-efficiency-review.md §5b): gpt-5.6-terra scored highest
+// (8.8/10 vs opus 8.2) at ~4× lower cost and ~3× lower latency, and matches
+// polite-ai's org-builder default so the builtin fallback behaves the same.
+const MODEL = process.env.SET_BUILDER_MODEL || 'text:openai/gpt-5.6-terra';
 // Development defaults to the NEXT (staging) channel — mcp-next.aplisay.com —
 // which tracks the staging API and is where in-development doc/truth fixes land.
 // Override with SET_BUILDER_MCP_URL (set it to https://mcp.aplisay.com/mcp for production).

--- a/tests/agent-chat-model-override.test.mjs
+++ b/tests/agent-chat-model-override.test.mjs
@@ -94,6 +94,7 @@ describe('POST /agents/{agentId}/chat model override', () => {
   });
 
   test('no model key leaves the builder default untouched', async () => {
+    const { SET_BUILDER_MODEL } = await import('../lib/set-builder-agent.js');
     const res = createMockResponse(asUser());
     await agentChat(createMockRequest({
       params: { agentId: 'builtin:set-builder' },
@@ -101,7 +102,7 @@ describe('POST /agents/{agentId}/chat model override', () => {
     }), res);
     expect(res._body.id).toBeDefined();
     const session = getChatSession(res._body.id);
-    expect(session.agent.modelName).toMatch(/^text:anthropic\//);
+    expect(session.agent.modelName).toBe(SET_BUILDER_MODEL);
     session.teardown();
   });
 


### PR DESCRIPTION
Flips the builtin set-builder's code default from claude-opus-4-8 to text:openai/gpt-5.6-terra, matching org-builder default per the measured bake-off — terra 8.8/10 vs opus 8.2 at ~4x lower cost. SET_BUILDER_MODEL env still overrides. Suite 538/538 green.