### PR TITLE
feat(text-chat): stream completions and announce tool calls at generation start

### DIFF
--- a/lib/models/anthropic.js
+++ b/lib/models/anthropic.js
@@ -6,6 +6,10 @@ const { ANTHROPIC_API_KEY } = process.env;
 // stalled MCP-connector round trip would hang a chat turn silently (no error,
 // spinner stuck) for that long. With this, a stall surfaces as a fast, visible
 // error instead. Retries kept low so a timeout doesn't compound. Both env-tunable.
+// Since the move to streaming (create() below), the SDK timeout only bounds
+// time-to-first-byte — the same value is therefore also applied as an
+// INACTIVITY window between stream events, preserving the original guarantee
+// (a mid-generation stall aborts within the bound instead of hanging forever).
 const REQUEST_TIMEOUT_MS = Number(process.env.ANTHROPIC_REQUEST_TIMEOUT_MS || 900000);
 const MAX_RETRIES = Number(process.env.ANTHROPIC_MAX_RETRIES ?? 1);
 
@@ -114,6 +118,9 @@ class Anthropic extends Llm {
 
   constructor({ logger, prompt, options, model, modelName, mcpServers, interactive }) {
     super(...arguments);
+    // The module-level SDK instance, referenced per-instance so tests can
+    // inject a fake client (parity with the openai driver's this.client).
+    this.client = anthropic;
     this.mcpServers = Array.isArray(mcpServers) ? mcpServers : [];
     // Handler-constructed (voice) sessions spread agent.dataValues, which has
     // only modelName — without this fallback they'd silently run the catalogue
@@ -242,8 +249,16 @@ class Anthropic extends Llm {
     return undefined;
   }
 
-  /** One Messages API call against the current conversation; MCP connector when configured. */
-  async create() {
+  /**
+   * One Messages API call against the current conversation; MCP connector when
+   * configured. STREAMED so a client tool call's NAME surfaces the moment its
+   * tool_use block starts — a builder set-save generates arguments for tens of
+   * seconds, and the UI needs "the team is being changed" at the start of that
+   * window, not the end (`callBack({ tool_use_start })`). The SDK stream helper
+   * accumulates the identical final message (`finalMessage()`), so the
+   * completion contract, history replay and usage accounting are unchanged.
+   */
+  async create(callBack) {
     const mcpServers = this.activeMcpServers();
     const tools = this.toolsParam(mcpServers);
     // Send the (static, re-sent every round) system prompt as a content block
@@ -264,8 +279,8 @@ class Anthropic extends Llm {
       messages,
       ...(tools.length ? { tools } : {}),
     };
-    if (mcpServers.length) {
-      return anthropic.beta.messages.create({
+    const stream = mcpServers.length
+      ? this.client.beta.messages.stream({
         ...request,
         mcp_servers: mcpServers.map((s) => {
           const token = this.serverAuthToken(s);
@@ -277,9 +292,25 @@ class Anthropic extends Llm {
           };
         }),
         betas: [MCP_BETA],
-      });
+      })
+      : this.client.messages.stream(request);
+    // Streaming moves the SDK timeout to time-to-first-byte only; keep the
+    // original stall guarantee by aborting after REQUEST_TIMEOUT_MS with no
+    // stream event (finalMessage() then rejects and the turn errors visibly).
+    let stallTimer = setTimeout(() => stream.abort(), REQUEST_TIMEOUT_MS);
+    stream.on('streamEvent', (event) => {
+      clearTimeout(stallTimer);
+      stallTimer = setTimeout(() => stream.abort(), REQUEST_TIMEOUT_MS);
+      if (event.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
+        this.logger.info({ tool: event.content_block.name }, 'anthropic tool_use block started');
+        callBack && callBack({ tool_use_start: { name: event.content_block.name } });
+      }
+    });
+    try {
+      return await stream.finalMessage();
+    } finally {
+      clearTimeout(stallTimer);
     }
-    return anthropic.messages.create(request);
   }
 
   /**
@@ -302,7 +333,7 @@ class Anthropic extends Llm {
     const usage = { provider: 'anthropic', model: this.model, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
     try {
       for (let hop = 0; hop < MAX_SERVER_HOPS; hop += 1) {
-        const message = await this.create();
+        const message = await this.create(callBack);
         const { content = [], role = 'assistant', stop_reason, usage: u } = message;
         if (u) {
           usage.inputTokens += u.input_tokens || 0;

--- a/lib/models/openai.js
+++ b/lib/models/openai.js
@@ -138,7 +138,14 @@ class OpenAi extends Llm {
   async rawCompletion(input, callBack) {
     if (input) this.gpt.input.push({ role: 'user', content: input });
     const tools = this.toolsParam();
-    const response = await this.client.responses.create({
+    // STREAMED so a client tool call's NAME surfaces the moment its
+    // function_call item is added — a builder set-save generates arguments for
+    // tens of seconds, and the UI needs "the team is being changed" at the
+    // start of that window, not the end (`callBack({ tool_use_start })`). The
+    // SDK stream helper accumulates the identical final response — lifecycle
+    // events carry the server's own final object, so the stateless replay of
+    // output items (encrypted reasoning included) and usage are unchanged.
+    const stream = this.client.responses.stream({
       model: this.gpt.model,
       instructions: this._prompt,
       input: this.gpt.input,
@@ -151,10 +158,33 @@ class OpenAi extends Llm {
       ...(this.effort ? { reasoning: { effort: this.effort } } : {}),
       ...(tools.length ? { tools } : {}),
     });
+    // Streaming moves the client timeout to time-to-first-byte only; keep a
+    // stall guarantee by aborting after OPENAI_TIMEOUT_MS with no stream
+    // event (finalResponse() then rejects and the turn errors visibly).
+    const stallMs = Number(process.env.OPENAI_TIMEOUT_MS || 900000);
+    let stallTimer = setTimeout(() => stream.abort(), stallMs);
+    stream.on('event', (event) => {
+      clearTimeout(stallTimer);
+      stallTimer = setTimeout(() => stream.abort(), stallMs);
+      if (event.type === 'response.output_item.added' && event.item?.type === 'function_call' && event.item.name) {
+        this.logger.info({ tool: event.item.name }, 'openai function_call item started');
+        callBack && callBack({ tool_use_start: { name: event.item.name } });
+      }
+    });
+    let response;
+    try {
+      response = await stream.finalResponse();
+    } finally {
+      clearTimeout(stallTimer);
+    }
 
     // Replay EVERYTHING (reasoning items included) — the API errors if
     // reasoning/function_call items are missing on a stateless follow-up.
-    this.gpt.input.push(...(response.output || []));
+    // The stream helper's finalResponse() runs the SDK parse pass, which
+    // ANNOTATES items with parse artifacts (function_call.parsed_arguments,
+    // output_text content .parsed) that are not valid REQUEST fields — strip
+    // them or the replay 400s ("Unknown parameter: 'input[N].parsed_arguments'").
+    this.gpt.input.push(...(response.output || []).map(OpenAi.stripParseArtifacts));
 
     let text = '';
     const calls = [];
@@ -200,6 +230,28 @@ class OpenAi extends Llm {
     } catch {
       return { _raw: raw };
     }
+  }
+
+  /**
+   * Drop the parse-pass annotations the stream helper's finalResponse() adds
+   * to output items (`parsed_arguments` on function/custom tool calls,
+   * `parsed` on output_text content parts). They are response-side sugar the
+   * Responses API rejects as unknown parameters when the item is replayed as
+   * INPUT on the next stateless request.
+   */
+  static stripParseArtifacts(item) {
+    if (!item || typeof item !== 'object') return item;
+    const { parsed_arguments, ...rest } = item;
+    if (Array.isArray(rest.content)) {
+      rest.content = rest.content.map((c) => {
+        if (c && typeof c === 'object' && 'parsed' in c) {
+          const { parsed, ...part } = c;
+          return part;
+        }
+        return c;
+      });
+    }
+    return rest;
   }
 
   async callResult(results, callBack) {

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -391,6 +391,15 @@ class TextChatSession {
       if (ev && ev.mcp_tool_use) {
         send({ type: 'tool_call', calls: [{ name: ev.mcp_tool_use.name, server: ev.mcp_tool_use.server, mcp: true }] });
       }
+      // A client tool call the model has STARTED generating (streaming drivers
+      // surface the name at block start, tens of seconds before a big set
+      // save's arguments finish). Lets the builder UI treat the canvas as
+      // provisional for the whole generation window, not just the save round
+      // trip — the definitive tool_call frame (with input) still follows once
+      // generation completes, and clients handle the repeat idempotently.
+      if (ev && typeof ev.tool_use_start?.name === 'string' && ev.tool_use_start.name) {
+        send({ type: 'tool_call', calls: [{ name: ev.tool_use_start.name }], streaming: true });
+      }
     };
     try {
       // A pending created AFTER this message was queued (the model paused again

--- a/tests/driver-streaming-tool-start.test.mjs
+++ b/tests/driver-streaming-tool-start.test.mjs
@@ -1,0 +1,214 @@
+// Streaming tool-use start events: the anthropic and openai (Responses)
+// drivers now STREAM each completion and surface a client tool call's NAME the
+// moment its block/item starts — `callBack({ tool_use_start: { name } })` —
+// so the builder UI can veil the canvas for the whole generation window of a
+// set save, not just the post-generation round trip. These tests pin that the
+// event fires (with the name, before the round resolves) AND that the
+// completion contract — { text, calls, truncated, usage }, history replay,
+// disjoint usage units — is byte-identical to the pre-streaming drivers.
+// No network: fake stream helpers stand in for the SDK stream objects.
+process.env.OPENAI_API_KEY ||= 'test-key';
+process.env.ANTHROPIC_API_KEY ||= 'test-key';
+
+const { default: OpenAi } = await import('../lib/models/openai.js');
+const { default: Anthropic } = await import('../lib/models/anthropic.js');
+
+const logger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const baseArgs = (model) => ({
+  logger,
+  user: 'test',
+  prompt: 'You are a test agent.',
+  options: { maxTokens: 4096 },
+  model,
+  modelName: model,
+  mcpServers: [],
+  keys: [],
+});
+
+/**
+ * Stand-in for the SDK stream helpers: listeners registered via .on() are
+ * replayed the queued events when finalMessage()/finalResponse() is awaited —
+ * the same relative order as the real helpers (events before resolution).
+ */
+function fakeStream({ events = [], final, eventName }) {
+  const listeners = [];
+  const finish = async () => {
+    for (const e of events) listeners.forEach((cb) => cb(e));
+    if (final instanceof Error) throw final;
+    return final;
+  };
+  return {
+    on(name, cb) {
+      if (name === eventName) listeners.push(cb);
+      return this;
+    },
+    abort() {},
+    finalMessage: finish,
+    finalResponse: finish,
+  };
+}
+
+describe('anthropic streaming tool_use_start', () => {
+  const finalMessage = {
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'Saving now.' },
+      { type: 'tool_use', id: 't1', name: 'update_agent_set', input: { id: 's1' } },
+    ],
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 10, output_tokens: 7, cache_read_input_tokens: 3, cache_creation_input_tokens: 2 },
+  };
+  const streamEvents = [
+    { type: 'message_start', message: {} },
+    { type: 'content_block_start', content_block: { type: 'text' } },
+    { type: 'content_block_start', content_block: { type: 'tool_use', name: 'update_agent_set' } },
+  ];
+
+  test('emits tool_use_start with the name at block start; round contract unchanged', async () => {
+    const claude = new Anthropic(baseArgs('text:anthropic/claude-sonnet-5'));
+    const streamParams = [];
+    claude.client = {
+      messages: {
+        stream: (params) => {
+          streamParams.push(params);
+          return fakeStream({ events: streamEvents, final: finalMessage, eventName: 'streamEvent' });
+        },
+      },
+      beta: { messages: { stream: () => { throw new Error('beta path must not be used without MCP servers'); } } },
+    };
+    const events = [];
+    const round = await claude.rawCompletion('save it', (ev) => events.push(ev));
+
+    // The early event: exactly one (the text block must not produce one), the
+    // name only — arguments don't exist yet at block start.
+    const starts = events.filter((e) => e.tool_use_start);
+    expect(starts).toEqual([{ tool_use_start: { name: 'update_agent_set' } }]);
+    // …and it arrived BEFORE the final-result callback.
+    expect(events.findIndex((e) => e.tool_use_start)).toBeLessThan(events.findIndex((e) => e.calls));
+
+    expect(round.text).toBe('Saving now.');
+    expect(round.calls).toEqual([{ name: 'update_agent_set', id: 't1', input: { id: 's1' } }]);
+    expect(round.truncated).toBe(false);
+    expect(round.usage).toMatchObject({
+      provider: 'anthropic', inputTokens: 10, outputTokens: 7, cacheReadTokens: 3, cacheWriteTokens: 2,
+    });
+    // History replay: the full assistant content rides the conversation.
+    expect(claude.gpt.messages.at(-1)).toEqual({ role: 'assistant', content: finalMessage.content });
+    // The request itself is the familiar non-streaming shape.
+    expect(streamParams[0]).toMatchObject({ model: 'claude-sonnet-5', max_tokens: 4096 });
+  });
+
+  test('pause_turn hops re-stream and accumulate usage across hops', async () => {
+    const claude = new Anthropic(baseArgs('text:anthropic/claude-sonnet-5'));
+    let hops = 0;
+    claude.client = {
+      messages: {
+        stream: () => {
+          hops += 1;
+          return fakeStream({
+            events: [],
+            eventName: 'streamEvent',
+            final: hops === 1
+              ? { role: 'assistant', content: [], stop_reason: 'pause_turn', usage: { input_tokens: 5, output_tokens: 1 } }
+              : { role: 'assistant', content: [{ type: 'text', text: 'done' }], stop_reason: 'end_turn', usage: { input_tokens: 6, output_tokens: 2 } },
+          });
+        },
+      },
+      beta: { messages: { stream: () => { throw new Error('beta path must not be used without MCP servers'); } } },
+    };
+    const round = await claude.rawCompletion('hi');
+    expect(hops).toBe(2);
+    expect(round.text).toBe('done');
+    expect(round.usage).toMatchObject({ inputTokens: 11, outputTokens: 3 });
+  });
+
+  test('MCP-configured sessions stream via the beta connector path', async () => {
+    const claude = new Anthropic({
+      ...baseArgs('text:anthropic/claude-sonnet-5'),
+      mcpServers: [{ name: 'aplisay', url: 'https://mcp.example/mcp' }],
+    });
+    const betaParams = [];
+    claude.client = {
+      messages: { stream: () => { throw new Error('non-beta path must not be used with MCP servers'); } },
+      beta: {
+        messages: {
+          stream: (params) => {
+            betaParams.push(params);
+            return fakeStream({
+              events: [],
+              eventName: 'streamEvent',
+              final: { role: 'assistant', content: [{ type: 'text', text: 'ok' }], stop_reason: 'end_turn', usage: {} },
+            });
+          },
+        },
+      },
+    };
+    await claude.rawCompletion('hi');
+    expect(betaParams[0].mcp_servers).toEqual([{ type: 'url', url: 'https://mcp.example/mcp', name: 'aplisay' }]);
+    expect(betaParams[0].betas).toBeDefined();
+  });
+});
+
+describe('openai (Responses) streaming tool_use_start', () => {
+  // finalResponse() runs the SDK parse pass, which annotates function_call
+  // items with parsed_arguments and output_text parts with parsed — exactly
+  // as the real helper returns them (caught live: replaying them 400s with
+  // "Unknown parameter: 'input[N].parsed_arguments'").
+  const finalResponse = {
+    status: 'completed',
+    output: [
+      { type: 'reasoning', id: 'rs_1', encrypted_content: 'opaque' },
+      { type: 'message', content: [{ type: 'output_text', text: 'Done.', parsed: null }] },
+      { type: 'function_call', call_id: 'c1', name: 'update_agent_set', arguments: '{"id":"s1"}', parsed_arguments: null },
+    ],
+    usage: { input_tokens: 100, output_tokens: 9, input_tokens_details: { cached_tokens: 40 } },
+  };
+  const streamEvents = [
+    { type: 'response.created', response: {} },
+    { type: 'response.output_item.added', item: { type: 'reasoning', id: 'rs_1' } },
+    { type: 'response.output_item.added', item: { type: 'function_call', name: 'update_agent_set' } },
+  ];
+
+  test('emits tool_use_start when the function_call item is added; round contract unchanged', async () => {
+    const oa = new OpenAi(baseArgs('text:openai/gpt-5.6-terra'));
+    const streamParams = [];
+    oa.client = {
+      responses: {
+        stream: (params) => {
+          streamParams.push(params);
+          return fakeStream({ events: streamEvents, final: finalResponse, eventName: 'event' });
+        },
+      },
+    };
+    const events = [];
+    const round = await oa.rawCompletion('save it', (ev) => events.push(ev));
+
+    const starts = events.filter((e) => e.tool_use_start);
+    expect(starts).toEqual([{ tool_use_start: { name: 'update_agent_set' } }]);
+    expect(events.findIndex((e) => e.tool_use_start)).toBeLessThan(events.findIndex((e) => e.calls));
+
+    expect(round.text).toBe('Done.');
+    expect(round.calls).toEqual([{ id: 'c1', name: 'update_agent_set', input: { id: 's1' } }]);
+    expect(round.truncated).toBe(false);
+    // Disjoint usage units: cached tokens subtracted from input_tokens.
+    expect(round.usage).toMatchObject({ inputTokens: 60, outputTokens: 9, cacheReadTokens: 40 });
+    // Stateless replay: EVERY output item (encrypted reasoning included) is
+    // appended to the input for the next request, with the parse-pass
+    // annotations STRIPPED (the API rejects them as unknown parameters).
+    expect(oa.gpt.input).toEqual(expect.arrayContaining([
+      finalResponse.output[0],
+      { type: 'message', content: [{ type: 'output_text', text: 'Done.' }] },
+      { type: 'function_call', call_id: 'c1', name: 'update_agent_set', arguments: '{"id":"s1"}' },
+    ]));
+    for (const item of oa.gpt.input) {
+      expect(item).not.toHaveProperty('parsed_arguments');
+      for (const part of item?.content || []) expect(part).not.toHaveProperty('parsed');
+    }
+    // The request keeps the statefulness contract of the non-streaming driver.
+    expect(streamParams[0]).toMatchObject({ store: false, include: ['reasoning.encrypted_content'] });
+  });
+});

--- a/tests/text-chat-tool-start-frames.test.mjs
+++ b/tests/text-chat-tool-start-frames.test.mjs
@@ -1,0 +1,94 @@
+// database-test-wrapper sets the POSTGRES_* env for the standard test container
+// BEFORE lib/database.js is imported (text-chat.js pulls it in transitively),
+// and its teardown closes the import-time connections so jest can exit.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+
+const { createChatSession } = await import('../lib/text-chat.js');
+
+// The early `tool_call` ws frame: streaming drivers surface a client tool
+// call's NAME the moment its block starts (callBack({ tool_use_start })),
+// tens of seconds before a big set save's arguments finish generating. The
+// chat loop forwards it as { type:'tool_call', calls:[{ name }], streaming:
+// true } so the builder UI can veil the canvas for the whole generation
+// window (polite-ai PR #115); the definitive post-generation tool_call frame
+// (with input) is unchanged. These tests pin the frame shape, its ordering
+// (before the agent reply), and that malformed/absent events emit nothing.
+
+const logger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const agent = {
+  id: 'agent-1',
+  organisationId: 'org-1',
+  userId: 'user-1',
+  modelName: 'text:anthropic/claude-sonnet-5',
+  functions: [],
+  keys: [],
+  options: {},
+  mcpServers: [],
+};
+
+beforeAll(async () => {
+  await setupRealDatabase();
+});
+
+afterAll(async () => {
+  await teardownRealDatabase();
+});
+
+function sessionWithLlm(rawCompletion) {
+  const session = createChatSession({ agent, logger });
+  session.llm = { rawCompletion };
+  return session;
+}
+
+describe('streaming tool_use_start → early tool_call frame', () => {
+  test('a driver tool_use_start emits {type:tool_call, streaming:true} before the reply', async () => {
+    const session = sessionWithLlm(async (text, cb) => {
+      cb({ tool_use_start: { name: 'update_agent_set' } });
+      return { text: 'Saved the team.', calls: [] };
+    });
+    const frames = [];
+    await session.runTurn('add a bookings agent', (f) => frames.push(f));
+
+    const early = frames.findIndex((f) => f.type === 'tool_call' && f.streaming);
+    const reply = frames.findIndex((f) => f.type === 'agent');
+    expect(frames[early]).toEqual({
+      type: 'tool_call',
+      calls: [{ name: 'update_agent_set' }],
+      streaming: true,
+    });
+    expect(early).toBeGreaterThan(-1);
+    expect(reply).toBeGreaterThan(early);
+    expect(frames.at(-1)).toEqual({ type: 'turn_complete' });
+  });
+
+  test('a nameless tool_use_start and the final-result callback emit no frame', async () => {
+    const session = sessionWithLlm(async (text, cb) => {
+      cb({ tool_use_start: {} }); // malformed — no name
+      const round = { text: 'ok', calls: [] };
+      cb(round); // drivers echo the final round through the same callback
+      return round;
+    });
+    const frames = [];
+    await session.runTurn('hello', (f) => frames.push(f));
+    expect(frames.filter((f) => f.type === 'tool_call')).toEqual([]);
+  });
+
+  test('mcp_tool_use events keep their existing frame shape alongside', async () => {
+    const session = sessionWithLlm(async (text, cb) => {
+      cb({ mcp_tool_use: { name: 'read_doc', server: 'aplisay' } });
+      cb({ tool_use_start: { name: 'patch_agent_set' } });
+      return { text: 'done', calls: [] };
+    });
+    const frames = [];
+    await session.runTurn('tweak it', (f) => frames.push(f));
+    const toolFrames = frames.filter((f) => f.type === 'tool_call');
+    expect(toolFrames).toEqual([
+      { type: 'tool_call', calls: [{ name: 'read_doc', server: 'aplisay', mcp: true }] },
+      { type: 'tool_call', calls: [{ name: 'patch_agent_set' }], streaming: true },
+    ]);
+  });
+});


### PR DESCRIPTION
## What

The builder UI veils the canvas as *provisional* while a set mutation is in flight — opening on a `tool_call` frame naming `create/update/patch_agent_set`, closing on the resulting `set` frame. Until now that frame was only emitted **after** the model finished generating the full tool arguments, so the veil covered just the ~1s save round-trip and missed the 10–60s window while a big set's JSON streams out of the model.

## How

- **`lib/models/anthropic.js` and `lib/models/openai.js` now stream each completion** via the SDK helpers (`messages.stream` / `beta.messages.stream`, `responses.stream`) and surface a client tool call's **name** the moment its block/item starts: `callBack({ tool_use_start: { name } })`. These two drivers cover the default builder model (gpt-5.6-terra) and every Claude choice.
- **`lib/text-chat.js`** forwards it as `{ type: 'tool_call', calls: [{ name }], streaming: true }`. The definitive post-generation frame (with `input`) is unchanged.
- The completion contract is untouched: `finalMessage()`/`finalResponse()` accumulate the identical final message, so `{ text, calls, truncated, usage }`, `pause_turn` hops, stateless history replay and the disjoint usage units all hold — pinned by the new tests.

## Side conditions found and handled

- **Parse artifacts (caught live, real API):** the Responses stream helper's `finalResponse()` runs the SDK parse pass, annotating `function_call` items with `parsed_arguments` (and `output_text` parts with `parsed`). Replaying those verbatim on the next stateless request 400s with `Unknown parameter: 'input[N].parsed_arguments'`. The replay now strips them (`OpenAi.stripParseArtifacts`).
- **Stall guard:** streaming moves the SDK request timeout to time-to-first-byte, which would have silently dropped the protection the 900s timeout exists for (a stalled connector round trip hanging a turn invisibly). Both drivers now abort the stream after the same bound passes with **no stream event**, so a mid-generation stall still errors fast and visibly.

## Deliberately out of scope

`openai-compatible` (kimi/groq/openrouter) and `gemini` stay non-streaming: streamed usage reporting is inconsistent across those providers and usage metering is billing-critical. Builders on those models keep today's late (post-generation) frame — the client contract degrades gracefully.

## Verified

- End-to-end against the real API through the builder (terra): early frame at **+1.9s** after send vs **+11.9s** for the definitive one — the veil now covers the full generation window; turn completes cleanly (`set` applied, no error frame).
- Real-API smoke of the Anthropic driver (haiku): `tool_use_start` mid-stream, follow-up `callResult` replay accepted.
- New suites `tests/driver-streaming-tool-start.test.mjs` (stream fakes: event-before-resolution, contract parity, pause_turn accumulation, beta/MCP path, artifact stripping) and `tests/text-chat-tool-start-frames.test.mjs` (frame shape/ordering, malformed events, mcp_tool_use coexistence). Full suite: **52 suites / 545 tests pass**.
