### PR TITLE
Gate agent RUN paths on model entitlement (chat/invoke/subagent)

### DIFF
--- a/api/paths/agent-db/subagent.js
+++ b/api/paths/agent-db/subagent.js
@@ -30,6 +30,14 @@ const subagentInvoke = async (req, res) => {
     return res.status(400).send({ error: 'organisationId is required' });
   }
 
+  // R1 model entitlement is enforced inside runSubagentById (below) — gating
+  // there covers this REST path AND in-process / nested delegation uniformly.
+  // A disallowed model throws SubagentError(403), caught below and returned as
+  // { error: 'model_not_permitted: ...' } (fail-closed: the subagent never
+  // runs). NOTE: the pipecat voice worker currently collapses a 403 body to
+  // "API request failed: 403" and delivers a null tool result to the LLM
+  // rather than the reason string — safe but not self-explanatory; improving
+  // that surfacing is a separate worker-side change.
   let timer;
   const timeout = new Promise((_, reject) => {
     timer = setTimeout(() => reject(new SubagentError(`Subagent invocation timed out after ${SUBAGENT_TIMEOUT}ms`, 504)), SUBAGENT_TIMEOUT);

--- a/api/paths/agents/{agentId}/chat.js
+++ b/api/paths/agents/{agentId}/chat.js
@@ -32,6 +32,22 @@ const agentChat = async (req, res) => {
     if (builtin && !isModelAllowed(agentId, res.locals.user?._allowedModels)) {
       return res.status(404).send({ message: `Agent with ID ${agentId} not found` });
     }
+    // R1 — RUNNING a stored agent is gated on its model, matching agentGet's
+    // read gate: an allow-list tightened after the agent was created (or a
+    // member with a narrower personal list than the agent's author) must not
+    // keep running a now-disallowed model on the org's bill. The per-session
+    // override below cannot rescue a disallowed base agent — if you may not
+    // read it, you may not run it.
+    // The org-pushed builder is a stored agent and IS gated here (it has no
+    // forgeable-free exemption — the description marker is tenant-settable via
+    // agentCreate, so trusting it would be a bypass). A restrictively-scoped
+    // org instead reaches the builder through the BUILTIN (gated by its
+    // `builtin:set-builder` access id, not its model): polite-ai retries the
+    // chat against the builtin on a 403, so an org granted `builtin:` keeps a
+    // working builder while its own pushed row is correctly policy-gated.
+    if (!builtin && !isModelAllowed(agent.modelName, res.locals.user?._allowedModels)) {
+      return res.status(403).send({ message: 'model_not_permitted', detail: `Model ${agent.modelName} is not permitted for your account.` });
+    }
     if ((agent.type || 'interactive-audio') !== 'text') {
       return res.status(400).send({
         message: `Agent ${agentId} is type ${agent.type || 'interactive-audio'}; only text agents support chat`,

--- a/api/paths/agents/{agentId}/invoke.js
+++ b/api/paths/agents/{agentId}/invoke.js
@@ -4,6 +4,7 @@ import { scopeWhereForUser } from '../../../../lib/scope.js';
 import { runSubagent, SubagentError } from '../../../../lib/subagent.js';
 import { recordSubagentUsage } from '../../../../lib/usage.js';
 import { requirePermission } from '../../../../lib/auth/permissions.js';
+import { isModelAllowed } from '../../../../lib/auth/model-access.js';
 
 let log;
 
@@ -28,6 +29,12 @@ const agentInvoke = async (req, res) => {
     }
     if ((agent.type || 'interactive-audio') !== 'text') {
       return res.status(400).send({ message: `Agent ${agentId} is type ${agent.type}; only text agents can be invoked` });
+    }
+    // R1 — running is gated on the agent's model, matching agentGet's read
+    // gate (this endpoint previously had NO model gate: a tightened allow-list
+    // could still invoke a now-disallowed model on the org's bill).
+    if (!isModelAllowed(agent.modelName, res.locals.user?._allowedModels)) {
+      return res.status(403).send({ message: 'model_not_permitted', detail: `Model ${agent.modelName} is not permitted for your account.` });
     }
     let timer;
     const timeout = new Promise((_, reject) => {

--- a/lib/subagent.js
+++ b/lib/subagent.js
@@ -251,6 +251,26 @@ export async function runSubagentById({ agentId, input, metadata, organisationId
   if (!ownedByOrganisation && !ownedByUser) {
     throw new SubagentError(`Subagent ${agentId} not found`, 404);
   }
+  // R1 — autonomous subagent execution is gated on the agent's ORG model floor.
+  // Gating HERE (not just at the REST endpoint) covers EVERY delegation path —
+  // the out-of-process REST call, in-process invokeSubagent, and nested
+  // subagent→subagent chains all funnel through this function, so an org that
+  // tightened its allow-list can no longer run a now-disallowed subagent via
+  // any of them. There is no user principal in this path (a voice call or a
+  // background delegation, never an interactive request), so we use the ORG
+  // floor rather than org∪user: an autonomous agent must not run a model the
+  // ORG forbids even if some user was individually granted it. An unrestricted
+  // org (empty union → null) imposes no gate. A user-owned agent with no org
+  // is likewise ungated (the user's own agent, no org policy to apply).
+  if (agent.organisationId) {
+    const { Organisation } = await import('./database.js');
+    const { effectiveAllowedModels, isModelAllowed } = await import('./auth/model-access.js');
+    const org = await Organisation.findByPk(agent.organisationId);
+    const orgAllowed = effectiveAllowedModels(null, org);
+    if (orgAllowed && !isModelAllowed(agent.modelName, orgAllowed)) {
+      throw new SubagentError(`model_not_permitted: ${agent.modelName} is not permitted for this organisation`, 403);
+    }
+  }
   return runSubagent({ agent, input, metadata, logger, depth, maxTurns, implementationOverride });
 }
 

--- a/tests/agent-model-entitlement.test.mjs
+++ b/tests/agent-model-entitlement.test.mjs
@@ -1,0 +1,182 @@
+// R1 model-entitlement gates on the RUN endpoints (chat / invoke / internal
+// subagent): reading an agent was already gated on its model (agentGet), but
+// running one was not — a tightened allow-list could keep executing a
+// now-disallowed model on the org's bill. These tests pin the new gates.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'node:crypto';
+
+process.env.ANTHROPIC_API_KEY ||= 'test-key';
+process.env.OPENAI_API_KEY ||= 'test-key';
+process.env.GROQ_API_KEY ||= 'test-key';
+process.env.GOOGLE_API_KEY ||= 'test-key';
+process.env.KIMI_KEY ||= 'test-key';
+process.env.OPENROUTER_KEY ||= 'test-key';
+
+const chatModule = (await import('../api/paths/agents/{agentId}/chat.js')).default;
+const invokeModule = (await import('../api/paths/agents/{agentId}/invoke.js')).default;
+const subagentModule = (await import('../api/paths/agent-db/subagent.js')).default;
+const { getChatSession } = await import('../lib/text-chat.js');
+const { runSubagentById, SubagentError } = await import('../lib/subagent.js');
+const { Agent, Organisation } = await import('../lib/database.js');
+
+const mockLogger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const agentChat = chatModule(mockLogger).POST;
+const agentInvoke = invokeModule(mockLogger).POST;
+const subagentInvoke = subagentModule(mockLogger).POST;
+
+const createMockRequest = (overrides = {}) => ({
+  body: {}, params: {}, query: {}, headers: {}, log: mockLogger, ...overrides,
+});
+const createMockResponse = (locals = {}) => ({
+  _status: null, _body: null, locals,
+  status(code) { this._status = code; return this; },
+  send(data) { this._body = data; return this; },
+  json(data) { this._body = data; return this; },
+});
+
+let orgId; let agentRow;
+
+beforeAll(async () => {
+  await setupRealDatabase();
+  orgId = randomUUID();
+  await Organisation.create({ id: orgId, name: 'entitlement-org' });
+  agentRow = await Agent.create({
+    name: 'opus text agent',
+    type: 'text',
+    modelName: 'text:anthropic/claude-opus-4-8',
+    prompt: 'You are a test agent.',
+    organisationId: orgId,
+  });
+});
+
+let builderRow;
+
+afterAll(async () => {
+  await Agent.destroy({ where: { id: agentRow.id } });
+  if (builderRow) await Agent.destroy({ where: { id: builderRow.id } });
+  await Organisation.destroy({ where: { id: orgId } });
+  await teardownRealDatabase();
+});
+
+const MARKER = '[polite:agent-builder]';
+
+// A user in the agent's org whose personal allow-list excludes its model.
+const restrictedUser = () => ({
+  user: {
+    id: 'user-ent-1', role: 'owner', organisationId: orgId,
+    _allowedModels: ['text:kimi', 'builtin:set-builder'],
+  },
+});
+const unrestrictedUser = () => ({
+  user: { id: 'user-ent-1', role: 'owner', organisationId: orgId, _allowedModels: null },
+});
+
+describe('chat endpoint model entitlement', () => {
+  test('a stored agent on a disallowed model is refused with 403 model_not_permitted', async () => {
+    const res = createMockResponse(restrictedUser());
+    await agentChat(createMockRequest({ params: { agentId: agentRow.id }, body: {} }), res);
+    expect(res._status).toBe(403);
+    expect(res._body.message).toBe('model_not_permitted');
+  });
+
+  test('a per-session override cannot rescue a disallowed base agent', async () => {
+    const res = createMockResponse(restrictedUser());
+    await agentChat(createMockRequest({
+      params: { agentId: agentRow.id },
+      body: { model: 'text:kimi/kimi-k2.6' }, // allowed model, disallowed agent
+    }), res);
+    expect(res._status).toBe(403);
+    expect(res._body.message).toBe('model_not_permitted');
+  });
+
+  test('an unrestricted user still chats the same agent', async () => {
+    const res = createMockResponse(unrestrictedUser());
+    await agentChat(createMockRequest({ params: { agentId: agentRow.id }, body: {} }), res);
+    expect(res._body.id).toBeDefined();
+    getChatSession(res._body.id).teardown();
+  });
+
+  test('builtins stay gated by their builtin: id, not their model', async () => {
+    // The restricted list includes builtin:set-builder — the builtin runs even
+    // though its DEFAULT model (text:openai/...) is outside the user's list.
+    const res = createMockResponse(restrictedUser());
+    await agentChat(createMockRequest({ params: { agentId: 'builtin:set-builder' }, body: {} }), res);
+    expect(res._body.id).toBeDefined();
+    getChatSession(res._body.id).teardown();
+  });
+
+  test('the org-pushed builder row is NOT exempt: its description marker is tenant-forgeable, so it is gated like any stored agent', async () => {
+    // A pushed org builder (marker in description) on a disallowed model is
+    // gated the same as any stored agent — trusting the tenant-settable marker
+    // would be a bypass. A restricted org reaches the builder via the BUILTIN
+    // (polite-ai retries against builtin:set-builder on this 403), not by
+    // exempting the org row.
+    builderRow = await Agent.create({
+      name: 'Polite Agent Builder',
+      description: `Org builder ${MARKER}`,
+      type: 'text',
+      modelName: 'text:openai/gpt-5.6-terra', // outside the restricted list
+      prompt: 'You are the builder.',
+      organisationId: orgId,
+    });
+    const res = createMockResponse(restrictedUser());
+    await agentChat(createMockRequest({ params: { agentId: builderRow.id }, body: {} }), res);
+    expect(res._status).toBe(403);
+    expect(res._body.message).toBe('model_not_permitted');
+  });
+});
+
+describe('invoke endpoint model entitlement', () => {
+  test('a stored agent on a disallowed model is refused with 403 before any LLM call', async () => {
+    const res = createMockResponse(restrictedUser());
+    await agentInvoke(createMockRequest({ params: { agentId: agentRow.id }, body: { input: {} } }), res);
+    expect(res._status).toBe(403);
+    expect(res._body.message).toBe('model_not_permitted');
+  });
+});
+
+describe('internal subagent endpoint org-level entitlement', () => {
+  test('an org allow-list excluding the target model refuses with 403', async () => {
+    await Organisation.update({ allowedModels: ['text:kimi'] }, { where: { id: orgId } });
+    try {
+      const res = createMockResponse({});
+      await subagentInvoke(createMockRequest({
+        body: { agentId: agentRow.id, organisationId: orgId, input: {} },
+      }), res);
+      expect(res._status).toBe(403);
+      expect(res._body.error).toMatch(/model_not_permitted/);
+    } finally {
+      await Organisation.update({ allowedModels: null }, { where: { id: orgId } });
+    }
+  });
+
+  test('an org with NO allow-list (unrestricted) is not blocked by the gate', async () => {
+    // Reaches past the gate into the real runSubagentById — with a test key
+    // the LLM call fails, which proves the 403 short-circuit did NOT fire.
+    const res = createMockResponse({});
+    await subagentInvoke(createMockRequest({
+      body: { agentId: agentRow.id, organisationId: orgId, input: {} },
+    }), res);
+    expect(res._status === 403 ? res._body.error : '').not.toMatch(/model_not_permitted/);
+  });
+});
+
+describe('runSubagentById gates EVERY delegation path (in-process + nested)', () => {
+  // The gate lives in runSubagentById, not just the REST endpoint, so an
+  // in-process invokeSubagent / nested subagent→subagent chain is covered too.
+  test('a disallowed model throws SubagentError(403) when called directly', async () => {
+    await Organisation.update({ allowedModels: ['text:kimi'] }, { where: { id: orgId } });
+    try {
+      await expect(
+        runSubagentById({ agentId: agentRow.id, input: {}, organisationId: orgId, logger: mockLogger }),
+      ).rejects.toMatchObject({ status: 403, message: expect.stringMatching(/model_not_permitted/) });
+    } finally {
+      await Organisation.update({ allowedModels: null }, { where: { id: orgId } });
+    }
+    expect(SubagentError).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

Reading an agent was already model-gated (`agentGet` → 403 `model_not_permitted`), but **running** one was not — so an org whose allow-list was tightened after an agent was created (or a member with a narrower personal list than the agent's author) could still execute a now-disallowed, more expensive model on the org's bill. This closes the gap on every run path:

- **`POST /agents/{id}/chat`** — gate stored (non-builtin) agents on `isModelAllowed(agent.modelName, …)`. Builtins keep their `builtin:<id>` access-id gate. Per-session override stays gated, after the base gate.
- **`POST /agents/{id}/invoke`** — same gate (had none).
- **`runSubagentById`** — org-floor gate (`effectiveAllowedModels(null, org)`; no user principal on an autonomous/voice/nested run). Placed here, not the REST endpoint, so it covers **all** delegation paths uniformly — out-of-process `/agent-db/subagent`, in-process `invokeSubagent`, and nested chains.

## Testing

`tests/agent-model-entitlement.test.mjs` (9): chat/invoke 403, override-can't-rescue, unrestricted passes, builtin id-gate, org-builder-is-gated, org-floor subagent 403, direct `runSubagentById` 403. Suite **554/554**.
