### PR TITLE
feat(text-chat): diagnose a self-initiated (manual) test as a hidden turn

### DIFF
--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -283,6 +283,17 @@ class TextChatSession {
     sessions.delete(this.id);
   }
 
+  // The leg-by-leg analysis guidance shared by the opening troubleshoot seed
+  // and a mid-session self-initiated test — a `legs` array, one entry per leg.
+  static TEST_ANALYSIS_GUIDANCE =
+    'The result has a `legs` array with ONE '
+    + 'entry per call leg — each with its own agentLabel/agentName, transcript, functions and invocationLog. '
+    + 'If the call transferred (transferred:true / more than one leg), there is a separate leg for each agent '
+    + 'the call passed through (e.g. reception → sales); analyse EVERY leg, and check the handover itself: did '
+    + 'the transfer_agent function fire on the source leg, and did the transferred-to agent pick up and run '
+    + 'its own functions on its leg? For each leg ask: did the agent actually speak? did the intended functions '
+    + 'fire with the right arguments? are there errors or warnings in the invocation log?';
+
   /** The hidden opening-turn prompt — build, edit, or diagnose depending on the seed. */
   openingPrompt() {
     const setJson = this.latestSet ? JSON.stringify(this.latestSet) : null;
@@ -311,13 +322,9 @@ class TextChatSession {
         ? `\n\nCURRENT SET (JSON):\n${setJson}\n\nTEST RESULT (JSON):\n${JSON.stringify(this.seedTestResult)}`
         : `${subject}\n\nTEST RESULT (JSON):\n${JSON.stringify(this.seedTestResult)}`;
       return intro
-        + 'Greet very briefly, then analyse the test result below. The result has a `legs` array with ONE '
-        + 'entry per call leg — each with its own agentLabel/agentName, transcript, functions and invocationLog. '
-        + 'If the call transferred (transferred:true / more than one leg), there is a separate leg for each agent '
-        + 'the call passed through (e.g. reception → sales); analyse EVERY leg, and check the handover itself: did '
-        + 'the transfer_agent function fire on the source leg, and did the transferred-to agent pick up and run '
-        + 'its own functions on its leg? For each leg ask: did the agent actually speak? did the intended functions '
-        + 'fire with the right arguments? are there errors or warnings in the invocation log? Explain what you find '
+        + 'Greet very briefly, then analyse the test result below. '
+        + TextChatSession.TEST_ANALYSIS_GUIDANCE
+        + ' Explain what you find '
         + 'in plain language and ' + apply + context;
     }
     if (setJson) {
@@ -328,6 +335,20 @@ class TextChatSession {
         + `CURRENT SET (JSON):\n${setJson}`;
     }
     return 'Greet me briefly and ask what agent set I would like to build.';
+  }
+
+  /**
+   * Framing for a SELF-INITIATED (manual, action-bar) in-browser test result:
+   * diagnosed mid-session as a HIDDEN turn (so the bundle never enters the
+   * durable transcript / the ongoing user-visible context). Unlike the opening
+   * troubleshoot seed it neither greets nor re-embeds the set — the builder
+   * already holds the current team.
+   */
+  manualTestDiagnosePrompt(resultJson) {
+    return 'The user just ran a live in-browser TEST of the current team. Analyse the test result below. '
+      + TextChatSession.TEST_ANALYSIS_GUIDANCE
+      + ' Explain what you find in plain language, fix it with patch_agent_set (using the set id), and offer to re-test.'
+      + `\n\nTEST RESULT (JSON):\n${resultJson}`;
   }
 
   async buildLlm() {
@@ -578,21 +599,30 @@ class TextChatSession {
   }
 
   /**
-   * Resolve a pending test_agent call from an explicit `test_result` frame
-   * ({type:'test_result', id, result}) — the unambiguous channel for clients
-   * that drive their own in-browser test flow (polite-ai). The id must match
-   * the pending tool-use id so a stale or duplicate frame can't hijack an
-   * unrelated turn. The legacy protocol — the next plain `user` message
-   * resumes the pending call (llm-frontend) — is unchanged; a client using
-   * this frame must send it BEFORE any queued user text so the paused turn
-   * consumes the result, not the chat message.
+   * Handle an explicit `test_result` frame ({type:'test_result', id?, result})
+   * — the unambiguous channel for clients that drive their own in-browser test
+   * flow (polite-ai). Two shapes:
+   *  - WITH a matching `id`: answers a paused test_agent tool call the builder
+   *    OFFERED. The id must match the pending tool-use id so a stale/duplicate
+   *    frame can't hijack an unrelated turn. The result rides the tool-call
+   *    context, so it resumes the turn verbatim (hidden).
+   *  - WITHOUT an `id` and with NO pending call: a SELF-INITIATED (manual,
+   *    action-bar) test. There's no tool-call context to say this JSON is a
+   *    test result, so it's framed as a diagnose turn — and run HIDDEN, so the
+   *    bundle stays out of the durable transcript and the ongoing user context.
+   * The legacy protocol — the next plain `user` message resumes a pending call
+   * (llm-frontend) — is unchanged; a client using the id form must send it
+   * BEFORE any queued user text so the paused turn consumes the result.
    */
   testResult(msg, send) {
-    if (!this.pending || msg.id !== this.pending.toolUseId) {
-      this.logger.warn({ id: this.id, frameId: msg.id }, 'test_result without a matching pending tool call — ignored');
-      return Promise.resolve();
+    if (this.pending && msg.id === this.pending.toolUseId) {
+      return this.turn(msg.result, send, true);
     }
-    return this.turn(msg.result, send, true);
+    if (!msg.id && !this.pending) {
+      return this.turn(this.manualTestDiagnosePrompt(msg.result), send, true);
+    }
+    this.logger.warn({ id: this.id, frameId: msg.id }, 'test_result without a matching pending tool call — ignored');
+    return Promise.resolve();
   }
 
   /** Record this round's LLM token usage against the chat session (best-effort). */


### PR DESCRIPTION
## What

Lets **team test** type agents feed their transcript back to the builder for review, without the call bundle ever landing in the durable transcript / user-visible context.


## Change (`lib/text-chat.js`)

`testResult(msg, send)` now routes on frame shape:

- **`id` matches the pending call** → answer the offered test (unchanged).
- **no `id` and no pending call** → a self-initiated test: run a fresh **HIDDEN** diagnose turn via new `manualTestDiagnosePrompt()`. Hidden ⇒ `runTurn` skips `record('user', …)`, so the bundle never enters the durable transcript or the ongoing user-visible context.
- **anything else** (stale/duplicate, or `id` mismatch while a call is pending) → ignored, preserving the anti-hijack guard.

The leg-by-leg analysis wording is extracted to a `static TEST_ANALYSIS_GUIDANCE` shared by `openingPrompt()` (troubleshoot seed) and the new manual prompt.

## Verify

- `node --check lib/text-chat.js` ✓
- Opening-prompt assembly `OLD === NEW` ✓ (byte-identical)
- `testResult` routing tree 5/5 (offered / manual / stale-dup / id-mismatch / no-id-while-pending)

