### PR TITLE
feat(handlers): gate handler families out of the roster when their env is unset

### DIFF
--- a/api/paths/voices.js
+++ b/api/paths/voices.js
@@ -9,7 +9,14 @@ export default function (logger, voices) {
 
   const voicesList = (async (req, res) => {
       try {
-        let voices = Object.fromEntries((await Promise.all((await handlers()).implementations.map(async ({ name, voices }) => ([name, await voices]))))
+        let voices = Object.fromEntries((await Promise.all((await handlers()).implementations
+          // A handler family whose transport credentials are unset isn't in the
+          // bundle, so don't advertise its voices — and, more importantly, don't
+          // await a `voices` static that rejects because its live catalogue API
+          // (e.g. jambonz, ultravox) has no server/key, which would 500 the whole
+          // endpoint.
+          .filter((impl) => impl.canLoad.ok)
+          .map(async ({ name, voices }) => ([name, await voices]))))
           // Headless handlers (e.g. `text` agents) have no TTS leg so don't belong in the voices list
           .filter(([, handlerVoices]) => handlerVoices && Object.keys(handlerVoices).length));
         res.send(voices);

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -68,6 +68,15 @@ export default class Handler {
  * ]
  */
   static get availableModels() {
+    // Handler-level env gate: a whole handler *family* drops out of the roster
+    // when its transport credentials are unset (e.g. no LIVEKIT_* → no livekit
+    // models, no JAMBONZ_* → no jambonz models). This is what lets us ship a
+    // pipecat-only or livekit-only instance. It is distinct from the per-model
+    // `canLoad` filter below, which gates individual LLM providers on their own
+    // API keys. Handlers with no `needKey` (e.g. `text`) are unaffected.
+    if (!this.canLoad.ok) {
+      return [];
+    }
     if (!this._availableModels) {
       this._availableModels = this.models
         // canLoad is an {ok, need} OBJECT — filtering on the object itself was

--- a/lib/handlers/jambonz.js
+++ b/lib/handlers/jambonz.js
@@ -40,14 +40,26 @@ class JambonzHandler extends Handler {
   }
   static needKey = { JAMBONZ_API_KEY, JAMBONZ_SERVER };
 
-  // Jambonz may have a subset of voice service providers configured for TTS
+  // Jambonz may have a subset of voice service providers configured for TTS.
+  // Guarded on canLoad so that in a jambonz-less instance (handler gated out of
+  // the roster) this initializer never constructs the Jambonz client (which
+  // requires the key) nor fires a credentials API call whose rejection would
+  // surface as an unhandled promise rejection at startup.
   static voices = (async (logger) => {
-    const jambonz = new Jambonz(logger, 'voices');
-    const voices = await Handler.voices
-    const filtered = (await jambonz.getCredentials())
-      .filter(provider => provider.use_for_tts && provider.tts_tested_ok && provider.vendor)
-      .reduce((o, { vendor }) => ({ ...o, [vendor]: voices[vendor] }), []);
-    return filtered;
+    // `this` in a static field initializer is the class (JambonzHandler).
+    if (!this.canLoad.ok) {
+      return {};
+    }
+    try {
+      const jambonz = new Jambonz(logger, 'voices');
+      const voices = await Handler.voices;
+      return (await jambonz.getCredentials())
+        .filter(provider => provider.use_for_tts && provider.tts_tested_ok && provider.vendor)
+        .reduce((o, { vendor }) => ({ ...o, [vendor]: voices[vendor] }), {});
+    } catch (e) {
+      defaultLogger.warn({ error: e?.message }, 'failed to load jambonz voices');
+      return {};
+    }
   })(defaultLogger);
 }
 

--- a/lib/handlers/ultravox.js
+++ b/lib/handlers/ultravox.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import Handler from './handler.js';
+import JambonzHandler from './jambonz.js';
 import UltravoxModel from '../models/ultravox.js';
 import { Call } from '../database.js';
 import { maybeSendCallHook } from '../call-hook.js';
@@ -38,7 +39,16 @@ const getVoices = (async () => {
 class Ultravox extends Handler {
   static name = 'ultravox';
   static description = 'Ultravox';
-  static hasTelephony = true;
+  // Native WebRTC (direct browser ↔ Ultravox) runs on our ULTRAVOX_API_KEY alone,
+  // so it is available whenever this handler loads. Telephony (inbound SIP),
+  // however, is delegated to jambonz — see `telephonyHandler` and the
+  // ultravox→jambonz number-pool mapping in Handler.activate(). So Ultravox is
+  // only telephony-capable when jambonz itself is in the bundle
+  // (JAMBONZ_API_KEY + JAMBONZ_SERVER set). Consumed per-model in GET /models and
+  // by the rate-components audio-path catalogue.
+  static get hasTelephony() {
+    return JambonzHandler.canLoad.ok;
+  }
   static hasWebRTC = true;
   static hasWebSocket = true;
   static telephonyHandler = 'jambonz';

--- a/lib/jambonz.js
+++ b/lib/jambonz.js
@@ -1,11 +1,11 @@
 import logger from './logger.js';
 import axios from "axios";
 
-if (!process.env.JAMBONZ_API_KEY) {
-  throw new Error(
-    "No Jambonz api key, set JAMBONZ_API_KEY in server environment ;"
-  );
-}
+// NB: this module must stay import-safe when JAMBONZ_API_KEY is unset, so the
+// jambonz handler can still be registered (and then cleanly gated out of the
+// roster) in a jambonz-less build — e.g. a pipecat-only or livekit-only
+// instance. The missing-key guard therefore lives in the constructor
+// (fail-fast on actual use) rather than throwing at module scope.
 
 let api = axios.create({
   baseURL: `${process.env.JAMBONZ_SERVER || "https://api.jambonz.xyz"}/v1`,
@@ -72,6 +72,9 @@ class Jambonz {
    * @memberof Jambonz
    */
   constructor(logger, user) {
+    if (!process.env.JAMBONZ_API_KEY) {
+      throw new Error('No Jambonz api key, set JAMBONZ_API_KEY in server environment');
+    }
     this.logger = logger.child({ user });
     this.serviceProvider = getServiceProvider();
   }

--- a/tests/handler-roster-gating.test.mjs
+++ b/tests/handler-roster-gating.test.mjs
@@ -1,0 +1,99 @@
+// Handler-level roster gating: a whole handler *family* must drop out of
+// `availableModels` (the GET /models roster) when its transport credentials are
+// unset, so we can ship a pipecat-only / livekit-only instance. This is distinct
+// from the per-model canLoad filter, which gates individual LLM providers on
+// their own API keys. `Handler` + the real handler classes pull lib/database.js,
+// whose module init calls sequelize.authenticate(); the DB lifecycle below is
+// only here to satisfy that import (the assertions themselves are pure).
+import { setupRealDatabase, teardownRealDatabase, databaseStarted } from './setup/database-test-wrapper.js';
+
+const Handler = (await import('../lib/handlers/handler.js')).default;
+
+beforeAll(async () => { await setupRealDatabase(); await databaseStarted; }, 30000);
+afterAll(async () => { await teardownRealDatabase(); }, 30000);
+
+// A loadable LLM model (its own provider key is present).
+class LoadableModel {
+  static get canLoad() { return { ok: true }; }
+  static allModels = [['openai/gpt-4o', 'Fake GPT-4o']];
+  static supportsFunctions = () => true;
+  static supportsMcp = () => false;
+  static audioModel = false;
+}
+// An LLM model whose provider key is missing.
+class UnloadableModel {
+  static get canLoad() { return { ok: false, need: ['SOME_LLM_KEY'] }; }
+  static allModels = [['openai/gpt-4o', 'Fake GPT-4o']];
+  static supportsFunctions = () => true;
+  static supportsMcp = () => false;
+  static audioModel = false;
+}
+
+describe('handler-level roster gating', () => {
+  it('lists models when the handler family credentials are present', () => {
+    class Loadable extends Handler {
+      static name = 'loadable';
+      static needKey = { FAMILY_KEY: 'present' };
+      static get models() { return [LoadableModel]; }
+    }
+    expect(Loadable.availableModels.map((m) => m.name)).toEqual(['loadable:openai/gpt-4o']);
+  });
+
+  it('drops the entire family when a handler credential is unset', () => {
+    class Unloadable extends Handler {
+      static name = 'unloadable';
+      // A missing (undefined) value in needKey => canLoad.ok is false.
+      static needKey = { FAMILY_KEY: undefined };
+      // The model itself would load — proving the *handler* gate, not the model gate.
+      static get models() { return [LoadableModel]; }
+    }
+    expect(Unloadable.availableModels).toEqual([]);
+  });
+
+  it('still applies the per-model gate once the handler family loads', () => {
+    class HandlerOkModelMissing extends Handler {
+      static name = 'partial';
+      static needKey = { FAMILY_KEY: 'present' };
+      static get models() { return [UnloadableModel]; }
+    }
+    expect(HandlerOkModelMissing.availableModels).toEqual([]);
+  });
+
+  it('leaves keyless handlers (e.g. text) ungated at the family level', () => {
+    class Keyless extends Handler {
+      static name = 'keyless';
+      // No needKey => canLoad.ok is unconditionally true.
+      static get models() { return [LoadableModel]; }
+    }
+    expect(Keyless.availableModels.map((m) => m.name)).toEqual(['keyless:openai/gpt-4o']);
+  });
+});
+
+// A jambonz-less build (no JAMBONZ_API_KEY) must still import the jambonz handler
+// cleanly — handlers() imports it unconditionally, so a module-load throw there
+// would take down GET /models, /voices and everything else. Env is controlled
+// here (and captured at handler module-eval time) so the assertion is
+// deterministic regardless of the ambient CI keys; the guarded voices IIFE means
+// no live Jambonz API call fires, keeping the test hermetic.
+describe('jambonz-less build: handler stays import-safe and gated out', () => {
+  const saved = {
+    key: process.env.JAMBONZ_API_KEY,
+    server: process.env.JAMBONZ_SERVER,
+  };
+  beforeAll(() => {
+    delete process.env.JAMBONZ_API_KEY;
+    delete process.env.JAMBONZ_SERVER;
+  });
+  afterAll(() => {
+    if (saved.key !== undefined) process.env.JAMBONZ_API_KEY = saved.key;
+    if (saved.server !== undefined) process.env.JAMBONZ_SERVER = saved.server;
+  });
+
+  it('imports without throwing, offers no models, and yields empty voices', async () => {
+    // First import of the module in this file's registry — captures the unset env.
+    const JambonzHandler = (await import('../lib/handlers/jambonz.js')).default;
+    expect(JambonzHandler.canLoad.ok).toBe(false);
+    expect(JambonzHandler.availableModels).toEqual([]);
+    await expect(JambonzHandler.voices).resolves.toEqual({});
+  });
+});


### PR DESCRIPTION
## What & why

Makes each handler **family** cleanly disappear from the agent roster (`GET /models`) when its transport env is unset, so we can ship a **pipecat-only** or **livekit-only** instance of llm-agent.

The gating already ran through one pattern — `needKey` → `canLoad {ok, need}` — at two layers: model-level (per LLM-provider key, actively used) and **handler-level** (`Handler.canLoad`, defined but never consumed). livekit/pipecat/ultravox happened to gate because their model classes re-declared the transport key; **jambonz did not** — its models are the shared LLM providers, so `jambonz:openai/gpt-4o` appeared with no jambonz configured.

## Changes

- **`lib/handlers/handler.js`** — `availableModels` returns `[]` when `this.canLoad.ok` is false (wires in the handler-level gate). Drops jambonz cleanly; tightens pipecat from 2 → all-4 `PIPECAT_*` vars.
- **`lib/handlers/ultravox.js`** — `hasTelephony` is now a getter = `JambonzHandler.canLoad.ok`. Native WebRTC stays on `ULTRAVOX_API_KEY` alone; telephony (delegated to jambonz over SIP) follows jambonz being bundled.
- **`api/paths/voices.js`** — filters to loadable handlers (an absent family's `voices` static rejects and would 500 the endpoint).
- **`lib/jambonz.js`** — **import-safety fix.** It threw at module load without `JAMBONZ_API_KEY`; since `handlers()` imports the jambonz handler unconditionally, a jambonz-less instance couldn't build the roster at all (`/models`, `/voices` → 500). Guard moved into the constructor; the handler's `voices` initializer is guarded so it neither constructs the client nor fires a credentials call whose rejection could crash startup on Node 23.
- **`tests/handler-roster-gating.test.mjs`** — new.

## Verification

6 runtime scenarios against the real `handlers()`:

| env | roster families | `Ultravox.hasTelephony` |
|---|---|---|
| all 4 `PIPECAT_*` | `{pipecat, text}` | false |
| all 3 `LIVEKIT_*` | `{livekit, text}` | false |
| `JAMBONZ_API_KEY`+`SERVER` | `{jambonz, text}` | true |
| pipecat 2-of-4 | `{text}` (gated out) | false |
| ultravox + jambonz | `{jambonz, ultravox, text}` | true |
| **ultravox, no jambonz** | `{ultravox, text}` | **false** (WebRTC still true) |

Scenario 1 also confirms jambonz stays absent even with `OPENAI_API_KEY` set — the original bug. Existing suites green with the full key set: `models-endpoint`, `rate-components`, `voices-endpoint`, `agent-chat-model-override` (26) + 5 new.

## Scope

Roster only. `HANDLER_NAMES` / `TELEPHONY_HANDLER_NAMES` (OpenAPI enums + phone-endpoint/trunk handler validation) are left static — a single-handler instance still documents/accepts the other families as phone-endpoint handlers. Can be tightened in a follow-up.
