### PR TITLE
feat(builder): list_voices search mode (uncapped, union) for large voice catalogues

### DIFF
--- a/lib/function-handler.js
+++ b/lib/function-handler.js
@@ -89,23 +89,37 @@ const hardwiredBuiltins = {
     return result;
   },
   /**
-   * Read-only TTS voice catalogue lookup for the set builder. With just
-   * `modelName` it returns the available locales (+ `voiceStack`); with a
-   * `locale` it returns that locale's `vendor → voices[]` rows (each voice has
-   * name/gender/description). Backed by the same lib/model-voices.js helpers as
-   * GET /models/:modelName/voices[/:locale], so the builder sees exactly what
-   * agent validation will accept. Lazy-imported so this module stays loadable in
+   * Read-only TTS voice catalogue lookup for the set builder. Three modes:
+   * - `modelName` only → the available locales (+ `voiceStack`).
+   * - `modelName` + `locale` → that locale's `vendor → voices[]` rows (each
+   *   voice has name/gender/description), trimmed to keep the payload bounded.
+   * - `modelName` + `search` → the UNION of voices across the whole catalogue
+   *   whose name/description/gender/locale matches ANY search term, with NO cap,
+   *   so the model can find a voice by accent/gender/persona (see
+   *   searchModelVoices). `search` takes precedence over `locale`.
+   * Backed by the same lib/model-voices.js helpers as GET
+   * /models/:modelName/voices[/:locale], so the builder sees exactly what agent
+   * validation will accept. Lazy-imported so this module stays loadable in
    * contexts without the voice/handler graph (it only runs in the API process,
    * where the interactive set-builder chat session lives).
    */
   list_voices: async (input) => {
-    const { modelName, locale } = input || {};
+    const { modelName, locale, search } = input || {};
     if (!modelName) throw new Error('list_voices requires a modelName (e.g. "livekit:ultravox/ultravox-v0.7")');
-    const [{ getModelVoiceLocales, getModelVoicesForLocale }, { default: Voices }] = await Promise.all([
+    const [{ getModelVoiceLocales, getModelVoicesForLocale, searchModelVoices }, { default: Voices }] = await Promise.all([
       import('./model-voices.js'),
       import('./voices/index.js'),
     ]);
     const voicesInstance = new Voices();
+    // `search` mode: union substring match across the whole catalogue, no cap,
+    // so a named/accented/gendered voice is reachable even when it sorts past
+    // the trimmed browse list (trimVoicesResult).
+    const hasSearch = Array.isArray(search)
+      ? search.some((t) => String(t ?? '').trim())
+      : (typeof search === 'string' && search.trim().length > 0);
+    if (hasSearch) {
+      return await searchModelVoices({ modelName, terms: search, voicesInstance });
+    }
     const result = locale
       ? await getModelVoicesForLocale({ modelName, locale, voicesInstance })
       : await getModelVoiceLocales({ modelName, voicesInstance });
@@ -113,13 +127,15 @@ const hardwiredBuiltins = {
   }
 };
 
-// Bound the list_voices payload for the LLM: the raw catalogue for a big
-// vendor set (ultravox realtime: ~25KB / ~6k tokens) rides the conversation
+// Bound the list_voices *browse* payload for the LLM: the raw catalogue for a
+// big vendor set (ultravox realtime: ~25KB / ~6k tokens) rides the conversation
 // for the rest of the session once fetched. Voice choice needs name, gender
 // and a short description — cap the description and the per-vendor list, with
-// an explicit trailing note so the model knows more exist and can narrow by
-// locale or ask the user rather than assume the list is complete. The REST
-// endpoint (GET /models/:modelName/voices) is untouched.
+// an explicit trailing note so the model knows more exist and can `search` the
+// full catalogue or ask the user rather than assume the list is complete. Only
+// the untargeted per-locale browse is trimmed: `search` mode returns every
+// match uncapped, and the REST endpoint (GET /models/:modelName/voices) is
+// untouched.
 const VOICES_PER_VENDOR = 60;
 const VOICE_DESCRIPTION_CHARS = 100;
 // Exported for tests only — not part of the module's public surface.
@@ -138,8 +154,10 @@ export function trimVoicesResult(result) {
     ));
     vendors[vendor] = voices.length > kept.length
       ? [...kept, {
-        note: `…and ${voices.length - kept.length} more ${vendor} voices not shown. If the user names a `
-          + 'specific voice, use that name verbatim — creation validates against the FULL catalogue, '
+        note: `…and ${voices.length - kept.length} more ${vendor} voices not shown. To find a specific voice, `
+          + 'call list_voices again with `search` terms (accent, gender, language or persona — e.g. '
+          + '["british","robotic"]); it returns every match across the FULL catalogue with no cap. If the user '
+          + 'names a specific voice, use that name verbatim — creation validates against the full catalogue, '
           + 'not this trimmed list.',
       }]
       : kept;

--- a/lib/model-voices.js
+++ b/lib/model-voices.js
@@ -323,6 +323,67 @@ export async function getVoiceNamesForAgentValidation({ modelName, Handler, voic
 }
 
 /**
+ * Normalise `list_voices` search input into a de-duplicated list of lowercase
+ * tokens. Accepts an array (each element is itself tokenised) or a string, and
+ * splits on whitespace and commas — so "british english", ["british","english"]
+ * and ["british english"] all yield ['british','english'].
+ *
+ * @param {string[] | string | undefined | null} terms
+ * @returns {string[]}
+ */
+export function normalizeSearchTerms(terms) {
+  const items = Array.isArray(terms) ? terms : [terms];
+  const out = [];
+  const seen = new Set();
+  for (const item of items) {
+    for (const tok of String(item ?? '').split(/[\s,]+/)) {
+      const s = tok.trim().toLowerCase();
+      if (s && !seen.has(s)) {
+        seen.add(s);
+        out.push(s);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Union substring search over a vendor → locale → voices[] tree. A voice is
+ * kept when its name / description / gender / locale text contains ANY of
+ * `terms` (case-insensitive), so ['british','robotic'] returns british voices
+ * OR robotic voices (a superset union, not an intersection). Each kept voice
+ * carries its `locale` (omitted for the locale-neutral `any` key). No cap —
+ * every match is returned; empty `terms` matches nothing.
+ *
+ * @param {Record<string, Record<string, unknown[]>>} tree
+ * @param {string[]} terms already-normalised lowercase tokens
+ * @returns {Record<string, unknown[]>} vendor → matching voices[]
+ */
+export function filterVoiceTreeBySearch(tree, terms) {
+  const vendors = {};
+  if (!tree || typeof tree !== 'object' || !Array.isArray(terms) || terms.length === 0) return vendors;
+  for (const [vendor, locMap] of Object.entries(tree)) {
+    if (!locMap || typeof locMap !== 'object') continue;
+    const matches = [];
+    const seen = new Set();
+    for (const [locale, arr] of Object.entries(locMap)) {
+      if (!Array.isArray(arr)) continue;
+      for (const v of arr) {
+        if (!v || typeof v !== 'object' || typeof v.name !== 'string') continue;
+        const hay = `${v.name} ${v.description || ''} ${v.gender || ''} ${locale}`.toLowerCase();
+        if (!terms.some((t) => hay.includes(t))) continue;
+        const key = `${locale} ${v.name}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        matches.push(locale && locale !== 'any' ? { ...v, locale } : { ...v });
+      }
+    }
+    if (matches.length) vendors[vendor] = matches;
+  }
+  return vendors;
+}
+
+/**
  * GET /models/:modelName/voices — sorted BCP-47 (or provider-specific) locale list.
  *
  * @param {object} p
@@ -449,6 +510,31 @@ export async function getModelVoicesForLocale({ modelName, locale, voicesInstanc
     err.statusCode = 400;
     throw err;
   }
+  const { tree, voiceStack } = await buildModelVoiceTree({ modelName, voicesInstance });
+  // `vendorsForLocale` uses the locale-with-`any`-fallback lookup so realtime
+  // voices keyed under `'any'` still appear for any requested locale.
+  return { vendors: vendorsForLocale(tree, locale), voiceStack };
+}
+
+/**
+ * Resolve the vendor → locale → voices[] tree a model actually offers — the
+ * same tree {@link getModelVoicesForLocale} serves, before locale selection.
+ * Encapsulates the per-handler branching (livekit/pipecat pipeline vs realtime,
+ * vendor scoping) so the per-locale lookup and {@link searchModelVoices} share
+ * one source of truth.
+ *
+ * @param {object} p
+ * @param {string} p.modelName
+ * @param {import('./voices/index.js').default} p.voicesInstance
+ * @returns {Promise<{ tree: Record<string, Record<string, unknown[]>>, voiceStack?: 'realtime' | 'pipeline' }>}
+ */
+async function buildModelVoiceTree({ modelName, voicesInstance }) {
+  const { handler, rest } = splitHandlerModel(modelName);
+  if (!handler || !rest) {
+    const err = new Error('Invalid modelName');
+    err.statusCode = 400;
+    throw err;
+  }
 
   const { implementations } = await handlers();
   const impl = implementations.find((h) => h.name === handler);
@@ -459,10 +545,12 @@ export async function getModelVoicesForLocale({ modelName, locale, voicesInstanc
   }
 
   if (handler === 'livekit' && isLivekitPipelineModelId(rest)) {
-    const tree = transformVoiceTreeForLiveKitPipeline(
-      voiceTreeWithoutGoogleVendorForPipelineList(await pipelineVendorTrees(voicesInstance)),
-    );
-    return { vendors: vendorsForLocale(tree, locale), voiceStack: 'pipeline' };
+    return {
+      tree: transformVoiceTreeForLiveKitPipeline(
+        voiceTreeWithoutGoogleVendorForPipelineList(await pipelineVendorTrees(voicesInstance)),
+      ),
+      voiceStack: 'pipeline',
+    };
   }
 
   if (handler === 'pipecat' && isPipecatPipelineModelId(rest)) {
@@ -470,30 +558,38 @@ export async function getModelVoicesForLocale({ modelName, locale, voicesInstanc
     // instantiate (see PIPECAT_PIPELINE_TTS_VENDORS). No name transform —
     // Pipecat hits each vendor's native API and accepts the catalogue IDs
     // verbatim.
-    const tree = pipecatPipelineTtsTree(await pipelineVendorTrees(voicesInstance));
-    return { vendors: vendorsForLocale(tree, locale), voiceStack: 'pipeline' };
+    return {
+      tree: pipecatPipelineTtsTree(await pipelineVendorTrees(voicesInstance)),
+      voiceStack: 'pipeline',
+    };
   }
 
-  let voiceTree = await impl.voices;
+  let tree = await impl.voices;
   if (handler === 'livekit') {
-    voiceTree = filterVoiceTreeVendors(
-      voiceTree,
-      livekitRealtimeVoiceVendorsForRestModelId(rest),
-    );
+    tree = filterVoiceTreeVendors(tree, livekitRealtimeVoiceVendorsForRestModelId(rest));
   } else if (handler === 'pipecat') {
-    voiceTree = filterVoiceTreeVendors(
-      voiceTree,
-      pipecatRealtimeVoiceVendorsForRestModelId(rest),
-    );
+    tree = filterVoiceTreeVendors(tree, pipecatRealtimeVoiceVendorsForRestModelId(rest));
   }
-  const vendors = {};
-  for (const [vendor, locMap] of Object.entries(voiceTree || {})) {
-    // Use the locale-with-`any`-fallback lookup so realtime voices keyed
-    // under `'any'` still appear for any requested locale.
-    const arr = voicesForLocaleWithAnyFallback(locMap, locale);
-    if (Array.isArray(arr) && arr.length) vendors[vendor] = arr;
-  }
-  const stack =
-    handler === 'livekit' || handler === 'pipecat' ? 'realtime' : undefined;
-  return { vendors, voiceStack: stack };
+  const voiceStack = handler === 'livekit' || handler === 'pipecat' ? 'realtime' : undefined;
+  return { tree, voiceStack };
+}
+
+/**
+ * Union substring search across a model's FULL voice catalogue — every locale,
+ * every vendor the model can use, with NO cap. Powers the `search` mode of the
+ * list_voices builtin: the builder passes accent / gender / language / persona
+ * terms (e.g. ['british','english','robotic']) and gets back every matching
+ * voice, so it can pick one by name without first guessing a locale or paging a
+ * capped browse list. Match is on name / description / gender / locale text.
+ *
+ * @param {object} p
+ * @param {string} p.modelName
+ * @param {string[] | string} p.terms search tokens (array or string)
+ * @param {import('./voices/index.js').default} p.voicesInstance
+ * @returns {Promise<{ vendors: Record<string, unknown[]>, voiceStack?: 'realtime' | 'pipeline', search: string[] }>}
+ */
+export async function searchModelVoices({ modelName, terms, voicesInstance }) {
+  const search = normalizeSearchTerms(terms);
+  const { tree, voiceStack } = await buildModelVoiceTree({ modelName, voicesInstance });
+  return { vendors: filterVoiceTreeBySearch(tree, search), voiceStack, search };
 }

--- a/lib/set-builder-agent.js
+++ b/lib/set-builder-agent.js
@@ -59,7 +59,11 @@ VOICE MODELS & TTS — never invent a voice/vendor
 
 FINDING A SPECIFIC VOICE (use list_voices — never invent a voice or locale)
 When the user wants a particular voice (an accent, gender, language or persona), or whenever a PIPELINE model
-needs a real options.tts.voice, find it with list_voices instead of guessing:
+needs a real options.tts.voice, find it with list_voices instead of guessing.
+FAST PATH — when you know the qualities you want, call list_voices with the modelName and a search array of the
+distinct terms (e.g. a "British English robotic voice" → search:["british","english","robotic"]). It returns the
+UNION of every voice matching ANY term across the whole catalogue, uncapped, each tagged with its locale — pick the
+best match and apply it (step 4). Prefer this over browsing; browse only to explore what's on offer:
 1. Call list_voices with just the modelName to get the available locales (and voiceStack: realtime or pipeline).
 2. Choose the locale: infer it when the request makes it clear (a UK line → en-GB, a US caller → en-US, "in
    French" → fr-FR); if it is genuinely unclear, ask_user with the returned locales as options. If the list
@@ -241,12 +245,15 @@ const listVoicesFunction = {
   description: 'Look up the REAL TTS voices available for a voice model and its TTS engines. Call with just '
     + '`modelName` to get the list of available locales (and whether the stack is realtime or pipeline); call '
     + 'again with a `locale` to get that locale\'s voices grouped by TTS vendor, each with a name, gender and '
-    + 'description. Use the returned vendor/voice names verbatim in options.tts — never invent a voice or locale.',
+    + 'description (a big catalogue is trimmed — use `search` to find a specific one). Pass `search` terms to get '
+    + 'the UNION of every voice matching ANY term across the whole catalogue, uncapped. Use the returned '
+    + 'vendor/voice names verbatim in options.tts — never invent a voice or locale.',
   input_schema: {
     type: 'object',
     properties: {
       modelName: { type: 'string', required: true, description: 'Handler-prefixed model id, e.g. "livekit:ultravox/ultravox-v0.7" (realtime) or a pipeline model like "livekit:openai/gpt-4o". The model determines which TTS engines and voices are available.' },
-      locale: { type: 'string', description: 'Optional BCP-47 locale taken from the locales list (e.g. "en-GB"), or "any" if the list offers it. Omit on the first call to discover the locales; provide it to get the voices for that locale.' },
+      locale: { type: 'string', description: 'Optional BCP-47 locale taken from the locales list (e.g. "en-GB"), or "any" if the list offers it. Omit on the first call to discover the locales; provide it to get the voices for that locale. Ignored when `search` is given.' },
+      search: { type: 'array', items: { type: 'string' }, description: 'Optional search terms. Returns the UNION of all voices whose name/description/gender/locale contains ANY term (case-insensitive substring), across every locale, with NO cap — each match carries its locale. Use this to find a voice by accent, language, gender or persona: for "a British English robotic voice" pass ["british","english","robotic"] and pick from the matches. Omit to browse locales/voices instead.' },
     },
     required: ['modelName'],
   },

--- a/tests/text-chat-reattach.test.mjs
+++ b/tests/text-chat-reattach.test.mjs
@@ -5,6 +5,7 @@ import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-w
 
 const { createChatSession, getChatSession } = await import('../lib/text-chat.js');
 const { trimVoicesResult } = await import('../lib/function-handler.js');
+const { normalizeSearchTerms, filterVoiceTreeBySearch } = await import('../lib/model-voices.js');
 
 // Session re-attach: after the websocket drops, the session (and its whole LLM
 // conversation) lingers for a grace window; a new socket for the same id
@@ -173,5 +174,49 @@ describe('list_voices payload bound', () => {
   test('locale-list results (no vendors) pass through untouched', () => {
     const result = { locales: ['en-GB', 'any'], voiceStack: 'realtime' };
     expect(trimVoicesResult(result)).toBe(result);
+  });
+});
+
+describe('list_voices search (union substring, no cap)', () => {
+  test('normalizeSearchTerms tokenises arrays and strings, lowercases and de-dupes', () => {
+    expect(normalizeSearchTerms(['British', 'english'])).toEqual(['british', 'english']);
+    expect(normalizeSearchTerms('British English robotic')).toEqual(['british', 'english', 'robotic']);
+    expect(normalizeSearchTerms(['british english', 'robotic'])).toEqual(['british', 'english', 'robotic']);
+    expect(normalizeSearchTerms(['robotic', 'Robotic', 'ROBOTIC'])).toEqual(['robotic']);
+    expect(normalizeSearchTerms(undefined)).toEqual([]);
+    expect(normalizeSearchTerms(['', '  '])).toEqual([]);
+  });
+
+  test('returns the UNION of matches across vendors, uncapped, tagging non-"any" locales', () => {
+    const tree = {
+      ultravox: {
+        any: [
+          { name: 'Dominus', description: 'British English male voice.', gender: 'unknown' },
+          { name: 'Vera', description: 'Spanish female voice.', gender: 'unknown' },
+          { name: 'Rob', description: 'A robotic android voice.', gender: 'unknown' },
+        ],
+      },
+      elevenlabs: {
+        'en-GB': [{ name: 'Alice', description: 'Warm narrator.', gender: 'female' }],
+      },
+    };
+    const out = filterVoiceTreeBySearch(tree, ['british', 'robotic']);
+    // british OR robotic → Dominus + Rob; Vera excluded; other vendor unmatched
+    expect(out.ultravox.map((v) => v.name).sort()).toEqual(['Dominus', 'Rob']);
+    expect(out.ultravox[0].locale).toBeUndefined(); // locale-neutral 'any' not tagged
+    expect(out.elevenlabs).toBeUndefined();
+  });
+
+  test('matches on the locale key too, and tags the voice with that locale', () => {
+    const tree = { google: { 'en-GB': [{ name: 'en-GB-Neural2-A', description: 'en-GB-Neural2-A', gender: 'female' }] } };
+    const out = filterVoiceTreeBySearch(tree, ['en-gb']);
+    expect(out.google).toHaveLength(1);
+    expect(out.google[0].locale).toBe('en-GB');
+  });
+
+  test('empty terms match nothing — never dumps the whole catalogue', () => {
+    const tree = { ultravox: { any: [{ name: 'X', description: 'y', gender: 'unknown' }] } };
+    expect(filterVoiceTreeBySearch(tree, [])).toEqual({});
+    expect(filterVoiceTreeBySearch(tree, normalizeSearchTerms('   '))).toEqual({});
   });
 });


### PR DESCRIPTION
## Why
The set builder's `list_voices` browse payload is trimmed to 60 voices/vendor (`trimVoicesResult`, added on `next` in 7fd38d2) to keep a big catalogue off the conversation, but it means voices are missed by builders.

## What
New optional `search` param on `list_voices`:
- Pass terms, e.g. `["british","english","robotic"]`.
- Returns the **UNION** of every voice whose name/description/gender/locale contains **ANY** term (case-insensitive substring), across **all locales**, with **no cap**, each tagged with its locale.
- `search` takes precedence over `locale`; browse/trim behaviour is otherwise unchanged, and the trim note now points the model at `search`.

## Changes
- `lib/model-voices.js` — pure `normalizeSearchTerms` + `filterVoiceTreeBySearch`, `searchModelVoices`, and a shared `buildModelVoiceTree` extracted from `getModelVoicesForLocale` (behaviour-preserving).
- `lib/function-handler.js` — route `search` → uncapped `searchModelVoices`; updated trim note.
- `lib/set-builder-agent.js` — schema + prompt fast-path.
- `tests/` — union / tokenise / no-cap / locale-tag assertions.

## Verified against the live Ultravox catalogue
- browse still 242 (realtime, Dominus present) — refactor preserved behaviour
- `["british","english","robotic"]` → 25 incl. Dominus · `["dominus"]` → 1 · `["female"]` → 72 (uncapped, >60)

Note: for realtime (Ultravox) accent lives in the voice description so it searches well; for pipeline vendors (ElevenLabs) accent is in the locale key, so those are still reached by locale.