### PR TITLE
feat(text-chat): request_review builtin — builder-triggered independent review

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -975,7 +975,7 @@ components:
             example: rest
           platform:
             type: string
-            enum: ["hangup", "transfer", "transfer_status", "metadata", "transfer_agent", "subagent", "result", "create_agent_set", "update_agent_set", "patch_agent_set", "list_voices", "ask_user", "test_agent"]
+            enum: ["hangup", "transfer", "transfer_status", "metadata", "transfer_agent", "subagent", "result", "create_agent_set", "update_agent_set", "patch_agent_set", "list_voices", "ask_user", "test_agent", "request_review"]
             description: >
                 For `builtin` functions, this is the name of a platform function as defined in the platform. The following platform functions are currently available:
                   * `transfer_agent` hands the live call over to another agent definition mid-call (LiveKit and Pipecat agents). Parameters:
@@ -1004,12 +1004,15 @@ components:
                   * `result` (text agents only) terminates a text-agent invocation and delivers its work product: the
                     (generated) arguments the agent passes become the result returned to the invoker. Define its
                     `input_schema` to describe the output you require from the agent.
-                  * `create_agent_set`, `update_agent_set`, `patch_agent_set`, `list_voices`, `ask_user`, `test_agent`
-                    (text agents only) are the agent-builder builtins. They are dispatched by the interactive **chat
-                    session** tool plane only: inside a chat session they perform org-scoped agent-set CRUD, voice
-                    listing, user questioning and set testing exactly as the builtin set builder does. Outside a chat
-                    session the set-CRUD builtins (`create_agent_set`/`update_agent_set`/`patch_agent_set`) fail
-                    closed with an error, and `ask_user`/`test_agent` yield empty results.
+                  * `create_agent_set`, `update_agent_set`, `patch_agent_set`, `list_voices`, `ask_user`, `test_agent`,
+                    `request_review` (text agents only) are the agent-builder builtins. They are dispatched by the
+                    interactive **chat session** tool plane only: inside a chat session they perform org-scoped
+                    agent-set CRUD, voice listing, user questioning, set testing, and requesting an independent review
+                    exactly as the builtin set builder does. `request_review` takes no parameters: it pauses the turn
+                    and emits a `review` frame; the client runs its own review flow and answers with a `review_result`
+                    frame whose result becomes this function's tool result. Outside a chat session the set-CRUD
+                    builtins (`create_agent_set`/`update_agent_set`/`patch_agent_set`) fail closed with an error, and
+                    `ask_user`/`test_agent`/`request_review` yield empty results.
                   * `hangup` takes no parameters and will hang up the call
                   * `metadata` interrogates the call metadata, returning a JSON object with the requested metadata keys and values.
                      `keys` is a comma-separated list of dot-notation paths (arbitrary depth), for example `aplisay.callId` or `toolsCalls.lookupDirectory.result.transferNumber`.

--- a/lib/database.js
+++ b/lib/database.js
@@ -531,10 +531,11 @@ Agent.init({
             case 'list_voices':
             case 'ask_user':
             case 'test_agent':
+            case 'request_review':
               // Builder builtins ride the chat-session tool plane; like `result`
               //  they are only meaningful on text agents. Outside a chat session
               //  the set-CRUD builtins fail closed at dispatch and
-              //  ask_user/test_agent yield empty results.
+              //  ask_user/test_agent/request_review yield empty results.
               if (agentType !== 'text') {
                 throw new Error(`The ${func.platform} platform function is only valid on agents of type "text" (function ${name})`);
               }
@@ -590,6 +591,7 @@ Agent.init({
             case 'list_voices':
             case 'ask_user':
             case 'test_agent':
+            case 'request_review':
               // Builder builtins: parameter shapes are defined by the chat
               //  session dispatcher, no structural constraints here.
               return true;

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -178,6 +178,8 @@ class TextChatSession {
         await this.turn(msg.text, send);
       } else if (msg.type === 'test_result' && typeof msg.result === 'string') {
         await this.testResult(msg, send);
+      } else if (msg.type === 'review_result' && typeof msg.result === 'string') {
+        await this.reviewResult(msg, send);
       }
     });
     ws.on('close', () => {
@@ -432,10 +434,10 @@ class TextChatSession {
       if (!pending && this.pending) {
         pending = this.pending;
         this.pending = null;
-        if (pending.platform === 'test_agent') {
+        if (pending.platform === 'test_agent' || pending.platform === 'request_review') {
           userText = JSON.stringify({
             ok: false,
-            reason: 'The user continued the conversation instead of running the test. Their message follows.',
+            reason: `The user continued the conversation instead of ${pending.platform === 'request_review' ? 'running the review' : 'running the test'}. Their message follows.`,
             userMessage: userText,
           });
         }
@@ -490,10 +492,12 @@ class TextChatSession {
             continue;
           }
           // Some builtins pause the turn for a user-driven step, resuming when the
-          // next user message arrives: ask_user (emit a question) and test_agent
-          // (open the test widget; the frontend returns the call's transcript/logs).
-          // Both resume via callResult with the user's reply as this tool's result.
-          const pause = round.calls.find((c) => ['ask_user', 'test_agent'].includes(this.platformOf(c.name)));
+          // next user message (or result frame) arrives: ask_user (emit a question),
+          // test_agent (open the test widget; the frontend returns the call's
+          // transcript/logs), and request_review (the client runs polite.ai's
+          // independent review and returns its findings). Each resumes via
+          // callResult with the reply/result as this tool's result.
+          const pause = round.calls.find((c) => ['ask_user', 'test_agent', 'request_review'].includes(this.platformOf(c.name)));
           if (pause) {
             const others = round.calls.filter((c) => c !== pause);
             let otherResults = [];
@@ -507,10 +511,15 @@ class TextChatSession {
             // The pause frame is kept on the pending record so a client that
             // re-attaches after a drop can be shown the ask again.
             let frame;
-            if (this.platformOf(pause.name) === 'test_agent') {
+            const pausePlatform = this.platformOf(pause.name);
+            if (pausePlatform === 'test_agent') {
               const label = pause.input?.label;
               const member = (this.latestSet?.agents || []).find((a) => a.label === label);
               frame = { type: 'test', id: pause.id, label, agentId: member?.id || null, name: member?.name || label };
+            } else if (pausePlatform === 'request_review') {
+              // The client runs polite.ai's independent review of the current set
+              //  and answers with a review_result frame carrying its findings.
+              frame = { type: 'review', id: pause.id };
             } else {
               frame = {
                 type: 'question',
@@ -527,7 +536,9 @@ class TextChatSession {
               'agent',
               frame.type === 'question'
                 ? `${frame.question}${frame.options?.length ? ` (options: ${frame.options.join(' / ')})` : ''}`
-                : `[offered a live in-browser test of “${frame.name}”]`,
+                : frame.type === 'review'
+                  ? '[requested an independent review of the set]'
+                  : `[offered a live in-browser test of “${frame.name}”]`,
             );
             send(frame);
             return; // paused — the next user message resumes this turn
@@ -622,6 +633,23 @@ class TextChatSession {
       return this.turn(this.manualTestDiagnosePrompt(msg.result), send, true);
     }
     this.logger.warn({ id: this.id, frameId: msg.id }, 'test_result without a matching pending tool call — ignored');
+    return Promise.resolve();
+  }
+
+  /**
+   * Handle a `review_result` frame ({type:'review_result', id, result}) — the
+   * client answering a paused `request_review` tool call with polite.ai's
+   * independent-review findings. The id must match the pending tool-use id so a
+   * stale/duplicate frame can't hijack an unrelated turn; the findings ride the
+   * tool-call context, resuming the builder's turn HIDDEN so it can weigh them
+   * and patch. There is no id-less form — a user-initiated review is fed back as
+   * a normal message by the client, not through here.
+   */
+  reviewResult(msg, send) {
+    if (this.pending && msg.id === this.pending.toolUseId) {
+      return this.turn(msg.result, send, true);
+    }
+    this.logger.warn({ id: this.id, frameId: msg.id }, 'review_result without a matching pending tool call — ignored');
     return Promise.resolve();
   }
 

--- a/tests/text-chat-review-result.test.mjs
+++ b/tests/text-chat-review-result.test.mjs
@@ -1,0 +1,95 @@
+// database-test-wrapper sets the POSTGRES_* env for the standard test container
+// BEFORE lib/database.js is imported (text-chat.js pulls it in transitively),
+// and its teardown closes the import-time connections so jest can exit.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+
+const { createChatSession } = await import('../lib/text-chat.js');
+
+// The `review_result` websocket frame ({type:'review_result', id, result}) that
+// resolves a paused `request_review` tool call — the channel polite-ai uses to
+// hand the builder its independent-review findings. Mirrors the test_result
+// guard rails: strict id match, no-op without a pending call, claim-at-ENQUEUE,
+// and resumption as a HIDDEN turn (findings ride the tool-call context). Unlike
+// test_result there is deliberately NO id-less form.
+
+const logger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const agent = {
+  id: 'agent-1',
+  organisationId: 'org-1',
+  userId: 'user-1',
+  modelName: 'text:anthropic/claude-sonnet-5',
+  functions: [],
+  keys: [],
+  options: {},
+  mcpServers: [],
+};
+
+beforeAll(async () => {
+  await setupRealDatabase();
+});
+
+afterAll(async () => {
+  await teardownRealDatabase();
+});
+
+function makeSession() {
+  const session = createChatSession({ agent, logger });
+  const turns = [];
+  session.runTurn = (text, send, hidden = false, claimed = null) => {
+    turns.push({ text, hidden, claimed });
+    return Promise.resolve();
+  };
+  return { session, turns };
+}
+
+const findings = '{"overall":"Solid, but no transfers.","findings":[{"severity":"high","area":"Transfers"}]}';
+
+describe('text-chat review_result frame', () => {
+  test('matching id claims the pending at enqueue and resumes as a hidden turn', async () => {
+    const { session, turns } = makeSession();
+    session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' };
+    await session.reviewResult({ type: 'review_result', id: 'toolu_1', result: findings }, () => {});
+    expect(turns).toEqual([
+      {
+        text: findings,
+        hidden: true,
+        claimed: { toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' },
+      },
+    ]);
+    // Claimed at enqueue: a duplicate frame or later user message can't recapture it.
+    expect(session.pending).toBeNull();
+  });
+
+  test('mismatched id is ignored (a stale frame cannot hijack another turn)', async () => {
+    const { session, turns } = makeSession();
+    session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' };
+    await session.reviewResult({ type: 'review_result', id: 'toolu_2', result: findings }, () => {});
+    expect(turns).toEqual([]);
+    expect(session.pending).toEqual({ toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' });
+  });
+
+  test('missing id is ignored (no id-less form for reviews)', async () => {
+    const { session, turns } = makeSession();
+    session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' };
+    await session.reviewResult({ type: 'review_result', result: findings }, () => {});
+    expect(turns).toEqual([]);
+  });
+
+  test('no pending tool call is a no-op', async () => {
+    const { session, turns } = makeSession();
+    await session.reviewResult({ type: 'review_result', id: 'toolu_1', result: findings }, () => {});
+    expect(turns).toEqual([]);
+  });
+
+  test('duplicate frame after the claim is ignored', async () => {
+    const { session, turns } = makeSession();
+    session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' };
+    await session.reviewResult({ type: 'review_result', id: 'toolu_1', result: findings }, () => {});
+    await session.reviewResult({ type: 'review_result', id: 'toolu_1', result: findings }, () => {});
+    expect(turns).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Adds a `request_review` builtin so the agent builder can trigger independent review itself (when the user asks, or before go-live), instead of telling the user to click a button. **Pairs with builder (client) — deploy llm-agent FIRST.**

## Mechanism — mirrors `test_agent` / `test_result`

- `request_review` is a paused text-agent builtin. When the builder calls it, the turn pauses and emits `{type:"review", id:<toolUseId>}`. The client runs its own review flow and answers with `{type:"review_result", id, result}`; the result resumes the turn **hidden** as the tool result, so the builder weighs the findings and patches in the same turn.
- Whitelisted in `database.js` `handlerLimitations` (type check + structural switch) and the `api-doc.yaml` platform enum + description, so agent create/update validates it.
- `review_result` routed on the chat WS; `reviewResult()` mirrors `testResult()` (strict id match, no-op without a pending call, claim-at-enqueue, hidden resume). No id-less form — a user-initiated review is fed back as a normal message by the client.
- A plain user message while a `request_review` is pending is declined with the text carried in the result (as for `test_agent`).

## Blast radius

The builtin set-builder gains no `request_review` function, so the legacy frontend sees no new frames — only a builder whose definition includes `request_review` (the builder) can emit them. Nothing else changes.

## Tests

New `text-chat-review-result` suite mirrors `text-chat-test-result`; the chat/builder suites pass (41 tests).

## Deploy ordering

Ship this BEFORE the change builder adds `request_review` to its pushed builder definition; if that pushes before this lands, agent create/update fails validation. An older llm-agent also ignores `review_result` frames.