### PR TITLE
feat(text-chat): headless chat sessions skip the builder opening turn

### DIFF
--- a/api/paths/agents/{agentId}/chat.js
+++ b/api/paths/agents/{agentId}/chat.js
@@ -58,7 +58,7 @@ const agentChat = async (req, res) => {
     // it the builder root-causes prompt/function bugs blind), and/or a
     // caller-formatted context block (e.g. website-knowledge state) appended
     // verbatim to the opening turn.
-    const { set, testResult, subjectAgent, knowledge, model } = req.body || {};
+    const { set, testResult, subjectAgent, knowledge, model, headless } = req.body || {};
     // Optional per-SESSION model override (e.g. a user's builder-model
     // preference). Two gates: the id must be a loadable `text:` catalogue
     // model, and the caller must be allowed to use it. The override is set
@@ -74,9 +74,9 @@ const agentChat = async (req, res) => {
       }
       agent.modelName = model;
     }
-    const session = createChatSession({ agent, set, testResult, subjectAgent, knowledge, logger: req.log });
+    const session = createChatSession({ agent, set, testResult, subjectAgent, knowledge, headless, logger: req.log });
     log.info(
-      { agentId, sessionId: session.id, edit: !!set, diagnose: !!testResult, subjectAgent: !!subjectAgent, knowledge: !!knowledge, model: model || undefined },
+      { agentId, sessionId: session.id, edit: !!set, diagnose: !!testResult, subjectAgent: !!subjectAgent, knowledge: !!knowledge, headless: !!headless, model: model || undefined },
       'agent chat session started');
     res.send({ id: session.id, socket: `/chat/${session.id}` });
   }
@@ -119,6 +119,7 @@ agentChat.apiDoc = {
             subjectAgent: { nullable: true, description: 'For a set-less troubleshoot: the diagnosed agent\'s own definition (prompt/functions/options) — or an array of definitions, one per distinct agent on the call — so fixes are grounded in what the agent actually says and does.' },
             knowledge: { type: 'string', nullable: true, description: 'A caller-formatted context block appended verbatim to the opening turn (e.g. website-knowledge state).' },
             model: { type: 'string', nullable: true, description: 'Per-session model override (a `text:` catalogue model the caller is allowed to use, e.g. from a user preference). 400 if unknown, 403 if not permitted.' },
+            headless: { type: 'boolean', nullable: true, description: 'When true, SKIP the builder opening turn — the session waits for the caller\'s first user message instead of auto-running the build/edit/diagnose greeting. For headless callers (e.g. polite.ai\'s independent reviewer) that drive the agent programmatically over the socket.' },
           },
         },
       },

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -51,9 +51,9 @@ export function getChatSession(id) {
  * and register it. Returns the session; read `session.id` / `/chat/${id}` for
  * the websocket path.
  */
-export function createChatSession({ agent, set, testResult, subjectAgent, knowledge, logger = defaultLogger }) {
+export function createChatSession({ agent, set, testResult, subjectAgent, knowledge, headless, logger = defaultLogger }) {
   const id = crypto.randomUUID();
-  const session = new TextChatSession({ id, agent, set, testResult, subjectAgent, knowledge, logger });
+  const session = new TextChatSession({ id, agent, set, testResult, subjectAgent, knowledge, headless, logger });
   sessions.set(id, session);
   session.expiry = setTimeout(() => {
     if (!session.connected) sessions.delete(id);
@@ -71,8 +71,14 @@ function interactiveSystemPrompt(agent) {
 }
 
 class TextChatSession {
-  constructor({ id, agent, set, testResult, subjectAgent, knowledge, logger }) {
+  constructor({ id, agent, set, testResult, subjectAgent, knowledge, headless, logger }) {
     Object.assign(this, { id, agent, logger });
+    // Headless caller (e.g. polite.ai's independent reviewer): drives the agent
+    // programmatically over the socket, so SKIP the builder opening turn — the
+    // session waits for the caller's first user message instead of auto-running
+    // the build/edit/diagnose greeting (which would poison a non-builder agent's
+    // context and burn a turn).
+    this.headless = !!headless;
     // Billing anchor for this text session: the interaction start. Stamped on
     // every usage row (metadata.startedAt) so cost resolution has a billing
     // instant for rows that have no Call (Q-E). Fixed for the session's life.
@@ -252,6 +258,12 @@ class TextChatSession {
       if (this.pending?.frame) send(this.pending.frame);
       return;
     }
+
+    // Headless caller: no builder opening turn — the caller sends the first user
+    // message itself (e.g. the independent reviewer's task). Auto-running the
+    // build/edit/diagnose greeting here would poison a non-builder agent's
+    // context and waste a turn.
+    if (this.headless) return;
 
     // Open with a hidden turn whose prompt depends on how the session was seeded
     // (build from scratch / edit an existing set / diagnose a test result). Any


### PR DESCRIPTION
Fixes the builder independent-reviewer timeout. **Deploy before the paired builder change.**

## Problem

Every chat first-attach auto-runs a hidden builder opening turn (`text-chat.js` → `openingPrompt()`: greet / build / edit / diagnose). That is correct for the builder, but wrong for a headless caller driving a NON-builder text agent over the socket — builder's independent reviewer. The builder greeting runs as a spurious first turn that **poisons the reviewer's context** (it responds conversationally instead of emitting its findings JSON) and burns a turn — the reviewer then never returns parseable findings and the review times out.

## Fix

Add a `headless` boolean to the chat start body (documented in the apiDoc). When true, skip the opening turn — the session just waits for the caller's first user message. Threaded `/chat` route → `createChatSession` → `TextChatSession` (`this.headless`), guarding the single `this.turn(openingPrompt(), …, true)` call.

Everything else is unchanged: attach, pause/resume, `request_review`, and the builder-only transcript persistence all behave exactly as before (the flag defaults false).

## Tests

`node --check` clean; 41 chat/builder tests pass (`text-chat`, `chat-sessions`, `set-builder`, `agent-chat`).

## Deploy order

Ship this first; then the builder reviewer starts passing `headless: true`. Against an older llm-agent the flag is simply ignored (no regression — same as today's broken behaviour), so ordering is safe either way, but the fix only takes effect once this is live.