### PR TITLE
feat(observability): info-level, event-tagged tool & MCP call logging

### DIFF
--- a/agents/livekit/lib/agent-tools.ts
+++ b/agents/livekit/lib/agent-tools.ts
@@ -1,6 +1,7 @@
 import { llm } from "@livekit/agents";
 import type { voice } from "@livekit/agents";
 import logger from "./logger.js";
+import { logToolCall, logToolResult, type ToolKind } from "./tool-log.js";
 import { functionHandler } from "../agent-lib/function-handler.js";
 import { invokeSubagent } from "./api-client.js";
 import type { Agent, AgentFunction, Call, CallMetadata } from "./api-client.js";
@@ -115,11 +116,17 @@ export function createTools({
             };
           })(),
           execute: async (args: unknown) => {
+            // Coarse tool classification for the InvocationLog. The livekit
+            // voice worker executes only the agent's own `functions`/builtins
+            // (MCP tools are proxied by the pipecat worker, not here), so a
+            // tool is either a platform builtin or a user function.
+            const kind: ToolKind =
+              fnc.implementation === "builtin" ? "builtin" : "function";
+            const startedAt = Date.now();
+            // INFO-level, event-tagged so every tool call is visible in the
+            // per-call debug log for production agents (see ./tool-log.ts).
+            logToolCall(logger, { tool: fnc.name, kind, args });
             try {
-              logger.debug(
-                { name: fnc.name, args, fnc },
-                `Got function call ${fnc.name}`,
-              );
               // A builtin transfer_agent performs its handover INSIDE the
               // handler below (not after functionHandler returns) so the result
               // the shared handler records and emits — the persisted tool
@@ -212,12 +219,18 @@ export function createTools({
               )) as FunctionResult;
               let { function_results } = result;
               let [{ result: data, error }] = function_results;
-              if (error) {
-                logger.info(
-                  { data, error, agentId: agent.id, callId: call.id },
-                  "error executing function",
-                );
-              }
+              // Emit the matching tool_result BEFORE any early return so it is
+              // recorded for every outcome, including an agent handover. `data`
+              // is the result the model sees (already redacted for `redact`
+              // functions), so nothing sensitive is added to the log here.
+              logToolResult(logger, {
+                tool: fnc.name,
+                kind,
+                ok: !error,
+                result: data,
+                error: error ?? undefined,
+                durationMs: Date.now() - startedAt,
+              });
               if (pendingHandoff) {
                 const { handoffAgent } = pendingHandoff;
                 if (handoffAgent) {
@@ -228,14 +241,16 @@ export function createTools({
                 // replaced; this result has no LLM left to speak it.
                 return data;
               }
-              logger.debug(
-                { data },
-                `function execute returning ${JSON.stringify(data)}`,
-              );
               return data;
             } catch (e) {
               const message = (e as Error).message;
-              logger.info({ error: message }, "error executing function");
+              logToolResult(logger, {
+                tool: fnc.name,
+                kind,
+                ok: false,
+                error: message,
+                durationMs: Date.now() - startedAt,
+              });
               throw new Error(`error executing function: ${message}`);
             }
           },

--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -337,6 +337,12 @@ export interface AgentFunction {
     // some definitions instead set `required: true` on each property).
     required?: string[];
   };
+  // How the shared function handler dispatches this function:
+  // "stub" | "rest" | "builtin". Consumed untyped by function-handler.js;
+  // modelled here so callers can classify a call (e.g. builtin vs function).
+  implementation?: string;
+  // For builtins, the platform builtin name (e.g. "transfer_agent", "hangup").
+  platform?: string;
 }
 
 export interface Call {

--- a/agents/livekit/lib/tool-log.ts
+++ b/agents/livekit/lib/tool-log.ts
@@ -1,0 +1,104 @@
+/**
+ * Structured, INFO-level logging of every LLM tool / MCP call and its result
+ * into the per-call InvocationLog ("debug log").
+ *
+ * The `event` field is the stable marker that distinguishes these entries from
+ * all other InvocationLog output:
+ *   - `event: "tool_call"`   — a tool/MCP call is being invoked (INFO)
+ *   - `event: "tool_result"` — the call returned (INFO on success, WARN on
+ *                              error — both are captured at the prod `info`
+ *                              level, so failures stay visible while keeping
+ *                              their severity)
+ *
+ * The field shape is kept deliberately identical to the Pipecat worker's
+ * `pipecat_aplisay/tool_log.py` so tool activity reads and correlates the same
+ * across the `livekit-agent` and `pipecat-agent` subsystems:
+ *   tool (name), kind (function|builtin|mcp), arguments, ok, result, error,
+ *   durationMs.
+ *
+ * Only log through the CAPTURING logger (`agents/livekit/lib/logger.js`). Logs
+ * emitted inside the shared `agent-lib/function-handler.js` use a different,
+ * non-capturing pino instance and never reach the InvocationLog buffer, so the
+ * instrumentation lives at the tool-dispatch choke point in agent-tools.ts.
+ */
+
+/** Coarse classification of a tool, shared with the pipecat worker. */
+export type ToolKind = "function" | "builtin" | "mcp";
+
+/** Minimal structural logger type so this stays decoupled from pino's exports. */
+interface ToolLogger {
+  info(obj: object, msg?: string): void;
+  warn(obj: object, msg?: string): void;
+}
+
+// Cap any single logged value so one large tool result (e.g. a big REST
+// payload) cannot dominate the size-bounded InvocationLog and crowd out the
+// rest of the call's log. Matches the pipecat helper's cap.
+const MAX_LOG_VALUE_CHARS = 8000;
+
+/**
+ * Return `value` unchanged when it serialises small (so pino logs it
+ * structured), otherwise a truncated string with an explicit marker.
+ */
+export function truncateForLog(value: unknown): unknown {
+  if (value === undefined || value === null) return value;
+  let s: string;
+  if (typeof value === "string") {
+    s = value;
+  } else {
+    try {
+      s = JSON.stringify(value);
+    } catch {
+      s = String(value);
+    }
+  }
+  if (s === undefined) return value;
+  if (s.length <= MAX_LOG_VALUE_CHARS) return value;
+  return `${s.slice(0, MAX_LOG_VALUE_CHARS)}…[truncated ${s.length - MAX_LOG_VALUE_CHARS} chars]`;
+}
+
+/** Log a tool/MCP invocation at INFO with `event: "tool_call"`. */
+export function logToolCall(
+  log: ToolLogger,
+  { tool, kind, args }: { tool: string; kind: ToolKind; args: unknown },
+): void {
+  log.info(
+    { event: "tool_call", tool, kind, arguments: truncateForLog(args) },
+    `tool call: ${tool}`,
+  );
+}
+
+/**
+ * Log a tool/MCP result with `event: "tool_result"` — INFO when `ok`, WARN
+ * otherwise (an errored call is still captured, but keeps warn severity).
+ */
+export function logToolResult(
+  log: ToolLogger,
+  {
+    tool,
+    kind,
+    ok,
+    result,
+    error,
+    durationMs,
+  }: {
+    tool: string;
+    kind: ToolKind;
+    ok: boolean;
+    result?: unknown;
+    error?: unknown;
+    durationMs: number;
+  },
+): void {
+  const fields: Record<string, unknown> = {
+    event: "tool_result",
+    tool,
+    kind,
+    ok,
+    durationMs,
+  };
+  if (result !== undefined) fields.result = truncateForLog(result);
+  if (error !== undefined && error !== null) fields.error = error;
+  if (ok) log.info(fields, `tool result: ${tool}`);
+  else log.warn(fields, `tool error: ${tool}`);
+}

--- a/agents/livekit/test/tool-log.test.ts
+++ b/agents/livekit/test/tool-log.test.ts
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { logToolCall, logToolResult, truncateForLog } from "../lib/tool-log.js";
+
+// Unit tests for the tool-call/result InvocationLog convention shared with the
+// pipecat worker's tool_log.py. Pure / SDK-free (the helpers take any logger
+// with info/warn): run with `node --import tsx --test test/tool-log.test.ts`.
+
+interface Logged {
+  level: "info" | "warn";
+  obj: Record<string, unknown>;
+  msg?: string;
+}
+
+function fakeLogger() {
+  const lines: Logged[] = [];
+  return {
+    lines,
+    info: (obj: object, msg?: string) =>
+      lines.push({ level: "info", obj: obj as Record<string, unknown>, msg }),
+    warn: (obj: object, msg?: string) =>
+      lines.push({ level: "warn", obj: obj as Record<string, unknown>, msg }),
+  };
+}
+
+test("logToolCall emits an info tool_call with the shared marker fields", () => {
+  const log = fakeLogger();
+  logToolCall(log, {
+    tool: "get_weather",
+    kind: "function",
+    args: { q: "London" },
+  });
+  assert.equal(log.lines.length, 1);
+  const [line] = log.lines;
+  assert.equal(line.level, "info"); // visible at the prod `info` capture level
+  assert.equal(line.obj.event, "tool_call"); // the distinguishing marker
+  assert.equal(line.obj.tool, "get_weather");
+  assert.equal(line.obj.kind, "function");
+  assert.deepEqual(line.obj.arguments, { q: "London" });
+  assert.equal(line.msg, "tool call: get_weather");
+});
+
+test("logToolResult(ok) emits an info tool_result with result + durationMs", () => {
+  const log = fakeLogger();
+  logToolResult(log, {
+    tool: "get_weather",
+    kind: "function",
+    ok: true,
+    result: "sunny",
+    durationMs: 12,
+  });
+  const [line] = log.lines;
+  assert.equal(line.level, "info");
+  assert.equal(line.obj.event, "tool_result");
+  assert.equal(line.obj.ok, true);
+  assert.equal(line.obj.result, "sunny");
+  assert.equal(line.obj.durationMs, 12);
+  assert.equal(line.msg, "tool result: get_weather");
+});
+
+test("logToolResult(error) logs at warn but keeps the tool_result marker", () => {
+  const log = fakeLogger();
+  logToolResult(log, {
+    tool: "do_thing",
+    kind: "builtin",
+    ok: false,
+    error: "boom",
+    durationMs: 3,
+  });
+  const [line] = log.lines;
+  // warn is still >= the info capture level, so an errored call stays visible
+  // in the debug log while keeping its severity.
+  assert.equal(line.level, "warn");
+  assert.equal(line.obj.event, "tool_result");
+  assert.equal(line.obj.ok, false);
+  assert.equal(line.obj.error, "boom");
+  assert.equal(line.obj.kind, "builtin");
+  assert.equal(line.msg, "tool error: do_thing");
+});
+
+test("truncateForLog returns small values structured and caps large ones", () => {
+  const small = { a: 1 };
+  assert.equal(truncateForLog(small), small); // same reference: logged structured
+
+  const big = "x".repeat(8000 + 500);
+  const out = truncateForLog(big);
+  assert.equal(typeof out, "string");
+  assert.ok((out as string).includes("[truncated 500 chars]"));
+  assert.ok((out as string).length < big.length);
+});

--- a/agents/pipecat/pipecat_aplisay/agent_tools.py
+++ b/agents/pipecat/pipecat_aplisay/agent_tools.py
@@ -183,7 +183,16 @@ def build_agent_tools(
                 logger.bind(error=str(e)).info("error executing function")
                 raise RuntimeError(f"error executing function: {e}") from e
 
-        descriptor: dict = {"schema": schema, "execute": execute}
+        descriptor: dict = {
+            "schema": schema,
+            "execute": execute,
+            # Coarse classification surfaced in the InvocationLog tool logs
+            # (see voice_session._runner / tool_log.py). MCP tools set their
+            # own "mcp" kind in mcp_tools._make_descriptor.
+            "kind": "builtin"
+            if fn_def.get("implementation") == "builtin"
+            else "function",
+        }
         if (
             fn_def.get("implementation") == "builtin"
             and fn_def.get("platform") == "transfer_agent"

--- a/agents/pipecat/pipecat_aplisay/mcp_tools.py
+++ b/agents/pipecat/pipecat_aplisay/mcp_tools.py
@@ -115,7 +115,10 @@ def _make_descriptor(
             raise RuntimeError(text or f"MCP tool {_name} returned an error")
         return text
 
-    return {"schema": schema, "execute": execute}
+    # ``kind: "mcp"`` is surfaced in the InvocationLog tool logs so MCP
+    # entrypoint calls are distinguishable from the agent's own functions
+    # (see voice_session._runner / tool_log.py).
+    return {"schema": schema, "execute": execute, "kind": "mcp"}
 
 
 def _resolve_key_auth(

--- a/agents/pipecat/pipecat_aplisay/tool_log.py
+++ b/agents/pipecat/pipecat_aplisay/tool_log.py
@@ -1,0 +1,100 @@
+"""Structured, INFO-level logging of every LLM tool / MCP call and its result
+into the per-call InvocationLog ("debug log").
+
+The ``event`` field is the stable marker that distinguishes these entries from
+all other InvocationLog output:
+
+* ``event="tool_call"``   — a tool/MCP call is being invoked (INFO)
+* ``event="tool_result"`` — the call returned (INFO on success / cancellation,
+  WARNING on error — all are >= the default ``LOGLEVEL=INFO`` capture sink, so
+  failures stay visible while keeping their severity)
+
+The field shape is kept deliberately identical to the livekit worker's
+``agents/livekit/lib/tool-log.ts`` so tool activity reads and correlates the
+same across the ``pipecat-agent`` and ``livekit-agent`` subsystems:
+``tool`` (name), ``kind`` (function|builtin|mcp), ``arguments``, ``ok``,
+``result``, ``error``, ``durationMs``.
+
+Records are only captured into the InvocationLog when emitted inside the
+``logger.contextualize(callId=...)`` scope — the capture sink
+(:mod:`pipecat_aplisay.invocation_log`) keys on ``callId``. Tool execution runs
+inside that scope via ``CallSession._run_prepared_once``, so these emit through
+to the debug log; the same dependency governs every other in-call log line.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from loguru import logger as _logger
+
+# Cap any single logged value so one large tool result (e.g. a big REST or MCP
+# payload) cannot dominate the size-bounded InvocationLog and crowd out the rest
+# of the call's log. Matches the livekit helper's cap.
+_MAX_LOG_VALUE_CHARS = 8000
+
+
+def _truncate_for_log(value: Any) -> Any:
+    """Return ``value`` unchanged when it serialises small (so loguru records it
+    structured), otherwise a truncated string with an explicit marker."""
+    if value is None:
+        return value
+    if isinstance(value, str):
+        s = value
+    else:
+        try:
+            s = json.dumps(value, default=str)
+        except Exception:  # noqa: BLE001
+            s = str(value)
+    if len(s) <= _MAX_LOG_VALUE_CHARS:
+        return value
+    return f"{s[:_MAX_LOG_VALUE_CHARS]}…[truncated {len(s) - _MAX_LOG_VALUE_CHARS} chars]"
+
+
+def log_tool_call(*, tool: str, kind: str, arguments: Any) -> None:
+    """Log a tool/MCP invocation at INFO with ``event="tool_call"``."""
+    _logger.bind(
+        event="tool_call",
+        tool=tool,
+        kind=kind,
+        arguments=_truncate_for_log(arguments),
+    ).info(f"tool call: {tool}")
+
+
+def log_tool_result(
+    *,
+    tool: str,
+    kind: str,
+    ok: bool,
+    duration_ms: int,
+    result: Any = None,
+    error: Any = None,
+    cancelled: bool = False,
+) -> None:
+    """Log a tool/MCP result with ``event="tool_result"``.
+
+    INFO on success or cancellation (an interrupted protected builtin keeps
+    running in the background — an expected lifecycle event, not a failure);
+    WARNING on a genuine error. All levels are captured at ``LOGLEVEL=INFO``.
+    """
+    fields: dict[str, Any] = {
+        "event": "tool_result",
+        "tool": tool,
+        "kind": kind,
+        "ok": ok,
+        "durationMs": duration_ms,
+    }
+    if result is not None:
+        fields["result"] = _truncate_for_log(result)
+    if error is not None:
+        fields["error"] = error if isinstance(error, str) else str(error)
+    if cancelled:
+        fields["cancelled"] = True
+    bound = _logger.bind(**fields)
+    if ok:
+        bound.info(f"tool result: {tool}")
+    elif cancelled:
+        bound.info(f"tool cancelled: {tool}")
+    else:
+        bound.warning(f"tool error: {tool}")

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -37,6 +37,8 @@ from pipecat.turns.user_mute.mute_until_first_bot_complete_user_mute_strategy im
     MuteUntilFirstBotCompleteUserMuteStrategy,
 )
 
+from .tool_log import log_tool_call, log_tool_result
+
 
 def _inactivity_timeout_secs(agent: dict) -> Optional[float]:
     """Return the configured inactivity (idle "kick") timeout in seconds, or
@@ -436,18 +438,25 @@ def _register_tools_on_llm(llm: Any, tools: list[dict]) -> ToolsSchema:
             params: FunctionCallParams,
             _execute=entry["execute"],
             _name=s["name"],
+            _kind=entry.get("kind", "function"),
             _suppress_result_run=bool(entry.get("suppress_result_run")),
             _protect=bool(entry.get("protect_from_interruption")),
         ) -> None:
-            # Breadcrumb so we can confirm the realtime path actually
-            # routes function calls through here (and therefore through
-            # function_handler.py's transaction-log emissions). Earlier
-            # symptoms suggested realtime calls weren't reaching the
-            # telemetry path at all.
-            from loguru import logger as _logger
-            _logger.bind(tool=_name, arguments=params.arguments).debug(
-                "tool runner invoked"
-            )
+            # Log every tool/MCP call and its result at INFO with an ``event``
+            # marker (see tool_log.py) so they are visible in the per-call debug
+            # log for production agents and distinguishable from other
+            # InvocationLog output. This ``_runner`` is the single choke point
+            # for BOTH agent functions/builtins and MCP tools — both are
+            # registered here as ``{schema, execute}`` descriptors — so one pair
+            # of log lines covers every tool the worker runs. Also confirms the
+            # realtime path routes function calls through here (and thus through
+            # function_handler.py's transaction-log emissions).
+            started = asyncio.get_running_loop().time()
+            log_tool_call(tool=_name, kind=_kind, arguments=params.arguments)
+
+            def _elapsed_ms() -> int:
+                return int((asyncio.get_running_loop().time() - started) * 1000)
+
             try:
                 if _protect:
                     # Side-effecting platform builtins must survive Pipecat's
@@ -465,21 +474,37 @@ def _register_tools_on_llm(llm: Any, tools: list[dict]) -> ToolsSchema:
                     try:
                         result = await asyncio.shield(exec_task)
                     except asyncio.CancelledError:
-                        _logger.bind(tool=_name).info(
-                            "tool call cancelled by interruption; protected builtin continues in background"
+                        log_tool_result(
+                            tool=_name,
+                            kind=_kind,
+                            ok=False,
+                            duration_ms=_elapsed_ms(),
+                            cancelled=True,
+                            error="cancelled by interruption; protected builtin continues in background",
                         )
                         raise
                 else:
                     result = await _execute(params.arguments)
             except Exception as e:  # noqa: BLE001
-                _logger.bind(tool=_name, error=str(e)).warning(
-                    "tool runner _execute raised"
+                log_tool_result(
+                    tool=_name,
+                    kind=_kind,
+                    ok=False,
+                    duration_ms=_elapsed_ms(),
+                    error=str(e),
                 )
                 # Surface the error to the LLM via the result callback so
                 # the conversation can recover, rather than dropping the
                 # whole turn.
                 await params.result_callback({"error": str(e)})
                 return
+            log_tool_result(
+                tool=_name,
+                kind=_kind,
+                ok=True,
+                duration_ms=_elapsed_ms(),
+                result=result,
+            )
             if (
                 _suppress_result_run
                 and isinstance(result, dict)

--- a/agents/pipecat/tests/test_tool_log.py
+++ b/agents/pipecat/tests/test_tool_log.py
@@ -1,0 +1,141 @@
+"""Tests for the tool-call / tool-result InvocationLog instrumentation
+(:mod:`pipecat_aplisay.tool_log`).
+
+These drive the *real* loguru capture sink at the production ``INFO`` level to
+prove that:
+  * every tool call + result is captured (not dropped as sub-INFO),
+  * each carries the ``event`` marker that distinguishes it from other log
+    output, plus the shared ``tool``/``kind``/``arguments``/``result`` fields,
+  * an errored result keeps WARNING severity while still being captured,
+  * a call/result emitted outside a ``contextualize(callId=...)`` scope is NOT
+    captured (documents the capture dependency),
+  * large values are truncated so one tool result can't dominate the log.
+"""
+
+from __future__ import annotations
+
+import pytest
+from loguru import logger
+
+from pipecat_aplisay import invocation_log, tool_log
+
+
+@pytest.fixture(autouse=True)
+def _clear_buffer():
+    with invocation_log._LOCK:
+        invocation_log._BUFFER.clear()
+    yield
+    with invocation_log._LOCK:
+        invocation_log._BUFFER.clear()
+
+
+@pytest.fixture()
+def capture():
+    """Install the real capture sink at INFO (as in production) for the duration
+    of the test, then remove it. Yields the shared buffer."""
+    sink_id = logger.add(
+        invocation_log._capture_sink,
+        level="INFO",
+        enqueue=False,
+        backtrace=False,
+        diagnose=False,
+    )
+    try:
+        yield invocation_log._BUFFER
+    finally:
+        logger.remove(sink_id)
+
+
+def _extra(entry: dict) -> dict:
+    return entry.get("extra") or {}
+
+
+def test_tool_call_and_result_captured_at_info(capture):
+    with logger.contextualize(callId="call-A"):
+        tool_log.log_tool_call(
+            tool="get_weather", kind="function", arguments={"q": "London"}
+        )
+        tool_log.log_tool_result(
+            tool="get_weather", kind="function", ok=True, duration_ms=12, result="sunny"
+        )
+
+    assert len(capture) == 2
+    call, result = capture
+
+    # tool_call: INFO (pino 30), event marker + shared fields, structured args.
+    assert call["level"] == 30
+    assert call["callId"] == "call-A"
+    assert _extra(call)["event"] == "tool_call"
+    assert _extra(call)["tool"] == "get_weather"
+    assert _extra(call)["kind"] == "function"
+    assert _extra(call)["arguments"] == {"q": "London"}
+
+    # tool_result: INFO, ok + result + durationMs.
+    assert result["level"] == 30
+    assert _extra(result)["event"] == "tool_result"
+    assert _extra(result)["ok"] is True
+    assert _extra(result)["result"] == "sunny"
+    assert _extra(result)["durationMs"] == 12
+
+
+def test_errored_result_is_warning_but_still_captured(capture):
+    with logger.contextualize(callId="call-A"):
+        tool_log.log_tool_result(
+            tool="do_thing", kind="function", ok=False, duration_ms=3, error="boom"
+        )
+
+    assert len(capture) == 1
+    (entry,) = capture
+    assert entry["level"] == 40  # pino WARNING — captured (>= INFO) but notable
+    assert entry["levelName"] == "WARNING"
+    assert _extra(entry)["event"] == "tool_result"
+    assert _extra(entry)["ok"] is False
+    assert _extra(entry)["error"] == "boom"
+
+
+def test_cancelled_result_is_info(capture):
+    with logger.contextualize(callId="call-A"):
+        tool_log.log_tool_result(
+            tool="transfer_agent",
+            kind="builtin",
+            ok=False,
+            duration_ms=1,
+            cancelled=True,
+            error="cancelled by interruption",
+        )
+
+    (entry,) = capture
+    # Cancellation of a protected builtin is an expected lifecycle event, so it
+    # stays at INFO even though ok is False.
+    assert entry["level"] == 30
+    assert _extra(entry)["cancelled"] is True
+    assert _extra(entry)["kind"] == "builtin"
+
+
+def test_mcp_kind_passthrough(capture):
+    with logger.contextualize(callId="call-A"):
+        tool_log.log_tool_call(
+            tool="weatherserver_lookup", kind="mcp", arguments={"city": "Paris"}
+        )
+    (entry,) = capture
+    assert _extra(entry)["kind"] == "mcp"
+    assert _extra(entry)["event"] == "tool_call"
+
+
+def test_not_captured_without_call_context(capture):
+    # No logger.contextualize(callId=...) scope -> the sink drops it.
+    tool_log.log_tool_call(tool="orphan", kind="function", arguments={})
+    tool_log.log_tool_result(tool="orphan", kind="function", ok=True, duration_ms=0)
+    assert capture == []
+
+
+def test_large_value_is_truncated():
+    small = {"a": 1}
+    assert tool_log._truncate_for_log(small) is small  # returned structured
+
+    big = "x" * (tool_log._MAX_LOG_VALUE_CHARS + 500)
+    out = tool_log._truncate_for_log(big)
+    assert isinstance(out, str)
+    assert out.startswith("x" * 100)
+    assert "[truncated 500 chars]" in out
+    assert len(out) < len(big)

--- a/docs/tools-mcp-logging.md
+++ b/docs/tools-mcp-logging.md
@@ -1,0 +1,131 @@
+# Tool & MCP call logging
+
+How every LLM **tool call**, **MCP entrypoint call**, and its **result** is logged
+so it can be isolated from the rest of a call's log output. Written for engineers
+consuming the logs (dashboards, debugging, log queries) and for anyone extending
+or re-implementing a voice worker who must preserve the contract.
+
+The logs land in the per-call **InvocationLog** ("debug log", subsystems
+`livekit-agent` / `pipecat-agent`) alongside every other worker log line. The
+convention below is what makes tool/MCP activity greppable within that stream.
+
+## 1. The contract
+
+Two log lines per tool/MCP call — one when it is invoked, one when it returns —
+each carrying a stable `event` marker plus a fixed set of structured fields. The
+shape is **identical across livekit and pipecat**, so entries correlate 1:1
+across subsystems.
+
+| field        | `event: "tool_call"` | `event: "tool_result"`                    |
+|--------------|----------------------|-------------------------------------------|
+| `event`      | `"tool_call"`        | `"tool_result"`                           |
+| `tool`       | tool name (MCP tools are server-namespaced) | same             |
+| `kind`       | `function` \| `builtin` \| `mcp` | same                          |
+| `arguments`  | model-supplied args  | —                                         |
+| `ok`         | —                    | `true` on success, `false` otherwise      |
+| `result`     | —                    | result returned to the model (when `ok`)  |
+| `error`      | —                    | error string (when not `ok`)              |
+| `durationMs` | —                    | elapsed milliseconds                      |
+
+`event` is the **only field you need to isolate these logs**. `tool`/`kind` narrow
+further (e.g. `kind == "mcp"` for MCP entrypoint calls only).
+
+Notes:
+- **Redaction & safety.** `arguments` are the model's own arguments (never the
+  `source: static`/`metadata`-injected values — those are resolved *inside* the
+  handler, downstream of the log point). `result` is what the model sees, so a
+  `redact`-flagged function logs its redacted `OK`/`FAILED`, not the raw payload.
+- **Truncation.** `arguments` and `result` are capped at 8000 chars (a large REST
+  or MCP payload is truncated with an explicit `…[truncated N chars]` marker) so
+  one call cannot dominate the size-bounded InvocationLog.
+
+## 2. How to isolate them
+
+**In the raw worker log stream** (pino JSON for livekit, loguru for pipecat) or in
+a persisted InvocationLog entry, filter on the `event` field:
+
+```
+event == "tool_call" || event == "tool_result"      # all tool + MCP activity
+event == "tool_result" && ok == false               # failures only
+event in ("tool_call","tool_result") && kind == "mcp"  # MCP entrypoint calls only
+```
+
+- **livekit** — pino puts bound fields at the top level of each JSON line, so
+  `.event` is a top-level key.
+- **pipecat** — loguru bound fields land under the pino-shaped entry's `extra`
+  object (`entry.extra.event`); `callId`, `level`, `msg` are top-level. See
+  `pipecat_aplisay/invocation_log.py::_record_to_entry`.
+- **Message fallback.** If you only have the rendered message string, the prefixes
+  are stable: `tool call: <name>`, `tool result: <name>`, `tool error: <name>`,
+  `tool cancelled: <name>`.
+
+## 3. Levels & capture
+
+Everything is emitted at a level that the production capture threshold (`info`)
+keeps, so tool activity is visible for production agents without turning on debug:
+
+| outcome                                   | level     | still captured? |
+|-------------------------------------------|-----------|-----------------|
+| `tool_call`, successful `tool_result`     | `info`    | yes             |
+| errored `tool_result` (`ok: false`)       | `warning` | yes (≥ info), keeps severity |
+| cancelled protected builtin               | `info`    | yes             |
+
+Capture thresholds: livekit pino sits at `info` in prod (`LOGLEVEL` unset);
+pipecat's capture sink is `LOGLEVEL` (default `INFO`). Do **not** emit tool logs
+at `debug` — they will be dropped in production.
+
+## 4. Where it is emitted
+
+Instrument the **single tool-dispatch choke point** each worker already has, and
+only through the **capturing** logger. Both workers funnel every registered tool —
+the agent's own `functions`, platform `builtins`, and MCP tools — through one
+callback, so one pair of log lines there covers everything.
+
+| worker  | choke point                                           | helper                                   |
+|---------|-------------------------------------------------------|------------------------------------------|
+| livekit | `agents/livekit/lib/agent-tools.ts` → `execute`       | `agents/livekit/lib/tool-log.ts`         |
+| pipecat | `pipecat_aplisay/voice_session.py` → `_runner`        | `pipecat_aplisay/tool_log.py`            |
+
+`kind` is derived at descriptor-build time: livekit from the function's
+`implementation` (`builtin` vs `function`); pipecat tags descriptors in
+`agent_tools.py` (`function`/`builtin`) and `mcp_tools.py` (`mcp`).
+
+Two constraints that are easy to get wrong:
+
+- **livekit — use the capturing logger.** Logs emitted inside the shared
+  `agent-lib/function-handler.js` use a *different, non-capturing* pino instance
+  and never reach the InvocationLog buffer. Instrument in `agents/livekit/lib/*`
+  (which imports the capturing `./logger.js`), i.e. at the `execute` choke point —
+  not in the shared handler.
+- **pipecat — stay inside the call context.** The capture sink only buffers
+  records emitted within `logger.contextualize(callId=…)` (set for the whole
+  pipeline run in `CallSession._run_prepared_once`). Tool execution runs inside
+  that scope, so the helper works; the same dependency governs every other
+  in-call log line.
+
+## 5. Coverage
+
+- **pipecat** covers `function` + `builtin` + `mcp` — MCP servers are proxied
+  in-worker (`mcp_tools.py`), so MCP entrypoint calls appear in the debug log.
+- **livekit** covers `function` + `builtin`. The livekit **voice** worker executes
+  no in-worker MCP: the pipeline LLM is a native LiveKit provider plugin
+  (`buildProviderPipelineLlm`), not the `lib/models/*` drivers, and MCP
+  (`McpToolBridge`) only runs in the text/model path — a different process. There
+  is therefore no `kind == "mcp"` line from a livekit voice call; that is a
+  property of the architecture, not a logging gap.
+
+## 6. Extending / preserving parity
+
+When you add a tool kind, a builtin, or a whole new worker:
+
+1. Emit **only** via the shared helper (`tool-log.ts` / `tool_log.py`) at the tool
+   choke point — do not hand-roll tool logs elsewhere.
+2. Keep the field names and `event` values above; do not rename them. Consumers
+   filter on `event`/`kind` across subsystems.
+3. Give every descriptor a `kind`; add a new value only if the coarse
+   `function`/`builtin`/`mcp` set genuinely does not fit.
+4. Keep the two-line call/result pairing and the level table in §3.
+
+Tests that lock this in: `agents/livekit/test/tool-log.test.ts`,
+`agents/pipecat/tests/test_tool_log.py` (the pipecat one drives the real capture
+sink at `info` to prove the markers land in the InvocationLog).


### PR DESCRIPTION
## What

Log every LLM **tool call**, **MCP entrypoint call**, and its **result** into the per-call InvocationLog ("debug log") at **info** level with a stable `event` marker so they can be isolated from other log output and correlated across the `livekit-agent` and `pipecat-agent` subsystems.

Two lines per call — `event: "tool_call"` on invoke, `event: "tool_result"` on return — sharing an identical field shape across both workers: `tool`, `kind` (`function`/`builtin`/`mcp`), `arguments`, `ok`, `result`, `error`, `durationMs` (values truncated at 8KB). Errors log at `warning` (still at or above the info capture level, keeping severity); a cancelled protected builtin logs at `info`.

## Where

Instrumented at the single tool-dispatch choke point each worker already has, via a small shared-convention helper:

| worker | choke point | helper |
|---|---|---|
| livekit | `agents/livekit/lib/agent-tools.ts` -> `execute` | `agents/livekit/lib/tool-log.ts` |
| pipecat | `pipecat_aplisay/voice_session.py` -> `_runner` (functions + builtins + MCP) | `pipecat_aplisay/tool_log.py` |

Two constraints preserved: livekit logs through the **capturing** `./logger.js` (the shared `function-handler.js` logger is not captured); pipecat emits inside the `contextualize(callId=...)` scope the capture sink keys on.

## Scope

The livekit **voice** worker runs no in-worker MCP (native provider plugins, not `lib/models/*`), so its coverage is functions+builtins; **pipecat** is where MCP entrypoint calls surface. This is architectural, not a logging gap.

## Docs and tests

- `docs/tools-mcp-logging.md` — the convention plus how to isolate/filter the logs.
- `agents/livekit/test/tool-log.test.ts` (32/32 suite green), `agents/pipecat/tests/test_tool_log.py` (30/30; drives the real capture sink at info to prove the markers land in the InvocationLog). Livekit `tsup` build clean.

Not yet live-call verified — worth confirming `tool_call`/`tool_result` rows render in a real call's debug log.
