### PR TITLE
models: direct DeepSeek driver (OpenAI-compatible)

### DIFF
--- a/lib/handlers/text.js
+++ b/lib/handlers/text.js
@@ -5,6 +5,7 @@ import Groq from '../models/groq.js';
 import Gemini from '../models/gemini.js';
 import Kimi from '../models/kimi.js';
 import OpenRouter from '../models/openrouter.js';
+import Deepseek from '../models/deepseek.js';
 
 /**
  * Implements the Handler class for headless `text` type agents.
@@ -36,7 +37,7 @@ class TextHandler extends Handler {
 
   static get models() {
     return [
-      Anthropic, OpenAi, Groq, Gemini, Kimi, OpenRouter
+      Anthropic, OpenAi, Groq, Gemini, Kimi, OpenRouter, Deepseek
     ];
   }
 

--- a/lib/models/deepseek.js
+++ b/lib/models/deepseek.js
@@ -1,0 +1,30 @@
+import OpenAiCompatible from './openai-compatible.js';
+const { DEEPSEEK_KEY } = process.env;
+
+/**
+ * DeepSeek via its OpenAI-compatible API (api.deepseek.com). The `deepseek-chat`
+ * and `deepseek-reasoner` ids are DeepSeek's stable aliases for the current
+ * V-series chat and R-series reasoner models (V4/R2 generation as of mid-2026);
+ * automatic context caching reports cached tokens via usage.cached_tokens,
+ * handled in the base class.
+ *
+ * @class Deepseek
+ * @extends {OpenAiCompatible}
+ */
+class Deepseek extends OpenAiCompatible {
+
+  static allModels = [
+    ['deepseek-chat', 'DeepSeek Chat (latest V-series)'],
+    ['deepseek-reasoner', 'DeepSeek Reasoner (latest R-series)'],
+  ].map(([name, description]) => ([`${this.name.toLowerCase()}/${name}`, description]));
+
+  static get needKey() {
+    return { DEEPSEEK_KEY };
+  }
+
+  static baseURL = 'https://api.deepseek.com/v1';
+  static apiKeyEnv = 'DEEPSEEK_KEY';
+  static provider = 'deepseek';
+}
+
+export default Deepseek;


### PR DESCRIPTION
Adds a direct DeepSeek driver (`text:deepseek/deepseek-chat`, `text:deepseek/deepseek-reasoner`) as a ~20-line OpenAiCompatible subclass (baseURL api.deepseek.com/v1, `DEEPSEEK_KEY`), registered in the text handler. Inherits function calling and the client-side MCP bridge from the base class — no other behaviour changes. DEEPSEEK_KEY is already in staging secrets; merging deploys DeepSeek support to llm-agent-staging for the builder benchmark roster.