### PR TITLE
models: self-heal invalid tool/MCP history instead of 400-looping forever

### DIFF
--- a/lib/models/anthropic.js
+++ b/lib/models/anthropic.js
@@ -213,6 +213,42 @@ class Anthropic extends Llm {
    * its prior cache entry within a 20-content-block lookback, so a single hop
    * adding more than ~20 blocks can still miss — rare enough to accept.)
    */
+  /**
+   * A stream that dies mid-connector-round (MCP server flap, network cut) can
+   * persist an assistant message whose content carries an `mcp_tool_use` with
+   * no paired `mcp_tool_result` — and the Messages API then rejects the whole
+   * replayed history on EVERY later request, bricking the session. Strip any
+   * unpaired connector blocks (either direction) before building a request;
+   * drop a message entirely if that leaves its content empty.
+   */
+  healOrphanMcpBlocks() {
+    const messages = this.gpt?.messages || [];
+    const uses = new Set();
+    const results = new Set();
+    for (const m of messages) {
+      if (!Array.isArray(m.content)) continue;
+      for (const b of m.content) {
+        if (b?.type === 'mcp_tool_use') uses.add(b.id);
+        else if (b?.type === 'mcp_tool_result') results.add(b.tool_use_id);
+      }
+    }
+    const orphanUses = [...uses].filter((id) => !results.has(id));
+    const orphanResults = [...results].filter((id) => !uses.has(id));
+    if (!orphanUses.length && !orphanResults.length) return;
+    this.logger.warn({ orphanUses, orphanResults },
+      'anthropic: stripping unpaired mcp_tool_use/mcp_tool_result blocks from history');
+    this.gpt.messages = messages
+      .map((m) => {
+        if (!Array.isArray(m.content)) return m;
+        const content = m.content.filter((b) => !(
+          (b?.type === 'mcp_tool_use' && orphanUses.includes(b.id))
+          || (b?.type === 'mcp_tool_result' && orphanResults.includes(b.tool_use_id))
+        ));
+        return content.length ? { ...m, content } : null;
+      })
+      .filter(Boolean);
+  }
+
   withMessageCacheBreakpoint(messages) {
     const copy = messages.slice();
     for (let m = copy.length - 1; m >= 0; m -= 1) {
@@ -270,6 +306,7 @@ class Anthropic extends Llm {
     // Two cache breakpoints (well under Anthropic's limit of 4): the static
     //  system prompt, and a rolling one on the last message so system + tools +
     //  the entire accumulated conversation are re-read from cache each round.
+    this.healOrphanMcpBlocks();
     const messages = this.withMessageCacheBreakpoint(this.gpt.messages);
     const request = {
       model: this.gpt.model,

--- a/lib/models/openai-compatible.js
+++ b/lib/models/openai-compatible.js
@@ -222,7 +222,14 @@ class OpenAiCompatible extends Llm {
     results.forEach(({ id, result }) => this.gpt.messages.push({
       role: 'tool',
       tool_call_id: id,
-      content: result,
+      // Same hazard as openai.js: an undefined result serialises without
+      // `content` and the provider rejects the whole history on every later
+      // request. Coerce, never drop.
+      content: typeof result === 'string'
+        ? result
+        : (result === undefined || result === null
+          ? 'ERROR: tool returned no result'
+          : JSON.stringify(result)),
     }));
     return this.rawCompletion(null, callBack);
   }

--- a/lib/models/openai.js
+++ b/lib/models/openai.js
@@ -281,7 +281,15 @@ class OpenAi extends Llm {
     results.forEach(({ id, result }) => this.gpt.input.push({
       type: 'function_call_output',
       call_id: id,
-      output: result,
+      // A missing/undefined result would serialise WITHOUT the `output` field,
+      // and the Responses API then rejects the replayed history on EVERY later
+      // request ("Missing required parameter: 'input[N].output'") — bricking
+      // the session. Coerce, never drop.
+      output: typeof result === 'string'
+        ? result
+        : (result === undefined || result === null
+          ? 'ERROR: tool returned no result'
+          : JSON.stringify(result)),
     }));
     return this.rawCompletion(null, callBack);
   }
@@ -295,6 +303,14 @@ class OpenAi extends Llm {
    */
   abandonTurn() {
     const input = this.gpt?.input || [];
+    // Repair output items that LOOK answered but would serialise invalid (an
+    // undefined/null output field is dropped by JSON and 400s every replay).
+    input.forEach((item) => {
+      if (item.type === 'function_call_output' && (item.output === undefined || item.output === null)) {
+        this.logger.warn({ call_id: item.call_id }, 'openai: repairing empty function_call_output');
+        item.output = 'ERROR: tool returned no result';
+      }
+    });
     const answered = new Set(
       input.filter((item) => item.type === 'function_call_output').map((item) => item.call_id));
     const dangling = input.filter((item) => item.type === 'function_call' && !answered.has(item.call_id));


### PR DESCRIPTION
Found via the builder benchmark against staging — two history-integrity bugs that permanently brick chat sessions with per-turn 400 retry loops:

1. **openai.js (Responses API)**: a tool that yields an undefined result gets a `function_call_output` whose `output` field is dropped at serialisation → `Missing required parameter: 'input[N].output'` on EVERY subsequent request. `abandonTurn()` couldn't repair it (the call looked answered). Fix: coerce results in `callResult` (string passthrough / JSON.stringify / explicit ERROR sentinel) and teach `abandonTurn` to repair empty output fields.
2. **anthropic.js**: a stream failing mid-MCP-connector-round persists an assistant message with `mcp_tool_use` and no paired `mcp_tool_result` → `mcp_tool_use … without a corresponding mcp_tool_result` forever. Fix: `healOrphanMcpBlocks()` strips unpaired connector blocks at request-build time.
3. **openai-compatible.js**: same coercion for `role:tool` content (kimi/openrouter/deepseek/groq inherit).

Staging log signatures: `chat turn failed … input[9].output` (sessions 14:31–14:43Z), `mcp_tool_use mcptoolu_01TA2k… without a corresponding mcp_tool_result` (14:46Z). All three changes are defensive at the driver boundary; no behavioural change for well-formed histories.