### PR TITLE
models: cache observability + compat fast-fail timeout + DeepSeek cache fields

### DIFF
--- a/lib/models/gemini.js
+++ b/lib/models/gemini.js
@@ -161,6 +161,12 @@ class Gemini extends Llm {
         usage.cacheReadTokens += cached;
         // Thought tokens are billed as output.
         usage.outputTokens += (u?.candidatesTokenCount || 0) + (u?.thoughtsTokenCount || 0);
+        // Per-hop cache observability (the July bake-off measured ~96k uncached
+        // input per scenario on this driver — implicit caching not engaging;
+        // this line is how we find out whether that is still true and when).
+        this.logger.info(
+          { model: this.model, in: Math.max(0, (u?.promptTokenCount || 0) - cached), cached, out: u?.candidatesTokenCount || 0 },
+          'gemini completion hop');
         truncated = candidate.finishReason === 'MAX_TOKENS';
         // Echo the model content VERBATIM — Gemini 3 thought signatures ride
         // the parts and must be replayed when self-managing history.

--- a/lib/models/openai-compatible.js
+++ b/lib/models/openai-compatible.js
@@ -61,7 +61,13 @@ class OpenAiCompatible extends Llm {
       apiKey,
       ...(this.constructor.extraHeaders ? { defaultHeaders: this.constructor.extraHeaders } : {}),
       maxRetries: 1,
-      timeout: Number(process.env.OPENAI_COMPAT_TIMEOUT_MS || 900000),
+      // These providers are called non-streaming, so this bounds the WHOLE
+      // request. Moonshot has been observed to occasionally hang on large
+      // contexts — at the old 15-minute default that pinned a chat turn far
+      // beyond any user's patience. 5 minutes passes every legitimately slow
+      // completion we've measured (~240s worst) while converting hangs into
+      // a visible fast failure + one retry.
+      timeout: Number(process.env.OPENAI_COMPAT_TIMEOUT_MS || 300000),
     });
     // Handler-constructed (voice) sessions spread agent.dataValues, which has
     // only modelName — without this fallback they'd silently run the catalogue
@@ -134,8 +140,14 @@ class OpenAiCompatible extends Llm {
   /** Normalise a provider usage object onto the ledger shape. */
   usageOf(u) {
     // Moonshot reports top-level cached_tokens; OpenAI-shape providers nest
-    // it under prompt_tokens_details (OpenRouter adds cache_write_tokens).
-    const cacheReadTokens = u?.prompt_tokens_details?.cached_tokens ?? u?.cached_tokens ?? 0;
+    // it under prompt_tokens_details (OpenRouter adds cache_write_tokens);
+    // DeepSeek reports prompt_cache_hit_tokens — without reading it, DeepSeek
+    // cache hits were ledgered as full-price input and invisible to
+    // diagnostics.
+    const cacheReadTokens = u?.prompt_tokens_details?.cached_tokens
+      ?? u?.cached_tokens
+      ?? u?.prompt_cache_hit_tokens
+      ?? 0;
     return {
       // prompt_tokens INCLUDES the cached subset — report the uncached
       // remainder so the ledger units stay disjoint (a cache hit must not be
@@ -172,6 +184,12 @@ class OpenAiCompatible extends Llm {
         usage.outputTokens += u.outputTokens;
         usage.cacheReadTokens += u.cacheReadTokens;
         usage.cacheWriteTokens += u.cacheWriteTokens;
+        // Per-hop cache observability: uncached input on a long-running
+        // session means the provider's automatic prefix cache is NOT engaging
+        // — the dominant latency term for big-context sessions. Keep at info.
+        this.logger.info(
+          { hop, model: this.model, in: u.inputTokens, cached: u.cacheReadTokens, out: u.outputTokens },
+          'compat completion hop');
         truncated = choice.finish_reason === 'length';
         // Push the assistant message WHOLE — reasoning_content (Moonshot) /
         // reasoning_details (OpenRouter) must ride the history in tool loops.

--- a/lib/models/openai.js
+++ b/lib/models/openai.js
@@ -243,6 +243,11 @@ class OpenAi extends Llm {
         cacheWriteTokens: 0,
       },
     };
+    // Per-request cache observability, symmetric with the compat/gemini hop
+    // logs — uncached input on a long session flags a broken prefix cache.
+    this.logger.info(
+      { model: this.model, in: result.usage.inputTokens, cached: result.usage.cacheReadTokens, out: result.usage.outputTokens },
+      'openai completion usage');
     callBack && callBack(result);
     return result;
   }


### PR DESCRIPTION
Follow-up to the builder-bench latency forensics:

1. **Compat driver fast-fail**: non-streaming whole-request timeout default 900s → 300s (`OPENAI_COMPAT_TIMEOUT_MS` still overrides). Moonshot has been observed hanging on large-context requests; at 15 minutes that pinned chat turns invisibly. 300s clears every legitimate completion measured (~240s worst) and converts hangs into a fast visible failure + retry.
2. **DeepSeek cache accounting**: DeepSeek reports cache hits as `prompt_cache_hit_tokens` which `usageOf` never read — hits were ledgered as full-price input and invisible. Now read alongside Moonshot/OpenAI-shape fields.
3. **Cache observability**: per-hop `{in, cached, out}` info logs on the compat, gemini and openai drivers. The bench's turn-latency curves (latency grows through the tool phase, collapses to 2–6s once tool calls stop, on a monotonically growing context) suggest prefix caches not engaging exactly when context is largest — these logs turn that from inference into measurement on the next benchmark cells. (July bake-off already measured gemini at ~96k uncached input/scenario.)

No behavioural change beyond the timeout default.