### PR TITLE
models: stream the OpenAI-compatible driver

### DIFF
--- a/lib/models/openai-compatible.js
+++ b/lib/models/openai-compatible.js
@@ -61,12 +61,11 @@ class OpenAiCompatible extends Llm {
       apiKey,
       ...(this.constructor.extraHeaders ? { defaultHeaders: this.constructor.extraHeaders } : {}),
       maxRetries: 1,
-      // These providers are called non-streaming, so this bounds the WHOLE
-      // request. Moonshot has been observed to occasionally hang on large
-      // contexts — at the old 15-minute default that pinned a chat turn far
-      // beyond any user's patience. 5 minutes passes every legitimately slow
-      // completion we've measured (~240s worst) while converting hangs into
-      // a visible fast failure + one retry.
+      // With streaming (streamOnce) the SDK timeout bounds TIME-TO-FIRST-BYTE
+      // only; the same value is re-applied as an inter-chunk inactivity window
+      // inside streamOnce, so a provider hang (Moonshot has been observed to
+      // hang on large contexts) aborts within the bound at any stage while a
+      // long legitimate generation streams on untouched.
       timeout: Number(process.env.OPENAI_COMPAT_TIMEOUT_MS || 300000),
     });
     // Handler-constructed (voice) sessions spread agent.dataValues, which has
@@ -176,10 +175,8 @@ class OpenAiCompatible extends Llm {
 
     try {
       for (let hop = 0; hop < MAX_MCP_HOPS; hop += 1) {
-        const completion = await this.client.chat.completions.create(this.requestBody(tools));
-        const choice = completion.choices?.[0];
-        if (!choice) throw new Error(`${this.constructor.name}: empty completion`);
-        const u = this.usageOf(completion.usage);
+        const { message, finishReason, usage: rawUsage } = await this.streamOnce(tools, callBack);
+        const u = this.usageOf(rawUsage);
         usage.inputTokens += u.inputTokens;
         usage.outputTokens += u.outputTokens;
         usage.cacheReadTokens += u.cacheReadTokens;
@@ -190,13 +187,14 @@ class OpenAiCompatible extends Llm {
         this.logger.info(
           { hop, model: this.model, in: u.inputTokens, cached: u.cacheReadTokens, out: u.outputTokens },
           'compat completion hop');
-        truncated = choice.finish_reason === 'length';
-        // Push the assistant message WHOLE — reasoning_content (Moonshot) /
-        // reasoning_details (OpenRouter) must ride the history in tool loops.
-        this.gpt.messages.push(choice.message);
-        if (choice.message.content) text += choice.message.content;
+        truncated = finishReason === 'length';
+        // Push the assistant message WHOLE — reasoning_content (Moonshot,
+        // DeepSeek) / reasoning_details (OpenRouter) must ride the history in
+        // tool loops.
+        this.gpt.messages.push(message);
+        if (message.content) text += message.content;
 
-        const toolCalls = (choice.message.tool_calls || []).map(({ id, function: fn }) => ({
+        const toolCalls = (message.tool_calls || []).map(({ id, function: fn }) => ({
           id, name: fn.name, input: this.parseArgs(fn.arguments),
         }));
         const mcpCalls = toolCalls.filter((c) => this.mcp.isMcpTool(c.name));
@@ -226,6 +224,95 @@ class OpenAiCompatible extends Llm {
     const result = { text, calls: clientCalls, truncated, usage };
     callBack && callBack(result);
     return result;
+  }
+
+  /**
+   * One STREAMED chat completion, manually accumulated back into a whole
+   * assistant message. Streamed (not create()) for two reasons: a client tool
+   * call's NAME surfaces the moment its first delta arrives — the UI needs
+   * "the team is being changed" at the START of a long argument generation
+   * (`callBack({ tool_use_start })`, parity with the openai/anthropic
+   * drivers) — and the request bound becomes time-to-first-byte + an
+   * INTER-CHUNK inactivity window instead of a whole-request ceiling, so a
+   * provider hang aborts fast while a long legitimate generation streams on.
+   *
+   * Accumulation is MANUAL (not the SDK's stream helper) because these
+   * providers extend the delta shape with fields the helper would drop —
+   * reasoning_content (Moonshot, DeepSeek) and reasoning_details (OpenRouter)
+   * — which MUST be reassembled onto the history message for tool-loop
+   * replay. Usage arrives in a final empty-choices chunk via
+   * stream_options.include_usage.
+   */
+  async streamOnce(tools, callBack) {
+    const stream = await this.client.chat.completions.create({
+      ...this.requestBody(tools),
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+    const stallMs = Number(process.env.OPENAI_COMPAT_TIMEOUT_MS || 300000);
+    let stallTimer;
+    let stalled = false;
+    const arm = () => {
+      clearTimeout(stallTimer);
+      stallTimer = setTimeout(() => { stalled = true; stream.controller.abort(); }, stallMs);
+    };
+    arm();
+
+    const message = { role: 'assistant', content: null };
+    const toolCalls = [];
+    const announced = new Set();
+    let finishReason = null;
+    let usage = null;
+    try {
+      for await (const chunk of stream) {
+        arm();
+        if (chunk.usage) usage = chunk.usage;
+        const choice = chunk.choices?.[0];
+        if (!choice) continue;
+        if (choice.finish_reason) finishReason = choice.finish_reason;
+        const d = choice.delta || {};
+        if (d.content) message.content = (message.content || '') + d.content;
+        if (d.reasoning_content) {
+          message.reasoning_content = (message.reasoning_content || '') + d.reasoning_content;
+        }
+        if (Array.isArray(d.reasoning_details)) {
+          // OpenRouter streams typed entries, each tagged with its index —
+          // merge text fragments per index so the replayed array matches the
+          // non-streamed shape; entries without an index are appended whole.
+          message.reasoning_details = message.reasoning_details || [];
+          for (const entry of d.reasoning_details) {
+            const at = Number.isInteger(entry?.index) ? entry.index : message.reasoning_details.length;
+            const cur = message.reasoning_details[at];
+            message.reasoning_details[at] = cur
+              ? { ...cur, ...entry, ...(entry.text ? { text: (cur.text || '') + entry.text } : {}) }
+              : { ...entry };
+          }
+        }
+        for (const tc of d.tool_calls || []) {
+          const i = Number.isInteger(tc.index) ? tc.index : 0;
+          toolCalls[i] = toolCalls[i] || { id: undefined, type: 'function', function: { name: '', arguments: '' } };
+          if (tc.id) toolCalls[i].id = tc.id;
+          if (tc.function?.name) toolCalls[i].function.name += tc.function.name;
+          if (tc.function?.arguments) toolCalls[i].function.arguments += tc.function.arguments;
+          const name = toolCalls[i].function.name;
+          if (name && !announced.has(i)) {
+            announced.add(i);
+            this.logger.info({ tool: name }, 'compat tool_call started');
+            callBack && callBack({ tool_use_start: { name } });
+          }
+        }
+      }
+    } catch (e) {
+      clearTimeout(stallTimer);
+      if (stalled) {
+        throw new Error(`${this.constructor.name}: stream stalled (no data for ${stallMs}ms)`);
+      }
+      throw e;
+    } finally {
+      clearTimeout(stallTimer);
+    }
+    if (toolCalls.length) message.tool_calls = toolCalls.filter(Boolean);
+    return { message, finishReason, usage };
   }
 
   parseArgs(raw) {


### PR DESCRIPTION
Follow-up to #163 and the benchmark latency findings — converts the compat driver (Moonshot/DeepSeek/OpenRouter/Groq) to streaming:

1. **Progress**: `tool_use_start` at the first tool-call delta — the dashboard shows 'team being changed' at the start of long saves, parity with openai/anthropic drivers.
2. **Hang immunity**: the bound becomes time-to-first-byte + inter-chunk inactivity (same `OPENAI_COMPAT_TIMEOUT_MS`), so Moonshot's observed large-context hangs abort fast at any stage while long legitimate generations stream on. This is the fix that should rehabilitate kimi's 9–14-minute benchmark scenarios.
3. **Fidelity**: manual accumulation preserves the non-standard delta fields the SDK helper would drop — `reasoning_content` (Moonshot/DeepSeek) and index-merged `reasoning_details` (OpenRouter) — which must replay in tool loops.
4. Usage via `stream_options.include_usage`; per-hop cache logs unchanged.

Verified with a fake-stream harness (fragmented tool-call name/argument reassembly, reasoning preservation, DeepSeek cache-split ledgering, stall abort with a named error).