### PR TITLE
tests: update compat-driver mock to the streaming contract

### DIFF
--- a/tests/driver-upgrades.test.mjs
+++ b/tests/driver-upgrades.test.mjs
@@ -130,12 +130,17 @@ describe('usage attached to errors from partially-completed hop loops', () => {
     const kimi = new Kimi(baseArgs('text:kimi/kimi-k2.6'));
     kimi.mcp = { ensure: async () => [], isMcpTool: (n) => n === 'srv_tool', call: async () => 'ok' };
     let n = 0;
+    // The driver streams (streamOnce): the mock returns an async-iterable
+    // "stream" of delta chunks with usage in a final empty-choices chunk.
     kimi.client = { chat: { completions: { create: async () => {
       n += 1;
       if (n === 2) throw new Error('boom');
       return {
-        choices: [{ finish_reason: 'tool_calls', message: { tool_calls: [{ id: 'x', function: { name: 'srv_tool', arguments: '{}' } }] } }],
-        usage: { prompt_tokens: 100, completion_tokens: 10 },
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield { choices: [{ delta: { tool_calls: [{ index: 0, id: 'x', function: { name: 'srv_tool', arguments: '{}' } }] }, finish_reason: 'tool_calls' }] };
+          yield { choices: [], usage: { prompt_tokens: 100, completion_tokens: 10 } };
+        },
       };
     } } } };
     await expect(kimi.rawCompletion('hi')).rejects.toMatchObject({


### PR DESCRIPTION
Fixes the CI failure #164 introduced on next: `tests/driver-upgrades.test.mjs` mocked the old non-streaming `create()` return. The mock now returns an async-iterable stream of delta chunks (tool-call delta + final usage chunk), matching the streamed driver. Test intent unchanged and verified locally: 17/17 pass under the ESM jest invocation. Unblocks the staging deploy that the streaming rollout and pending benchmark probes are waiting on.