### PR TITLE
Native Ultravox: honour portable greeting/inactivity + vendorSpecific pass-through

### DIFF
--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -1735,19 +1735,13 @@ export async function runAgentWorker({
     // First pass:
     // - OpenAI realtime: `generateReply({ instructions: <greeting>, allowInterruptions:false })` and wait for playout.
     // - Pipeline: fixed greeting uses `say(<text>, { allowInterruptions:false })`; LLM greeting uses `generateReply(...)`.
-    // - Ultravox realtime: prefer vendorSpecific.ultravox.firstSpeakerSettings (handled provider-side), so we skip here
-    //   unless a portable greeting is explicitly configured and no Ultravox firstSpeakerSettings are present.
+    // - Ultravox realtime: always handled provider-side — caller-supplied
+    //   vendorSpecific.ultravox.firstSpeakerSettings pass through, and a portable
+    //   options.greeting is mapped to firstSpeakerSettings by the session factory.
+    //   The say()/generateReply fallback below is inert for Ultravox (no TTS, and the
+    //   plugin never sends response.create), so skip it entirely.
     try {
       const greeting = agent?.options?.greeting;
-      const hasUltravoxFirstSpeaker =
-        Boolean(
-          agent?.options?.vendorSpecific?.ultravox?.firstSpeakerSettings?.agent
-            ?.text,
-        ) ||
-        Boolean(
-          agent?.options?.vendorSpecific?.ultravox?.firstSpeakerSettings?.agent
-            ?.prompt,
-        );
 
       const voiceMode = resolvedVoiceMode || resolveVoiceMode(modelName, agent.options);
       const text = (greeting?.text || "").trim();
@@ -1758,8 +1752,7 @@ export async function runAgentWorker({
       const wantGreeting =
         hasGreeting &&
         !invalidGreeting &&
-        // For Ultravox realtime, let provider-native firstSpeakerSettings handle it.
-        !(voiceMode === "realtime" && modelName.includes("livekit:ultravox/") && hasUltravoxFirstSpeaker);
+        !(voiceMode === "realtime" && modelName.includes("livekit:ultravox/"));
 
       if (wantGreeting && session) {
         const waitForPlayout = true;

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -556,10 +556,15 @@ components:
 
             Honoured by both the Pipecat worker (via Pipecat's built-in user-idle detection) and the
             LiveKit worker (via the session `userAwayTimeout` / `user_state_changed` → "away" event),
-            including the Ultravox realtime path on both stacks.
+            including the Ultravox realtime path on both stacks. Also honoured by native Ultravox
+            agents (`ultravox:` model names) on every medium — WebRTC, WebSocket, and jambonz-routed
+            telephony — where it is applied provider-side via Ultravox `inactivityMessages` (the same
+            nudge re-fires after each further `timeout` of continued silence, up to 3 times, and the
+            call is never hung up by this mechanism).
 
             Note: this is distinct from the provider-native `vendorSpecific.ultravox.inactivityMessages`,
-            which is handled entirely server-side by Ultravox and is not portable across workers.
+            which is handled entirely server-side by Ultravox and is not portable across workers; when
+            both are set on an Ultravox-backed path, the vendor-specific block wins.
           type: object
           properties:
             timeout:
@@ -819,8 +824,12 @@ components:
           - If you need an interruptible greeting, do not use this option; prompt the model to greet naturally as part of the normal dialogue.
 
         Availability:
-          - Supported for LiveKit agents and Ultravox WebRTC agents (model names prefixed `livekit:` and `ultravox:`).
-          - No-op on Jambonz telephony agents.
+          - Supported for LiveKit agents (`livekit:` model names) on all stacks.
+          - Supported for native Ultravox agents (`ultravox:` model names) on every medium —
+            WebRTC, WebSocket, and jambonz-routed telephony — applied provider-side via Ultravox
+            `firstSpeakerSettings`. A caller-supplied `vendorSpecific.ultravox.firstSpeakerSettings`
+            takes precedence over this option, as does `options.firstSpeaker: 'user'`.
+          - No-op on Jambonz pipeline telephony agents (non-Ultravox models routed via Jambonz).
 
         Note for LiveKit OpenAI realtime (`livekit:openai/...`):
           - Even with `text`, speech is produced through the realtime model; treat it as best-effort verbatim, not a guaranteed "speak exactly these characters" primitive.

--- a/docs/ultravox-vendor-specific-options.md
+++ b/docs/ultravox-vendor-specific-options.md
@@ -1,6 +1,6 @@
 # Ultravox vendor-specific agent options
 
-This document describes how to configure **Ultravox-only** settings for agents that use the LiveKit Ultravox integration, via `options.vendorSpecific.ultravox`. Values are passed through to Ultravox when creating a call (see the [Ultravox Create Call API](https://docs.ultravox.ai/api-reference/calls/calls-post)).
+This document describes how to configure **Ultravox-only** settings for Ultravox-backed agents — both the LiveKit Ultravox integration (`livekit:ultravox/...` models) and native Ultravox agents (`ultravox:` prefixed models) — via `options.vendorSpecific.ultravox`. Values are passed through to Ultravox when creating a call (see the [Ultravox Create Call API](https://docs.ultravox.ai/api-reference/calls/calls-post)).
 
 ---
 
@@ -12,7 +12,7 @@ This document describes how to configure **Ultravox-only** settings for agents t
 
 - **Portability.** Relying on vendor blocks makes an agent **non-portable** in practice: you are encoding assumptions about one provider’s API and lifecycle, not about Aplisay’s stable agent contract.
 
-- **Cross-platform behaviour.** On stacks that are not Ultravox-backed LiveKit, `vendorSpecific` is generally **ignored**—so the same agent JSON may still “run” elsewhere. That is **not** the same as behaving the same. If **important** behaviour (for example a fixed welcome line encoded only in `firstSpeakerSettings`, turn-taking tuned only via `vadSettings`, or silence handling only via `inactivityMessages`) lives exclusively in these options, **other models or handlers will not reproduce it**, because those options are not applied there. Prefer putting durable behaviour in the **prompt**, **standard agent options**, and **tools** that every platform you care about supports.
+- **Cross-platform behaviour.** On stacks that are not Ultravox-backed, `vendorSpecific` is generally **ignored**—so the same agent JSON may still “run” elsewhere. That is **not** the same as behaving the same. If **important** behaviour (for example a fixed welcome line encoded only in `firstSpeakerSettings`, turn-taking tuned only via `vadSettings`, or silence handling only via `inactivityMessages`) lives exclusively in these options, **other models or handlers will not reproduce it**, because those options are not applied there. Prefer putting durable behaviour in the **prompt**, **standard agent options**, and **tools** that every platform you care about supports.
 
 Use vendor-specific knobs when you understand the trade-offs and accept that they may need revisiting whenever Ultravox or our integration changes.
 
@@ -20,7 +20,7 @@ Use vendor-specific knobs when you understand the trade-offs and accept that the
 
 ## Overview
 
-The `vendorSpecific` object on agent `options` is an opaque pass-through for provider-specific configuration. For LiveKit Ultravox agents, the worker forwards `vendorSpecific.ultravox` into the Ultravox realtime plugin, which merges supported keys into the Ultravox `POST /api/calls` body.
+The `vendorSpecific` object on agent `options` is an opaque pass-through for provider-specific configuration. For LiveKit Ultravox agents, the worker forwards `vendorSpecific.ultravox` into the Ultravox realtime plugin, which merges supported keys into the Ultravox `POST /api/calls` body. Native Ultravox agents (`ultravox:` prefixed models) forward the same whitelist of keys directly from the model driver, on every medium (WebRTC, WebSocket, and jambonz-routed telephony).
 
 Supported keys today include (non-exhaustive; see implementation and Ultravox docs):
 

--- a/docs/uninterruptible-greetings.md
+++ b/docs/uninterruptible-greetings.md
@@ -49,7 +49,7 @@ Recommendations:
 
 ## Behaviour quirks by model stack
 
-This feature is only available the through the Livekit, an ultravox pipeline agents (all `livekit:` handler prefixed models, and Ultravox `ultravox:` prefixed WebRTC models only). It is a no-op on Jambonz telephony agents.
+This feature is available on all `livekit:` handler prefixed models, and on native Ultravox agents (`ultravox:` prefixed models) on every medium — WebRTC, WebSocket, and jambonz-routed telephony — where it is applied provider-side by mapping the greeting to Ultravox `firstSpeakerSettings` (a caller-supplied `vendorSpecific.ultravox.firstSpeakerSettings` takes precedence, as does `options.firstSpeaker: 'user'`). It is a no-op on Jambonz pipeline telephony agents (non-Ultravox models routed via Jambonz).
 
 Within that group of implementations, most models (Ultravox, plus all pipeline agents) should reasonably reliably output an `options.greeting.text` verbatim. The only exception is...
 

--- a/lib/handlers/ultravox.js
+++ b/lib/handlers/ultravox.js
@@ -110,7 +110,10 @@ class Ultravox extends Handler {
             clientBufferSizeMs: 60
           }
         },
-        firstSpeaker,
+        // Ultravox rejects a request carrying both the legacy `firstSpeaker` enum and
+        // `firstSpeakerSettings` (set by the model driver for `options.greeting` or
+        // vendorSpecific pass-through), so only send the enum when no settings exist.
+        ...(modelData.firstSpeakerSettings ? {} : { firstSpeaker }),
         recordingEnabled: true
       });
       let {

--- a/lib/models/ultravox.js
+++ b/lib/models/ultravox.js
@@ -265,6 +265,31 @@ class Ultravox extends Llm {
   }
 
   /**
+   * Parse `options.inactivity.timeout` into seconds: a number of seconds or a
+   * duration string like `"8s"` — the same convention as the LiveKit worker's
+   * `inactivityAwayTimeoutSecs`. Returns undefined when the block is absent or
+   * malformed (no usable timeout, or no non-empty message), in which case no
+   * inactivityMessages are sent and behaviour is unchanged.
+   *
+   * @static
+   * @memberof Ultravox
+   */
+  static inactivityTimeoutSecs(inactivity) {
+    if (!inactivity || typeof inactivity !== 'object') return undefined;
+    let { timeout, message } = inactivity;
+    if (typeof message !== 'string' || !message.trim()) return undefined;
+    let secs;
+    if (typeof timeout === 'number' && isFinite(timeout)) {
+      secs = timeout;
+    }
+    else if (typeof timeout === 'string') {
+      let m = timeout.trim().match(/^(\d+(?:\.\d+)?)s?$/);
+      m && (secs = parseFloat(m[1]));
+    }
+    return secs > 0 ? secs : undefined;
+  }
+
+  /**
    * Get the model data for the LLM. This model instantiation data in a form which can be used
    * to instantiate an agent in thier `call` rest endpoint.
    *
@@ -273,7 +298,7 @@ class Ultravox extends Llm {
    */
   get modelData() {
     let { _prompt: systemPrompt, _options, logger, tools, gpt: { model }} = this;
-    let { temperature, voice, maxDuration, timeExceededMessage } = _options || {};
+    let { temperature, voice, maxDuration, timeExceededMessage, greeting, inactivity, firstSpeaker, vendorSpecific } = _options || {};
     let data = {
       model: model.replace(/^.*\//, ''),
       maxDuration: maxDuration || '305s',
@@ -284,6 +309,40 @@ class Ultravox extends Llm {
       voice,
       transcriptOptional: false,
     };
+
+    // Provider-native pass-through: same whitelist as the LiveKit Ultravox plugin.
+    let uv = vendorSpecific?.ultravox || {};
+    uv.experimentalSettings && (data.experimentalSettings = uv.experimentalSettings);
+    uv.vadSettings && (data.vadSettings = uv.vadSettings);
+    Array.isArray(uv.inactivityMessages) && uv.inactivityMessages.length && (data.inactivityMessages = uv.inactivityMessages);
+    uv.firstSpeakerSettings && (data.firstSpeakerSettings = uv.firstSpeakerSettings);
+
+    // Portable `options.greeting` → firstSpeakerSettings, mirroring the LiveKit
+    // session factory: exactly one of text|instructions, always uninterruptible.
+    // Caller-supplied native firstSpeakerSettings win, as does an explicit
+    // `firstSpeaker: 'user'` (websocket callers dialling into another agent).
+    let greetingText = greeting?.text?.trim() || '';
+    let greetingInstructions = greeting?.instructions?.trim() || '';
+    let userFirst = ['user', 'first_speaker_user'].includes(String(firstSpeaker ?? '').toLowerCase());
+    if (!data.firstSpeakerSettings && !userFirst && (!!greetingText !== !!greetingInstructions)) {
+      data.firstSpeakerSettings = {
+        agent: greetingText
+          ? { uninterruptible: true, text: greetingText }
+          : { uninterruptible: true, prompt: greetingInstructions }
+      };
+    }
+
+    // Portable `options.inactivity` → provider-native inactivityMessages.
+    // Ultravox fires each entry once, in sequence, after `duration` of further
+    // user inactivity — a short run of identical entries gives the "re-fire on
+    // each further timeout of continued silence" behaviour (up to 3 nudges).
+    // endBehavior left default: never hang up. Native entries above win.
+    let inactivitySecs = Ultravox.inactivityTimeoutSecs(inactivity);
+    if (!data.inactivityMessages && inactivitySecs) {
+      let entry = { duration: `${inactivitySecs}s`, message: inactivity.message.trim() };
+      data.inactivityMessages = [entry, entry, entry];
+    }
+
     logger.debug({ data }, 'Getting Ultravox data');
     return data;
   }

--- a/tests/ultravox-native-options.test.mjs
+++ b/tests/ultravox-native-options.test.mjs
@@ -1,0 +1,152 @@
+import Ultravox from '../lib/models/ultravox.js';
+
+/**
+ * Unit tests for the native Ultravox driver's option mapping (lib/models/ultravox.js):
+ * portable `options.greeting` → firstSpeakerSettings, portable `options.inactivity`
+ * → inactivityMessages, and the vendorSpecific.ultravox pass-through whitelist.
+ * These are the options applied to the Ultravox `POST /calls` body for
+ * `ultravox:`-prefixed agents on every medium (WebRTC, WebSocket, jambonz telephony).
+ */
+
+const mockLogger = {
+  info: () => {},
+  error: () => {},
+  warn: () => {},
+  debug: () => {},
+  child: () => mockLogger,
+};
+
+const makeModel = (options = {}) =>
+  new Ultravox({
+    logger: mockLogger,
+    user: 'test-user',
+    prompt: 'You are a test agent.',
+    options,
+    modelName: 'ultravox:ultravox/ultravox-v0.6',
+  });
+
+describe('Ultravox native driver option mapping', () => {
+  describe('baseline', () => {
+    test('no options produces defaults and no greeting/inactivity settings', () => {
+      const data = makeModel().modelData;
+      expect(data.model).toBe('ultravox-v0.6');
+      expect(data.maxDuration).toBe('305s');
+      expect(data.timeExceededMessage).toMatch(/great chatting/);
+      expect(data.firstSpeakerSettings).toBeUndefined();
+      expect(data.inactivityMessages).toBeUndefined();
+      expect(data.vadSettings).toBeUndefined();
+      expect(data.experimentalSettings).toBeUndefined();
+    });
+
+    test('custom maxDuration and timeExceededMessage pass through', () => {
+      const data = makeModel({
+        maxDuration: '120s',
+        timeExceededMessage: 'Time is up, goodbye!',
+      }).modelData;
+      expect(data.maxDuration).toBe('120s');
+      expect(data.timeExceededMessage).toBe('Time is up, goodbye!');
+    });
+  });
+
+  describe('options.greeting → firstSpeakerSettings', () => {
+    test('greeting.text maps to an uninterruptible agent text', () => {
+      const data = makeModel({ greeting: { text: 'Hello, how can I help?' } }).modelData;
+      expect(data.firstSpeakerSettings).toEqual({
+        agent: { uninterruptible: true, text: 'Hello, how can I help?' },
+      });
+    });
+
+    test('greeting.instructions maps to an uninterruptible agent prompt', () => {
+      const data = makeModel({ greeting: { instructions: 'Greet the caller briefly.' } }).modelData;
+      expect(data.firstSpeakerSettings).toEqual({
+        agent: { uninterruptible: true, prompt: 'Greet the caller briefly.' },
+      });
+    });
+
+    test('whitespace-only greeting is ignored', () => {
+      const data = makeModel({ greeting: { text: '   ' } }).modelData;
+      expect(data.firstSpeakerSettings).toBeUndefined();
+    });
+
+    test('invalid greeting with both text and instructions is not mapped', () => {
+      const data = makeModel({
+        greeting: { text: 'Hello', instructions: 'Say hello' },
+      }).modelData;
+      expect(data.firstSpeakerSettings).toBeUndefined();
+    });
+
+    test('explicit firstSpeaker user suppresses the greeting mapping', () => {
+      const data = makeModel({
+        firstSpeaker: 'user',
+        greeting: { text: 'Hello, how can I help?' },
+      }).modelData;
+      expect(data.firstSpeakerSettings).toBeUndefined();
+    });
+
+    test('caller-supplied vendorSpecific firstSpeakerSettings win over greeting', () => {
+      const native = { agent: { text: 'Native greeting' } };
+      const data = makeModel({
+        greeting: { text: 'Portable greeting' },
+        vendorSpecific: { ultravox: { firstSpeakerSettings: native } },
+      }).modelData;
+      expect(data.firstSpeakerSettings).toBe(native);
+    });
+  });
+
+  describe('options.inactivity → inactivityMessages', () => {
+    test('duration-string timeout maps to three repeated nudges with no hang-up', () => {
+      const data = makeModel({
+        inactivity: { timeout: '30s', message: 'Are you still there?' },
+      }).modelData;
+      expect(data.inactivityMessages).toEqual([
+        { duration: '30s', message: 'Are you still there?' },
+        { duration: '30s', message: 'Are you still there?' },
+        { duration: '30s', message: 'Are you still there?' },
+      ]);
+      expect(data.inactivityMessages.every((m) => m.endBehavior === undefined)).toBe(true);
+    });
+
+    test('numeric timeout is converted to a duration string', () => {
+      const data = makeModel({
+        inactivity: { timeout: 20, message: 'Hello?' },
+      }).modelData;
+      expect(data.inactivityMessages[0]).toEqual({ duration: '20s', message: 'Hello?' });
+    });
+
+    test('malformed inactivity blocks are ignored', () => {
+      expect(makeModel({ inactivity: { timeout: '30s', message: '  ' } }).modelData.inactivityMessages).toBeUndefined();
+      expect(makeModel({ inactivity: { timeout: 0, message: 'Hello?' } }).modelData.inactivityMessages).toBeUndefined();
+      expect(makeModel({ inactivity: { message: 'Hello?' } }).modelData.inactivityMessages).toBeUndefined();
+      expect(makeModel({ inactivity: { timeout: 'soon', message: 'Hello?' } }).modelData.inactivityMessages).toBeUndefined();
+    });
+
+    test('caller-supplied vendorSpecific inactivityMessages win over portable inactivity', () => {
+      const native = [{ duration: '45s', message: 'Native nudge', endBehavior: 'END_BEHAVIOR_HANG_UP_SOFT' }];
+      const data = makeModel({
+        inactivity: { timeout: '30s', message: 'Portable nudge' },
+        vendorSpecific: { ultravox: { inactivityMessages: native } },
+      }).modelData;
+      expect(data.inactivityMessages).toBe(native);
+    });
+  });
+
+  describe('vendorSpecific.ultravox pass-through', () => {
+    test('vadSettings and experimentalSettings are forwarded', () => {
+      const vadSettings = { turnEndpointDelay: '0.5s' };
+      const experimentalSettings = { transcriptionProvider: 'deepgram-nova-3' };
+      const data = makeModel({
+        vendorSpecific: { ultravox: { vadSettings, experimentalSettings } },
+      }).modelData;
+      expect(data.vadSettings).toBe(vadSettings);
+      expect(data.experimentalSettings).toBe(experimentalSettings);
+    });
+
+    test('unlisted vendorSpecific keys are not forwarded', () => {
+      const data = makeModel({
+        vendorSpecific: { ultravox: { recordingEnabled: false, model: 'evil-override' } },
+      }).modelData;
+      expect(data.recordingEnabled).toBeUndefined();
+      expect(data.model).toBe('ultravox-v0.6');
+    });
+  });
+});


### PR DESCRIPTION
<!-- No tracking issue: customer-reported defect, PR raised directly. -->

## What changed
- The native `ultravox:` driver now maps portable `options.greeting` → Ultravox `firstSpeakerSettings` (`uninterruptible: true`, `text` | `prompt`) and `options.inactivity` → `inactivityMessages` (three repeated nudges, never hang up), and forwards the `vendorSpecific.ultravox` whitelist (`firstSpeakerSettings`, `inactivityMessages`, `vadSettings`, `experimentalSettings`) — mirroring `agents/livekit/lib/voice-session-factory.ts`. Caller-supplied native settings win over the portable mappings; an explicit `firstSpeaker: 'user'` (websocket callers dialling another agent) still suppresses the greeting; `join()` no longer sends the legacy `firstSpeaker` enum alongside `firstSpeakerSettings` (Ultravox rejects the combination).
- Docs aligned with implemented behaviour: `api/api-doc.yaml` (`AgentGreeting` availability, `inactivity` description), `docs/uninterruptible-greetings.md`, `docs/ultravox-vendor-specific-options.md`.
- LiveKit runtime: the `say()`/`generateReply` greeting fallback is now skipped entirely for Ultravox realtime — it was inert (no TTS to `say()` with; the plugin never sends `response.create`), and the factory's `firstSpeakerSettings` mapping is the single real path.

## Why
Customer-reported: uninterruptible greetings and inactivity messages work on `livekit:ultravox` phone calls but not on native Ultravox WebRTC web calls. Root cause: `lib/models/ultravox.js` `modelData` only ever forwarded `maxDuration`/`timeExceededMessage`, while the public API schema and `docs/uninterruptible-greetings.md` claimed `ultravox:` WebRTC greeting support. This closes the contract gap on every native-Ultravox medium (WebRTC, WebSocket, jambonz-routed telephony).

## Lane(s) / files touched
`lib/models/ultravox.js`, `lib/handlers/ultravox.js` (**hot: `lib/handlers/*`**), `api/api-doc.yaml` (**hot**), `agents/livekit/lib/voice-agent-runtime.ts`, `tests/ultravox-native-options.test.mjs` (new), two `docs/*.md`.

## How verified
```
cd agents/livekit && yarn build   # configured verify gate — passes (tsup build success)
yarn test:no-db                   # Test Suites: 1 skipped, 54 passed, 54 of 55 total
                                  # Tests: 2 skipped, 502 passed, 504 total
```
Includes new `tests/ultravox-native-options.test.mjs`: 14 tests over the greeting/inactivity/vendorSpecific mapping and precedence rules (native-wins, `firstSpeaker: 'user'` suppression, malformed-block no-ops, whitelist containment).

## Checklist
- [x] The repo's configured verify check passes locally
- [x] No temporary scaffolding/debug code left behind
- [x] Public API changes are reflected in `api/api-doc.yaml`
- [x] Follows the conventions in docs/CONTEXT.md
- [x] Rebased on the latest `next` (branched from `ed69955`)
