### PR TITLE
livekit: honour custom timeExceededMessage on Ultravox realtime calls

### DIFF
--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -92,6 +92,12 @@ export interface Agent {
      */
     maxDuration?: string;
     /**
+     * Message the agent delivers when `maxDuration` is reached. Only consumed
+     * by providers with a native wind-down message (Ultravox); other realtime
+     * providers use the worker hard-stop with a generic prompt instead.
+     */
+    timeExceededMessage?: string;
+    /**
      * Inter-digit DTMF timeout in milliseconds. Buffered DTMF digits are flushed
      * to the LLM after this period of keypad silence. Defaults to 1500ms.
      * Set to 0 to flush each digit individually (no buffering delay).

--- a/agents/livekit/lib/voice-session-factory.ts
+++ b/agents/livekit/lib/voice-session-factory.ts
@@ -165,6 +165,107 @@ class PipelineVoiceAgent extends voice.Agent {
   }
 }
 
+/**
+ * Build the RealtimeModel constructor options for a `livekit:<plugin>/...` model.
+ *
+ * Exported for unit tests: this is where portable agent options are translated
+ * into provider-native ones (Ultravox firstSpeakerSettings / inactivityMessages,
+ * maxDuration / timeExceededMessage), so the mapping and its precedence rules
+ * are testable without constructing plugin models or an AgentSession.
+ */
+export function buildRealtimeLlmOptions(
+  modelName: string,
+  agent: Agent,
+  callId: string,
+): Record<string, unknown> {
+  const providerModelName = parseProviderModelName(modelName);
+  const maxDurationString: string = agent?.options?.maxDuration || "305s";
+  const llmOptions: Record<string, unknown> = {
+    voice: agent?.options?.tts?.voice,
+    maxDuration: maxDurationString,
+    // Only the Ultravox plugin consumes timeExceededMessage — its native
+    // wind-down line at maxDuration (empty ⇒ plugin default, matching the
+    // native ultravox: driver). Other realtime providers ignore it and are
+    // wound down by the worker hard-stop with a generic prompt instead
+    // (voice-agent-runtime.ts; see api-doc.yaml `timeExceededMessage`).
+    timeExceededMessage: agent?.options?.timeExceededMessage || undefined,
+    instructions: agent?.prompt || "You are a helpful assistant.",
+    callId,
+  };
+  if (providerModelName) {
+    llmOptions.model = providerModelName;
+  }
+  const vendorSpecific = (agent?.options?.vendorSpecific ||
+    undefined) as Record<string, any> | undefined;
+
+  // Ultravox realtime: map portable `options.greeting` → provider-native firstSpeakerSettings
+  // so the greeting actually happens at call start (Ultravox doesn't support response.create).
+  if (modelName.includes("livekit:ultravox/")) {
+    const greetingText = agent?.options?.greeting?.text?.trim() || "";
+    const greetingInstructions = agent?.options?.greeting?.instructions?.trim() || "";
+    const hasGreeting = Boolean(greetingText) || Boolean(greetingInstructions);
+
+    const existingFirstSpeaker =
+      vendorSpecific?.ultravox?.firstSpeakerSettings?.agent?.text ||
+      vendorSpecific?.ultravox?.firstSpeakerSettings?.agent?.prompt ||
+      vendorSpecific?.ultravox?.firstSpeakerSettings?.user;
+
+    if (hasGreeting && !existingFirstSpeaker) {
+      llmOptions.vendorSpecific = {
+        ...(vendorSpecific || {}),
+        ultravox: {
+          ...(vendorSpecific?.ultravox || {}),
+          firstSpeakerSettings: {
+            agent: greetingText
+              ? { uninterruptible: true, text: greetingText }
+              : { uninterruptible: true, prompt: greetingInstructions },
+          },
+        },
+      };
+    } else if (vendorSpecific) {
+      llmOptions.vendorSpecific = vendorSpecific;
+    }
+  } else if (vendorSpecific) {
+    llmOptions.vendorSpecific = vendorSpecific;
+  }
+
+  // Ultravox realtime: map portable `options.inactivity` → provider-native
+  // `inactivityMessages` so Ultravox itself does the idle detection and speaks
+  // the phrase in-model. Ultravox is speech-to-speech with no separate TTS, so
+  // the JS-side say()/generateReply kick is unreliable for it; the generic SDK
+  // user-away kick (voice-agent-runtime.ts) is gated to NON-ultravox models, and
+  // the Ultravox session omits `userAwayTimeout`. A native
+  // `vendorSpecific.ultravox.inactivityMessages` supplied by the caller wins.
+  if (modelName.includes("livekit:ultravox/")) {
+    const inactivitySecs = inactivityAwayTimeoutSecs(agent);
+    const inactivityMsg =
+      typeof agent?.options?.inactivity?.message === "string"
+        ? agent.options.inactivity.message.trim()
+        : "";
+    const base =
+      (llmOptions.vendorSpecific as Record<string, any> | undefined) ||
+      vendorSpecific ||
+      undefined;
+    const alreadyNative = (base as any)?.ultravox?.inactivityMessages;
+    if (inactivitySecs !== undefined && inactivityMsg && !alreadyNative) {
+      // Ultravox fires each entry once, in sequence, after `duration` of further
+      // user inactivity — so a short run of identical entries gives the
+      // "re-fire every `timeout` of continued silence" behaviour (here up to 3
+      // nudges). endBehavior left default: do NOT hang up after the last one.
+      const entry = { duration: `${inactivitySecs}s`, message: inactivityMsg };
+      llmOptions.vendorSpecific = {
+        ...(base || {}),
+        ultravox: {
+          ...((base && base.ultravox) || {}),
+          inactivityMessages: [entry, entry, entry],
+        },
+      };
+    }
+  }
+
+  return llmOptions;
+}
+
 export interface CreateVoiceModelAndSessionParams {
   voiceMode: VoiceMode;
   modelName: string;
@@ -240,88 +341,14 @@ export function createVoiceModelAndSession(
     );
   }
 
-  const providerModelName = parseProviderModelName(modelName);
-  const maxDurationString: string = agent?.options?.maxDuration || "305s";
-  const llmOptions: Record<string, unknown> = {
-    voice: agent?.options?.tts?.voice,
-    maxDuration: maxDurationString,
-    instructions: agent?.prompt || "You are a helpful assistant.",
-    callId: call.id,
-  };
-  if (providerModelName) {
-    llmOptions.model = providerModelName;
-  }
-  const vendorSpecific = (agent?.options?.vendorSpecific ||
-    undefined) as Record<string, any> | undefined;
+  const llmOptions = buildRealtimeLlmOptions(modelName, agent, call.id);
 
-  // Ultravox realtime: map portable `options.greeting` → provider-native firstSpeakerSettings
-  // so the greeting actually happens at call start (Ultravox doesn't support response.create).
-  if (modelName.includes("livekit:ultravox/")) {
-    const greetingText = agent?.options?.greeting?.text?.trim() || "";
-    const greetingInstructions = agent?.options?.greeting?.instructions?.trim() || "";
-    const hasGreeting = Boolean(greetingText) || Boolean(greetingInstructions);
-
-    const existingFirstSpeaker =
-      vendorSpecific?.ultravox?.firstSpeakerSettings?.agent?.text ||
-      vendorSpecific?.ultravox?.firstSpeakerSettings?.agent?.prompt ||
-      vendorSpecific?.ultravox?.firstSpeakerSettings?.user;
-
-    if (hasGreeting && !existingFirstSpeaker) {
-      llmOptions.vendorSpecific = {
-        ...(vendorSpecific || {}),
-        ultravox: {
-          ...(vendorSpecific?.ultravox || {}),
-          firstSpeakerSettings: {
-            agent: greetingText
-              ? { uninterruptible: true, text: greetingText }
-              : { uninterruptible: true, prompt: greetingInstructions },
-          },
-        },
-      };
-    } else if (vendorSpecific) {
-      llmOptions.vendorSpecific = vendorSpecific;
-    }
-  } else if (vendorSpecific) {
-    llmOptions.vendorSpecific = vendorSpecific;
-  }
-
-  // Ultravox realtime: map portable `options.inactivity` → provider-native
-  // `inactivityMessages` so Ultravox itself does the idle detection and speaks
-  // the phrase in-model. Ultravox is speech-to-speech with no separate TTS, so
-  // the JS-side say()/generateReply kick is unreliable for it; the generic SDK
-  // user-away kick (voice-agent-runtime.ts) is gated to NON-ultravox models, and
-  // we omit `userAwayTimeout` on the Ultravox session below. A native
-  // `vendorSpecific.ultravox.inactivityMessages` supplied by the caller wins.
-  const isUltravox = modelName.includes("livekit:ultravox/");
-  if (isUltravox) {
-    const inactivitySecs = inactivityAwayTimeoutSecs(agent);
-    const inactivityMsg =
-      typeof agent?.options?.inactivity?.message === "string"
-        ? agent.options.inactivity.message.trim()
-        : "";
-    const base =
-      (llmOptions.vendorSpecific as Record<string, any> | undefined) ||
-      vendorSpecific ||
-      undefined;
-    const alreadyNative = (base as any)?.ultravox?.inactivityMessages;
-    if (inactivitySecs !== undefined && inactivityMsg && !alreadyNative) {
-      // Ultravox fires each entry once, in sequence, after `duration` of further
-      // user inactivity — so a short run of identical entries gives the
-      // "re-fire every `timeout` of continued silence" behaviour (here up to 3
-      // nudges). endBehavior left default: do NOT hang up after the last one.
-      const entry = { duration: `${inactivitySecs}s`, message: inactivityMsg };
-      llmOptions.vendorSpecific = {
-        ...(base || {}),
-        ultravox: {
-          ...((base && base.ultravox) || {}),
-          inactivityMessages: [entry, entry, entry],
-        },
-      };
-    }
-  }
-  // Ultravox does idle natively (above); only NON-ultravox realtime uses the
-  // SDK user-away timer + say()/generateReply kick.
-  const realtimeInactivityVoiceOptions = isUltravox ? {} : inactivityVoiceOptions;
+  // Ultravox does idle natively (mapped to provider inactivityMessages in
+  // buildRealtimeLlmOptions); only NON-ultravox realtime uses the SDK
+  // user-away timer + say()/generateReply kick.
+  const realtimeInactivityVoiceOptions = modelName.includes("livekit:ultravox/")
+    ? {}
+    : inactivityVoiceOptions;
 
   const session = new voice.AgentSession({
     llm: new realtime.RealtimeModel(llmOptions),

--- a/agents/livekit/test/voice-session-factory.test.ts
+++ b/agents/livekit/test/voice-session-factory.test.ts
@@ -1,0 +1,140 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildRealtimeLlmOptions } from "../lib/voice-session-factory.js";
+
+// Covers the portable-option → RealtimeModel options mapping for realtime models:
+// maxDuration/timeExceededMessage passthrough and the Ultravox-specific
+// greeting/inactivity → vendorSpecific translations with their precedence rules.
+// run: node --import tsx --test test/voice-session-factory.test.ts
+
+const ULTRAVOX = "livekit:ultravox/ultravox-v0.7";
+const OPENAI = "livekit:openai/gpt-4o-realtime";
+
+const makeAgent = (options: Record<string, unknown> = {}) =>
+  ({ prompt: "You are a test agent.", options }) as any;
+
+test("basic shape: model, voice, instructions, callId and defaults", () => {
+  const opts = buildRealtimeLlmOptions(ULTRAVOX, makeAgent({ tts: { voice: "Mark" } }), "call-1");
+  assert.equal(opts.model, "ultravox-v0.7");
+  assert.equal(opts.voice, "Mark");
+  assert.equal(opts.instructions, "You are a test agent.");
+  assert.equal(opts.callId, "call-1");
+  assert.equal(opts.maxDuration, "305s");
+  assert.equal(opts.timeExceededMessage, undefined);
+  assert.equal(opts.vendorSpecific, undefined);
+});
+
+test("custom maxDuration and timeExceededMessage pass through to the plugin", () => {
+  const opts = buildRealtimeLlmOptions(
+    ULTRAVOX,
+    makeAgent({ maxDuration: "120s", timeExceededMessage: "Time is up, goodbye!" }),
+    "call-1",
+  );
+  assert.equal(opts.maxDuration, "120s");
+  assert.equal(opts.timeExceededMessage, "Time is up, goodbye!");
+});
+
+test("empty timeExceededMessage falls back to the plugin default (undefined)", () => {
+  const opts = buildRealtimeLlmOptions(ULTRAVOX, makeAgent({ timeExceededMessage: "" }), "call-1");
+  assert.equal(opts.timeExceededMessage, undefined);
+});
+
+test("timeExceededMessage is passed for non-ultravox realtime too (ignored there)", () => {
+  const opts = buildRealtimeLlmOptions(
+    OPENAI,
+    makeAgent({ timeExceededMessage: "Time is up!" }),
+    "call-1",
+  );
+  assert.equal(opts.timeExceededMessage, "Time is up!");
+});
+
+test("ultravox: portable greeting.text maps to uninterruptible firstSpeakerSettings", () => {
+  const opts = buildRealtimeLlmOptions(
+    ULTRAVOX,
+    makeAgent({ greeting: { text: "Hello, how can I help?" } }),
+    "call-1",
+  ) as any;
+  assert.deepEqual(opts.vendorSpecific.ultravox.firstSpeakerSettings, {
+    agent: { uninterruptible: true, text: "Hello, how can I help?" },
+  });
+});
+
+test("ultravox: portable greeting.instructions maps to an uninterruptible prompt", () => {
+  const opts = buildRealtimeLlmOptions(
+    ULTRAVOX,
+    makeAgent({ greeting: { instructions: "Greet the caller briefly." } }),
+    "call-1",
+  ) as any;
+  assert.deepEqual(opts.vendorSpecific.ultravox.firstSpeakerSettings, {
+    agent: { uninterruptible: true, prompt: "Greet the caller briefly." },
+  });
+});
+
+test("ultravox: caller-supplied firstSpeakerSettings win over the portable greeting", () => {
+  const native = { agent: { text: "Native greeting" } };
+  const opts = buildRealtimeLlmOptions(
+    ULTRAVOX,
+    makeAgent({
+      greeting: { text: "Portable greeting" },
+      vendorSpecific: { ultravox: { firstSpeakerSettings: native } },
+    }),
+    "call-1",
+  ) as any;
+  assert.deepEqual(opts.vendorSpecific.ultravox.firstSpeakerSettings, native);
+});
+
+test("ultravox: portable inactivity maps to three repeated inactivityMessages", () => {
+  const opts = buildRealtimeLlmOptions(
+    ULTRAVOX,
+    makeAgent({ inactivity: { timeout: "30s", message: "Are you still there?" } }),
+    "call-1",
+  ) as any;
+  const entry = { duration: "30s", message: "Are you still there?" };
+  assert.deepEqual(opts.vendorSpecific.ultravox.inactivityMessages, [entry, entry, entry]);
+});
+
+test("ultravox: caller-supplied inactivityMessages win over portable inactivity", () => {
+  const native = [{ duration: "45s", message: "Native nudge" }];
+  const opts = buildRealtimeLlmOptions(
+    ULTRAVOX,
+    makeAgent({
+      inactivity: { timeout: "30s", message: "Portable nudge" },
+      vendorSpecific: { ultravox: { inactivityMessages: native } },
+    }),
+    "call-1",
+  ) as any;
+  assert.deepEqual(opts.vendorSpecific.ultravox.inactivityMessages, native);
+});
+
+test("ultravox: greeting and inactivity merge into one vendorSpecific block", () => {
+  const opts = buildRealtimeLlmOptions(
+    ULTRAVOX,
+    makeAgent({
+      greeting: { text: "Hello!" },
+      inactivity: { timeout: 20, message: "Hello?" },
+    }),
+    "call-1",
+  ) as any;
+  assert.deepEqual(opts.vendorSpecific.ultravox.firstSpeakerSettings, {
+    agent: { uninterruptible: true, text: "Hello!" },
+  });
+  assert.deepEqual(opts.vendorSpecific.ultravox.inactivityMessages[0], {
+    duration: "20s",
+    message: "Hello?",
+  });
+});
+
+test("non-ultravox: greeting/inactivity are not mapped, vendorSpecific passes through verbatim", () => {
+  const vendorSpecific = { openai: { something: true } };
+  const opts = buildRealtimeLlmOptions(
+    OPENAI,
+    makeAgent({
+      greeting: { text: "Hello!" },
+      inactivity: { timeout: "30s", message: "Hello?" },
+      vendorSpecific,
+    }),
+    "call-1",
+  ) as any;
+  assert.equal(opts.vendorSpecific, vendorSpecific);
+  assert.equal(opts.vendorSpecific.ultravox, undefined);
+});


### PR DESCRIPTION
<!-- No tracking issue: customer-reported defect, PR raised directly. Follow-up to #166. -->

## What changed
- `agents/livekit/lib/voice-session-factory.ts` now forwards `agent.options.timeExceededMessage` into the realtime `llmOptions` (empty ⇒ `undefined` so the plugin default applies, matching the native `ultravox:` driver's `|| default` semantics). Only the Ultravox plugin consumes it — its native wind-down line at `maxDuration`; OpenAI/Google realtime ignore the key and keep being wound down by the worker hard-stop with its generic prompt (`voice-agent-runtime.ts:2162-2199`), exactly as `api/api-doc.yaml` documents.
- The realtime `llmOptions` assembly (including the `options.greeting` → `firstSpeakerSettings` and `options.inactivity` → `inactivityMessages` mappings from #166's counterpart factory code) is extracted into an exported pure function `buildRealtimeLlmOptions(modelName, agent, callId)` so the mapping and its precedence rules are unit-testable without constructing plugin models or an `AgentSession`. No behaviour change beyond the new passthrough.
- `timeExceededMessage?: string` declared on the `Agent` options type in `agents/livekit/lib/api-client.ts`.
- New `agents/livekit/test/voice-session-factory.test.ts` (node:test): 11 tests covering the `timeExceededMessage` passthrough (custom / unset / empty / non-Ultravox), `maxDuration`, and regression cover for the Ultravox greeting/inactivity/vendorSpecific mappings and native-wins precedence.

## Why
Customer-reported: the custom time-limit message plays on `ultravox:` native WebRTC calls but never on `livekit:ultravox` calls (phone via LiveKit SIP, or LiveKit WebRTC) — callers get the canned "It has been great chatting with you, but we have exceeded our time now." instead. Root cause: the factory forwarded `maxDuration` but not `timeExceededMessage`, so `agents/livekit/plugins/ultravox/src/realtime/realtime_model.ts` always fell back to its constructor default in the Ultravox `POST /calls` body. The public API contract (`api/api-doc.yaml` `timeExceededMessage`) explicitly promises the custom message is honoured for Ultravox. Companion fix to #166 (which fixed the same customer's greeting/inactivity gap on the native path).

## Lane(s) / files touched
`agents/livekit/lib/voice-session-factory.ts`, `agents/livekit/lib/api-client.ts`, `agents/livekit/test/voice-session-factory.test.ts` (new). No hot shared files; no public API surface change (`api-doc.yaml` already documents the promised behaviour — this makes it true).

## How verified
```
cd agents/livekit && yarn build          # configured verify gate — passes (tsup build success)
node --import tsx --test test/*.test.ts  # 44 tests, 44 pass, 0 fail (incl. 11 new)
yarn test:no-db                          # root suite against the rebuilt worker dist — green
```
`npx tsc --noEmit` reports only three pre-existing errors in `usage-meter.ts` / `voice-agent-runtime.ts` (UsageVendors casts, already on `next`); nothing in the files touched here.

## Checklist
- [x] The repo's configured verify check passes locally
- [x] No temporary scaffolding/debug code left behind
- [x] Public API changes are reflected in `api/api-doc.yaml` (n/a — implements already-documented behaviour)
- [x] Follows the conventions in docs/CONTEXT.md
- [x] Rebased on the latest `next` (branched from `ffdd88a`, includes #166)
