### PR TITLE
fix(pipecat): Ultravox realtime data tools stall — register them async

### DIFF
--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -418,6 +418,20 @@ def _build_tools_schema(tools: list[dict]) -> ToolsSchema:
 _protected_tool_tasks: set = set()
 
 
+def _is_ultravox_realtime(llm: Any) -> bool:
+    """True when ``llm`` is Pipecat's Ultravox realtime service (or our shim).
+
+    Lazy import so the check never pulls the Ultravox service into the pipeline
+    (text-LLM) code path, and never hard-fails a worker whose extras don't
+    include it.
+    """
+    try:
+        from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService
+    except Exception:  # noqa: BLE001
+        return False
+    return isinstance(llm, UltravoxRealtimeLLMService)
+
+
 def _register_tools_on_llm(llm: Any, tools: list[dict]) -> ToolsSchema:
     """Register the platform's tool descriptors against a Pipecat LLM service.
 
@@ -425,7 +439,41 @@ def _register_tools_on_llm(llm: Any, tools: list[dict]) -> ToolsSchema:
     :func:`agent_tools.build_agent_tools`: each entry has ``schema`` and
     ``execute``. The schema is converted to ``FunctionSchema`` and registered
     with the service so it appears on the LLM-visible tool surface.
+
+    Registration mode (``cancel_on_interruption``) is chosen per tool. On the
+    **Ultravox realtime** path, data-returning tools (REST functions, MCP tools,
+    stubs — anything that is not a shielded side-effecting builtin) are
+    registered ASYNCHRONOUSLY (``cancel_on_interruption=False``). This is the
+    fix for a staging incident (2026-07-24) where a booking agent's
+    ``calendar_*`` calls stalled 18-36s or were skipped:
+
+    * Ultravox FREEZES the conversation between ``client_tool_invocation`` and
+      the matching ``client_tool_result``. With synchronous registration the
+      constant speech-to-speech interruptions cancel the in-flight call
+      (``LLMService._handle_interruptions`` cancels every
+      ``cancel_on_interruption=True`` call ~30ms in), and — worse — the result,
+      when it does arrive, is only shipped to Ultravox on the NEXT context push,
+      which the assistant aggregator skips while the caller is still speaking
+      (``_handle_function_call_result`` guards the push on
+      ``not self._user_speaking``). Net effect: the call sits frozen until the
+      *next* tool call flushes the stale result.
+    * Async registration makes Pipecat (a) not cancel the call on interruption
+      and (b) ship an immediate placeholder ``client_tool_result`` that unfreezes
+      the conversation the moment the tool is invoked; the real result is then
+      injected as a user-side message when ready. This is Pipecat's sanctioned
+      mechanism for realtime tools — and because we don't enable
+      ``enable_async_tool_cancellation`` on the service, it does NOT inject a
+      cancel tool or alter the system prompt.
+
+    Side-effecting builtins (``hangup``, ``transfer``, ``transfer_agent``,
+    ``subagent`` — flagged ``protect_from_interruption``) stay SYNCHRONOUS: their
+    handover machinery (``suppress_result_run`` + ``CallSession._apply_agent_transfer``)
+    depends on the normal result path, and the ``_runner`` already shields their
+    execution from interruption. Off the Ultravox path (the pipeline STT→LLM→TTS
+    mode) every tool stays synchronous — the freeze is Ultravox-specific and the
+    text-LLM aggregator's deferred push is correct there.
     """
+    ultravox_realtime = _is_ultravox_realtime(llm)
     schemas: list[FunctionSchema] = []
     for entry in tools:
         s = entry["schema"]
@@ -525,7 +573,14 @@ def _register_tools_on_llm(llm: Any, tools: list[dict]) -> ToolsSchema:
                 return
             await params.result_callback(result)
 
-        llm.register_function(s["name"], _runner)
+        # Async (cancel_on_interruption=False) for Ultravox-realtime data tools;
+        # synchronous for shielded builtins and for every tool off the Ultravox
+        # path. See this function's docstring for the why.
+        is_builtin_side_effect = bool(entry.get("protect_from_interruption"))
+        cancel_on_interruption = not (ultravox_realtime and not is_builtin_side_effect)
+        llm.register_function(
+            s["name"], _runner, cancel_on_interruption=cancel_on_interruption
+        )
 
     return ToolsSchema(standard_tools=schemas)
 

--- a/agents/pipecat/tests/test_ultravox_async_tools.py
+++ b/agents/pipecat/tests/test_ultravox_async_tools.py
@@ -1,0 +1,199 @@
+"""Registration mode of tools on the Ultravox realtime path
+(:func:`pipecat_aplisay.voice_session._register_tools_on_llm`).
+
+Regression guard for the 2026-07-24 staging incident: a booking agent's
+``calendar_*`` REST calls stalled 18-36s or were skipped because they were
+registered SYNCHRONOUSLY against Ultravox, whose freeze-until-tool-result model
+plus the assistant aggregator's ``not user_speaking`` push guard left each
+result unshipped until the *next* tool call. The fix registers data-returning
+tools (REST / MCP / stub) asynchronously (``cancel_on_interruption=False``) on
+the Ultravox realtime path so Pipecat won't cancel them on interruption and
+ships an immediate placeholder that unfreezes the conversation — while
+side-effecting builtins (``protect_from_interruption``) and every tool off the
+Ultravox path stay synchronous.
+
+These are pure registration assertions: ``_register_tools_on_llm`` only builds
+schemas and calls ``llm.register_function`` — the ``_runner`` closures are never
+executed — so no network, socket or loguru scope is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pipecat_aplisay.voice_session import _is_ultravox_realtime, _register_tools_on_llm
+
+# Skip cleanly if the Ultravox extra isn't installed in this environment.
+ultravox_llm = pytest.importorskip("pipecat.services.ultravox.llm")
+UltravoxRealtimeLLMService = ultravox_llm.UltravoxRealtimeLLMService
+
+
+async def _noop_execute(_args):
+    return {"ok": True}
+
+
+def _tools() -> list[dict]:
+    """A data REST tool, an MCP tool, and a shielded side-effecting builtin."""
+    return [
+        {
+            "schema": {"name": "calendar_get_slots", "description": "d", "properties": {}, "required": []},
+            "execute": _noop_execute,
+            "kind": "function",
+        },
+        {
+            "schema": {"name": "knowledge_search", "description": "d", "properties": {}, "required": []},
+            "execute": _noop_execute,
+            "kind": "mcp",
+        },
+        {
+            "schema": {"name": "hangup", "description": "d", "properties": {}, "required": []},
+            "execute": _noop_execute,
+            "kind": "builtin",
+            "protect_from_interruption": True,
+        },
+    ]
+
+
+class _FakeNonRealtimeLLM:
+    """Records registration mode; deliberately NOT an Ultravox service."""
+
+    def __init__(self):
+        self.registered: dict[str, bool] = {}
+
+    def register_function(self, name, handler, *, cancel_on_interruption=True, timeout_secs=None):
+        self.registered[name] = cancel_on_interruption
+
+
+def _new_ultravox_service() -> UltravoxRealtimeLLMService:
+    """A real Ultravox service instance WITHOUT running __init__ (no socket/keys).
+
+    ``register_function`` only touches ``self._functions``, so seeding that dict
+    is enough to exercise the real (inherited) registration path and read back
+    the stored ``cancel_on_interruption`` per tool.
+    """
+    llm = object.__new__(UltravoxRealtimeLLMService)
+    llm._functions = {}
+    return llm
+
+
+def test_detection_matches_ultravox_and_our_shim_only():
+    from pipecat_aplisay.ultravox_compat import AplisayUltravoxRealtimeLLMService
+
+    assert _is_ultravox_realtime(_new_ultravox_service()) is True
+    assert _is_ultravox_realtime(object.__new__(AplisayUltravoxRealtimeLLMService)) is True
+    assert _is_ultravox_realtime(_FakeNonRealtimeLLM()) is False
+
+
+def test_ultravox_registers_data_tools_async_builtins_sync():
+    llm = _new_ultravox_service()
+    schemas = _register_tools_on_llm(llm, _tools())
+
+    # Data-returning tools run async so interruptions don't cancel them and
+    # their results reach Ultravox promptly.
+    assert llm._functions["calendar_get_slots"].cancel_on_interruption is False
+    assert llm._functions["knowledge_search"].cancel_on_interruption is False
+    # Side-effecting builtins stay synchronous (handover machinery + shield).
+    assert llm._functions["hangup"].cancel_on_interruption is True
+    # Tool surface is unchanged — every tool still registered + schema'd.
+    assert {s.name for s in schemas.standard_tools} == {
+        "calendar_get_slots",
+        "knowledge_search",
+        "hangup",
+    }
+
+
+def test_non_ultravox_path_keeps_every_tool_sync():
+    llm = _FakeNonRealtimeLLM()
+    _register_tools_on_llm(llm, _tools())
+
+    # Off the Ultravox path (pipeline STT->LLM->TTS) the freeze doesn't apply
+    # and the text-LLM aggregator's deferred push is correct — leave sync.
+    assert llm.registered == {
+        "calendar_get_slots": True,
+        "knowledge_search": True,
+        "hangup": True,
+    }
+
+
+def test_async_tool_ships_immediate_placeholder_to_unfreeze_the_call():
+    """The core UX fix: because a data tool is async, Ultravox's
+    ``_handle_tool_invocation`` ships a placeholder ``client_tool_result`` the
+    instant the tool is invoked, so the frozen call is released immediately
+    instead of waiting for the real result (or the next tool call) to arrive.
+
+    ``run_function_calls`` (which needs a full pipeline/task manager) is stubbed
+    to a no-op so this isolates the placeholder path — the behaviour that
+    depends directly on the async registration mode via ``_function_is_async``.
+    """
+    llm = _new_ultravox_service()
+    llm._started_placeholder_sent = set()
+    sent: list[dict] = []
+
+    async def _fake_send(payload):
+        sent.append(payload)
+
+    async def _noop_run_function_calls(_calls):
+        return None
+
+    llm._send = _fake_send
+    llm.run_function_calls = _noop_run_function_calls
+
+    # Register the tool async, exactly as the worker does on Ultravox.
+    _register_tools_on_llm(
+        llm,
+        [
+            {
+                "schema": {"name": "calendar_get_slots", "description": "d", "properties": {}, "required": []},
+                "execute": _noop_execute,
+                "kind": "function",
+            }
+        ],
+    )
+    assert llm._function_is_async("calendar_get_slots") is True
+
+    invocation_id = "tool-call-1"
+    asyncio.run(llm._handle_tool_invocation("calendar_get_slots", invocation_id, {}))
+
+    placeholders = [
+        m for m in sent if m.get("type") == "client_tool_result" and m.get("invocationId") == invocation_id
+    ]
+    assert placeholders, "async tool must unfreeze the call with an immediate placeholder result"
+
+
+def test_sync_tool_sends_no_placeholder_leaving_the_call_frozen():
+    """Counterpart: a SYNC tool (the old behaviour / off-Ultravox builtins) does
+    NOT ship a placeholder, so Ultravox stays frozen until the real result — the
+    exact condition the fix removes for data tools. Locks the contrast so a
+    regression that flips data tools back to sync is caught here too.
+    """
+    llm = _new_ultravox_service()
+    llm._started_placeholder_sent = set()
+    sent: list[dict] = []
+
+    async def _fake_send(payload):
+        sent.append(payload)
+
+    async def _noop_run_function_calls(_calls):
+        return None
+
+    llm._send = _fake_send
+    llm.run_function_calls = _noop_run_function_calls
+
+    # A shielded builtin stays synchronous even on Ultravox.
+    _register_tools_on_llm(
+        llm,
+        [
+            {
+                "schema": {"name": "hangup", "description": "d", "properties": {}, "required": []},
+                "execute": _noop_execute,
+                "kind": "builtin",
+                "protect_from_interruption": True,
+            }
+        ],
+    )
+    assert llm._function_is_async("hangup") is False
+
+    asyncio.run(llm._handle_tool_invocation("hangup", "tool-call-2", {}))
+    assert not sent, "sync tool must not ship a placeholder result"


### PR DESCRIPTION
## Symptom (staging, 2026-07-24 HomeTrades booking test)
On the pipecat worker, every tool call logged `_cancel_function_call ... has been cancelled` ~30ms after it started, and each tool RESULT only reached Ultravox (`_send_tool_result`) when the *next* tool call fired — e.g. `calendar_list_events` result shipped 18s late exactly when `calendar_create_event` started. Net effect: the voice agent froze for 18-36s per tool or improvised without the result (it fell back to a callback instead of booking).

## Root cause
A sync-registration ↔ Ultravox-realtime interaction, not a bug in our handler:
- Ultravox **freezes the conversation** between `client_tool_invocation` and the matching `client_tool_result` (documented in pipecat's ultravox service).
- We registered data tools (REST/MCP) **synchronously** — `register_function` defaults `cancel_on_interruption=True`. In speech-to-speech the caller's trailing audio fires an `InterruptionFrame` milliseconds after the tool call, and `LLMService._handle_interruptions` cancels every `cancel_on_interruption=True` call → the ~30ms cancel.
- Even when the result was produced, the assistant aggregator's `_handle_function_call_result` **skips the upstream context push while `self._user_speaking`** (and never reschedules it), so the `LLMContextFrame` that triggers `_send_tool_result` only arrived on the next tool call.

## Fix
On the **Ultravox realtime path only**, register data-returning tools (REST / MCP / stub — everything that isn't a shielded side-effecting builtin) with `cancel_on_interruption=False`. Pipecat then:
1. does not cancel them on interruption, and
2. ships an immediate placeholder `client_tool_result` that unfreezes the call the instant the tool is invoked; the real result is injected as a user-side message when ready.

`enable_async_tool_cancellation` stays off, so **no cancel tool and no system-prompt change** are injected. Side-effecting builtins (hangup/transfer/transfer_agent/subagent) stay **synchronous** — their handover machinery needs the normal result path and `_runner` already shields their execution. Off the Ultravox path (pipeline STT→LLM→TTS) every tool stays synchronous; the freeze is Ultravox-specific and the text-LLM aggregator's deferred push is correct there.

## Tests
`tests/test_ultravox_async_tools.py` (5 tests): registration mode per tool-type across Ultravox vs non-Ultravox + our shim detection; async tools ship the unfreeze placeholder, sync tools don't. Related suites (agent_tools/mcp/handover/tool_log = 55 tests) still green.

## ⚠️ Needs live-call validation before merge
This changes result delivery on Ultravox to pipecat's async path: the real result arrives as a **user-side message** (`[Async tool result for tool_call_id=…] …`) rather than a classic tool result. Pipecat designed this framing for realtime, but a real booking call should confirm the model reads slots/confirmation naturally and that the immediate placeholder ("result not yet ready … keep the conversation going") produces good voice UX. Scoped to Ultravox + data tools, so easy to revert.

Possible follow-up: OpenAI Realtime / Gemini Live branches are also realtime and may share the class of issue — not addressed here (unverified).