### PR TITLE
feat: current date/time for agents via get_metadata (aplisay.dateTime)

### DIFF
--- a/agents/pipecat/pipecat_aplisay/current_datetime.py
+++ b/agents/pipecat/pipecat_aplisay/current_datetime.py
@@ -1,0 +1,49 @@
+"""The call's "current date/time" for the ``metadata`` builtin (get_metadata).
+
+Python twin of ``lib/current-datetime.js`` — keep the format identical so
+``aplisay.dateTime`` reads the same across the node/livekit and pipecat workers.
+
+Voice/text models have no clock: on a 2026-07-24 staging call an Ultravox agent
+called ``calendar_list_events`` with a 2025-06-18 range (over a year in the
+past). Exposing the current date/time under the metadata key ``aplisay.dateTime``
+gives an agent that reasons about dates ("today", "next Tuesday", calendar
+ranges) ground truth via ``get_metadata(["aplisay.dateTime"])``. Computed live at
+call time (not seeded) so it is always current and needs no change to the
+scattered call-metadata composition sites. Timezone defaults to Europe/London,
+overridable per-deployment with ``AGENT_TIMEZONE``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+_DATETIME_KEY_RE = re.compile(r"^(aplisay\.)?date_?time$", re.IGNORECASE)
+
+
+def is_datetime_metadata_key(key: object) -> bool:
+    """True for the metadata keys that resolve to the live current date/time."""
+    return isinstance(key, str) and bool(_DATETIME_KEY_RE.match(key.strip()))
+
+
+def agent_timezone() -> str:
+    """IANA timezone the date/time is rendered in (AGENT_TIMEZONE, else Europe/London)."""
+    return (os.environ.get("AGENT_TIMEZONE") or "").strip() or "Europe/London"
+
+
+def current_datetime_string(now: datetime | None = None, tz: str | None = None) -> str:
+    """A human- and model-readable current date/time, e.g.
+    ``Thursday 2026-07-24 14:05 Europe/London``: weekday (for "next Tuesday"
+    reasoning), ISO-8601 date (usable directly in calendar ranges), 24h local
+    time and zone. ``now``/``tz`` are injectable for tests.
+    """
+    zone_name = tz or agent_timezone()
+    try:
+        zone = ZoneInfo(zone_name)
+    except (ZoneInfoNotFoundError, ValueError, OSError):
+        # Invalid AGENT_TIMEZONE — fall back to UTC rather than raising mid-call.
+        zone_name, zone = "UTC", timezone.utc
+    moment = (now or datetime.now(timezone.utc)).astimezone(zone)
+    return f"{moment:%A} {moment:%Y-%m-%d} {moment:%H:%M} {zone_name}"

--- a/agents/pipecat/pipecat_aplisay/function_handler.py
+++ b/agents/pipecat/pipecat_aplisay/function_handler.py
@@ -24,6 +24,8 @@ from typing import Any, Awaitable, Callable, Optional
 import httpx
 from loguru import logger
 
+from .current_datetime import current_datetime_string, is_datetime_metadata_key
+
 
 def _get_by_path(obj: Any, path: str) -> Any:
     if not path:
@@ -78,9 +80,15 @@ def _builtin_metadata(args: dict, metadata: dict, options: dict) -> dict:
     out: dict[str, Any] = {}
     allow_tools_calls = bool(options.get("allowToolsCallsMetadataPaths"))
     for key in keys:
-        if not allow_tools_calls and (key == "toolsCalls" or key.startswith("toolsCalls.")):
+        if not allow_tools_calls and (isinstance(key, str) and (key == "toolsCalls" or key.startswith("toolsCalls."))):
             raise PermissionError("Access to metadata.toolsCalls is not allowed for this handler")
         value = _get_by_path(metadata, key)
+        # `aplisay.dateTime` is the live current date/time, computed here rather
+        # than seeded — models have no clock, so this is their ground truth for
+        # date reasoning (see current_datetime.py). A real seeded value wins.
+        if value is None and is_datetime_metadata_key(key):
+            out[key] = current_datetime_string()
+            continue
         out[key] = "unknown" if value is None else value
     logger.bind(keys=keys, result=out).debug("metadata builtin result")
     return out

--- a/agents/pipecat/tests/test_metadata_datetime.py
+++ b/agents/pipecat/tests/test_metadata_datetime.py
@@ -1,0 +1,62 @@
+"""Live `aplisay.dateTime` from the pipecat `metadata` builtin + its helper.
+
+Ground-truth date for date-reasoning agents (2026-07-24 incident: an Ultravox
+agent called calendar_list_events with a 2025-06-18 range). Mirrors the node
+guard in tests/function-handler-metadata.test.mjs so the two workers stay in
+lockstep.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+from pipecat_aplisay.current_datetime import (
+    current_datetime_string,
+    is_datetime_metadata_key,
+)
+from pipecat_aplisay.function_handler import _builtin_metadata
+
+_FORMAT = re.compile(r"^[A-Za-z]+ \d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$")
+
+
+def test_helper_format_and_timezone():
+    fixed = datetime(2026, 7, 24, 13, 5, tzinfo=timezone.utc)
+    # 13:05 UTC is 14:05 BST in London on 2026-07-24.
+    assert current_datetime_string(fixed, "Europe/London") == "Friday 2026-07-24 14:05 Europe/London"
+    assert current_datetime_string(fixed, "UTC") == "Friday 2026-07-24 13:05 UTC"
+    # An invalid zone falls back to UTC instead of raising mid-call.
+    assert current_datetime_string(fixed, "Not/AZone").endswith("UTC")
+    assert _FORMAT.match(current_datetime_string())
+
+
+def test_key_matcher():
+    assert is_datetime_metadata_key("aplisay.dateTime")
+    assert is_datetime_metadata_key("dateTime")
+    assert is_datetime_metadata_key("date_time")
+    assert not is_datetime_metadata_key("aplisay.callerId")
+    assert not is_datetime_metadata_key(None)
+
+
+def test_builtin_returns_live_datetime_alongside_seeded_keys():
+    metadata = {"aplisay": {"callerId": "+441632960001"}}
+    out = _builtin_metadata({"keys": ["aplisay.callerId", "aplisay.dateTime"]}, metadata, {})
+    assert out["aplisay.callerId"] == "+441632960001"
+    assert _FORMAT.match(out["aplisay.dateTime"])
+    assert out["aplisay.dateTime"] != "unknown"
+
+
+def test_seeded_datetime_wins_over_computed():
+    metadata = {"aplisay": {"dateTime": "Monday 2020-01-06 09:00 Europe/London"}}
+    out = _builtin_metadata({"keys": ["dateTime", "aplisay.dateTime"]}, metadata, {})
+    # bare `dateTime` (unseeded) is computed live…
+    assert _FORMAT.match(out["dateTime"])
+    # …a genuinely seeded `aplisay.dateTime` passes through untouched.
+    assert out["aplisay.dateTime"] == "Monday 2020-01-06 09:00 Europe/London"
+
+
+def test_toolscalls_guard_does_not_choke_on_a_non_string_key():
+    # The toolsCalls guard now checks isinstance(key, str) first, so a non-string
+    # key (e.g. keys=[None]) no longer raises AttributeError on .startswith.
+    out = _builtin_metadata({"keys": [None]}, {"aplisay": {}}, {})
+    assert None in out  # returned without raising

--- a/docs/tool-call-chaining-metadata-priming.md
+++ b/docs/tool-call-chaining-metadata-priming.md
@@ -19,6 +19,27 @@ After executing a tool named `someTool`, in a livekit based agent, the server st
 
 You can reference either of these with `source: "metadata"` using arbitrary-depth dot paths (e.g. `toolsCalls.someTool.result.transferNumber`).
 
+## Platform-provided metadata keys (and `get_metadata`)
+
+Besides `toolsCalls.*`, the platform seeds each call's metadata under `aplisay.*` with call context an agent can read — either as a `source: "metadata"` parameter, or by giving the agent the **metadata builtin** so it can fetch values on demand at conversation time:
+
+```json
+{
+  "name": "get_metadata",
+  "implementation": "builtin",
+  "platform": "metadata",
+  "input_schema": { "properties": { "keys": { "source": "generated", "type": "string" } } }
+}
+```
+
+The model calls it with a comma-separated `keys` list and gets an object back, e.g. `get_metadata(keys: "aplisay.callerId, aplisay.dateTime")`. Readable keys include:
+
+- `aplisay.callerId` / `aplisay.calledId` — the calling / called numbers.
+- `aplisay.callId` — the platform call id.
+- **`aplisay.dateTime` — the current date and time**, e.g. `"Friday 2026-07-24 14:05 Europe/London"` (weekday, ISO-8601 date, 24-hour local time, IANA zone; zone defaults to `Europe/London`, set `AGENT_TIMEZONE` to change it). It is computed live per read, so it is always current.
+
+**Give any agent that reasons about dates or times the `get_metadata` builtin and tell it to call `get_metadata` for `aplisay.dateTime` before doing date maths.** Language models do not know the current date — an agent that books appointments, checks a calendar, or resolves "today" / "tomorrow" / "next Tuesday" will otherwise invent a date (a real agent once queried a calendar for a range over a year in the past). The current date/time is the ground truth it must anchor to.
+
 ## Security model for “hardwiring” sensitive values
 
 The key safety property is this: if a tool parameter is defined with `source: "metadata"`, the LLM cannot “invent” or replace the value because that parameter is resolved algorithmically by the agent framework from metadata. This guards against, for example, prompt injection attacks being used to inject harmful values into critical function calls.

--- a/lib/current-datetime.js
+++ b/lib/current-datetime.js
@@ -1,0 +1,55 @@
+/**
+ * The call's "current date/time" for the `metadata` builtin (get_metadata).
+ *
+ * Voice/text models have no idea what day it is — on a 2026-07-24 staging call
+ * an Ultravox agent called calendar_list_events with a 2025-06-18 range, over a
+ * year in the past. So we expose the current date/time under the metadata key
+ * `aplisay.dateTime`: an agent that reasons about dates ("today", "next
+ * Tuesday", calendar ranges) calls get_metadata(["aplisay.dateTime"]) and gets
+ * ground truth alongside the other call metadata (callerId, calledId, …).
+ *
+ * Computed live at get_metadata time (not seeded at call start) so it is always
+ * current and needs no change to the ~10 scattered call-metadata composition
+ * sites — the two `metadata` builtins (this for node + livekit, the Python twin
+ * in the pipecat worker) are the single delivery point. The timezone defaults
+ * to Europe/London and is overridable per-deployment with AGENT_TIMEZONE.
+ */
+
+/** The metadata keys that resolve to the live current date/time. */
+export function isDateTimeMetadataKey(key) {
+  return typeof key === 'string' && /^(aplisay\.)?date[_]?time$/i.test(key.trim());
+}
+
+/** IANA timezone the date/time is rendered in (AGENT_TIMEZONE, else Europe/London). */
+export function agentTimezone() {
+  const tz = (process.env.AGENT_TIMEZONE || '').trim();
+  return tz || 'Europe/London';
+}
+
+/**
+ * A human- and model-readable current date/time string, e.g.
+ * "Thursday 2026-07-24 14:05 Europe/London". Carries the weekday (for "next
+ * Tuesday" reasoning), an ISO-8601 date (directly usable in calendar ranges),
+ * the 24h local time and the zone. `now`/`tz` are injectable for tests.
+ */
+export function currentDateTimeString(now = new Date(), tz = agentTimezone()) {
+  let parts;
+  try {
+    parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone: tz,
+      weekday: 'long',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).formatToParts(now);
+  } catch {
+    // Invalid AGENT_TIMEZONE — fall back to UTC rather than throwing mid-call.
+    return currentDateTimeString(now, 'UTC');
+  }
+  const p = Object.fromEntries(parts.filter((x) => x.type !== 'literal').map((x) => [x.type, x.value]));
+  const hour = p.hour === '24' ? '00' : p.hour; // some environments emit 24:00
+  return `${p.weekday} ${p.year}-${p.month}-${p.day} ${hour}:${p.minute} ${tz}`;
+}

--- a/lib/function-handler.js
+++ b/lib/function-handler.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import logger from './logger.js';
 import { getByPath } from './metadata-path.js';
+import { currentDateTimeString, isDateTimeMetadataKey } from './current-datetime.js';
 import { InfrastructureError } from './errors.js';
 
 const hardwiredBuiltins = {
@@ -81,6 +82,14 @@ const hardwiredBuiltins = {
     keys.forEach(key => {
       if (!options.allowToolsCallsMetadataPaths && (key === 'toolsCalls' || key.startsWith('toolsCalls.'))) {
         throw new InfrastructureError('Access to metadata.toolsCalls is only allowed in LiveKit agents');
+      }
+      // `aplisay.dateTime` is the live current date/time, computed here rather
+      // than seeded — models have no clock, so this is their ground truth for
+      // date reasoning (see current-datetime.js). A real value in the metadata
+      // still wins (nothing seeds it today).
+      if (isDateTimeMetadataKey(key) && (getByPath(metadata, key) === undefined || getByPath(metadata, key) === null)) {
+        result[key] = currentDateTimeString();
+        return;
       }
       const value = getByPath(metadata, key);
       result[key] = value === undefined || value === null ? 'unknown' : value;

--- a/tests/function-handler-metadata.test.mjs
+++ b/tests/function-handler-metadata.test.mjs
@@ -127,6 +127,67 @@ describe('function-handler metadata deep paths', () => {
     expect(payload['deep.nested.v']).toBe('123');
   });
 
+  test('built-in `metadata` helper returns a live aplisay.dateTime alongside seeded keys', async () => {
+    // The exact "get_metadata for dateTime alongside callerId" flow: callerId is
+    // seeded in the call metadata; dateTime is NOT seeded but is computed live so
+    // an agent doing date reasoning gets ground truth (2026-07-24 incident: a
+    // voice model called calendar_list_events with a 2025 range).
+    const metadata = { aplisay: { callerId: '+441632960001' } };
+
+    const functions = [
+      {
+        name: 'get_metadata',
+        implementation: 'builtin',
+        platform: 'metadata',
+        input_schema: { properties: { keys: { source: 'generated', type: 'string' } } },
+      },
+    ];
+
+    const { function_results } = await functionHandler(
+      [{ name: 'get_metadata', input: { keys: 'aplisay.callerId,aplisay.dateTime' } }],
+      functions,
+      [],
+      jest.fn(),
+      metadata,
+      {},
+      {},
+    );
+
+    const payload = JSON.parse(function_results[0].result);
+    expect(payload['aplisay.callerId']).toBe('+441632960001');
+    // e.g. "Friday 2026-07-24 14:05 Europe/London" — weekday, ISO date, 24h time, zone.
+    expect(payload['aplisay.dateTime']).toMatch(/^[A-Za-z]+ \d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$/);
+    expect(payload['aplisay.dateTime']).not.toBe('unknown');
+  });
+
+  test('the bare `dateTime` key also resolves, and a seeded value wins over the computed one', async () => {
+    const metadata = { aplisay: { dateTime: 'Monday 2020-01-06 09:00 Europe/London' } };
+    const functions = [
+      {
+        name: 'get_metadata',
+        implementation: 'builtin',
+        platform: 'metadata',
+        input_schema: { properties: { keys: { source: 'generated', type: 'string' } } },
+      },
+    ];
+
+    const { function_results } = await functionHandler(
+      [{ name: 'get_metadata', input: { keys: 'dateTime,aplisay.dateTime' } }],
+      functions,
+      [],
+      jest.fn(),
+      metadata,
+      {},
+      {},
+    );
+
+    const payload = JSON.parse(function_results[0].result);
+    // `dateTime` (unseeded) is computed live…
+    expect(payload['dateTime']).toMatch(/^[A-Za-z]+ \d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$/);
+    // …while a genuinely seeded `aplisay.dateTime` is passed through untouched.
+    expect(payload['aplisay.dateTime']).toBe('Monday 2020-01-06 09:00 Europe/London');
+  });
+
   test('rejects toolsCalls.* metadata reads unless explicitly allowed', async () => {
     const metadata = { toolsCalls: {} };
 


### PR DESCRIPTION
## Why
Voice/text models have no clock. On the 2026-07-24 staging booking call an Ultravox agent called `calendar_list_events` with a **2025-06-18** range — over a year in the past — because nothing tells the model what day it is.

## Mechanism (as requested)
Seed the date/time into call metadata under `aplisay.dateTime`, and let an agent fetch it with the existing **metadata builtin** (`get_metadata`), alongside `aplisay.callerId` etc. The model calls `get_metadata(keys: "aplisay.callerId, aplisay.dateTime")` and gets:

```
aplisay.dateTime → "Friday 2026-07-24 14:05 Europe/London"
```
weekday (for "next Tuesday"), ISO-8601 date (usable directly in calendar ranges), 24h local time, IANA zone. Zone defaults to `Europe/London`, override with `AGENT_TIMEZONE`.

## Implementation
`aplisay.dateTime` is resolved **live in the metadata builtin** (computed per read, always current) rather than seeded into the ~10 scattered `aplisay:{}` composition sites (handlers + every transfer/consult leg), which would be fragile and easy to miss. A genuinely seeded value still wins if one is ever added.

One delivery point per worker covers all three workers:
- **node + livekit**: `lib/current-datetime.js` + `lib/function-handler.js` — livekit's `agent-tools.ts` dispatches tools through node's `functionHandler`, so both share it.
- **pipecat**: Python twin `current_datetime.py` + `function_handler.py`, identical output format.

The `toolsCalls` guard also gained an `isinstance(key, str)` check so a non-string key can't raise.

## Docs + the "tell the agent" half
`docs/tool-call-chaining-metadata-priming.md` now documents the readable `aplisay.*` keys and instructs: give any date-reasoning agent the `get_metadata` builtin and tell it to fetch `aplisay.dateTime` before date maths. The builder reads these docs via the aplisay MCP. **Companion builder change still needed**: the agent builder should actually wire a `get_metadata` function onto booking/calendar agents and prompt them to call it — I'll do that as a follow-up unless you'd prefer otherwise.

## Tests
- node `tests/function-handler-metadata.test.mjs`: get_metadata returns a live `aplisay.dateTime` alongside a seeded `callerId`; bare `dateTime` resolves; a seeded value wins (12 pass).
- pipecat `tests/test_metadata_datetime.py`: helper format/timezone/fallback, key matcher, builtin delivery, seeded-wins, non-string-key guard (5 pass).

Builder's server-computed booking flow was already immune; this covers the generic calendar tools and any relative-date conversation.