### PR TITLE
fix(agent-sets): preserve platform-wired keyed functions on set saves

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -165,6 +165,17 @@ components:
               type: string
             description:
               type: string
+            removeFunctions:
+              type: array
+              items:
+                type: string
+              description: |-
+                Names of stored functions to delete from this member explicitly. A stored function that
+                references a write-only key entry (its `key` property) is treated as platform-wired: an
+                update whose `functions` merely omits it keeps it in place, so a document written before
+                the wiring can never strip it. Listing the function's name here is how it is actually
+                removed. Names listed here also delete ordinary stored functions when `functions` is not
+                supplied at all (a remove-only patch).
         - $ref: "#/components/schemas/Agent"
     AgentSetInput:
       type: object

--- a/api/paths/agent-sets.js
+++ b/api/paths/agent-sets.js
@@ -7,6 +7,7 @@ import {
   validateAgentTargets,
   AgentSetValidationError
 } from '../../lib/agent-set-labels.js';
+import { mergeMemberFunctions } from '../../lib/agent-set-functions.js';
 import { assertAgentsNotWired, WiredListenerError } from '../../lib/deployment-guard.js';
 
 let log;
@@ -56,6 +57,11 @@ export async function renderSet(setId, user) {
  * Create (or, for updateAgentSet, reconcile) the members of a set inside a
  * transaction: build/refresh rows, resolve label references against the new
  * membership, validate cross-references, then save.
+ *
+ * Member `functions` are merged, not blindly replaced: stored functions that
+ * reference a write-only key entry (platform-wired tools) survive a document
+ * that omits them, and are deleted only via the member's `removeFunctions`
+ * list (see lib/agent-set-functions.js).
  */
 export async function reconcileMembers({ set, byLabel, existing = [], user, transaction, patch = false, removeLabels = [] }) {
   const existingByLabel = new Map(existing.map((agent) => [agent.label, agent]));
@@ -117,10 +123,19 @@ export async function reconcileMembers({ set, byLabel, existing = [], user, tran
   });
 
   for (const { label, def, agent } of members) {
+    // `functions` is merged, never blindly replaced: keyed (platform-wired)
+    // functions on the stored row survive a document that omits them, and a
+    // member's `removeFunctions` deletes stored functions by name — see
+    // lib/agent-set-functions.js. Capture the stored value before the copy.
+    const priorFunctions = agent.isNewRecord ? undefined : agent.functions;
+    const mergedFunctions = mergeMemberFunctions(priorFunctions, def.functions, def.removeFunctions);
     for (const field of MEMBER_FIELDS) {
       if (def[field] !== undefined) {
         agent[field] = field === 'type' ? defaultType(def) : def[field];
       }
+    }
+    if (mergedFunctions !== undefined) {
+      agent.functions = mergedFunctions;
     }
     if (agent.functions || agent.options?.bridgedTransferToAgent) {
       fixupLabelReferences(agent.functions || [], labelMap, label, agent.options);

--- a/api/paths/agent-sets/{agentSetId}.js
+++ b/api/paths/agent-sets/{agentSetId}.js
@@ -106,7 +106,12 @@ agentSetUpdate.apiDoc = {
                 existing labels are updated in place (keeping their agent IDs), new labels are created,
                 and members whose label is absent from the document are deleted. All \`label:\` references
                 (and previously fixed-up \`fromLabel\` annotations) are re-resolved against the new membership.
-                The whole operation is transactional: it either fully applies or fails leaving the set unchanged.`,
+                The whole operation is transactional: it either fully applies or fails leaving the set unchanged.
+                A member's stored functions that reference a write-only key entry (their \`key\` property —
+                platform-wired tools such as calendar booking) are PRESERVED even when the incoming member's
+                \`functions\` omits them: an incoming function of the same name replaces the stored one, and a
+                name listed in the member's \`removeFunctions\` deletes it, but omission alone never strips a
+                keyed function. Documents written before such wiring therefore round-trip safely.`,
   operationId: 'updateAgentSet',
   tags: ["Agent Sets"],
   parameters: [agentSetIdParameter],

--- a/docs/agent-sets-and-subagents.md
+++ b/docs/agent-sets-and-subagents.md
@@ -209,6 +209,16 @@ Semantics:
 * `PUT /agent-sets/{id}` reconciles by label: existing labels are updated in
   place (keeping their agent ids — live listeners stay attached), new labels
   are created, absent labels are deleted.
+* A member's stored functions that reference a **write-only key entry** (their
+  `key` property — platform-wired tools such as calendar booking, injected onto
+  the rows by an attach panel rather than authored in the document) are
+  **preserved on update even when the incoming member's `functions` omits
+  them**. Key values never round-trip through `GET`, so no document-driven
+  editor can faithfully re-author a keyed function; a stale working copy must
+  therefore never strip one by omission. An incoming function of the same name
+  still replaces the stored one, and listing a name in the member's
+  `removeFunctions` array deletes it explicitly (`removeFunctions` also works
+  without resending `functions` at all — a remove-only patch).
 * `DELETE /agent-sets/{id}` removes the set and all member agents.
 
 Endpoints: `POST /agent-sets`, `GET /agent-sets`, `GET /agent-sets/{id}`,

--- a/lib/agent-set-functions.js
+++ b/lib/agent-set-functions.js
@@ -1,0 +1,102 @@
+/**
+ * Preservation of platform-wired (keyed) member functions across agent-set
+ * saves.
+ *
+ * Set documents are CONTENT: a builder session (or a versioning service)
+ * round-trips them and writes each member back wholesale. But some functions on
+ * a member row are WIRING, not content — a platform panel (e.g. polite-ai's
+ * calendar-booking or email-notify attach flow) injects rest functions directly
+ * onto the saved rows and arms the write-only `Agent.keys` entry they reference
+ * (their `key` property, e.g. "POLITE_BOOKING"). A document produced before the
+ * injection doesn't contain them, so a naive replace-on-save silently strips
+ * the wiring from the team (the 2026-07-25 beta incident class).
+ *
+ * The invariant: a function that REFERENCES a keys entry was necessarily wired
+ * by a caller with key custody — key values are write-only and never round-trip
+ * through GET, so no document-driven editor can faithfully re-author one.
+ * Removing such a function must therefore be EXPLICIT: a member definition may
+ * carry `removeFunctions: ["name", ...]` alongside `functions`; omission alone
+ * never strips a keyed function. An incoming function with the same name still
+ * wins, which is how the panels themselves update their wiring in place.
+ *
+ * The rule keys on the key REFERENCE, not on the key being armed: versioning
+ * paths fork fresh rows keyless (a platform sweep re-arms them asynchronously),
+ * so requiring an armed key would reopen exactly the window being closed.
+ *
+ * Functions are stored either as an array or as an object keyed by function
+ * name; both shapes are accepted everywhere in the platform and both are
+ * handled here. The merged result keeps the INCOMING document's shape.
+ */
+
+/** True when a function definition references a write-only Agent.keys entry. */
+export function isKeyedFunction(fn) {
+  return !!fn && typeof fn === 'object' && typeof fn.key === 'string' && fn.key.length > 0;
+}
+
+/**
+ * Iterate a functions value (array, or object keyed by function name) as
+ * [name, fn] pairs. Array entries take their name from `fn.name`; object
+ * entries fall back to their object key when the value carries no name.
+ */
+function* entriesOf(functions) {
+  if (Array.isArray(functions)) {
+    for (const fn of functions) {
+      if (fn && typeof fn === 'object') {
+        yield [typeof fn.name === 'string' ? fn.name : undefined, fn];
+      }
+    }
+  } else if (functions && typeof functions === 'object') {
+    for (const [key, fn] of Object.entries(functions)) {
+      if (fn && typeof fn === 'object') {
+        yield [typeof fn.name === 'string' ? fn.name : key, fn];
+      }
+    }
+  }
+}
+
+/**
+ * Merge a member's stored functions into the incoming definition for a set
+ * save.
+ *
+ *  - Keyed functions present on the row but absent from the document are
+ *    preserved (appended), unless their name is listed in `removeNames`.
+ *  - An incoming function always replaces a stored one of the same name.
+ *  - Unkeyed stored functions keep today's semantics: the document replaces
+ *    them wholesale.
+ *  - With no incoming `functions` at all, the stored value is left untouched —
+ *    except that `removeNames` still deletes the named functions (keyed or
+ *    not), so a remove-only patch works without resending the member's tools.
+ *
+ * @param {Array|object|null|undefined} prior functions stored on the row
+ * @param {Array|object|undefined} incoming functions from the document
+ *   (undefined = field not supplied)
+ * @param {string[]} [removeNames] function names to delete explicitly
+ * @returns the merged value in the incoming document's shape, or undefined
+ *   when the stored field should be left untouched
+ */
+export function mergeMemberFunctions(prior, incoming, removeNames = []) {
+  const remove = new Set((Array.isArray(removeNames) ? removeNames : []).filter(Boolean).map(String));
+
+  if (incoming === undefined) {
+    if (!remove.size || prior === undefined || prior === null) {
+      return undefined;
+    }
+    // Remove-only: drop the named functions, keeping the stored shape.
+    if (Array.isArray(prior)) {
+      return prior.filter((fn) => !remove.has(`${fn?.name ?? ''}`));
+    }
+    return Object.fromEntries([...entriesOf(prior)].filter(([name]) => !remove.has(`${name}`)));
+  }
+
+  const incomingNames = new Set(
+    [...entriesOf(incoming)].map(([name]) => name).filter((name) => name !== undefined));
+  const preserved = [...entriesOf(prior)].filter(([name, fn]) =>
+    isKeyedFunction(fn) && !incomingNames.has(name) && !remove.has(`${name}`));
+
+  if (Array.isArray(incoming)) {
+    // Entries preserved from an object-shaped store may carry their name only
+    // as the object key — materialise it, an array entry has nowhere else.
+    return [...incoming, ...preserved.map(([name, fn]) => (fn.name === name ? fn : { ...fn, name }))];
+  }
+  return { ...incoming, ...Object.fromEntries(preserved) };
+}

--- a/lib/set-builder-agent.js
+++ b/lib/set-builder-agent.js
@@ -96,6 +96,14 @@ MCP KNOWLEDGEBASES (giving the team access to a knowledge/docs MCP server)
   subagent function. Do NOT make the design depend on a pipecat voice agent just to reach an MCP — route
   knowledge through a text subagent, which works no matter what runtime the voice agents use.
 
+PLATFORM-WIRED (KEYED) FUNCTIONS — preserved on save; remove only explicitly
+Some member functions are wired by the platform outside your session (e.g. calendar-booking or email tools
+added by a setup panel); they carry a "key" naming a stored credential you cannot see. Saving a member does
+NOT remove such functions just because your document omits them — keyed functions the document leaves out are
+preserved, so a working copy that predates the wiring stays safe to save. Sending a function with the same
+name updates it in place. To genuinely remove one, list its name in that member's "removeFunctions" array in
+the same save. Never rewrite or invent a function's "key" value.
+
 OTHER FUNCTIONS — look up exact parameters on the MCP before using; DON'T guess
 The platform supports more function types than the links above, and you do NOT know their exact schemas by heart.
 When a member needs one of these, look it up on the MCP server first (search_docs / read_doc / get_api_endpoint)
@@ -178,14 +186,16 @@ const updateSetFunction = {
   name: 'update_agent_set',
   implementation: 'builtin',
   platform: 'update_agent_set',
-  description: 'Revise a set created earlier this session (keeps it saved as you refine). Members are reconciled by label.',
+  description: 'Revise a set created earlier this session (keeps it saved as you refine). Members are reconciled by label. '
+    + 'Stored member functions that carry a "key" (platform-wired tools) are preserved even when a member\'s functions '
+    + 'array omits them — delete one only by listing its name in that member\'s removeFunctions.',
   input_schema: {
     type: 'object',
     properties: {
       id: { type: 'string', required: true, description: 'The id of the set to update (from a previous create_agent_set result)' },
       name: { type: 'string', description: 'Set name (omit to keep the existing name)' },
       description: { type: 'string' },
-      agents: { type: 'array', required: true, description: 'The full desired set of members' },
+      agents: { type: 'array', required: true, description: 'The full desired set of members. A member may include removeFunctions: ["name", ...] to delete stored (e.g. platform-wired keyed) functions explicitly.' },
     },
     required: ['id', 'agents'],
   },
@@ -205,7 +215,7 @@ const patchSetFunction = {
     type: 'object',
     properties: {
       id: { type: 'string', required: true, description: 'The id of the set to patch (from create_agent_set).' },
-      agents: { type: 'array', description: 'ONLY the members to add or update, each with its unique "label" and full definition. Omit members you are not changing — they are kept as-is. May be empty/omitted if you are only removing members or editing name/description.' },
+      agents: { type: 'array', description: 'ONLY the members to add or update, each with its unique "label" and full definition. Omit members you are not changing — they are kept as-is. May be empty/omitted if you are only removing members or editing name/description. A member may include removeFunctions: ["name", ...] to delete stored (e.g. platform-wired keyed) functions explicitly; omitting a keyed function from "functions" never removes it.' },
       removeLabels: { type: 'array', items: { type: 'string' }, description: 'Labels of members to delete from the set.' },
       name: { type: 'string', description: 'New set name (optional).' },
       description: { type: 'string', description: 'New set description (optional).' },

--- a/tests/agent-set-functions.test.mjs
+++ b/tests/agent-set-functions.test.mjs
@@ -1,0 +1,103 @@
+import { mergeMemberFunctions, isKeyedFunction } from '../lib/agent-set-functions.js';
+
+/**
+ * Pure merge semantics for keyed (platform-wired) function preservation on
+ * agent-set saves — the DB-backed end-to-end behaviour is covered in
+ * agent-sets.test.mjs; this file pins the shape handling and edge cases.
+ */
+
+const keyed = (name, extra = {}) => ({
+  name,
+  implementation: 'rest',
+  method: 'post',
+  url: `https://integrations.example.com/v1/tools/${name}`,
+  key: 'POLITE_BOOKING',
+  ...extra
+});
+const plain = (name) => ({ name, implementation: 'rest', method: 'get', url: 'https://api.example.com/x' });
+
+describe('isKeyedFunction', () => {
+  test('true only for a non-empty string key', () => {
+    expect(isKeyedFunction(keyed('a'))).toBe(true);
+    expect(isKeyedFunction(plain('a'))).toBe(false);
+    expect(isKeyedFunction({ name: 'a', key: '' })).toBe(false);
+    expect(isKeyedFunction({ name: 'a', key: 42 })).toBe(false);
+    expect(isKeyedFunction(null)).toBe(false);
+  });
+});
+
+describe('mergeMemberFunctions', () => {
+  test('keyed functions omitted by the document are appended; unkeyed are dropped', () => {
+    const prior = [plain('old_tool'), keyed('booking_get_slots'), keyed('booking_book')];
+    const incoming = [plain('new_tool')];
+    const merged = mergeMemberFunctions(prior, incoming);
+    expect(merged.map((f) => f.name)).toEqual(['new_tool', 'booking_get_slots', 'booking_book']);
+  });
+
+  test('an incoming function of the same name wins over the stored keyed one', () => {
+    const prior = [keyed('booking_book', { description: 'stored' })];
+    const incoming = [keyed('booking_book', { description: 'incoming' })];
+    const merged = mergeMemberFunctions(prior, incoming);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].description).toBe('incoming');
+  });
+
+  test('removeFunctions deletes a keyed function the document omits', () => {
+    const prior = [keyed('booking_get_slots'), keyed('booking_book')];
+    const merged = mergeMemberFunctions(prior, [plain('t')], ['booking_book']);
+    expect(merged.map((f) => f.name)).toEqual(['t', 'booking_get_slots']);
+  });
+
+  test('no incoming functions and no removals leaves the field untouched', () => {
+    expect(mergeMemberFunctions([keyed('a')], undefined)).toBeUndefined();
+    expect(mergeMemberFunctions([keyed('a')], undefined, [])).toBeUndefined();
+    expect(mergeMemberFunctions(undefined, undefined, ['a'])).toBeUndefined();
+    expect(mergeMemberFunctions(null, undefined, ['a'])).toBeUndefined();
+  });
+
+  test('remove-only (no functions supplied) deletes by name, keyed or not, keeping shape', () => {
+    const prior = [plain('a'), keyed('b'), keyed('c')];
+    expect(mergeMemberFunctions(prior, undefined, ['a', 'c']).map((f) => f.name)).toEqual(['b']);
+
+    const priorObj = { a: plain('a'), b: keyed('b') };
+    expect(mergeMemberFunctions(priorObj, undefined, ['a'])).toEqual({ b: keyed('b') });
+  });
+
+  test('object-shaped stored functions are preserved into an array-shaped document, gaining a name', () => {
+    // Entries stored keyed-by-name may carry no inner name — an array entry must.
+    const { name: _n, ...nameless } = keyed('booking_book');
+    const prior = { booking_book: nameless };
+    const merged = mergeMemberFunctions(prior, [plain('t')]);
+    expect(merged.map((f) => f.name)).toEqual(['t', 'booking_book']);
+    expect(merged[1].key).toBe('POLITE_BOOKING');
+  });
+
+  test('object-shaped documents gain preserved entries as named keys', () => {
+    const prior = [keyed('booking_book')];
+    const merged = mergeMemberFunctions(prior, { t: plain('t') });
+    expect(Object.keys(merged).sort()).toEqual(['booking_book', 't']);
+    expect(merged.booking_book.key).toBe('POLITE_BOOKING');
+  });
+
+  test('name matching spans shapes: an object-keyed incoming entry beats a stored array entry', () => {
+    const prior = [keyed('booking_book', { description: 'stored' })];
+    const merged = mergeMemberFunctions(prior, { booking_book: keyed('booking_book', { description: 'incoming' }) });
+    expect(Object.keys(merged)).toEqual(['booking_book']);
+    expect(merged.booking_book.description).toBe('incoming');
+  });
+
+  test('an empty incoming array still preserves keyed functions (and only those)', () => {
+    const prior = [plain('a'), keyed('b')];
+    expect(mergeMemberFunctions(prior, []).map((f) => f.name)).toEqual(['b']);
+  });
+
+  test('explicit removal plus empty incoming empties the member', () => {
+    const prior = [keyed('booking_get_slots'), keyed('booking_book')];
+    expect(mergeMemberFunctions(prior, [], ['booking_get_slots', 'booking_book'])).toEqual([]);
+  });
+
+  test('tolerates junk entries without throwing', () => {
+    const merged = mergeMemberFunctions([null, 'bogus', keyed('b')], [undefined, plain('t')]);
+    expect(merged.filter((f) => f && f.name).map((f) => f.name)).toEqual(['t', 'b']);
+  });
+});

--- a/tests/agent-sets.test.mjs
+++ b/tests/agent-sets.test.mjs
@@ -113,10 +113,35 @@ function setDocument() {
   };
 }
 
+/**
+ * A platform-wired rest function shaped as polite-ai's calendar-booking attach
+ * panel injects it directly onto saved member rows (out-of-band of any builder
+ * document): implementation rest, referencing the write-only POLITE_BOOKING
+ * key, with a static policy parameter.
+ */
+function bookingFunction(name, extra = {}) {
+  return {
+    name,
+    description: `Platform-injected ${name}`,
+    implementation: 'rest',
+    method: 'post',
+    url: `https://integrations.example.com/v1/tools/${name}`,
+    key: 'POLITE_BOOKING',
+    input_schema: {
+      properties: {
+        policy: { type: 'string', source: 'static', from: 'bpol_test1', in: 'body' },
+        callerNumber: { type: 'string', source: 'metadata', from: 'aplisay.callerId', in: 'body' }
+      }
+    },
+    ...extra
+  };
+}
+
 describe('Agent sets', () => {
   let user;
   let createAgentSet, listAgentSets, getAgentSet, updateAgentSet, deleteAgentSet;
   let createAgent;
+  let updateAgentSetForAgent, patchAgentSetForAgent;
 
   beforeAll(async () => {
     await setupRealDatabase();
@@ -130,6 +155,7 @@ describe('Agent sets', () => {
     updateAgentSet = item.PUT;
     deleteAgentSet = item.DELETE;
     createAgent = agents.POST;
+    ({ updateAgentSetForAgent, patchAgentSetForAgent } = await import('../lib/agent-set-service.js'));
   }, 60000);
 
   afterAll(async () => {
@@ -525,6 +551,148 @@ describe('Agent sets', () => {
       }), missingRes);
       expect(missingRes.statusCode).toBe(400);
       expect(missingRes.body.message).toMatch(/does not exist/);
+    });
+  });
+
+  describe('platform-wired (keyed) function preservation on set saves', () => {
+    // The 2026-07-25 beta incident class: an attach panel injects keyed booking
+    // functions straight onto saved member rows and arms their write-only key;
+    // the builder's working document predates the injection, so its next save
+    // must NOT strip them.
+
+    /** Create the standard set and inject booking wiring onto one member row. */
+    async function createSetWithInjectedBooking(label = 'specialist') {
+      const createRes = makeRes(user);
+      await createAgentSet(makeReq(setDocument()), createRes);
+      expect(createRes.statusCode).toBe(200);
+      const member = createRes.body.agents.find((a) => a.label === label);
+      const row = await Agent.findByPk(member.id);
+      await row.update({
+        functions: [
+          ...(row.functions || []),
+          bookingFunction('booking_get_slots'),
+          bookingFunction('booking_book')
+        ],
+        keys: [{ name: 'POLITE_BOOKING', in: 'bearer', value: 'pik_test_secret' }]
+      });
+      return { setId: createRes.body.id, memberId: member.id };
+    }
+
+    const owner = () => ({ userId: user.id, organisationId: user.organisationId });
+    const namesOf = (fns) => (fns || []).map((f) => f.name).sort();
+
+    test('builder update_agent_set with a pre-injection document keeps the booking functions', async () => {
+      const { setId, memberId } = await createSetWithInjectedBooking();
+
+      // The builder's working copy: the original document, no booking functions.
+      const rendered = await updateAgentSetForAgent(setId, setDocument(), owner());
+
+      const specialist = rendered.agents.find((a) => a.label === 'specialist');
+      expect(namesOf(specialist.functions)).toEqual(
+        ['booking_book', 'booking_get_slots', 'transfer_to_specialist']);
+      // Document-authored content still replaced as usual, on the same row.
+      expect(specialist.id).toBe(memberId);
+      // Untouched member unaffected.
+      const triage = rendered.agents.find((a) => a.label === 'triage');
+      expect(namesOf(triage.functions)).toEqual(['ask_researcher', 'transfer_to_specialist']);
+
+      // The armed key survives too (documents never carry keys), and is still
+      // referenced by the preserved functions.
+      const row = await Agent.findByPk(memberId);
+      expect(namesOf(row.functions)).toEqual(
+        ['booking_book', 'booking_get_slots', 'transfer_to_specialist']);
+      expect(row.functions.find((f) => f.name === 'booking_book').key).toBe('POLITE_BOOKING');
+      expect(row.keys).toEqual([{ name: 'POLITE_BOOKING', in: 'bearer', value: 'pik_test_secret' }]);
+    });
+
+    test('REST PUT preserves them too, idempotently across repeated saves', async () => {
+      const { setId, memberId } = await createSetWithInjectedBooking();
+
+      for (let pass = 0; pass < 2; pass++) {
+        const res = makeRes(user);
+        await updateAgentSet(makeReq(setDocument(), { agentSetId: setId }), res);
+        expect(res.statusCode).toBe(200);
+      }
+      const row = await Agent.findByPk(memberId);
+      // Merged once, not duplicated on the second pass.
+      expect(namesOf(row.functions)).toEqual(
+        ['booking_book', 'booking_get_slots', 'transfer_to_specialist']);
+    });
+
+    test('patch_agent_set resending the member without them keeps them and replaces the rest', async () => {
+      const { setId, memberId } = await createSetWithInjectedBooking();
+
+      const rendered = await patchAgentSetForAgent(setId, {
+        agents: [{
+          label: 'specialist',
+          prompt: 'You handle specialist enquiries v3.',
+          functions: [transferAgentFunction('label:triage')]
+        }]
+      }, owner());
+
+      const specialist = rendered.agents.find((a) => a.label === 'specialist');
+      expect(specialist.id).toBe(memberId);
+      expect(specialist.prompt).toBe('You handle specialist enquiries v3.');
+      expect(namesOf(specialist.functions)).toEqual(
+        ['booking_book', 'booking_get_slots', 'transfer_to_specialist']);
+    });
+
+    test('a document that includes a keyed function by name updates it in place', async () => {
+      const { setId, memberId } = await createSetWithInjectedBooking();
+
+      const doc = setDocument();
+      doc.agents.find((a) => a.label === 'specialist').functions.push(
+        bookingFunction('booking_get_slots', { description: 'round-tripped and edited' }));
+      await updateAgentSetForAgent(setId, doc, owner());
+
+      const row = await Agent.findByPk(memberId);
+      const slots = row.functions.filter((f) => f.name === 'booking_get_slots');
+      expect(slots).toHaveLength(1);
+      expect(slots[0].description).toBe('round-tripped and edited');
+      // The other keyed function is still preserved by omission.
+      expect(row.functions.some((f) => f.name === 'booking_book')).toBe(true);
+    });
+
+    test('removeFunctions deletes keyed functions explicitly', async () => {
+      const { setId, memberId } = await createSetWithInjectedBooking();
+
+      const doc = setDocument();
+      doc.agents.find((a) => a.label === 'specialist').removeFunctions = ['booking_book'];
+      await updateAgentSetForAgent(setId, doc, owner());
+
+      const row = await Agent.findByPk(memberId);
+      // Removed name gone; the one merely omitted still preserved.
+      expect(namesOf(row.functions)).toEqual(['booking_get_slots', 'transfer_to_specialist']);
+    });
+
+    test('a remove-only patch (no functions resent) deletes without touching the rest', async () => {
+      const { setId, memberId } = await createSetWithInjectedBooking();
+
+      await patchAgentSetForAgent(setId, {
+        agents: [{ label: 'specialist', removeFunctions: ['booking_get_slots', 'booking_book'] }]
+      }, owner());
+
+      const row = await Agent.findByPk(memberId);
+      expect(namesOf(row.functions)).toEqual(['transfer_to_specialist']);
+      // The document-authored function was left exactly as stored (still resolved).
+      expect(row.functions[0].input_schema.properties.agent.fromLabel).toBe('triage');
+    });
+
+    test('unkeyed out-of-band functions are NOT preserved — the document still replaces content', async () => {
+      const createRes = makeRes(user);
+      await createAgentSet(makeReq(setDocument()), createRes);
+      const member = createRes.body.agents.find((a) => a.label === 'specialist');
+      const row = await Agent.findByPk(member.id);
+      await row.update({
+        functions: [
+          ...(row.functions || []),
+          { name: 'ad_hoc_tool', implementation: 'rest', method: 'get', url: 'https://api.example.com/x' }
+        ]
+      });
+
+      await updateAgentSetForAgent(createRes.body.id, setDocument(), owner());
+      const after = await Agent.findByPk(member.id);
+      expect(namesOf(after.functions)).toEqual(['transfer_to_specialist']);
     });
   });
 });


### PR DESCRIPTION
## The problem (2026-07-25 beta incident follow-up)

Builders attach panels (calendar booking, team-email notify) wire tools onto a team by writing rest functions **directly onto the saved member agent rows** and arming the write-only `Agent.keys` entry those functions reference. The builder's working document predates that injection, so its next save — `update_agent_set` / `patch_agent_set` builtins, or any `PUT /agent-sets/{id}` built from an older snapshot (versioning restore) — replaced each member's `functions` wholesale and **silently stripped calendar booking from the team**. A prompt-level guardrail exists on the builder side (314ba70), but the durable fix belongs here.

## The fix

`reconcileMembers` (the single chokepoint for REST POST/PUT and all three builder builtins) now **merges** member functions instead of blindly replacing:

- A stored function that **references a keys entry** (its `key` property) survives a document that omits it. Rationale: key values are write-only and never round-trip through GET, so no document-driven editor can faithfully re-author a keyed function — omission is always staleness, never intent.
- An **incoming function of the same name still wins** — that's how panels update their wiring in place, and how a post-injection round-tripped document behaves identically to today.
- Deletion is now **explicit**: a member definition may carry `removeFunctions: ["name", ...]`. It also works without resending `functions` at all (remove-only patch).
- **Unkeyed** functions keep today's replace-wholesale semantics (regression-tested boundary).
- The rule keys on the *reference*, not on the key being *armed*: versioning paths fork rows keyless and builders' re-arm sweep is async, so requiring an armed key would reopen exactly the window being closed.

New helper: `lib/agent-set-functions.js` (handles both array and name-keyed-object function shapes; merged result keeps the incoming document's shape).

## Versioning-path audit (builder `app/lib/versioning/service.server.ts`)

All three paths ride `POST`/`PUT /agent-sets` and were checked against the merge:

| Path | Behaviour |
|---|---|
| Draft fork (`ensureDraft` → POST) | New rows; the forked doc is a faithful full copy, so injected functions ride in the document. Unchanged. Keys still re-armed by the sweep. |
| Publish (`publishDraft` → PUT onto live) | Previously could wipe live's injected functions when the draft was forked *before* an attach. Now the live twins' keyed functions survive. |
| Restore (`restoreVersion` → PUT onto draft) | Restoring a pre-attach snapshot no longer disconnects booking — content restores, platform wiring stays. `removeFunctions` remains the deliberate disconnect path. |

## Also in this change

- Builder `SYSTEM_PROMPT` + `update_agent_set`/`patch_agent_set` builtin descriptions teach the contract (preserved-on-omission, `removeFunctions` to delete, never invent a `key`).
- OpenAPI: `AgentSetMemberInput.removeFunctions` + PUT description; `docs/agent-sets-and-subagents.md` section.

## Known non-goals (flagged, deliberate)

- A document that explicitly supplies `keys` for a member still replaces the armed keys wholesale — unchanged, and unreachable from builder round-trips since GET never returns keys.
- `mcpServers` is untouched: the knowledge MCP entry is builder-authored content, so no out-of-band `mcpServers` injection exists today.
- Per-agent `PUT /agents/{id}` keeps replace semantics — it's the panels' own custody path and their disconnect mechanism.

## Tests

- `tests/agent-set-functions.test.mjs` — 12 unit tests pinning merge semantics and shape handling.
- `tests/agent-sets.test.mjs` — 7 DB-backed regression tests: inject booking-shaped keyed functions + key out-of-band onto a member (exactly as the panel does), then assert survival through a pre-injection `update_agent_set`, an idempotent repeated REST PUT, and a member-resending `patch_agent_set`; plus same-name-wins, explicit `removeFunctions`, remove-only patch, and the unkeyed-functions-still-replaced boundary.
- Full DB suite: **57 suites passed (1 skipped), 616 tests passed, 2 skipped, 0 failures.**
