### PR TITLE
Resolve actionable CodeQL alerts

### DIFF
--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -251,7 +251,7 @@ if (enabled) {
     plugins: [bearer(), oneTimeToken({ expiresIn: 1, storeToken: 'hashed', disableClientRequest: true })],
   });
 
-  logger.info({ trustedOrigins, google: !!auth.options?.socialProviders?.google },
+  logger.info({ trustedOrigins: '[REDACTED]', google: !!auth.options?.socialProviders?.google },
     'better-auth enabled');
 }
 

--- a/lib/voices/xilabs.js
+++ b/lib/voices/xilabs.js
@@ -14,9 +14,9 @@ const accentMap = {
   default: 'en-US'
 }
 
-const getAccent = (name) => {
+export const getAccent = (name) => {
   let [accent, language] = Object.entries(accentMap).find(([a,]) => a.startsWith(name.toLowerCase())) || ['', accentMap['default']];
-  return { language, decorator: accent.replace(new RegExp(`${name}\-*`), '')};
+  return { language, decorator: accent.slice(name.length).replace(/^-+/, '')};
 };
 
 const URI = 'https://api.elevenlabs.io/v1/voices';

--- a/tests/xilabs.test.mjs
+++ b/tests/xilabs.test.mjs
@@ -1,0 +1,15 @@
+import { getAccent } from '../lib/voices/xilabs.js';
+
+describe('XiLabs accent parsing', () => {
+  test('maps a complete accent name without a decorator', () => {
+    expect(getAccent('british')).toEqual({ language: 'en-GB', decorator: '' });
+  });
+
+  test('keeps the unmatched suffix as the decorator', () => {
+    expect(getAccent('brit')).toEqual({ language: 'en-GB', decorator: 'ish' });
+  });
+
+  test('treats regular-expression characters as plain input', () => {
+    expect(getAccent('[')).toEqual({ language: 'en-US', decorator: '' });
+  });
+});


### PR DESCRIPTION
## Summary

- Redact Better Auth trusted-origin values from the structured startup log while retaining the Pino event and provider-status signal.
- Replace XiLabs' dynamic accent regex with deterministic string slicing.
- Add focused tests for complete, partial, and regex-metacharacter accent inputs.

## CodeQL disposition

Fixed in code:

- #17 `js/clear-text-logging` — `lib/auth/index.js`
- #5 `js/useless-regexp-character-escape` — `lib/voices/xilabs.js`

Dismissed as intentional with audit comments:

- #21, #20, #19 — operator-run billing credential provisioning output
- #2 — explicitly invoked local `list-authkeys` admin command
- #18 — accepted certificate-verification behavior inside the controlled private SIP boundary
- #16 — private authenticated endpoint already protected by upstream rate limiting

## Impact

Runtime logs no longer expose the configured Better Auth origin list, and provider-supplied accent labels are no longer compiled into a regular expression. Operator-facing maintenance CLI behavior and the two accepted private-endpoint controls remain unchanged.

## Verification

- `node --check lib/auth/index.js`
- `node --check lib/voices/xilabs.js`
- `node --experimental-vm-modules node_modules/.bin/jest --config jest.config.no-db.js tests/xilabs.test.mjs --runInBand` (3/3 passed)
- `git diff --check`
