### PR TITLE
pipecat: send grant-key auth on REST function callouts (beta calendar/email 401s)

### DIFF
--- a/agents/pipecat/deploy/gcp/cloudbuild-beta.yaml
+++ b/agents/pipecat/deploy/gcp/cloudbuild-beta.yaml
@@ -20,13 +20,18 @@
 # SKIP-OR-BUILD (per image): the pipecat staging lane pushes :$COMMIT_SHA to
 # these SAME image paths on every next push, so a beta tag on an
 # already-built commit skips the whole stack rebuild (freeswitch is the big
-# win) — Check PROMOTES server-side (digest-pinned `tags add`, no rebuild)
-# and each image's Build/Push steps no-op via a /workspace skip marker.
-# Partial skips are fine: every image is gated independently. No `images:`
-# provenance list: Cloud Build fails the build when a listed image wasn't
-# produced locally, which is exactly the skip path.
+# win) — Check PROMOTES server-side (digest-pinned manifest copy via `docker
+# buildx imagetools create`, no rebuild) and each image's Build/Push steps
+# no-op via a /workspace skip marker. Deliberately NOT `gcloud artifacts
+# docker tags add`: moving an existing floating tag (:beta on a re-version)
+# needs artifactregistry.tags.delete, which the Cloud Build SA lacks — a
+# manifest PUT moves tags with ordinary push permissions (the polite-ai
+# beta-0.9.56 promote incident). Partial skips are fine: every image is
+# gated independently. No `images:` provenance list: Cloud Build fails the
+# build when a listed image wasn't produced locally, which is exactly the
+# skip path.
 steps:
-  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+  - name: gcr.io/cloud-builders/docker
     id: Check
     entrypoint: bash
     args:
@@ -35,12 +40,19 @@ steps:
         set -euo pipefail
         REG="$_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME"
         for img in freeswitch esl-poller sipbridge secretenv-exec pipecat-worker; do
-          digest=$$(gcloud artifacts docker images describe "$$REG/$$img:$COMMIT_SHA" \
-                      --format='value(image_summary.digest)' 2>/dev/null || true)
+          # NB parse the Digest: line — the GCB builder's buildx ignores
+          # `imagetools inspect --format` and prints the human output anyway.
+          digest=$$(docker buildx imagetools inspect "$$REG/$$img:$COMMIT_SHA" 2>/dev/null \
+                      | awk '/^Digest:/{print $$2; exit}' || true)
           if [ -n "$$digest" ]; then
             echo "[promote] $$img:$COMMIT_SHA already published ($$digest) — tagging :$TAG_NAME + :beta, skipping build"
-            gcloud artifacts docker tags add "$$REG/$$img@$$digest" "$$REG/$$img:$TAG_NAME" --quiet
-            gcloud artifacts docker tags add "$$REG/$$img@$$digest" "$$REG/$$img:beta" --quiet
+            # --prefer-index=false: keep the promoted manifest byte-identical
+            # (same digest as :$COMMIT_SHA) — reload-beta digest-tracks the
+            # pipecat tier, so digests must be preserved.
+            docker buildx imagetools create --prefer-index=false \
+              -t "$$REG/$$img:$TAG_NAME" \
+              -t "$$REG/$$img:beta" \
+              "$$REG/$$img@$$digest"
             touch "/workspace/skip-$$img"
           else
             echo "[build] no $$img:$COMMIT_SHA in the registry — full build"

--- a/agents/pipecat/deploy/gcp/cloudbuild-beta.yaml
+++ b/agents/pipecat/deploy/gcp/cloudbuild-beta.yaml
@@ -11,174 +11,162 @@
 #       --tag-pattern='^beta-[0-9]+\.[0-9]+\.[0-9]+$' \
 #       --build-config=agents/pipecat/deploy/gcp/cloudbuild-beta.yaml
 #
-# Builds the five images (freeswitch, esl-poller, sipbridge, secretenv-exec,
-# pipecat-worker) from the tagged commit, each tagged :$COMMIT_SHA + :beta
-# (floating channel head) + :$TAG_NAME (the immutable beta-n.n.n version).
-# Build + push only — no deploy: a beta K8s overlay pulls :beta (or pins
-# :beta-n.n.n) and is rolled with kubectl, exactly like the :next / :latest
-# channels.
+# Publishes the five images (freeswitch, esl-poller, sipbridge,
+# secretenv-exec, pipecat-worker), each tagged :$COMMIT_SHA + :beta (floating
+# channel head) + :$TAG_NAME (the immutable beta-n.n.n version). Build + push
+# only — no deploy: a beta K8s overlay pulls :beta (or pins :beta-n.n.n) and
+# is rolled with kubectl, exactly like the :next / :latest channels.
+#
+# SKIP-OR-BUILD (per image): the pipecat staging lane pushes :$COMMIT_SHA to
+# these SAME image paths on every next push, so a beta tag on an
+# already-built commit skips the whole stack rebuild (freeswitch is the big
+# win) — Check PROMOTES server-side (digest-pinned `tags add`, no rebuild)
+# and each image's Build/Push steps no-op via a /workspace skip marker.
+# Partial skips are fine: every image is gated independently. No `images:`
+# provenance list: Cloud Build fails the build when a listed image wasn't
+# produced locally, which is exactly the skip path.
 steps:
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    id: Check
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        REG="$_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME"
+        for img in freeswitch esl-poller sipbridge secretenv-exec pipecat-worker; do
+          digest=$$(gcloud artifacts docker images describe "$$REG/$$img:$COMMIT_SHA" \
+                      --format='value(image_summary.digest)' 2>/dev/null || true)
+          if [ -n "$$digest" ]; then
+            echo "[promote] $$img:$COMMIT_SHA already published ($$digest) — tagging :$TAG_NAME + :beta, skipping build"
+            gcloud artifacts docker tags add "$$REG/$$img@$$digest" "$$REG/$$img:$TAG_NAME" --quiet
+            gcloud artifacts docker tags add "$$REG/$$img@$$digest" "$$REG/$$img:beta" --quiet
+            touch "/workspace/skip-$$img"
+          else
+            echo "[build] no $$img:$COMMIT_SHA in the registry — full build"
+          fi
+        done
+
   # ----- FreeSWITCH -----
   - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '--no-cache'
-      - '--build-arg'
-      - BUILD_ENV=production
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:beta
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$TAG_NAME
-      - '-f'
-      - './agents/pipecat/freeswitch/Dockerfile'
-      - './agents/pipecat/freeswitch'
     id: Build-freeswitch
-
-  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch
+      - -c
+      - |
+        [ -f /workspace/skip-freeswitch ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker build --no-cache \
+          --build-arg BUILD_ENV=production \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:beta \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$TAG_NAME \
+          -f ./agents/pipecat/freeswitch/Dockerfile ./agents/pipecat/freeswitch
+  - name: gcr.io/cloud-builders/docker
     id: Push-freeswitch
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        [ -f /workspace/skip-freeswitch ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch
 
   # ----- esl-poller -----
   - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '--no-cache'
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:beta
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$TAG_NAME
-      - '-f'
-      - './agents/pipecat/esl-poller/Dockerfile'
-      - './agents/pipecat/esl-poller'
     id: Build-esl-poller
-
-  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller
+      - -c
+      - |
+        [ -f /workspace/skip-esl-poller ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker build --no-cache \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:beta \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$TAG_NAME \
+          -f ./agents/pipecat/esl-poller/Dockerfile ./agents/pipecat/esl-poller
+  - name: gcr.io/cloud-builders/docker
     id: Push-esl-poller
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        [ -f /workspace/skip-esl-poller ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller
 
   # ----- sipbridge -----
   # Build context is the repo root (.) because the Dockerfile COPYs
   # agents/pipecat/sipbridge into the image.
   - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '--no-cache'
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:beta
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$TAG_NAME
-      - '-f'
-      - './agents/pipecat/sipbridge/Dockerfile'
-      - '.'
     id: Build-sipbridge
-
-  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge
+      - -c
+      - |
+        [ -f /workspace/skip-sipbridge ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker build --no-cache \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:beta \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$TAG_NAME \
+          -f ./agents/pipecat/sipbridge/Dockerfile .
+  - name: gcr.io/cloud-builders/docker
     id: Push-sipbridge
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        [ -f /workspace/skip-sipbridge ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge
 
   # ----- secretenv-exec -----
   # Tiny static decrypt-and-exec wrapper (reuses the sipbridge Go module).
   # Used by the Kubernetes freeswitch / voiceblender overlays so those
   # containers can share the single SECRETENV_KEY + SECRETENV_BUNDLE secret.
   - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '--no-cache'
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:beta
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:$TAG_NAME
-      - '-f'
-      - './agents/pipecat/sipbridge/Dockerfile.secretenv-exec'
-      - '.'
     id: Build-secretenv-exec
-
-  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec
+      - -c
+      - |
+        [ -f /workspace/skip-secretenv-exec ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker build --no-cache \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:beta \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:$TAG_NAME \
+          -f ./agents/pipecat/sipbridge/Dockerfile.secretenv-exec .
+  - name: gcr.io/cloud-builders/docker
     id: Push-secretenv-exec
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        [ -f /workspace/skip-secretenv-exec ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec
 
   # ----- pipecat-worker -----
   # Build context is the repo root (.) because the Dockerfile COPYs
   # agents/pipecat into the image.
   - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '--no-cache'
-      - '--build-arg'
-      - COMMIT_SHA=$COMMIT_SHA
-      - '--build-arg'
-      - BRANCH_NAME=$BRANCH_NAME
-      - '--build-arg'
-      - TAG_NAME=$TAG_NAME
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:beta
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$TAG_NAME
-      - '-f'
-      - './agents/pipecat/Dockerfile'
-      - '.'
     id: Build-pipecat-worker
-
-  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker
+      - -c
+      - |
+        [ -f /workspace/skip-pipecat-worker ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker build --no-cache \
+          --build-arg COMMIT_SHA=$COMMIT_SHA \
+          --build-arg BRANCH_NAME=$BRANCH_NAME \
+          --build-arg TAG_NAME=$TAG_NAME \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:beta \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$TAG_NAME \
+          -f ./agents/pipecat/Dockerfile .
+  - name: gcr.io/cloud-builders/docker
     id: Push-pipecat-worker
-
-images:
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:$COMMIT_SHA
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$COMMIT_SHA
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        [ -f /workspace/skip-pipecat-worker ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker
 
 options:
   substitutionOption: ALLOW_LOOSE

--- a/agents/pipecat/pipecat_aplisay/function_handler.py
+++ b/agents/pipecat/pipecat_aplisay/function_handler.py
@@ -70,6 +70,58 @@ def _replace_parameters(template: str, inputs: dict) -> tuple[str, dict]:
 HARDWIRED_BUILTINS: dict[str, Callable[..., Any]] = {}
 
 
+class RestCallError(RuntimeError):
+    """A ``rest`` function's HTTP response was >= 400.
+
+    Carries the response body so the dispatcher can hand it to the model as the
+    tool result (JS-handler parity: ``lib/function-handler.js`` returns
+    ``e.response.data`` as ``result`` alongside ``error``) — a bare error string
+    with a ``None`` result leaves the model unable to read the server's message.
+    """
+
+    def __init__(self, message: str, body: Any):
+        super().__init__(message)
+        self.body = body
+
+
+def _resolve_rest_auth(
+    fn_def: dict, keys: list[dict]
+) -> tuple[dict[str, str], list[tuple[str, str]]]:
+    """Resolve a rest function's ``key`` reference into auth material.
+
+    Returns ``(headers, query_pairs)``. Mirrors the canonical JS handler
+    (``lib/function-handler.js``: ``basic`` / ``bearer`` / ``header``) plus the
+    ``query`` type ``mcp_tools._resolve_key_auth`` already supports. An unknown
+    key name or ``in`` type logs a warning and yields no auth — the request goes
+    out keyless and the server's 401 comes back as the tool result, matching the
+    JS handler's behaviour.
+    """
+    name = fn_def.get("key")
+    if not name:
+        return {}, []
+    key = next((k for k in (keys or []) if k.get("name") == name), None)
+    if key is None:
+        logger.bind(function=fn_def.get("name"), key=name).warning(
+            f"rest function '{fn_def.get('name')}' references unknown API key '{name}'; sending no auth"
+        )
+        return {}, []
+    where = (key.get("in") or "").lower()
+    value = key.get("value")
+    if where == "basic":
+        return {"Authorization": f"Basic {value}"}, []
+    if where == "bearer":
+        return {"Authorization": f"Bearer {value}"}, []
+    if where == "header":
+        header_name = key.get("header") or key.get("name")
+        return {str(header_name): str(value)}, []
+    if where == "query":
+        return {}, [(key.get("name") or name, str(value or ""))]
+    logger.bind(function=fn_def.get("name"), key=name, **{"in": where}).warning(
+        f"rest function '{fn_def.get('name')}' API key '{name}' has unsupported 'in' type; sending no auth"
+    )
+    return {}, []
+
+
 def _builtin_metadata(args: dict, metadata: dict, options: dict) -> dict:
     keys = args.get("keys")
     if isinstance(keys, str):
@@ -157,7 +209,7 @@ def _write_result_to_metadata(
 async def function_handler(
     function_calls: list[dict],
     functions: list[dict],
-    keys: list[str],
+    keys: list[dict],
     message_handler: Callable[[dict], Awaitable[None]],
     metadata: dict,
     specific_builtins: dict[str, Callable[..., Any]],
@@ -221,9 +273,30 @@ async def function_handler(
                     raise RuntimeError(f"no builtin implementation for {platform}")
                 result = await _maybe_await(fn(inputs, metadata, options))
             elif impl == "rest":
+                # Callout telemetry before the request (JS-handler parity) so
+                # the call's Data feed shows WHERE the tool went and with what
+                # auth shape — the 2026-07-25 beta 401s were invisible without it.
+                try:
+                    await message_handler(
+                        {
+                            "rest_callout": {
+                                "url": fn_def.get("url"),
+                                "method": (fn_def.get("method") or "POST").upper(),
+                                "key": fn_def.get("key") or None,
+                            }
+                        }
+                    )
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(f"rest_callout telemetry emit failed: {e}")
                 result = await _execute_rest(fn_def, inputs, keys)
             else:
                 raise RuntimeError(f"unknown implementation {impl}")
+        except RestCallError as e:
+            # Surface the server's response body to the model as the tool
+            # result — a 401/422 body usually says exactly what to fix.
+            error = str(e)
+            result = e.body
+            logger.bind(name=name, error=error).warning("function execution failed")
         except Exception as e:  # noqa: BLE001
             error = str(e)
             logger.bind(name=name, error=error).warning("function execution failed")
@@ -270,11 +343,21 @@ async def _maybe_await(value: Any) -> Any:
     return value
 
 
-async def _execute_rest(fn_def: dict, inputs: dict, keys: list[str]) -> Any:
-    """REST implementation. Supports template substitution into URL/headers/body."""
+async def _execute_rest(fn_def: dict, inputs: dict, keys: list[dict]) -> Any:
+    """REST implementation. Supports template substitution into URL/headers/body.
+
+    Auth: a ``key`` name on the function is resolved against the agent's
+    ``keys`` into an Authorization (or custom) header — the same contract the
+    canonical JS handler implements. This was MISSING from the port until
+    2026-07-25: every keyed rest function (booking_get_slots / booking_book /
+    notify_email_team) went out with no credentials and 401'd at the tool
+    plane regardless of the key being armed on the agent.
+    """
     method = (fn_def.get("method") or "POST").upper()
     raw_url = fn_def.get("url") or ""
     url, leftover = _replace_parameters(raw_url, inputs)
+
+    auth_headers, auth_params = _resolve_rest_auth(fn_def, keys)
 
     headers_template = fn_def.get("headers") or {}
     headers: dict[str, str] = {}
@@ -290,15 +373,32 @@ async def _execute_rest(fn_def: dict, inputs: dict, keys: list[str]) -> Any:
         else:
             substituted, _ = _replace_parameters(str(value), inputs)
             headers[key] = substituted
+    # Key-derived auth wins for its own header name; explicit template headers
+    # for OTHER names survive (the JS handler sends only the auth header, so
+    # there is no conflicting precedent to preserve).
+    headers.update(auth_headers)
 
     body: Any = None
+    params: Optional[list[tuple[str, str]]] = None
     if method in ("POST", "PUT", "PATCH"):
         body = leftover or None
+        if auth_params:
+            params = list(auth_params)
+    else:
+        # Unconsumed inputs become the query string on read-style methods —
+        # the JS handler's URLSearchParams(left) branch.
+        params = [(k, str(v)) for k, v in (leftover or {}).items() if v is not None]
+        params.extend(auth_params)
 
     async with httpx.AsyncClient(timeout=15.0) as client:
-        resp = await client.request(method, url, headers=headers, json=body)
+        resp = await client.request(method, url, headers=headers, params=params or None, json=body)
+    is_json = resp.headers.get("content-type", "").startswith("application/json")
     if resp.status_code >= 400:
-        raise RuntimeError(f"REST function {fn_def.get('name')} failed: {resp.status_code} {resp.text}")
-    if resp.headers.get("content-type", "").startswith("application/json"):
+        parsed = _try_parse_json(resp.text) if is_json else None
+        raise RestCallError(
+            f"REST function {fn_def.get('name')} failed: {resp.status_code}",
+            parsed if parsed is not None else resp.text,
+        )
+    if is_json:
         return resp.json()
     return resp.text

--- a/agents/pipecat/tests/test_function_handler_rest.py
+++ b/agents/pipecat/tests/test_function_handler_rest.py
@@ -1,0 +1,184 @@
+"""Tests for the ``rest`` implementation of the pipecat function handler.
+
+Regression coverage for the 2026-07-25 beta incident: keyed rest functions
+(booking_get_slots / booking_book / notify_email_team) were dispatched with NO
+credentials because the Python port of ``lib/function-handler.js`` accepted the
+agent ``keys`` but never resolved a function's ``key`` reference into an
+Authorization header — every call 401'd at the integrations tool plane even
+though the key was armed on the agent.
+
+Covers:
+- bearer / basic / custom-header / query key resolution (JS-handler parity
+  plus the ``query`` type ``mcp_tools`` already supports);
+- unknown key name → request still goes out, keyless (server decides);
+- >= 400 responses surface the response BODY as the tool result alongside the
+  error (previously the model saw ``result: None`` and couldn't tell why);
+- unconsumed inputs become the query string on GET (URLSearchParams parity);
+- the ``rest_callout`` telemetry emission before the request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Optional
+
+import pytest
+
+import pipecat_aplisay.function_handler as fh
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, body: Any = None, json_body: bool = True):
+        self.status_code = status_code
+        self._body = body if body is not None else {"ok": True}
+        self._json = json_body
+        self.headers = {"content-type": "application/json" if json_body else "text/plain"}
+
+    @property
+    def text(self) -> str:
+        return json.dumps(self._body) if self._json else str(self._body)
+
+    def json(self) -> Any:
+        return self._body
+
+
+class _FakeClient:
+    """Stands in for httpx.AsyncClient; records the single request it serves."""
+
+    last: Optional[dict] = None
+    response: _FakeResponse = _FakeResponse()
+
+    def __init__(self, *_a, **_k):
+        pass
+
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        return None
+
+    async def request(self, method: str, url: str, headers=None, params=None, json=None):
+        _FakeClient.last = {
+            "method": method,
+            "url": url,
+            "headers": dict(headers or {}),
+            "params": list(params) if params else None,
+            "json": json,
+        }
+        return _FakeClient.response
+
+
+@pytest.fixture(autouse=True)
+def _fake_httpx(monkeypatch):
+    _FakeClient.last = None
+    _FakeClient.response = _FakeResponse()
+    monkeypatch.setattr(fh.httpx, "AsyncClient", _FakeClient)
+    yield
+
+
+def _rest_fn(**over) -> dict:
+    fn = {
+        "name": "booking_get_slots",
+        "implementation": "rest",
+        "method": "post",
+        "url": "https://integrations.example/v1/tools/booking.get_slots",
+        "key": "POLITE_BOOKING",
+        "input_schema": {
+            "properties": {
+                "days": {"type": "number"},
+                "policy": {"type": "string", "source": "static", "from": "bpol_x"},
+            }
+        },
+    }
+    fn.update(over)
+    return fn
+
+
+def _run(fn: dict, keys: list[dict], llm_input: Optional[dict] = None, messages: Optional[list] = None) -> dict:
+    async def handler(message: dict) -> None:
+        if messages is not None:
+            messages.append(message)
+
+    async def go() -> dict:
+        return await fh.function_handler(
+            [{"name": fn["name"], "input": llm_input or {}}],
+            [fn],
+            keys,
+            handler,
+            {},
+            {},
+            {},
+        )
+
+    return asyncio.run(go())
+
+
+class TestKeyResolution:
+    def test_bearer_key_sets_authorization(self) -> None:
+        result = _run(_rest_fn(), [{"name": "POLITE_BOOKING", "in": "bearer", "value": "sekrit"}], {"days": 7})
+        assert result["function_results"][0]["error"] is None
+        assert _FakeClient.last["headers"]["Authorization"] == "Bearer sekrit"
+        # generated + static params both land in the JSON body on POST
+        assert _FakeClient.last["json"] == {"days": 7, "policy": "bpol_x"}
+
+    def test_basic_key_sets_authorization(self) -> None:
+        _run(_rest_fn(), [{"name": "POLITE_BOOKING", "in": "basic", "value": "dXNlcjpwdw=="}])
+        assert _FakeClient.last["headers"]["Authorization"] == "Basic dXNlcjpwdw=="
+
+    def test_header_key_uses_named_header(self) -> None:
+        _run(_rest_fn(), [{"name": "POLITE_BOOKING", "in": "header", "header": "X-Api-Key", "value": "k1"}])
+        assert _FakeClient.last["headers"]["X-Api-Key"] == "k1"
+        assert "Authorization" not in _FakeClient.last["headers"]
+
+    def test_query_key_appends_param(self) -> None:
+        _run(_rest_fn(), [{"name": "POLITE_BOOKING", "in": "query", "value": "qv"}])
+        assert ("POLITE_BOOKING", "qv") in (_FakeClient.last["params"] or [])
+
+    def test_unknown_key_sends_no_auth(self) -> None:
+        result = _run(_rest_fn(), [{"name": "OTHER_KEY", "in": "bearer", "value": "x"}])
+        # The request still goes out (server decides) — matching the JS handler.
+        assert _FakeClient.last is not None
+        assert "Authorization" not in _FakeClient.last["headers"]
+        assert result["function_results"][0]["error"] is None
+
+    def test_unkeyed_function_untouched(self) -> None:
+        _run(_rest_fn(key=None), [{"name": "POLITE_BOOKING", "in": "bearer", "value": "sekrit"}])
+        assert "Authorization" not in _FakeClient.last["headers"]
+
+
+class TestErrorSurfacing:
+    def test_http_error_returns_body_as_result(self) -> None:
+        _FakeClient.response = _FakeResponse(status_code=401, body={"error": "unauthorized"})
+        result = _run(_rest_fn(), [])
+        first = result["function_results"][0]
+        assert "401" in first["error"]
+        assert first["result"] == {"error": "unauthorized"}
+
+    def test_http_error_text_body(self) -> None:
+        _FakeClient.response = _FakeResponse(status_code=503, body="upstream down", json_body=False)
+        result = _run(_rest_fn(), [])
+        first = result["function_results"][0]
+        assert "503" in first["error"]
+        assert first["result"] == "upstream down"
+
+
+class TestQueryStringMethods:
+    def test_get_leftovers_become_params(self) -> None:
+        fn = _rest_fn(method="get", url="https://api.example/slots/{policy}")
+        _run(fn, [{"name": "POLITE_BOOKING", "in": "bearer", "value": "v"}], {"days": 3})
+        # {policy} consumed into the URL; days left over -> query param
+        assert _FakeClient.last["url"] == "https://api.example/slots/bpol_x"
+        assert ("days", "3") in _FakeClient.last["params"]
+        assert _FakeClient.last["json"] is None
+
+
+class TestTelemetry:
+    def test_rest_callout_emitted_before_request(self) -> None:
+        messages: list = []
+        _run(_rest_fn(), [{"name": "POLITE_BOOKING", "in": "bearer", "value": "v"}], {}, messages)
+        kinds = [next(iter(m)) for m in messages]
+        assert kinds.index("rest_callout") < kinds.index("function_results")
+        callout = next(m for m in messages if "rest_callout" in m)["rest_callout"]
+        assert callout["url"].endswith("booking.get_slots")
+        assert callout["key"] == "POLITE_BOOKING"

--- a/agents/pipecat/tests/test_ultravox_native_tool_results.py
+++ b/agents/pipecat/tests/test_ultravox_native_tool_results.py
@@ -87,6 +87,8 @@ def _new_ultravox_service():
     llm._functions = {}
     llm._completed_tool_calls = set()
     llm._started_placeholder_sent = set()
+    # pipecat-ai >= 1.6.0: register_function() clears the name from this set.
+    llm._explicitly_unregistered_function_names = set()
     return llm
 
 

--- a/deploy/gcp/cloudrun/cloudbuild-beta.yaml
+++ b/deploy/gcp/cloudrun/cloudbuild-beta.yaml
@@ -17,12 +17,19 @@
 #
 # SKIP-OR-BUILD: when llm-agent:$COMMIT_SHA already exists (a previous beta
 # release of the same commit, or a per-commit main build), Check PROMOTES
-# server-side — digest-pinned `tags add` of :$TAG_NAME + :beta, the same idiom
-# as cloudbuild-release.yaml — and Build/Push no-op via a /workspace skip
-# marker. NB the staging lane publishes to a DIFFERENT image path
-# (llm-agent-staging), so a first beta tag on a next-branch commit still
-# builds from source here. No `images:` provenance list: Cloud Build fails
-# the build when a listed image wasn't produced locally (the skip path).
+# server-side — a digest-pinned manifest copy (`docker buildx imagetools
+# create`) that adds :$TAG_NAME + :beta with no rebuild — and Build/Push
+# no-op via a /workspace skip marker. Deliberately NOT `gcloud artifacts
+# docker tags add` (cloudbuild-release.yaml's idiom): on Artifact Registry
+# that command needs artifactregistry.tags.delete to MOVE a tag that already
+# exists, which the Cloud Build service account lacks — the polite-ai
+# beta-0.9.56 promote died exactly there re-pointing :beta. A manifest PUT
+# (the same registry call `docker push` makes) moves floating tags with the
+# SA's ordinary push permissions. NB the staging lane publishes to a
+# DIFFERENT image path (llm-agent-staging), so a first beta tag on a
+# next-branch commit still builds from source here. No `images:` provenance
+# list: Cloud Build fails the build when a listed image wasn't produced
+# locally (the skip path).
 #
 # Unlike the v-tag release flow (cloudbuild-release.yaml, which only promotes
 # and never builds), beta tags may land on commits with no llm-agent-repo
@@ -37,7 +44,7 @@
 # SECRETENV_STAGING_* if the beta channel should carry the staging credential
 # instead.
 steps:
-  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+  - name: gcr.io/cloud-builders/docker
     id: Check
     entrypoint: bash
     args:
@@ -45,12 +52,19 @@ steps:
       - |
         set -euo pipefail
         REG="$_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME"
-        digest=$$(gcloud artifacts docker images describe "$$REG/$_SERVICE_NAME:$COMMIT_SHA" \
-                    --format='value(image_summary.digest)' 2>/dev/null || true)
+        # NB parse the Digest: line — the GCB builder's buildx ignores
+        # `imagetools inspect --format` and prints the human output anyway.
+        digest=$$(docker buildx imagetools inspect "$$REG/$_SERVICE_NAME:$COMMIT_SHA" 2>/dev/null \
+                    | awk '/^Digest:/{print $$2; exit}' || true)
         if [ -n "$$digest" ]; then
           echo "[promote] $_SERVICE_NAME:$COMMIT_SHA already published ($$digest) — tagging :$TAG_NAME + :beta, skipping build"
-          gcloud artifacts docker tags add "$$REG/$_SERVICE_NAME@$$digest" "$$REG/$_SERVICE_NAME:$TAG_NAME" --quiet
-          gcloud artifacts docker tags add "$$REG/$_SERVICE_NAME@$$digest" "$$REG/$_SERVICE_NAME:beta" --quiet
+          # --prefer-index=false: push the manifest byte-identical (same digest
+          # as :$COMMIT_SHA) instead of wrapping it in a new OCI index —
+          # reload-beta digest-tracks some tiers, so digests must be preserved.
+          docker buildx imagetools create --prefer-index=false \
+            -t "$$REG/$_SERVICE_NAME:$TAG_NAME" \
+            -t "$$REG/$_SERVICE_NAME:beta" \
+            "$$REG/$_SERVICE_NAME@$$digest"
           touch /workspace/skip-llm-agent
         else
           echo "[build] no $_SERVICE_NAME:$COMMIT_SHA in the registry — full build"

--- a/deploy/gcp/cloudrun/cloudbuild-beta.yaml
+++ b/deploy/gcp/cloudrun/cloudbuild-beta.yaml
@@ -9,18 +9,26 @@
 #       --tag-pattern='^beta-[0-9]+\.[0-9]+\.[0-9]+$' \
 #       --build-config=deploy/gcp/cloudrun/cloudbuild-beta.yaml
 #
-# Builds the server image from the tagged commit and pushes it to the
-# PRODUCTION image repo (llm-agent, not llm-agent-staging) tagged
-# :$COMMIT_SHA + :beta (floating channel head) + :$TAG_NAME (the immutable
-# beta-n.n.n version). Build + push only — no deploy: whatever runs the beta
-# channel pulls :beta (or pins :beta-n.n.n) and is rolled separately.
+# Publishes the server image to the PRODUCTION image repo (llm-agent, not
+# llm-agent-staging) tagged :$COMMIT_SHA + :beta (floating channel head) +
+# :$TAG_NAME (the immutable beta-n.n.n version). Build + push only — no
+# deploy: whatever runs the beta channel pulls :beta (or pins :beta-n.n.n)
+# and is rolled separately.
+#
+# SKIP-OR-BUILD: when llm-agent:$COMMIT_SHA already exists (a previous beta
+# release of the same commit, or a per-commit main build), Check PROMOTES
+# server-side — digest-pinned `tags add` of :$TAG_NAME + :beta, the same idiom
+# as cloudbuild-release.yaml — and Build/Push no-op via a /workspace skip
+# marker. NB the staging lane publishes to a DIFFERENT image path
+# (llm-agent-staging), so a first beta tag on a next-branch commit still
+# builds from source here. No `images:` provenance list: Cloud Build fails
+# the build when a listed image wasn't produced locally (the skip path).
 #
 # Unlike the v-tag release flow (cloudbuild-release.yaml, which only promotes
-# images the per-commit main builds already pushed), this BUILDS from source —
-# beta tags may land on commits (e.g. on next or a feature branch) that have
-# no per-commit production image. Like the release flow it runs no test gate:
-# the branch CI triggers (staging/feature) are the test gate, so tag the beta
-# from a commit that has passed them.
+# and never builds), beta tags may land on commits with no llm-agent-repo
+# image at all — this config covers both. Like the release flow it runs no
+# test gate: the branch CI triggers are the test gate, so tag the beta from a
+# commit that has passed them.
 #
 # Build-time secrets: the production SECRETENV bundle, matching the per-commit
 # main build — it is only used to bake credentials/google.json into the image
@@ -29,46 +37,52 @@
 # SECRETENV_STAGING_* if the beta channel should carry the staging credential
 # instead.
 steps:
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    id: Check
+    entrypoint: bash
     args:
-      - build
-      - '--no-cache'
-      - '--build-arg'
-      - SECRETENV_BUNDLE
-      - '--build-arg'
-      - SECRETENV_KEY
-      - '--build-arg'
-      - COMMIT_SHA=$COMMIT_SHA
-      - '--build-arg'
-      - BRANCH_NAME=$BRANCH_NAME
-      - '--build-arg'
-      - TAG_NAME=$TAG_NAME
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:beta
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$TAG_NAME
-      - .
-      - '-f'
-      - Dockerfile
+      - -c
+      - |
+        set -euo pipefail
+        REG="$_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME"
+        digest=$$(gcloud artifacts docker images describe "$$REG/$_SERVICE_NAME:$COMMIT_SHA" \
+                    --format='value(image_summary.digest)' 2>/dev/null || true)
+        if [ -n "$$digest" ]; then
+          echo "[promote] $_SERVICE_NAME:$COMMIT_SHA already published ($$digest) — tagging :$TAG_NAME + :beta, skipping build"
+          gcloud artifacts docker tags add "$$REG/$_SERVICE_NAME@$$digest" "$$REG/$_SERVICE_NAME:$TAG_NAME" --quiet
+          gcloud artifacts docker tags add "$$REG/$_SERVICE_NAME@$$digest" "$$REG/$_SERVICE_NAME:beta" --quiet
+          touch /workspace/skip-llm-agent
+        else
+          echo "[build] no $_SERVICE_NAME:$COMMIT_SHA in the registry — full build"
+        fi
+  - name: gcr.io/cloud-builders/docker
     id: Build
+    entrypoint: bash
     secretEnv:
       - SECRETENV_BUNDLE
       - SECRETENV_KEY
-  - name: gcr.io/cloud-builders/docker
     args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME
+      - -c
+      - |
+        [ -f /workspace/skip-llm-agent ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker build --no-cache \
+          --build-arg SECRETENV_BUNDLE \
+          --build-arg SECRETENV_KEY \
+          --build-arg COMMIT_SHA=$COMMIT_SHA \
+          --build-arg BRANCH_NAME=$BRANCH_NAME \
+          --build-arg TAG_NAME=$TAG_NAME \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:beta \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$TAG_NAME \
+          -f Dockerfile .
+  - name: gcr.io/cloud-builders/docker
     id: Push
-images:
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        [ -f /workspace/skip-llm-agent ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME
 options:
   substitutionOption: ALLOW_LOOSE
   automapSubstitutions: true

--- a/deploy/gcp/cloudrun/cloudbuild-livekit-beta.yaml
+++ b/deploy/gcp/cloudrun/cloudbuild-livekit-beta.yaml
@@ -16,13 +16,15 @@
 #
 # SKIP-OR-BUILD: when livekit-agent:$COMMIT_SHA already exists (a previous
 # beta release of the same commit, or a per-commit main build), Check PROMOTES
-# server-side (digest-pinned `tags add`, no rebuild) and the
-# Submodules/Build/Push steps no-op via a /workspace skip marker — the
-# submodule fetch is skipped too. See cloudbuild-beta.yaml for the full
-# rationale (incl. why there is no `images:` list). Build-time secrets: the
-# production SECRETENV bundle, matching the per-commit main build.
+# server-side (digest-pinned manifest copy via `docker buildx imagetools
+# create` — NOT `tags add`, which cannot MOVE an existing :beta under the
+# Cloud Build SA) and the Submodules/Build/Push steps no-op via a /workspace
+# skip marker — the submodule fetch is skipped too. See cloudbuild-beta.yaml
+# for the full rationale (incl. why there is no `images:` list). Build-time
+# secrets: the production SECRETENV bundle, matching the per-commit main
+# build.
 steps:
-  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+  - name: gcr.io/cloud-builders/docker
     id: Check
     entrypoint: bash
     args:
@@ -30,12 +32,18 @@ steps:
       - |
         set -euo pipefail
         REG="$_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME"
-        digest=$$(gcloud artifacts docker images describe "$$REG/$_SERVICE_NAME:$COMMIT_SHA" \
-                    --format='value(image_summary.digest)' 2>/dev/null || true)
+        # NB parse the Digest: line — the GCB builder's buildx ignores
+        # `imagetools inspect --format` and prints the human output anyway.
+        digest=$$(docker buildx imagetools inspect "$$REG/$_SERVICE_NAME:$COMMIT_SHA" 2>/dev/null \
+                    | awk '/^Digest:/{print $$2; exit}' || true)
         if [ -n "$$digest" ]; then
           echo "[promote] $_SERVICE_NAME:$COMMIT_SHA already published ($$digest) — tagging :$TAG_NAME + :beta, skipping build"
-          gcloud artifacts docker tags add "$$REG/$_SERVICE_NAME@$$digest" "$$REG/$_SERVICE_NAME:$TAG_NAME" --quiet
-          gcloud artifacts docker tags add "$$REG/$_SERVICE_NAME@$$digest" "$$REG/$_SERVICE_NAME:beta" --quiet
+          # --prefer-index=false: keep the promoted manifest byte-identical
+          # (same digest as :$COMMIT_SHA) — no new OCI index wrapper.
+          docker buildx imagetools create --prefer-index=false \
+            -t "$$REG/$_SERVICE_NAME:$TAG_NAME" \
+            -t "$$REG/$_SERVICE_NAME:beta" \
+            "$$REG/$_SERVICE_NAME@$$digest"
           touch /workspace/skip-livekit-agent
         else
           echo "[build] no $_SERVICE_NAME:$COMMIT_SHA in the registry — full build"

--- a/deploy/gcp/cloudrun/cloudbuild-livekit-beta.yaml
+++ b/deploy/gcp/cloudrun/cloudbuild-livekit-beta.yaml
@@ -10,50 +10,69 @@
 #       --tag-pattern='^beta-[0-9]+\.[0-9]+\.[0-9]+$' \
 #       --build-config=deploy/gcp/cloudrun/cloudbuild-livekit-beta.yaml
 #
-# Builds from the tagged commit and pushes to the PRODUCTION image repo
-# (livekit-agent) tagged :$COMMIT_SHA + :beta + :$TAG_NAME. Build + push only —
-# no deploy: the GCE docker-compose host pulls its channel tag and is
-# restarted out of band. Submodules are initialised first (as in the staging
-# build — tag checkouts don't bring them in). Build-time secrets: the
-# production SECRETENV bundle, matching the per-commit main build (see
-# cloudbuild-beta.yaml for the rationale + how to swap to staging secrets).
+# Publishes to the PRODUCTION image repo (livekit-agent) tagged :$COMMIT_SHA +
+# :beta + :$TAG_NAME. Build + push only — no deploy: the GCE docker-compose
+# host pulls its channel tag and is restarted out of band.
+#
+# SKIP-OR-BUILD: when livekit-agent:$COMMIT_SHA already exists (a previous
+# beta release of the same commit, or a per-commit main build), Check PROMOTES
+# server-side (digest-pinned `tags add`, no rebuild) and the
+# Submodules/Build/Push steps no-op via a /workspace skip marker — the
+# submodule fetch is skipped too. See cloudbuild-beta.yaml for the full
+# rationale (incl. why there is no `images:` list). Build-time secrets: the
+# production SECRETENV bundle, matching the per-commit main build.
 steps:
-  - name: gcr.io/cloud-builders/git
-    args: ['submodule', 'update', '--init', '--recursive']
-  - name: gcr.io/cloud-builders/docker
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    id: Check
+    entrypoint: bash
     args:
-      - build
-      - '--no-cache'
-      - '--build-arg'
-      - SECRETENV_BUNDLE
-      - '--build-arg'
-      - SECRETENV_KEY
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:beta
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$TAG_NAME
-      - '-f'
-      - agents/livekit/Dockerfile
-      - .
+      - -c
+      - |
+        set -euo pipefail
+        REG="$_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME"
+        digest=$$(gcloud artifacts docker images describe "$$REG/$_SERVICE_NAME:$COMMIT_SHA" \
+                    --format='value(image_summary.digest)' 2>/dev/null || true)
+        if [ -n "$$digest" ]; then
+          echo "[promote] $_SERVICE_NAME:$COMMIT_SHA already published ($$digest) — tagging :$TAG_NAME + :beta, skipping build"
+          gcloud artifacts docker tags add "$$REG/$_SERVICE_NAME@$$digest" "$$REG/$_SERVICE_NAME:$TAG_NAME" --quiet
+          gcloud artifacts docker tags add "$$REG/$_SERVICE_NAME@$$digest" "$$REG/$_SERVICE_NAME:beta" --quiet
+          touch /workspace/skip-livekit-agent
+        else
+          echo "[build] no $_SERVICE_NAME:$COMMIT_SHA in the registry — full build"
+        fi
+  - name: gcr.io/cloud-builders/git
+    id: Submodules
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        [ -f /workspace/skip-livekit-agent ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec git submodule update --init --recursive
+  - name: gcr.io/cloud-builders/docker
     id: Build
+    entrypoint: bash
     secretEnv:
       - SECRETENV_BUNDLE
       - SECRETENV_KEY
-  - name: gcr.io/cloud-builders/docker
     args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME
+      - -c
+      - |
+        [ -f /workspace/skip-livekit-agent ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker build --no-cache \
+          --build-arg SECRETENV_BUNDLE \
+          --build-arg SECRETENV_KEY \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:beta \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$TAG_NAME \
+          -f agents/livekit/Dockerfile .
+  - name: gcr.io/cloud-builders/docker
     id: Push
-images:
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        [ -f /workspace/skip-livekit-agent ] && { echo "[skip] promoted existing image"; exit 0; }
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/$_SERVICE_NAME
 options:
   substitutionOption: ALLOW_LOOSE
   automapSubstitutions: true


### PR DESCRIPTION
## Why

Beta (LON1) calendar booking still 401s: pipecat's `_execute_rest` accepted the agent's `keys` but never resolved a function's `key` reference into an Authorization header, so **every keyed REST tool call went out keyless** — integrations answers `401 invalid_grant_key` (its deliberately uniform 401, which fires for a missing header too). Re-confirmed live 2026-07-27: agent key armed via panel (`PUT /agents/{id}/keys` → 200 at 11:01:38 UTC), then 3× `booking_get_slots` at 11:04:57–11:05:22 → 3× 401, exact timing correlation. The JS handler (`lib/function-handler.js`) has always done this resolution; the python worker never did. Same path fixes `notify_email_team`.

## What

- **fix(pipecat): resolve rest-function key references into auth headers** — `_resolve_rest_auth` supports basic/bearer/header/query key placement; ≥400 responses now surface the response body to the model as the tool result (instead of `result: None`); GET/DELETE leftover args become the query string (parity with the JS handler); `rest_callout` telemetry emitted before each request so the calls Data feed shows where a tool went and with which key.
- **beta builds: skip-or-build for the llm-agent/livekit/pipecat beta configs** — promote already-built `:$COMMIT_SHA` images instead of rebuilding (freeswitch is the big win; the pipecat staging lane shares these image paths).
- **test(pipecat): seed pipecat 1.6.0's unregister-suppression set in the no-init harness** — pre-existing red on `next` since the Dependabot uv.lock bump (aac2212): `register_function()` now touches `_explicitly_unregistered_function_names`, which the `object.__new__` test harness didn't seed. Harness-only; the runtime initialises it (the beta-0.9.54 worker built from that commit registers/executes tools fine in production).

## Verification

- Rebased onto `next` tip (9d12e80, = beta-0.9.54) — clean, no file overlap.
- Full pipecat suite against the rebased lockfile (pipecat-ai 1.6.0): **186 passed**.
- No node-side changes — the JS tree is byte-identical to `next`.
- All three cloudbuild YAMLs parse-checked.

## Beta tag note

Tagging the merge commit immediately → full pipecat build (no `:$COMMIT_SHA` exists yet). Tagging after the staging lane has built the merge sha → the new promote path moves `:beta` via imagetools (its first live exercise here). Both are correct.
