### PR TITLE
pipecat: stamp explicit timeout on Ultravox tool definitions (duplicate-booking fix)

### DIFF
--- a/agents/pipecat/pipecat_aplisay/ultravox_compat.py
+++ b/agents/pipecat/pipecat_aplisay/ultravox_compat.py
@@ -1,6 +1,6 @@
 """Compatibility shims for Pipecat's upstream ``UltravoxRealtimeLLMService``.
 
-Two fixes live here today:
+Three fixes live here today:
 
 1. ``_receive_messages`` teardown race (original): upstream wraps its
    ``try/except`` around the loop *body* rather than the iteration itself, so
@@ -22,6 +22,17 @@ Two fixes live here today:
    placeholder and deliver the true result as a native ``client_tool_result``
    for the same invocation id instead.
 
+3. Tool ``timeout`` (see ``_to_selected_tools``): Ultravox limits client tools
+   to a DEFAULT execution window of 2.5 seconds — a tool whose result arrives
+   later is treated as failed, the late ``client_tool_result`` is discarded as
+   stale, and the model retries the call. Upstream's ``_to_selected_tools``
+   emits ``temporaryTool`` definitions with no ``timeout`` field, so every tool
+   gets that default (beta 2026-07-27: booking_book's ~4s round-trip — freebusy
+   re-validation + Google event insert — was retried with identical args after
+   each SUCCESSFUL booking, and the duplicate 409'd as slot_unavailable, so the
+   agent told the caller a slot they had just secured was taken). We stamp an
+   explicit per-tool timeout on every definition.
+
 This file is intended to shrink as upstream fixes land.
 """
 
@@ -31,12 +42,33 @@ import json
 from typing import Any
 
 from loguru import logger
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.services.llm_service import FunctionCallFromLLM
 from pipecat.services.ultravox.llm import UltravoxRealtimeLLMService
 
+# Ultravox's client-tool execution window (protobuf Duration string, 40s max).
+# 10s clears our slowest data tools (booking_book ≈ 4s, MCP knowledge search)
+# with margin, while still bounding how long a wedged tool can freeze the
+# conversation. Ultravox delivers results the moment they arrive — a generous
+# ceiling adds no latency to the common fast path.
+ULTRAVOX_TOOL_TIMEOUT = "10s"
+
 
 class AplisayUltravoxRealtimeLLMService(UltravoxRealtimeLLMService):
-    """Drop-in replacement: teardown-race fix + native tool-result delivery."""
+    """Drop-in replacement: teardown-race fix + native tool-result delivery +
+    explicit tool timeouts."""
+
+    def _to_selected_tools(self, tool: ToolsSchema) -> list[dict[str, Any]]:
+        """Upstream's mapping, plus an explicit ``timeout`` on every
+        ``temporaryTool`` so slow-but-healthy data tools aren't cut off at
+        Ultravox's 2.5s default (which discards the late result and makes the
+        model retry — duplicate side effects for non-idempotent tools)."""
+        selected = super()._to_selected_tools(tool)
+        for entry in selected:
+            temporary = entry.get("temporaryTool")
+            if isinstance(temporary, dict):
+                temporary.setdefault("timeout", ULTRAVOX_TOOL_TIMEOUT)
+        return selected
 
     async def deliver_native_tool_result(self, tool_call_id: str, result: Any) -> None:
         """Send a REAL native ``client_tool_result`` for a data tool the instant

--- a/agents/pipecat/tests/test_ultravox_tool_timeout.py
+++ b/agents/pipecat/tests/test_ultravox_tool_timeout.py
@@ -1,0 +1,63 @@
+"""Explicit per-tool ``timeout`` on Ultravox ``temporaryTool`` definitions
+(:mod:`pipecat_aplisay.ultravox_compat`).
+
+Ultravox limits client tools to a 2.5s default execution window; a result
+arriving later is discarded as stale and the model RETRIES the call. On beta
+(2026-07-27) booking_book's ~4s round-trip meant every successful booking was
+immediately re-attempted with identical args — the duplicate 409'd
+(slot_unavailable) and the agent told the caller their just-secured slot was
+taken. The shim stamps ``timeout`` on every tool definition so slow-but-healthy
+data tools survive; these tests lock that in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
+
+pytest.importorskip("pipecat.services.ultravox.llm")
+
+from pipecat_aplisay.ultravox_compat import (  # noqa: E402
+    ULTRAVOX_TOOL_TIMEOUT,
+    AplisayUltravoxRealtimeLLMService,
+)
+
+
+def _schema(names: list[str]) -> ToolsSchema:
+    return ToolsSchema(
+        standard_tools=[
+            FunctionSchema(name=n, description="d", properties={"a": {"type": "string"}}, required=["a"])
+            for n in names
+        ]
+    )
+
+
+def _service() -> AplisayUltravoxRealtimeLLMService:
+    # _to_selected_tools is stateless (reads only its argument), so a no-init
+    # instance exercises the real inherited + overridden code path.
+    return object.__new__(AplisayUltravoxRealtimeLLMService)
+
+
+def test_every_temporary_tool_gets_the_explicit_timeout():
+    selected = _service()._to_selected_tools(_schema(["booking_book", "booking_get_slots"]))
+    assert len(selected) == 2
+    for entry in selected:
+        assert entry["temporaryTool"]["timeout"] == ULTRAVOX_TOOL_TIMEOUT
+
+
+def test_upstream_fields_survive_untouched():
+    (entry,) = _service()._to_selected_tools(_schema(["booking_book"]))
+    tool = entry["temporaryTool"]
+    assert tool["modelToolName"] == "booking_book"
+    assert tool["client"] == {}
+    (param,) = tool["dynamicParameters"]
+    assert param["name"] == "a" and param["required"] is True
+
+
+def test_timeout_is_within_ultravox_bounds():
+    # Duration-string form, above the 2.5s default, at or below the 40s max.
+    assert ULTRAVOX_TOOL_TIMEOUT.endswith("s")
+    seconds = float(ULTRAVOX_TOOL_TIMEOUT[:-1])
+    assert 2.5 < seconds <= 40


### PR DESCRIPTION
## Why

Beta 2026-07-27 (HomeTrades, call `25a6bc45…`): both `booking_book` calls **succeeded** (200 in ~3.8s/3.9s at integrations), yet each was immediately re-attempted with byte-identical arguments and the duplicate 409'd `slot_unavailable` — so the agent told the caller the slot they had just secured was taken.

Root cause: **Ultravox limits client tools to a 2.5s default execution window** ("tools are limited to a default execution time of 2.5 seconds", raisable per-tool via the `timeout` field, max 40s). A result arriving later is treated as failed and the late `client_tool_result` is discarded as stale, so the model retries. Upstream pipecat's `_to_selected_tools` emits `temporaryTool` definitions with **no `timeout` field**, so every tool got the default. `booking_get_slots` (~0.5s) never crossed the threshold — which is why only `book` duplicated, both times.

## What

`AplisayUltravoxRealtimeLLMService._to_selected_tools` now runs upstream's mapping and `setdefault`s `"timeout": "10s"` on every `temporaryTool`: clears our slowest data tools (booking_book ≈ 4s, MCP knowledge search) with margin, adds no latency to the fast path (results deliver the moment they arrive), and still bounds how long a wedged tool can freeze the conversation.

## Verification

- 3 new tests (`test_ultravox_tool_timeout.py`): every definition stamped, upstream fields untouched, value within Ultravox bounds (>2.5s, ≤40s).
- Full pipecat suite: **189 passed**.

Companion fix (separate polite-ai PR): `booking.book` becomes idempotent so a duplicate re-book of the same slot by the same caller replays the original success instead of 409ing — belt and braces for any duplicate source.
