### PR TITLE
pipecat: omit unsupplied rest params instead of fabricating nulls (no-slots root cause)

### DIFF
--- a/agents/pipecat/pipecat_aplisay/function_handler.py
+++ b/agents/pipecat/pipecat_aplisay/function_handler.py
@@ -152,7 +152,19 @@ HARDWIRED_BUILTINS["metadata"] = _builtin_metadata
 def _resolve_inputs(
     fn: dict, llm_args: dict, metadata: dict, options: dict
 ) -> dict:
-    """Resolve a function's parameters by source. Mirrors the JS dispatcher."""
+    """Resolve a function's parameters by source. Mirrors the JS dispatcher.
+
+    A parameter that resolves to ``None`` is OMITTED, never sent as ``null``:
+    in the JS handler an absent argument resolves to ``undefined``, which
+    ``JSON.stringify`` drops from the request body — but Python's ``None``
+    survives serialisation as a REAL ``null`` the server must interpret. Beta
+    2026-07-27: every no-preference booking_get_slots went out as
+    ``{"from": null, "days": null}``; the server's ``Number(null) === 0``
+    coerced that to a one-day scan, so afternoon callers were told no slots
+    existed anywhere. (For metadata sources the JS handler throws when the
+    path is missing; omitting is deliberately softer — absent optional
+    metadata degrades to \"parameter not sent\" instead of failing the call.)
+    """
     properties = (fn.get("input_schema") or {}).get("properties") or {}
     resolved: dict[str, Any] = {}
     allow_tools_calls = bool(options.get("allowToolsCallsMetadataPaths"))
@@ -170,9 +182,12 @@ def _resolve_inputs(
             value = _get_by_path(metadata, from_path)
             if value is None and "default" in entry:
                 value = entry["default"]
-            resolved[key] = value
+            if value is not None:
+                resolved[key] = value
         else:  # generated (default)
-            resolved[key] = llm_args.get(key, entry.get("default"))
+            value = llm_args.get(key, entry.get("default"))
+            if value is not None:
+                resolved[key] = value
 
     # transfer.number security boundary — section 5.2.
     if fn.get("name") == "transfer" or fn.get("platform") == "transfer":

--- a/agents/pipecat/tests/test_function_handler_rest.py
+++ b/agents/pipecat/tests/test_function_handler_rest.py
@@ -182,3 +182,37 @@ class TestTelemetry:
         callout = next(m for m in messages if "rest_callout" in m)["rest_callout"]
         assert callout["url"].endswith("booking.get_slots")
         assert callout["key"] == "POLITE_BOOKING"
+
+
+class TestUnsuppliedParamsOmitted:
+    """Params the model didn't supply are OMITTED, never fabricated as null.
+
+    Beta 2026-07-27: {"from": null, "days": null} reached booking.get_slots
+    for every no-preference call; Number(null) === 0 server-side coerced the
+    scan to one day and afternoon callers were told nothing was available.
+    """
+
+    def test_unsupplied_generated_param_is_absent_from_the_body(self) -> None:
+        _run(_rest_fn(), [{"name": "POLITE_BOOKING", "in": "bearer", "value": "k"}], {})
+        assert _FakeClient.last["json"] == {"policy": "bpol_x"}
+        assert "days" not in _FakeClient.last["json"]
+
+    def test_model_sent_explicit_null_is_treated_as_unsupplied(self) -> None:
+        _run(_rest_fn(), [{"name": "POLITE_BOOKING", "in": "bearer", "value": "k"}], {"days": None})
+        assert "days" not in _FakeClient.last["json"]
+
+    def test_declared_default_still_fills_an_absent_param(self) -> None:
+        fn = _rest_fn()
+        fn["input_schema"]["properties"]["days"] = {"type": "number", "default": 7}
+        _run(fn, [{"name": "POLITE_BOOKING", "in": "bearer", "value": "k"}], {})
+        assert _FakeClient.last["json"]["days"] == 7
+
+    def test_missing_metadata_without_default_is_omitted_not_null(self) -> None:
+        fn = _rest_fn()
+        fn["input_schema"]["properties"]["callerNumber"] = {
+            "type": "string",
+            "source": "metadata",
+            "from": "aplisay.callerId",
+        }
+        _run(fn, [{"name": "POLITE_BOOKING", "in": "bearer", "value": "k"}], {"days": 3})
+        assert _FakeClient.last["json"] == {"days": 3, "policy": "bpol_x"}


### PR DESCRIPTION
Companion to polite-ai #164 — the worker half of the "agent claims no slots" root cause.

`_resolve_inputs` set every declared-but-unsupplied generated param to `None`, which serialises as a real `null` (the JS handler's `undefined` drops from the JSON body). Every no-preference `booking_get_slots` therefore arrived as `{"from": null, "days": null}` and `Number(null) === 0` server-side clamped the scan to ONE day — legitimately empty every afternoon after last-slot-minus-notice.

Params resolving to `None` are now omitted (generated + metadata; explicit model-sent nulls treated as unsupplied; declared defaults still fill). Metadata divergence from JS (throw → omit) is deliberate and documented. 4 new tests; pipecat suite **193 green**.