### PR TITLE
feat: promptMetadata — state call facts in the agent's system prompt

### DIFF
--- a/agents/livekit/agent-lib/current-datetime.js
+++ b/agents/livekit/agent-lib/current-datetime.js
@@ -1,0 +1,1 @@
+../../../lib/current-datetime.js

--- a/agents/livekit/agent-lib/prompt-metadata.js
+++ b/agents/livekit/agent-lib/prompt-metadata.js
@@ -1,0 +1,1 @@
+../../../lib/prompt-metadata.js

--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -61,6 +61,8 @@ export interface Agent {
   label?: string;
   name?: string;
   prompt?: string;
+  /** Call metadata stated in the system prompt — see agent-lib/prompt-metadata.js. */
+  promptMetadata?: { description?: string; from: string }[];
   options?: {
     /**
      * Optional opening greeting played right after the session starts.

--- a/agents/livekit/lib/voice-session-factory.ts
+++ b/agents/livekit/lib/voice-session-factory.ts
@@ -8,6 +8,7 @@ import * as openai from "@livekit/agents-plugin-openai";
 import * as google from "@livekit/agents-plugin-google";
 import * as ultravox from "../plugins/ultravox/src/index.js";
 import type { Agent, Call } from "./api-client.js";
+import { promptWithMetadata } from "../agent-lib/prompt-metadata.js";
 import type { VoiceMode } from "./voice-mode.js";
 import {
   inferTtsVendor,
@@ -279,7 +280,19 @@ export interface CreateVoiceModelAndSessionParams {
 export function createVoiceModelAndSession(
   params: CreateVoiceModelAndSessionParams,
 ): { session: voice.AgentSession; model: voice.Agent } {
-  const { voiceMode, modelName, agent, call, tools, vad } = params;
+  const { voiceMode, modelName, agent: agentDef, call, tools, vad } = params;
+
+  // Resolve the agent's `promptMetadata` declaration ONCE, here: every session
+  // passes through this factory — the initial run and each transfer_agent
+  // handover — and both prompt sites (this one and buildRealtimeLlmOptions
+  // below) read `agent.prompt`, so rewriting it here states the declared facts
+  // (today's date, the caller's number, …) to whichever agent is now speaking,
+  // freshly for each. A declaration that resolves to nothing returns the agent
+  // untouched. See agent-lib/prompt-metadata.js.
+  const basePrompt = agentDef?.prompt ?? "";
+  const composedPrompt = promptWithMetadata(basePrompt, agentDef?.promptMetadata, call?.metadata);
+  const agent =
+    composedPrompt === basePrompt ? agentDef : ({ ...agentDef, prompt: composedPrompt } as Agent);
 
   const agentOptions = {
     instructions: agent?.prompt || "You are a helpful assistant.",

--- a/agents/livekit/test/prompt-metadata.test.ts
+++ b/agents/livekit/test/prompt-metadata.test.ts
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  promptWithMetadata,
+  resolvePromptMetadataLines,
+  PROMPT_METADATA_HEADING,
+} from "../agent-lib/prompt-metadata.js";
+
+// `promptMetadata` — call metadata stated in the system prompt instead of
+// fetched with a get_metadata tool call (docs/prompt-metadata.md). The LiveKit
+// worker consumes the SHARED lib/prompt-metadata.js via an agent-lib symlink
+// (no TS twin to drift), and resolves it in createVoiceModelAndSession so the
+// initial session and every transfer_agent handover both get it.
+// run: node --import tsx --test test/prompt-metadata.test.ts
+
+const METADATA = {
+  aplisay: { callerId: "+447700900123", calledId: "+441234567890" },
+  crm: { tier: "gold" },
+};
+
+test("renders '<description> <value>' per entry, in declaration order", () => {
+  const lines = resolvePromptMetadataLines(
+    [
+      { description: "The number this caller is calling from is", from: "aplisay.callerId" },
+      { description: "They dialled", from: "aplisay.calledId" },
+    ],
+    METADATA,
+  );
+  assert.deepEqual(lines, [
+    "The number this caller is calling from is +447700900123",
+    "They dialled +441234567890",
+  ]);
+});
+
+test("aplisay.dateTime is computed live, and a seeded value wins", () => {
+  const [live] = resolvePromptMetadataLines([{ from: "aplisay.dateTime" }], METADATA);
+  assert.match(live!, /^\w+day \d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$/);
+  assert.deepEqual(
+    resolvePromptMetadataLines([{ from: "aplisay.dateTime" }], { aplisay: { dateTime: "SEEDED" } }),
+    ["SEEDED"],
+  );
+});
+
+test("absent values are omitted, never stated as 'undefined'", () => {
+  const lines = resolvePromptMetadataLines(
+    [
+      { description: "Account tier is", from: "crm.tier" },
+      { description: "Loyalty number is", from: "crm.loyaltyNumber" },
+    ],
+    METADATA,
+  );
+  assert.deepEqual(lines, ["Account tier is gold"]);
+  assert.doesNotMatch(lines.join("\n"), /undefined/);
+});
+
+test("the block is appended after the agent's own prompt", () => {
+  const out = promptWithMetadata(
+    "You are a booking agent.",
+    [{ description: "Today is", from: "aplisay.dateTime" }],
+    METADATA,
+  );
+  assert.ok(out.startsWith("You are a booking agent."));
+  assert.ok(out.includes(PROMPT_METADATA_HEADING));
+  assert.match(out.split("\n").pop()!, /^Today is /);
+});
+
+test("the prompt is returned untouched when nothing resolves", () => {
+  const prompt = "You are a helpful assistant.";
+  assert.equal(promptWithMetadata(prompt, undefined, METADATA), prompt);
+  assert.equal(promptWithMetadata(prompt, [], METADATA), prompt);
+  assert.equal(promptWithMetadata(prompt, [{ from: "not.present" }], METADATA), prompt);
+});

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -30,6 +30,7 @@ from . import api_client
 from . import invocation_log
 from .agent_tools import build_agent_tools
 from .mcp_tools import close_mcp_servers, connect_mcp_servers
+from .prompt_metadata import prompt_with_metadata
 from .constants import DISCONNECT_REASONS, PLATFORM
 from .recording import RecordingSession
 from .sip_gateway.base import (
@@ -335,6 +336,14 @@ class CallSession:
         failure.
         """
         metadata = self.call.metadata
+        # Every session's prompt passes through here — the initial run, each
+        # transfer_agent handover and the consult-side bot — so resolving the
+        # agent's own promptMetadata declaration at this one point states its
+        # facts (today's date, caller number, …) to whichever agent is now
+        # speaking, freshly for each. See prompt_metadata.py.
+        system_prompt = prompt_with_metadata(
+            system_prompt, agent.get("promptMetadata"), metadata
+        )
         # When this session is a TransferAgent (consult-side bot), it
         # has a ``parent_session`` and a different tool surface — only
         # accept_transfer / reject_transfer, no hangup or nested

--- a/agents/pipecat/pipecat_aplisay/prompt_metadata.py
+++ b/agents/pipecat/pipecat_aplisay/prompt_metadata.py
@@ -1,0 +1,115 @@
+"""``promptMetadata`` — call metadata stated to the model IN ITS SYSTEM PROMPT
+instead of left for it to fetch with a ``get_metadata`` tool call.
+
+Python twin of ``lib/prompt-metadata.js`` — keep the rendering identical so an
+agent definition produces the same prompt on every worker.
+
+    promptMetadata: [
+      {"description": "The current date/time is", "from": "aplisay.dateTime"},
+      {"description": "The caller is calling from", "from": "aplisay.callerId"},
+    ]
+
+Why, when ``get_metadata`` already exposes the same values: a tool round-trip
+only happens if the model REMEMBERS to make it, and on realtime providers it
+freezes the conversation while it runs. Facts the agent reasons with from its
+first utterance — today's date above all — belong in the prompt. Beta
+2026-07-27: a booking agent kept computing "next Monday" as a 2025 date and
+sending it as a slot-search start, because nothing in its context said what day
+it was.
+
+Rules (identical to the JS module):
+  * ``from`` is a dot-path into the same call metadata that ``source:
+    "metadata"`` function parameters read.
+  * ``aplisay.dateTime`` is computed live here, exactly as the ``metadata``
+    builtin does — a seeded value still wins.
+  * An entry whose value is missing/None/blank is OMITTED, never rendered as
+    "None": an absent optional fact must not become a statement the model then
+    treats as true.
+  * Mappings/sequences render as compact JSON; values are length-capped.
+  * An empty/absent declaration leaves the prompt completely untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional, Sequence
+
+from .current_datetime import current_datetime_string, is_datetime_metadata_key
+from .function_handler import _get_by_path
+
+PROMPT_METADATA_HEADING = "Call context (current facts about this call):"
+
+MAX_PROMPT_METADATA_ENTRIES = 20
+MAX_DESCRIPTION_CHARS = 200
+MAX_VALUE_CHARS = 500
+
+
+def _render_value(value: Any) -> Optional[str]:
+    """One resolved value as prompt text, or None when it carries nothing."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        # Match JS: booleans render lower-case, not Python's True/False.
+        text = "true" if value else "false"
+    elif isinstance(value, str):
+        text = value
+    elif isinstance(value, (int, float)):
+        text = str(value)
+    else:
+        try:
+            text = json.dumps(value, default=str, ensure_ascii=False, separators=(",", ":"))
+        except (TypeError, ValueError):
+            return None
+    text = text.strip()
+    if not text:
+        return None
+    return f"{text[:MAX_VALUE_CHARS]}…" if len(text) > MAX_VALUE_CHARS else text
+
+
+def resolve_prompt_metadata_lines(
+    prompt_metadata: Optional[Sequence[dict]], metadata: Optional[dict]
+) -> list[str]:
+    """Resolve a ``promptMetadata`` declaration into rendered prompt lines."""
+    if not isinstance(prompt_metadata, (list, tuple)) or not prompt_metadata:
+        return []
+
+    lines: list[str] = []
+    for entry in list(prompt_metadata)[:MAX_PROMPT_METADATA_ENTRIES]:
+        if not isinstance(entry, dict):
+            continue
+        raw_from = entry.get("from")
+        from_path = raw_from.strip() if isinstance(raw_from, str) else ""
+        if not from_path:
+            continue
+
+        value = _get_by_path(metadata or {}, from_path)
+        # Live clock, same rule as the `metadata` builtin: a seeded value wins.
+        if value is None and is_datetime_metadata_key(from_path):
+            value = current_datetime_string()
+
+        rendered = _render_value(value)
+        if rendered is None:
+            continue
+
+        raw_description = entry.get("description")
+        description = (
+            raw_description.strip()[:MAX_DESCRIPTION_CHARS] if isinstance(raw_description, str) else ""
+        )
+        lines.append(f"{description} {rendered}" if description else rendered)
+    return lines
+
+
+def prompt_with_metadata(
+    prompt: Optional[str], prompt_metadata: Optional[Sequence[dict]], metadata: Optional[dict]
+) -> str:
+    """``prompt`` with its resolved ``promptMetadata`` appended.
+
+    Returns ``prompt`` unchanged when nothing resolves, so an agent without the
+    feature is byte-identical to before.
+    """
+    lines = resolve_prompt_metadata_lines(prompt_metadata, metadata)
+    base = prompt if isinstance(prompt, str) else ""
+    if not lines:
+        return base
+    block = PROMPT_METADATA_HEADING + "\n" + "\n".join(lines)
+    return f"{base.rstrip()}\n\n{block}" if base.strip() else block

--- a/agents/pipecat/tests/test_prompt_metadata.py
+++ b/agents/pipecat/tests/test_prompt_metadata.py
@@ -1,0 +1,107 @@
+"""``promptMetadata`` rendering on the pipecat worker
+(:mod:`pipecat_aplisay.prompt_metadata`).
+
+The python twin of ``lib/prompt-metadata.js`` must render identically — an
+agent definition has to produce the same system prompt whichever worker takes
+the call. These lock the shared semantics: live dateTime, omission of absent
+values (never "None" in a prompt), and an untouched prompt when nothing
+resolves.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pipecat_aplisay.prompt_metadata import (
+    MAX_VALUE_CHARS,
+    PROMPT_METADATA_HEADING,
+    prompt_with_metadata,
+    resolve_prompt_metadata_lines,
+)
+
+METADATA = {
+    "aplisay": {"callerId": "+447700900123", "calledId": "+441234567890"},
+    "crm": {"tier": "gold", "openTickets": 2, "vip": True, "contact": {"name": "Bob"}},
+}
+
+DATETIME_RE = re.compile(r"^\w+day \d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$")
+
+
+def test_renders_description_then_value_in_order():
+    lines = resolve_prompt_metadata_lines(
+        [
+            {"description": "The number this caller is calling from is", "from": "aplisay.callerId"},
+            {"description": "They dialled", "from": "aplisay.calledId"},
+        ],
+        METADATA,
+    )
+    assert lines == [
+        "The number this caller is calling from is +447700900123",
+        "They dialled +441234567890",
+    ]
+
+
+def test_datetime_is_live_but_a_seeded_value_wins():
+    (live,) = resolve_prompt_metadata_lines([{"from": "aplisay.dateTime"}], METADATA)
+    assert DATETIME_RE.match(live)
+    assert resolve_prompt_metadata_lines([{"from": "aplisay.dateTime"}], {"aplisay": {"dateTime": "SEEDED"}}) == ["SEEDED"]
+
+
+def test_absent_values_are_omitted_never_stated_as_none():
+    lines = resolve_prompt_metadata_lines(
+        [
+            {"description": "Account tier is", "from": "crm.tier"},
+            {"description": "Loyalty number is", "from": "crm.loyaltyNumber"},
+            {"description": "Nothing at", "from": "no.such.path"},
+            {"description": "Blank is", "from": "crm.blank"},
+        ],
+        {**METADATA, "crm": {**METADATA["crm"], "blank": "   "}},
+    )
+    assert lines == ["Account tier is gold"]
+    assert "None" not in "\n".join(lines)
+
+
+def test_scalar_and_structured_rendering_matches_the_js_twin():
+    lines = resolve_prompt_metadata_lines(
+        [
+            {"description": "Open tickets:", "from": "crm.openTickets"},
+            {"description": "VIP:", "from": "crm.vip"},
+            {"description": "Contact name is", "from": "crm.contact.name"},
+            {"description": "Contact record:", "from": "crm.contact"},
+        ],
+        METADATA,
+    )
+    # booleans lower-case (JS parity), objects as compact JSON
+    assert lines == ["Open tickets: 2", "VIP: true", "Contact name is Bob", 'Contact record: {"name":"Bob"}']
+
+
+def test_large_value_is_capped():
+    (line,) = resolve_prompt_metadata_lines([{"from": "big"}], {"big": "x" * 5000})
+    assert len(line) <= MAX_VALUE_CHARS + 1
+
+
+def test_malformed_or_empty_declarations_are_inert():
+    assert resolve_prompt_metadata_lines(None, METADATA) == []
+    assert resolve_prompt_metadata_lines([], METADATA) == []
+    assert resolve_prompt_metadata_lines([{"description": "no from"}, None, "x"], METADATA) == []
+
+
+def test_prompt_with_metadata_appends_a_block_after_the_prompt():
+    out = prompt_with_metadata(
+        "You are a booking agent.", [{"description": "Today is", "from": "aplisay.dateTime"}], METADATA
+    )
+    assert out.startswith("You are a booking agent.")
+    assert PROMPT_METADATA_HEADING in out
+    assert out.splitlines()[-1].startswith("Today is ")
+
+
+def test_prompt_untouched_when_nothing_resolves():
+    prompt = "You are a helpful assistant."
+    assert prompt_with_metadata(prompt, None, METADATA) == prompt
+    assert prompt_with_metadata(prompt, [], METADATA) == prompt
+    assert prompt_with_metadata(prompt, [{"from": "not.present"}], METADATA) == prompt
+
+
+def test_block_stands_alone_when_the_agent_has_no_prompt():
+    out = prompt_with_metadata("", [{"description": "Caller:", "from": "aplisay.callerId"}], METADATA)
+    assert out == f"{PROMPT_METADATA_HEADING}\nCaller: +447700900123"

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -127,6 +127,8 @@ components:
           $ref: "#/components/schemas/AgentType"
         prompt:
           $ref: "#/components/schemas/Prompt"
+        promptMetadata:
+          $ref: "#/components/schemas/PromptMetadata"
         options:
           $ref: "#/components/schemas/AgentOptions"
         functions:
@@ -370,6 +372,55 @@ components:
       example: |-
         You work for Robs Flags, a company that manufactures flags.
         You can only chat with callers about submitting or organising the return of an order that the user has previously made...
+    PromptMetadata:
+      type: array
+      description: |-
+        Call metadata to STATE TO THE MODEL IN ITS SYSTEM PROMPT, rather than leaving it to fetch the
+        value with a `get_metadata` tool call. Each entry renders as one `<description> <value>` line
+        appended to the agent's prompt under a "Call context" heading, resolved fresh for every call
+        (and again after a `transfer_agent` handover, for the incoming agent's own declaration).
+
+        Use it for facts the agent must reason with from its FIRST utterance — today's date above all.
+        A tool round-trip only happens if the model remembers to make it, and on realtime providers it
+        freezes the conversation while it runs; a prompt statement is always present and costs nothing
+        at turn time. The `metadata` builtin remains the right tool for values needed occasionally, or
+        that may change during a long call.
+
+        Rules:
+          * `from` is a dot-path into the same call metadata that `source: "metadata"` function
+            parameters read — e.g. `aplisay.callerId`, `aplisay.calledId`, `aplisay.dateTime`, or any
+            key the deployment seeds into instance metadata.
+          * `aplisay.dateTime` is computed live at prompt-composition time (a seeded value wins), so an
+            agent that reasons about dates never has to guess what day it is.
+          * An entry whose value is missing, null or empty is OMITTED — an absent optional fact never
+            becomes a statement the model would then treat as true.
+          * `metadata.toolsCalls.*` paths are only permitted on handlers with dynamic metadata support
+            (LiveKit), matching the rule for `source: "metadata"` parameters and the `metadata` builtin.
+          * Object and array values render as compact JSON; long values are truncated.
+      maxItems: 20
+      items:
+        type: object
+        required:
+          - from
+        properties:
+          description:
+            type: string
+            maxLength: 200
+            description: |-
+              Sentence fragment placed before the value, e.g. "The current date/time is". Written so
+              `<description> <value>` reads as a complete statement of fact. Optional: with no
+              description the bare value is stated on its own line.
+            example: The current date/time is
+          from:
+            type: string
+            maxLength: 200
+            description: Dot-path into the call metadata, e.g. `aplisay.dateTime`.
+            example: aplisay.dateTime
+      example:
+        - description: The current date/time is
+          from: aplisay.dateTime
+        - description: The number this caller is calling from is
+          from: aplisay.callerId
     AgentOptions:
       type: object
       properties:

--- a/api/paths/agent-sets.js
+++ b/api/paths/agent-sets.js
@@ -20,7 +20,7 @@ export default function (logger) {
   };
 };
 
-const MEMBER_FIELDS = ['name', 'description', 'modelName', 'prompt', 'options', 'functions', 'mcpServers', 'keys', 'type'];
+const MEMBER_FIELDS = ['name', 'description', 'modelName', 'prompt', 'promptMetadata', 'options', 'functions', 'mcpServers', 'keys', 'type'];
 
 /** Default the agent type from the model name's handler prefix when not given explicitly. */
 export function defaultType(def) {

--- a/api/paths/agents.js
+++ b/api/paths/agents.js
@@ -20,7 +20,7 @@ export default function (logger, voices, wsServer) {
 };
 
 const agentCreate = (async (req, res) => {
-  let { name, description, modelName, prompt, options, functions, mcpServers, keys, type } = req.body;
+  let { name, description, modelName, prompt, promptMetadata, options, functions, mcpServers, keys, type } = req.body;
   let { id: userId, organisationId } = res.locals.user;
   // RBAC: a single `agent` resource — text-vs-audio is NOT a separate permission.
   if (!requirePermission(res, 'agent', 'create')) return;
@@ -30,7 +30,7 @@ const agentCreate = (async (req, res) => {
   }
   // Default the agent type from the model's handler prefix when not given explicitly
   type = type ?? (typeof modelName === 'string' && modelName.startsWith('text:') ? 'text' : 'interactive-audio');
-  let agent = Agent.build({ name, description, modelName, prompt, options, functions, mcpServers, keys, type, userId, organisationId });
+  let agent = Agent.build({ name, description, modelName, prompt, promptMetadata, options, functions, mcpServers, keys, type, userId, organisationId });
 
   log.info({ modelName, prompt, options, functions, mcpServers, userId, organisationId, type }, 'create API call');
 
@@ -83,6 +83,9 @@ agentCreate.apiDoc = {
             },
             prompt: {
               $ref: '#/components/schemas/Prompt'
+            },
+            promptMetadata: {
+              $ref: '#/components/schemas/PromptMetadata'
             },
             options: {
               $ref: '#/components/schemas/AgentOptions'
@@ -140,6 +143,9 @@ agentCreate.apiDoc = {
               },
               prompt: {
                 $ref: '#/components/schemas/Prompt'
+              },
+              promptMetadata: {
+                $ref: '#/components/schemas/PromptMetadata'
               },
               options: {
                 $ref: '#/components/schemas/AgentOptions'

--- a/api/paths/agents/{agentId}.js
+++ b/api/paths/agents/{agentId}.js
@@ -106,6 +106,9 @@ agentGet.apiDoc = {
               prompt: {
                 $ref: '#/components/schemas/Prompt'
               },
+              promptMetadata: {
+                $ref: '#/components/schemas/PromptMetadata'
+              },
               options: {
                 $ref: '#/components/schemas/AgentOptions'
               },
@@ -153,7 +156,7 @@ agentGet.apiDoc = {
 };
 
 const agentUpdate = async (req, res) => {
-  let { name, description, prompt, options, functions, mcpServers, keys, modelName, type } = req.body;
+  let { name, description, prompt, promptMetadata, options, functions, mcpServers, keys, modelName, type } = req.body;
   let { agentId } = req.params;
 
   if (isBuiltinAgentId(agentId)) {
@@ -177,7 +180,7 @@ const agentUpdate = async (req, res) => {
       lookupAgent: (targetId) => Agent.findOne({ where: { id: targetId, ...scopeWhereForUser(res.locals.user) } }),
       options
     });
-    await agent.update({ name, description, prompt, options, functions, mcpServers, keys, modelName, type });
+    await agent.update({ name, description, prompt, promptMetadata, options, functions, mcpServers, keys, modelName, type });
     req.log.info({ ...agent.dataValues, keys: undefined }, 'Agent updated');
     res.send({ ...agent.dataValues, keys: undefined });
   }
@@ -277,6 +280,9 @@ agentUpdate.apiDoc = {
               },
               prompt: {
                 $ref: '#/components/schemas/Prompt'
+              },
+              promptMetadata: {
+                $ref: '#/components/schemas/PromptMetadata'
               },
               functions: {
                 $ref: '#/components/schemas/Functions'

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Index of the docs in this directory. Start with the first table if you're new; t
 | [multi-agent-api.md](multi-agent-api.md) | The multi-agent REST surface and agent-to-agent transfer |
 | [mcp-servers.md](mcp-servers.md) | Attaching remote MCP tool servers to agents |
 | [tool-call-chaining-metadata-priming.md](tool-call-chaining-metadata-priming.md) | Static/metadata parameter sourcing and chained tool calls |
+| [prompt-metadata.md](prompt-metadata.md) | Stating call facts (date/time, caller number, seeded data) in the agent's prompt |
 | [uninterruptible-greetings.md](uninterruptible-greetings.md) | Barge-in control for opening prompts |
 | [ultravox-vendor-specific-options.md](ultravox-vendor-specific-options.md) | Ultravox model variants and tuning options |
 | [agent-concurrency-limits.md](agent-concurrency-limits.md) | Per-agent/user/organisation concurrency caps |

--- a/docs/prompt-metadata.md
+++ b/docs/prompt-metadata.md
@@ -1,0 +1,169 @@
+# Stating call facts in the prompt (`promptMetadata`)
+
+> Status: supported on **every interactive-audio handler** — `ultravox:`,
+> `livekit:` and `pipecat:` — and stored (but unused) on `text:` agents, which
+> have no call metadata to resolve. No model capability flag is involved: the
+> value is resolved by the platform and reaches the model as ordinary prompt
+> text, so it works on any model.
+
+An agent can declare call metadata that is **stated to the model in its system
+prompt**, instead of leaving the model to fetch it with a `get_metadata` tool
+call:
+
+```jsonc
+{
+  "modelName": "pipecat:ultravox/ultravox-v0.7",
+  "prompt": "You are the booking assistant for HomeTrades…",
+  "promptMetadata": [
+    { "description": "The current date/time is", "from": "aplisay.dateTime" },
+    { "description": "The number this caller is calling from is", "from": "aplisay.callerId" }
+  ]
+}
+```
+
+Every call, each entry is resolved and appended to the agent's prompt:
+
+```
+You are the booking assistant for HomeTrades…
+
+Call context (current facts about this call):
+The current date/time is Tuesday 2026-07-28 10:32 Europe/London
+The number this caller is calling from is +447700900123
+```
+
+## Why not just use the `get_metadata` tool?
+
+Both mechanisms read the same call metadata. They differ in *when* the model
+learns the value:
+
+| | `promptMetadata` | `get_metadata` builtin |
+|---|---|---|
+| Model sees it | From its first utterance, always | Only after it decides to call the tool |
+| Reliability | Guaranteed — it's in the prompt | Depends on the model remembering |
+| Turn cost | None | A tool round-trip; on realtime providers this **freezes the conversation** while it runs |
+| Freshness | Resolved at call start (and again after each handover) | Resolved at the moment of the call |
+
+Use `promptMetadata` for facts the agent must **reason with from the start** —
+today's date above all. Use `get_metadata` for values needed only occasionally,
+or that may change during a long call.
+
+The date case is not hypothetical. Voice models have no clock: on beta
+(2026-07-27) a booking agent repeatedly computed "next Monday" as a **2025**
+date and sent it as a slot-search start, because nothing in its context said
+what day it was. It had a `get_metadata` tool available and did not think to
+call it.
+
+## Entry shape
+
+```jsonc
+{ "description": "The current date/time is", "from": "aplisay.dateTime" }
+```
+
+| Field | Required | Meaning |
+|---|---|---|
+| `from` | yes | Dot-path into the call metadata |
+| `description` | no | Sentence fragment placed **before** the value |
+
+Write `description` so that `<description> <value>` reads as a complete
+statement of fact — the model reads it as a sentence, not a key/value pair.
+With no `description`, the bare value is stated on its own line.
+
+At most **20** entries; `description` is capped at 200 characters and each
+rendered value at 500.
+
+## Available `from` paths
+
+`from` resolves against exactly the same metadata that a function parameter's
+`{"source": "metadata", "from": …}` reads, so anything addressable there works
+here:
+
+| Path | Value |
+|---|---|
+| `aplisay.dateTime` | Current date/time, e.g. `Tuesday 2026-07-28 10:32 Europe/London` — weekday included so the model can reason about "next Tuesday". Computed **live**; timezone from `AGENT_TIMEZONE` (default `Europe/London`) |
+| `aplisay.callerId` | Caller's number (`WebRTC` for browser sessions) |
+| `aplisay.calledId` | Number the caller dialled |
+| `aplisay.callId` | Platform call id |
+| `aplisay.modelName` | Model handling the call |
+| *anything you seed* | Keys placed in instance metadata at call creation — CRM lookups, account tier, agent-specific context |
+| `toolsCalls.*` | Results of earlier tool calls. **LiveKit only** — same capability gate as `source: "metadata"` parameters and the `metadata` builtin; rejected at create/update time on other handlers |
+
+## Rules
+
+- **Absent values are omitted.** An entry whose value is missing, `null` or
+  blank produces *no line at all* — never `undefined`. An optional fact that
+  isn't there must not become a statement the model would then treat as true.
+  A declaration where nothing resolves leaves the prompt byte-identical.
+- **`aplisay.dateTime` is computed live** at prompt-composition time. A value
+  actually seeded at that path wins, which is what makes date behaviour
+  testable.
+- **Objects and arrays** render as compact JSON, so `{"from": "crm.contact"}`
+  yields `{"name":"Bob"}`. Long values are truncated with `…`.
+- **Resolved per session.** After a `transfer_agent` handover the *incoming*
+  agent's own declaration is resolved against the same call — each agent in a
+  set states its own facts, and a set can mix agents that declare
+  `promptMetadata` with agents that don't.
+
+## Worked examples
+
+**Booking agent** — the case this feature exists for. With the date stated, the
+agent computes a real `from` date for an availability search instead of guessing:
+
+```jsonc
+"promptMetadata": [
+  { "description": "The current date/time is", "from": "aplisay.dateTime" }
+]
+```
+
+**Recognising a returning caller** — pair with a CRM lookup seeded into instance
+metadata at call creation:
+
+```jsonc
+"promptMetadata": [
+  { "description": "The caller is calling from", "from": "aplisay.callerId" },
+  { "description": "Our records show this customer as", "from": "crm.accountName" },
+  { "description": "Their support tier is", "from": "crm.tier" }
+]
+```
+
+If the CRM lookup found nothing, those last two lines simply don't appear and
+the agent greets an unknown caller normally — no "the customer is undefined".
+
+**Value with no description** — when the fact is self-describing:
+
+```jsonc
+"promptMetadata": [
+  { "from": "briefing.todaysPromotion" }
+]
+```
+
+## Where it applies
+
+`promptMetadata` is a top-level Agent property, so it is set the same way
+everywhere an agent is defined:
+
+- `POST /agents` and `PUT /agents/{agentId}`
+- agent-set members in `POST /agent-sets` / `PUT /agent-sets/{agentSetId}` —
+  it round-trips through GET like any other member field
+- it survives publish/restore in the versioning paths
+
+Malformed declarations are rejected at create/update time with a message naming
+the offending entry, so a broken declaration can never reach a live call.
+
+## Implementation notes
+
+The rendering is defined **once** in `lib/prompt-metadata.js` and shared:
+
+- the node handlers (`ultravox:`, and any future server-side handler) import it
+  directly;
+- the **LiveKit** worker consumes the same file through an `agent-lib` symlink,
+  resolving it in `createVoiceModelAndSession` — the single point both the
+  initial session and every handover pass through;
+- the **pipecat** worker has a Python twin,
+  `pipecat_aplisay/prompt_metadata.py`, applied in `CallSession.prepare_run`,
+  which likewise covers the initial run, handovers and the consult-side bot.
+
+Keep the twin in step with the JS module: identical rendering is what lets one
+agent definition behave the same whichever worker takes the call. Both are
+covered by tests asserting the same cases (`tests/prompt-metadata.test.mjs`,
+`agents/pipecat/tests/test_prompt_metadata.py`,
+`agents/livekit/test/prompt-metadata.test.ts`).

--- a/lib/database.js
+++ b/lib/database.js
@@ -6,11 +6,14 @@ import { getHandler } from './handlers/index.js';
 import Voices from './voices/index.js';
 import { getVoiceNamesForAgentValidation, getTtsVendorsForAgentValidation } from './model-voices.js';
 import { validateToolsCallsMetadataUsage } from './handlers/toolsCalls-metadata-capability.js';
+import { validatePromptMetadata } from './prompt-metadata-validate.js';
 import { initPhoneRegistration } from './database-models/phone-registration.js';
 import { encryptSecret, decryptSecret } from './utils/credentials.js';
 import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-limits.js';
 
-const schemaVersion = 55;  // 55: `chat_sessions` — persisted interactive text-agent chat sessions
+const schemaVersion = 56;  // 56: `agents.prompt_metadata` — declared call metadata stated to the model in its
+                           //     system prompt (docs/prompt-metadata.md); resolved per call by every worker.
+                           // 55: `chat_sessions` — persisted interactive text-agent chat sessions
                            //     (transcript, set linkage, mode, usage joins on usage_records.session_id)
                            //     backing the builder session-history API (GET /chat-sessions).
                            // 54: `organisations.chargeable_number_limit` (max numbers an org may hold on
@@ -269,6 +272,12 @@ Agent.init({
   functions: {
     type: DataTypes.JSONB
   },
+  // Call metadata stated to the model in its system prompt rather than fetched
+  // with a get_metadata tool call — see lib/prompt-metadata.js and
+  // docs/prompt-metadata.md. Resolved per call by every worker.
+  promptMetadata: {
+    type: DataTypes.JSONB
+  },
   mcpServers: {
     type: DataTypes.JSONB
   },
@@ -331,6 +340,7 @@ Agent.init({
           throw new Error(`Agent type ${agentType} is not valid for model ${this.modelName} which implements ${handlerAgentType} agents`);
         }
         validateToolsCallsMetadataUsage({ Handler, functions: this.functions });
+        validatePromptMetadata({ Handler, promptMetadata: this.promptMetadata });
         if (this.options?.tts?.voice || this.options?.tts?.vendor) {
           const voicesInstance = new Voices();
           if (this.options?.tts?.voice) {

--- a/lib/handlers/ultravox.js
+++ b/lib/handlers/ultravox.js
@@ -5,6 +5,7 @@ import UltravoxModel from '../models/ultravox.js';
 import { Call } from '../database.js';
 import { maybeSendCallHook } from '../call-hook.js';
 import { AgentConcurrencyLimitExceededError } from '../concurrency/agent-concurrency-limits.js';
+import { promptWithMetadata } from '../prompt-metadata.js';
 const { ULTRAVOX_API_KEY, JAMBONZ_AGENT_NAME } = process.env;
 import { v4 as uuidv4 } from 'uuid';
 
@@ -64,7 +65,7 @@ class Ultravox extends Handler {
 
 
   async join({ websocket, telephony = false, options = {}, callerId = 'WebRTC', calledId = 'WebRTC', callId = this.callId }) {
-    let { agent: { id: agentId, userId, organisationId, modelName, options: agentOptions = {} }, logger, instance: { id: instanceId, metadata: instanceMetadata } } = this;
+    let { agent: { id: agentId, userId, organisationId, modelName, promptMetadata, options: agentOptions = {} }, logger, instance: { id: instanceId, metadata: instanceMetadata } } = this;
     let { fallback: { number: fallbackNumbers } = {} } = agentOptions;
     if (!callId) {
       callId = uuidv4();
@@ -85,6 +86,11 @@ class Ultravox extends Handler {
    
 
     this.model.metadata = metadata;
+    // State the agent's declared `promptMetadata` facts (today's date, the
+    // caller's number, …) in its system prompt now that call metadata exists —
+    // the prompt setter propagates into the messages array too. Composed from
+    // initialPrompt so a re-join can never stack blocks. See lib/prompt-metadata.js.
+    this.model.prompt = promptWithMetadata(this.model.initialPrompt, promptMetadata, metadata);
     this.model.functions = this.model._functions || [];
     let { model: { modelData } } = this;
 

--- a/lib/prompt-metadata-validate.js
+++ b/lib/prompt-metadata-validate.js
@@ -1,0 +1,73 @@
+/**
+ * Shape + capability validation for an agent's `promptMetadata` declaration.
+ *
+ * Runs in the Agent model's validate block, so a malformed declaration is
+ * rejected at create/update time rather than silently producing a broken system
+ * prompt on a live call. Semantics of the values themselves live in
+ * lib/prompt-metadata.js; this module only decides what may be STORED.
+ *
+ * The `toolsCalls` rule is deliberately identical to the one
+ * validateToolsCallsMetadataUsage enforces for `source: "metadata"` parameters
+ * and the `metadata` builtin: those paths carry other tools' results and are
+ * only available on handlers that opt in (Handler.hasDynamicMetadata — LiveKit).
+ * Without this, promptMetadata would be a way around that gate.
+ */
+import {
+  MAX_PROMPT_METADATA_ENTRIES,
+  MAX_DESCRIPTION_CHARS,
+} from './prompt-metadata.js';
+
+const isToolsCallsPath = (from) =>
+  typeof from === 'string' && (from === 'toolsCalls' || from.startsWith('toolsCalls.'));
+
+/** Dot-path of ordinary identifier segments (numeric segments index arrays). */
+const PATH_RE = /^[A-Za-z0-9_$-]+(\.[A-Za-z0-9_$-]+)*$/;
+
+/**
+ * @param {Object} args
+ * @param {Object} args.Handler the resolved handler class for the agent's model
+ * @param {*} args.promptMetadata the declaration as supplied
+ * @throws {Error} with a message safe to return to the API caller
+ */
+export function validatePromptMetadata({ Handler, promptMetadata }) {
+  if (promptMetadata === undefined || promptMetadata === null) return;
+
+  if (!Array.isArray(promptMetadata)) {
+    throw new Error('promptMetadata must be an array of { description, from } entries');
+  }
+  if (promptMetadata.length > MAX_PROMPT_METADATA_ENTRIES) {
+    throw new Error(`promptMetadata may declare at most ${MAX_PROMPT_METADATA_ENTRIES} entries`);
+  }
+
+  const allowDynamicMetadata = !!Handler?.hasDynamicMetadata;
+
+  promptMetadata.forEach((entry, index) => {
+    const at = `promptMetadata[${index}]`;
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new Error(`${at} must be an object with a 'from' metadata path`);
+    }
+    const { from, description } = entry;
+    if (typeof from !== 'string' || !from.trim()) {
+      throw new Error(`${at}.from is required and must be a metadata path, e.g. 'aplisay.dateTime'`);
+    }
+    if (!PATH_RE.test(from.trim())) {
+      throw new Error(`${at}.from '${from}' is not a valid metadata path`);
+    }
+    if (!allowDynamicMetadata && isToolsCallsPath(from.trim())) {
+      throw new Error('Access to metadata.toolsCalls is only allowed in LiveKit agents');
+    }
+    if (description !== undefined && description !== null) {
+      if (typeof description !== 'string') {
+        throw new Error(`${at}.description must be a string`);
+      }
+      if (description.length > MAX_DESCRIPTION_CHARS) {
+        throw new Error(`${at}.description must be ${MAX_DESCRIPTION_CHARS} characters or fewer`);
+      }
+    }
+    for (const key of Object.keys(entry)) {
+      if (key !== 'from' && key !== 'description') {
+        throw new Error(`${at} has unknown property '${key}' (expected 'description' and 'from')`);
+      }
+    }
+  });
+}

--- a/lib/prompt-metadata.js
+++ b/lib/prompt-metadata.js
@@ -1,0 +1,111 @@
+/**
+ * `promptMetadata` — declare call metadata that is stated to the model IN ITS
+ * SYSTEM PROMPT, instead of leaving it to fetch the value with a tool call.
+ *
+ *   promptMetadata: [
+ *     { description: "The current date/time is", from: "aplisay.dateTime" },
+ *     { description: "The caller is calling from", from: "aplisay.callerId" }
+ *   ]
+ *
+ * Each entry renders as one `<description> <value>` line appended to the
+ * agent's prompt under a short header.
+ *
+ * WHY, when `get_metadata` already exposes the same values: a tool round-trip
+ * only happens if the model REMEMBERS to make it, and on realtime providers it
+ * freezes the conversation while it runs. Facts the agent reasons with from its
+ * very first utterance — today's date above all — belong in the prompt. Beta
+ * 2026-07-27: a booking agent repeatedly computed "next Monday" as a 2025 date
+ * and sent it as a slot-search start, because nothing in its context said what
+ * day it was.
+ *
+ * Semantics (identical across the node/ultravox, livekit and pipecat workers —
+ * the python twin is agents/pipecat/pipecat_aplisay/prompt_metadata.py):
+ *  - `from` is a dot-path into the same call metadata that `source: "metadata"`
+ *    function parameters read (getByPath), so `aplisay.callerId`,
+ *    `aplisay.calledId`, and any instance metadata the deployment seeds.
+ *  - `aplisay.dateTime` is computed live at prompt-composition time, exactly as
+ *    the `metadata` builtin does — a seeded value still wins.
+ *  - An entry whose value is missing, null or empty is OMITTED, never rendered
+ *    as "undefined": an absent optional fact must not become a statement the
+ *    model then treats as true.
+ *  - Objects/arrays render as compact JSON; every value is length-capped so a
+ *    large seeded blob cannot crowd out the prompt.
+ *  - An empty/absent `promptMetadata` returns the prompt completely untouched.
+ */
+import { getByPath } from './metadata-path.js';
+import { isDateTimeMetadataKey, currentDateTimeString } from './current-datetime.js';
+
+/** Heading the resolved lines are appended under. */
+export const PROMPT_METADATA_HEADING = 'Call context (current facts about this call):';
+
+/** Bounds — also enforced by the model validation, so these are belt and braces. */
+export const MAX_PROMPT_METADATA_ENTRIES = 20;
+export const MAX_DESCRIPTION_CHARS = 200;
+export const MAX_VALUE_CHARS = 500;
+
+/** Render one resolved value as prompt text, or null when it carries nothing. */
+function renderValue(value) {
+  if (value === undefined || value === null) return null;
+  let text;
+  if (typeof value === 'string') text = value;
+  else if (typeof value === 'number' || typeof value === 'boolean') text = String(value);
+  else {
+    try {
+      text = JSON.stringify(value);
+    } catch {
+      return null;
+    }
+  }
+  text = text.trim();
+  if (!text) return null;
+  return text.length > MAX_VALUE_CHARS ? `${text.slice(0, MAX_VALUE_CHARS)}…` : text;
+}
+
+/**
+ * Resolve `promptMetadata` against a call's metadata into rendered lines.
+ * Exported for tests and for workers that want the lines without the prompt.
+ *
+ * @param {Array<{description?: string, from: string}>} [promptMetadata]
+ * @param {Object} [metadata] the call metadata object
+ * @returns {string[]} one line per entry that resolved to a value
+ */
+export function resolvePromptMetadataLines(promptMetadata, metadata) {
+  if (!Array.isArray(promptMetadata) || promptMetadata.length === 0) return [];
+  const lines = [];
+  for (const entry of promptMetadata.slice(0, MAX_PROMPT_METADATA_ENTRIES)) {
+    if (!entry || typeof entry !== 'object') continue;
+    const from = typeof entry.from === 'string' ? entry.from.trim() : '';
+    if (!from) continue;
+
+    let value = getByPath(metadata, from);
+    // Live clock, same rule as the `metadata` builtin: a seeded value wins.
+    if ((value === undefined || value === null) && isDateTimeMetadataKey(from)) {
+      value = currentDateTimeString();
+    }
+    const rendered = renderValue(value);
+    if (rendered === null) continue;
+
+    const description =
+      typeof entry.description === 'string' ? entry.description.trim().slice(0, MAX_DESCRIPTION_CHARS) : '';
+    lines.push(description ? `${description} ${rendered}` : rendered);
+  }
+  return lines;
+}
+
+/**
+ * The agent's prompt with its resolved `promptMetadata` appended.
+ * Returns `prompt` unchanged when nothing resolves, so an agent without the
+ * feature — or one whose values are all absent — is byte-identical to before.
+ *
+ * @param {string} [prompt] the agent's own system prompt
+ * @param {Array<{description?: string, from: string}>} [promptMetadata] the agent's declaration
+ * @param {Object} [metadata] the call metadata
+ * @returns {string}
+ */
+export function promptWithMetadata(prompt, promptMetadata, metadata) {
+  const lines = resolvePromptMetadataLines(promptMetadata, metadata);
+  if (lines.length === 0) return prompt;
+  const base = typeof prompt === 'string' ? prompt : '';
+  const block = `${PROMPT_METADATA_HEADING}\n${lines.join('\n')}`;
+  return base.trim() ? `${base.trimEnd()}\n\n${block}` : block;
+}

--- a/tests/prompt-metadata.test.mjs
+++ b/tests/prompt-metadata.test.mjs
@@ -1,0 +1,142 @@
+import {
+  promptWithMetadata,
+  resolvePromptMetadataLines,
+  PROMPT_METADATA_HEADING,
+  MAX_VALUE_CHARS,
+} from '../lib/prompt-metadata.js';
+import { validatePromptMetadata } from '../lib/prompt-metadata-validate.js';
+
+/**
+ * `promptMetadata` — call metadata stated in the system prompt instead of
+ * fetched with a tool call (docs/prompt-metadata.md).
+ *
+ * Pins the semantics every worker must share: live dateTime, omission of
+ * absent values (never "undefined" in a prompt), untouched prompt when nothing
+ * resolves, and the toolsCalls capability gate that stops promptMetadata being
+ * a way around the `source: "metadata"` rule.
+ */
+
+const METADATA = {
+  aplisay: { callerId: '+447700900123', calledId: '+441234567890', callId: 'c-1' },
+  crm: { tier: 'gold', openTickets: 2, contact: { name: 'Bob' } },
+};
+
+const dateTimeRe = /^\w+day \d{4}-\d{2}-\d{2} \d{2}:\d{2} \S+$/;
+
+describe('resolvePromptMetadataLines', () => {
+  it('renders "<description> <value>" per entry, in declaration order', () => {
+    const lines = resolvePromptMetadataLines(
+      [
+        { description: 'The number this caller is calling from is', from: 'aplisay.callerId' },
+        { description: 'They dialled', from: 'aplisay.calledId' },
+      ],
+      METADATA,
+    );
+    expect(lines).toEqual([
+      'The number this caller is calling from is +447700900123',
+      'They dialled +441234567890',
+    ]);
+  });
+
+  it('computes aplisay.dateTime live, and lets a seeded value win', () => {
+    const [live] = resolvePromptMetadataLines([{ from: 'aplisay.dateTime' }], METADATA);
+    expect(live).toMatch(dateTimeRe);
+
+    const seeded = resolvePromptMetadataLines([{ from: 'aplisay.dateTime' }], {
+      aplisay: { dateTime: 'SEEDED' },
+    });
+    expect(seeded).toEqual(['SEEDED']);
+  });
+
+  it('OMITS entries whose value is missing, null or blank — never states "undefined"', () => {
+    const lines = resolvePromptMetadataLines(
+      [
+        { description: 'Account tier is', from: 'crm.tier' },
+        { description: 'Loyalty number is', from: 'crm.loyaltyNumber' },
+        { description: 'Agent alias is', from: 'nothing.here.at.all' },
+        { description: 'Blank is', from: 'crm.blank' },
+      ],
+      { ...METADATA, crm: { ...METADATA.crm, blank: '   ' } },
+    );
+    expect(lines).toEqual(['Account tier is gold']);
+    expect(lines.join('\n')).not.toMatch(/undefined|null/);
+  });
+
+  it('renders numbers, nested paths and structured values usefully', () => {
+    const lines = resolvePromptMetadataLines(
+      [
+        { description: 'Open tickets:', from: 'crm.openTickets' },
+        { description: 'Contact name is', from: 'crm.contact.name' },
+        { description: 'Contact record:', from: 'crm.contact' },
+      ],
+      METADATA,
+    );
+    expect(lines).toEqual(['Open tickets: 2', 'Contact name is Bob', 'Contact record: {"name":"Bob"}']);
+  });
+
+  it('caps a large value so a seeded blob cannot crowd out the prompt', () => {
+    const [line] = resolvePromptMetadataLines([{ from: 'big' }], { big: 'x'.repeat(5000) });
+    expect(line.length).toBeLessThanOrEqual(MAX_VALUE_CHARS + 1);
+  });
+
+  it('is inert for absent/empty/malformed declarations', () => {
+    expect(resolvePromptMetadataLines(undefined, METADATA)).toEqual([]);
+    expect(resolvePromptMetadataLines([], METADATA)).toEqual([]);
+    expect(resolvePromptMetadataLines([{ description: 'no from' }, null, 'x'], METADATA)).toEqual([]);
+  });
+});
+
+describe('promptWithMetadata', () => {
+  it('appends the resolved block under the heading, after the agent prompt', () => {
+    const out = promptWithMetadata('You are a booking agent.', [{ description: 'Today is', from: 'aplisay.dateTime' }], METADATA);
+    expect(out.startsWith('You are a booking agent.')).toBe(true);
+    expect(out).toContain(PROMPT_METADATA_HEADING);
+    expect(out.split('\n').pop()).toMatch(/^Today is /);
+  });
+
+  it('returns the prompt byte-identical when nothing resolves', () => {
+    const prompt = 'You are a helpful assistant.';
+    expect(promptWithMetadata(prompt, undefined, METADATA)).toBe(prompt);
+    expect(promptWithMetadata(prompt, [], METADATA)).toBe(prompt);
+    expect(promptWithMetadata(prompt, [{ from: 'not.present' }], METADATA)).toBe(prompt);
+  });
+
+  it('still produces the block when the agent has no prompt of its own', () => {
+    const out = promptWithMetadata('', [{ description: 'Caller:', from: 'aplisay.callerId' }], METADATA);
+    expect(out).toBe(`${PROMPT_METADATA_HEADING}\nCaller: +447700900123`);
+  });
+});
+
+describe('validatePromptMetadata', () => {
+  const dynamic = { hasDynamicMetadata: true };
+  const plain = {};
+
+  it('accepts a well-formed declaration and an absent one', () => {
+    expect(() => validatePromptMetadata({ Handler: plain, promptMetadata: undefined })).not.toThrow();
+    expect(() =>
+      validatePromptMetadata({
+        Handler: plain,
+        promptMetadata: [{ description: 'The current date/time is', from: 'aplisay.dateTime' }, { from: 'crm.tier' }],
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects a non-array, bad entries and unknown properties', () => {
+    expect(() => validatePromptMetadata({ Handler: plain, promptMetadata: 'nope' })).toThrow(/must be an array/);
+    expect(() => validatePromptMetadata({ Handler: plain, promptMetadata: [{ description: 'no from' }] })).toThrow(/from is required/);
+    expect(() => validatePromptMetadata({ Handler: plain, promptMetadata: [{ from: 'a b' }] })).toThrow(/not a valid metadata path/);
+    expect(() => validatePromptMetadata({ Handler: plain, promptMetadata: [{ from: 'a', description: 5 }] })).toThrow(/description must be a string/);
+    expect(() => validatePromptMetadata({ Handler: plain, promptMetadata: [{ from: 'a', value: 'x' }] })).toThrow(/unknown property 'value'/);
+  });
+
+  it('caps the number of entries', () => {
+    const many = Array.from({ length: 21 }, () => ({ from: 'aplisay.callerId' }));
+    expect(() => validatePromptMetadata({ Handler: plain, promptMetadata: many })).toThrow(/at most 20/);
+  });
+
+  it('gates toolsCalls paths to dynamic-metadata handlers, like source:"metadata" does', () => {
+    const decl = [{ description: 'Last tool said', from: 'toolsCalls.t1.result.name' }];
+    expect(() => validatePromptMetadata({ Handler: plain, promptMetadata: decl })).toThrow(/only allowed in LiveKit/);
+    expect(() => validatePromptMetadata({ Handler: dynamic, promptMetadata: decl })).not.toThrow();
+  });
+});


### PR DESCRIPTION
Adds `promptMetadata`: call metadata **stated to the model in its system prompt**, instead of left for it to fetch with a `get_metadata` tool call.

```jsonc
"promptMetadata": [
  { "description": "The current date/time is", "from": "aplisay.dateTime" },
  { "description": "The number this caller is calling from is", "from": "aplisay.callerId" }
]
```

renders, per call:

```
Call context (current facts about this call):
The current date/time is Tuesday 2026-07-28 10:32 Europe/London
The number this caller is calling from is +447700900123
```

## Why

Both mechanisms read the same metadata; they differ in **when** the model learns it. A tool round-trip only happens if the model remembers to make it, and on realtime providers it freezes the conversation while it runs. Facts an agent reasons with from its first utterance — today's date above all — belong in the prompt. Beta 2026-07-27: a booking agent repeatedly computed "next Monday" as a **2025** date and sent it as a slot-search start, with `get_metadata` available and never called.

## Semantics (defined once, shared by every worker)

- `from` is a dot-path into the same metadata `source: "metadata"` params read.
- `aplisay.dateTime` is computed **live**; a seeded value wins.
- Entries whose value is missing/null/blank are **omitted** — an absent optional fact never becomes a statement the model treats as true. A declaration that resolves to nothing leaves the prompt byte-identical.
- Objects/arrays render as compact JSON; values are length-capped.
- `toolsCalls.*` stays gated to `hasDynamicMetadata` handlers (LiveKit) — the same rule as `source: "metadata"` params, so this isn't a way around it.

## Wiring

Each at the single funnel every session passes through, so initial runs, `transfer_agent` handovers and consult bots all get it:

- **node/ultravox handler** — composed from `initialPrompt` once call metadata exists (re-join can't stack blocks).
- **LiveKit** — `createVoiceModelAndSession`; consumes the **shared** `lib/prompt-metadata.js` via an `agent-lib` symlink, so there's no TS twin to drift. Also adds the missing `current-datetime.js` symlink its own `function-handler.js` already imported.
- **pipecat** — `CallSession.prepare_run`, via the Python twin `prompt_metadata.py`.

## API

`PromptMetadata` schema + `Agent.promptMetadata` in api-doc, create/update paths, and `MEMBER_FIELDS` so it round-trips through agent sets and survives publish/restore. New `agents.prompt_metadata` JSONB column (schemaVersion **56**). Malformed declarations are rejected at create/update naming the offending entry.

## Docs

`docs/prompt-metadata.md` (+ index row): why-vs-`get_metadata` comparison, entry shape, path table, rules, worked examples.

## Verification

- **13** node + **9** pipecat + **5** livekit tests, all asserting the same shared cases.
- Suites: node no-db **541 passed**, pipecat **202 passed**, livekit `tsc --noEmit` **0 errors**.
- ⚠️ `yarn build` in agents/livekit fails with 70 esbuild dependency errors — **identical on pristine `next`** (verified by stashing), pre-existing and unrelated to this change.