### PR TITLE
fix(livekit): scope tsup plugin entries to plugin sources

### DIFF
--- a/agents/livekit/tsup.config.ts
+++ b/agents/livekit/tsup.config.ts
@@ -1,7 +1,10 @@
 import type { Options } from 'tsup';
 
 const defaultOptions: Options = {
-  entry: ["./realtime.ts", "lib/*.ts", "plugins/**/*.ts"],
+  // Match plugin sources only: a broader `plugins/**/*.ts` also picks up a
+  // plugin's own node_modules/ and dist/, and esbuild fails on the .d.ts files
+  // it finds there.
+  entry: ["./realtime.ts", "lib/*.ts", "plugins/*/src/**/*.ts"],
   format: ["esm"],
   splitting: false,
   sourcemap: true,


### PR DESCRIPTION
## Problem

`agents/livekit/tsup.config.ts` used `plugins/**/*.ts` as an entry glob. That glob matches everything under a plugin's own `node_modules/`, so now that `plugins/ultravox/` has an install of its own, the entry list expands from 6 files to **6257** and the build dies:

```
Error: Build failed with 65 errors:
plugins/ultravox/node_modules/@livekit/rtc-node/node_modules/pino/pino.d.ts:839:13: ERROR: The constant "destination" must be initialized
...
```

esbuild is being handed dependency `.d.ts` files as entry points, and ambient declarations aren't valid entries.

This breaks two things:

- `yarn build` in `agents/livekit`
- `yarn test` at the repo root on a fresh checkout — `tests/setup/global-setup.js` runs that build whenever `agents/livekit/dist/lib/livekit-model-registry.js` is missing

## Fix

Match the actual source layout, `plugins/*/src/**/*.ts`, instead of everything under `plugins/`.

I chose this over a `!plugins/**/node_modules/**` negation (tinyglobby supports it, I checked) because it also excludes a standalone plugin `dist/`. `plugins/ultravox` has its own `tsup.config.ts` and `api-extractor.json`, so building it standalone emits `.d.ts` files that would fail the build in exactly the same way — the negation would leave that foot-gun in place.

The plugin's sources still have to be emitted: `lib/voice-session-factory.ts` imports `../plugins/ultravox/src/index.js` and the build runs `bundle: false`, so `dist/plugins/ultravox/src/*.js` must exist at runtime. It does.

## Verification

All in a clean worktree off `next` with both `node_modules` trees present, so the failure reproduces faithfully.

- Reproduced the failure on unmodified `next` — 65 esbuild errors, exit 1
- `yarn build` after the fix: **success**, exit 0
- `agents/livekit/dist/lib/livekit-model-registry.js` emitted
- No `node_modules` paths anywhere in `dist`
- All 27 `lib/*.ts` sources and all 5 plugin sources emitted
- Every relative import in the 75 emitted files resolves (the only unresolved ones are pre-existing, inside `dist/agent-lib/`, which the `onSuccess` hook copies verbatim — untouched by this change)
- **Output parity:** built with the old glob with `plugins/ultravox/node_modules` moved aside (i.e. the old glob's *intended* behaviour), and diffed the file trees. Identical except for the plugin's own build config `dist/plugins/ultravox/tsup.config.js` and its sourcemap, which nothing imports (grepped).
- Fresh-checkout test path: deleted `agents/livekit/dist`, ran jest with the no-db config; global setup rebuilt cleanly and the suite passed (7/7).
