### PR TITLE
fix(livekit): stop agent-initiated hangup stranding live calls

### DIFF
--- a/agents/livekit/lib/agent-tools.ts
+++ b/agents/livekit/lib/agent-tools.ts
@@ -1,11 +1,21 @@
 import { llm } from "@livekit/agents";
 import type { voice } from "@livekit/agents";
 import logger from "./logger.js";
-import { logToolCall, logToolResult, type ToolKind } from "./tool-log.js";
+import {
+  logToolCall,
+  logToolLoop,
+  logToolResult,
+  type ToolKind,
+} from "./tool-log.js";
 import { functionHandler } from "../agent-lib/function-handler.js";
 import { invokeSubagent } from "./api-client.js";
 import type { Agent, AgentFunction, Call, CallMetadata } from "./api-client.js";
-import type { MessageData, TransferArgs, FunctionResult } from "./types.js";
+import type {
+  MessageData,
+  TransferArgs,
+  FunctionResult,
+  HangupResult,
+} from "./types.js";
 import type { Room } from "@livekit/rtc-node";
 import type { ParticipantInfo } from "./types.js";
 
@@ -15,6 +25,22 @@ export interface AgentTransferArgs {
   includeHistory?: boolean;
   summary?: string;
 }
+
+// ---- Runaway tool-call breaker -------------------------------------------
+// A realtime model that gets an unsatisfying tool result can re-issue the same
+// call as fast as it can generate — far faster than any human-paced turn. On a
+// live call that burns carrier minutes, model minutes and tokens silently, with
+// no error raised anywhere. These bounds are per tool name, per session.
+//
+// Sizing: a genuine voice turn needs speech in and speech out, so even an
+// impatient caller cannot legitimately drive one tool past a handful of calls
+// in 20s. REFUSE is set well above that; KILL is set where the loop is plainly
+// mechanical and the model has shown it will not stop on its own.
+const TOOL_LOOP_WINDOW_MS = 20_000;
+/** Stop executing the tool and hand the model an explicit error instead. */
+const TOOL_LOOP_REFUSE_CALLS = 10;
+/** Unrecoverable: tear the call down rather than keep billing it. */
+const TOOL_LOOP_KILL_CALLS = 25;
 
 /**
  * Creates tools for the agent based on the agent's functions configuration
@@ -31,6 +57,7 @@ export function createTools({
   getTransferState,
   onAgentTransfer,
   onSendDtmf,
+  onToolLoopDetected,
 }: {
   agent: Agent;
   call: Call;
@@ -38,7 +65,13 @@ export function createTools({
   participant: ParticipantInfo | null;
   sendMessage: (message: MessageData, createdAt?: Date) => Promise<void>;
   metadata: CallMetadata;
-  onHangup: () => Promise<void>;
+  /**
+   * Requests agent-initiated termination. Resolves with the result handed to
+   * the model — never void, and never empty (see HangupResult). Repeat calls
+   * while a hangup is already in flight resolve with an explicit
+   * "already in progress" detail rather than silently re-arming teardown.
+   */
+  onHangup: () => Promise<HangupResult>;
   onTransfer: ({
     args,
     participant,
@@ -68,8 +101,45 @@ export function createTools({
   onSendDtmf?: (args: {
     digits: string;
   }) => Promise<{ status: string; detail?: string; error?: string }>;
+  /**
+   * Called when a tool breaches the runaway-loop kill threshold. The runtime
+   * wires this to a forced teardown: at that point the model has demonstrated
+   * it will not stop, and every further second is billed on both legs.
+   */
+  onToolLoopDetected?: (info: {
+    tool: string;
+    calls: number;
+    windowMs: number;
+  }) => void;
 }): llm.ToolContext {
   const { functions = [], keys = [] } = agent;
+
+  // Per-session sliding window of invocation times, keyed by tool name. The
+  // closure is created once per createTools() call — i.e. once per agent stack
+  // — so counts do not leak across calls or survive an agent handover.
+  const recentCalls = new Map<string, number[]>();
+  // Teardown is requested once; further refused calls in the window before the
+  // session actually comes down must not re-fire it or spam the error log.
+  let toolLoopKilled = false;
+
+  /**
+   * Records an invocation and reports whether this tool has breached either
+   * loop threshold within the trailing window.
+   */
+  const noteCallAndCheckLoop = (
+    tool: string,
+  ): { calls: number; refuse: boolean; kill: boolean } => {
+    const now = Date.now();
+    const cutoff = now - TOOL_LOOP_WINDOW_MS;
+    const times = (recentCalls.get(tool) ?? []).filter((t) => t > cutoff);
+    times.push(now);
+    recentCalls.set(tool, times);
+    return {
+      calls: times.length,
+      refuse: times.length > TOOL_LOOP_REFUSE_CALLS,
+      kill: times.length > TOOL_LOOP_KILL_CALLS,
+    };
+  };
 
   return (
     functions &&
@@ -132,6 +202,44 @@ export function createTools({
             // INFO-level, event-tagged so every tool call is visible in the
             // per-call debug log for production agents (see ./tool-log.ts).
             logToolCall(logger, { tool: fnc.name, kind, args });
+
+            // Runaway-loop breaker. Checked BEFORE dispatch so a spinning model
+            // cannot keep re-entering the tool body, and after logToolCall so
+            // the refused attempts still appear in the debug log rather than
+            // vanishing from the record of what the model actually did.
+            const loop = noteCallAndCheckLoop(fnc.name);
+            if (loop.refuse) {
+              const kill = loop.kill && !toolLoopKilled;
+              logToolLoop(logger, {
+                tool: fnc.name,
+                kind,
+                calls: loop.calls,
+                windowMs: TOOL_LOOP_WINDOW_MS,
+                action: kill ? "terminated" : "refused",
+              });
+              if (kill) {
+                toolLoopKilled = true;
+                onToolLoopDetected?.({
+                  tool: fnc.name,
+                  calls: loop.calls,
+                  windowMs: TOOL_LOOP_WINDOW_MS,
+                });
+              }
+              const error = `tool "${fnc.name}" has been called ${loop.calls} times in the last ${
+                Math.round(TOOL_LOOP_WINDOW_MS / 1000)
+              } seconds and is being rate limited. Do not call it again. Continue the conversation, or say nothing.`;
+              logToolResult(logger, {
+                tool: fnc.name,
+                kind,
+                ok: false,
+                error,
+                durationMs: Date.now() - startedAt,
+              });
+              // Returned (not thrown) so the model receives it as this tool's
+              // result and can act on it, mirroring the builtin failure path.
+              return JSON.stringify({ status: "FAILED", error });
+            }
+
             try {
               // A builtin transfer_agent performs its handover INSIDE the
               // handler below (not after functionHandler returns) so the result
@@ -151,7 +259,10 @@ export function createTools({
                 sendMessage,
                 metadata,
                 {
-                  hangup: () => onHangup(),
+                  // Returns onHangup's result verbatim: the model must be told
+                  // the hangup was accepted, otherwise it reads the empty
+                  // result as a failure and immediately retries.
+                  hangup: async () => await onHangup(),
                   transfer: async (a: TransferArgs) =>
                     await onTransfer({ args: a, participant: participant! }),
                   transfer_status: async () => {

--- a/agents/livekit/lib/livekit-constants.ts
+++ b/agents/livekit/lib/livekit-constants.ts
@@ -11,6 +11,15 @@ export const DISCONNECT_REASONS = {
   AGENT_INITIATED_HANGUP: "Agent initiated hangup",
   UNCAUGHT_ERROR_RUNNING_AGENT: "UNCAUGHT ERROR: running agent worker",
   WATCHDOG_NO_PARTICIPANTS: "Watchdog: no remote participants",
+  // The agent asked to hang up but the AgentStateChanged edge that normally
+  // drives teardown never arrived (see the hangup watchdog in
+  // voice-agent-runtime.ts). Distinct from AGENT_INITIATED_HANGUP so the
+  // fallback path is visible in call records rather than masquerading as the
+  // healthy one.
+  HANGUP_WATCHDOG: "Agent initiated hangup (watchdog)",
+  // A tool was invoked in a runaway loop past the kill threshold; the call is
+  // being torn down because the model cannot recover on its own.
+  TOOL_LOOP_DETECTED: "Runaway tool-call loop detected",
 } as const;
 
 export const roomService = new RoomServiceClient(

--- a/agents/livekit/lib/tool-log.ts
+++ b/agents/livekit/lib/tool-log.ts
@@ -9,6 +9,10 @@
  *                              error — both are captured at the prod `info`
  *                              level, so failures stay visible while keeping
  *                              their severity)
+ *   - `event: "tool_loop"`   — the same tool breached the runaway-loop rate
+ *                              limit (ERROR; this is the alertable signal that
+ *                              a model is spinning a tool on a live, billed
+ *                              call — see the breaker in agent-tools.ts)
  *
  * The field shape is kept deliberately identical to the Pipecat worker's
  * `pipecat_aplisay/tool_log.py` so tool activity reads and correlates the same
@@ -35,6 +39,7 @@ export type ToolKind = "function" | "builtin" | "mcp" | "subagent";
 interface ToolLogger {
   info(obj: object, msg?: string): void;
   warn(obj: object, msg?: string): void;
+  error(obj: object, msg?: string): void;
 }
 
 // Cap any single logged value so one large tool result (e.g. a big REST
@@ -107,4 +112,36 @@ export function logToolResult(
   if (error !== undefined && error !== null) fields.error = error;
   if (ok) log.info(fields, `tool result: ${tool}`);
   else log.warn(fields, `tool error: ${tool}`);
+}
+
+/**
+ * Log a runaway tool-call loop at ERROR with `event: "tool_loop"`.
+ *
+ * This is the alertable signal for the class of failure where a realtime model
+ * re-issues the same tool as fast as it can generate (observed at ~2.5 calls/s
+ * against Ultravox): the call stays up and billed, no error is raised anywhere
+ * else, and nothing in the transcript looks wrong. `action` says what the
+ * breaker did — `"refused"` (tool not executed, hard error returned to the
+ * model) or `"terminated"` (call torn down).
+ */
+export function logToolLoop(
+  log: ToolLogger,
+  {
+    tool,
+    kind,
+    calls,
+    windowMs,
+    action,
+  }: {
+    tool: string;
+    kind: ToolKind;
+    calls: number;
+    windowMs: number;
+    action: "refused" | "terminated";
+  },
+): void {
+  log.error(
+    { event: "tool_loop", tool, kind, calls, windowMs, action },
+    `runaway tool loop: ${tool} called ${calls} times in ${windowMs}ms (${action})`,
+  );
 }

--- a/agents/livekit/lib/types.ts
+++ b/agents/livekit/lib/types.ts
@@ -13,6 +13,28 @@ import { type ParticipantInfo } from "livekit-server-sdk";
 // Re-export ParticipantInfo for convenience
 export { ParticipantInfo };
 
+/**
+ * Result of the `hangup` builtin, as handed back to the model.
+ *
+ * The model MUST get a non-empty result. `onHangup` previously returned void,
+ * which serialises to an empty tool result; a realtime model reads that as "my
+ * request went nowhere" and retries immediately — the mechanism behind the
+ * observed 337-call hangup loop. `detail` also tells the model not to keep
+ * talking, since the call is on its way down.
+ */
+export interface HangupResult {
+  status: "OK";
+  detail: string;
+}
+
+/**
+ * Tears the call down when the deferred-hangup path cannot. Registered by the
+ * voice runtime (which owns `cleanupAndClose`) into the worker scope that owns
+ * the hangup latch, mirroring `registerBridgedTakeover`. Cleared with null on
+ * teardown.
+ */
+export type HangupExecutor = () => void;
+
 // The return type from SipClient.createSipParticipant - this is what bridgeParticipant returns
 export interface SipParticipant {
   participantId: string;
@@ -129,8 +151,15 @@ export interface RunAgentWorkerParams<TContext = any, TRoom = any> {
   metadata: any;
   sendMessage: (message: any, createdAt?: Date) => Promise<void>;
   call: Call;
-  onHangup: () => Promise<void>;
+  onHangup: () => Promise<HangupResult>;
   onTransfer: (params: { args: any; participant: ParticipantInfo }) => Promise<any>;
+  /**
+   * Hands the worker's hangup latch a way to drive teardown directly, so an
+   * agent-initiated hangup no longer depends solely on an AgentStateChanged
+   * edge that may never arrive. Optional: transfer-only runs have no LLM and
+   * therefore no hangup tool.
+   */
+  registerHangupExecutor?: (execute: HangupExecutor | null) => void;
   sessionRef: (session: voice.AgentSession | null) => voice.AgentSession | null;
   modelRef: (model: voice.Agent | null) => voice.Agent | null;
   getBridgedParticipant: () => SipParticipant | null;

--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -56,6 +56,7 @@ export async function runAgentWorker({
   startHandoverTone,
   stopHandoverTone,
   registerBridgedTakeover,
+  registerHangupExecutor,
   transferOnly = false,
   transferArgs,
 }: RunAgentWorkerParams & {
@@ -246,6 +247,35 @@ export async function runAgentWorker({
   // closeOnDisconnect or the manual ParticipantDisconnected handler.
   let watchdogInterval: NodeJS.Timeout | null = null;
   const WATCHDOG_INTERVAL_MS = 120 * 1000;
+
+  // ---- Agent-initiated hangup ------------------------------------------
+  // The healthy path closes the call on the AgentStateChanged → "listening"
+  // edge, which lets a closing utterance finish before the line drops. That
+  // edge is not guaranteed: it only fires on a state TRANSITION, so a hangup
+  // issued while the session is already listening (a tool-call-only turn with
+  // no goodbye) never triggers it. These two guards make the latch safe:
+  //   - lastAgentState lets executeHangup see there is no speech to wait for
+  //     and close on a short grace instead of waiting for a transition;
+  //   - hangupTimer bounds every other case, so no missing or late transition
+  //     can strand a live, billed call.
+  let lastAgentState: string | null = null;
+  let hangupTimer: NodeJS.Timeout | null = null;
+  let hangupArmed = false;
+  /**
+   * Long-stop measured from the LAST state change, not from the hangup request:
+   * while the session keeps transitioning (thinking ↔ speaking) it is alive and
+   * working through a closing utterance, so the timer is pushed out each time.
+   * It only expires when the session has gone quiet with a hangup outstanding —
+   * which is exactly the stuck case, and never a long-but-healthy goodbye.
+   */
+  const HANGUP_WATCHDOG_MS = 15 * 1000;
+  /**
+   * Grace applied when no speech is pending at all. Long enough for the hangup
+   * tool result to reach the model and for a generation that started in the
+   * same turn to announce itself (which re-arms to the full watchdog above),
+   * short enough that the stuck case ends in seconds rather than minutes.
+   */
+  const HANGUP_IDLE_GRACE_MS = 2 * 1000;
 
   // DTMF buffering: accumulate digits and send as a single input after timeout.
   // Both values default here and may be overridden per-agent from
@@ -596,6 +626,10 @@ export async function runAgentWorker({
 
     // The call is coming down: no bridged human→agent takeover can start now.
     registerBridgedTakeover?.(null);
+    // Likewise the hangup path — drop the executor and any pending timer so a
+    // late hangup tool call cannot re-enter teardown on a dead session.
+    registerHangupExecutor?.(null);
+    clearHangupTimer();
 
     const exitStatus: {
       callEnded: boolean;
@@ -712,6 +746,116 @@ export async function runAgentWorker({
       exitStatus.error =
         error.message || "unknown error caught during cleanup and close";
     }
+  };
+
+  /** Cancels a pending hangup timer (teardown, or a superseded arming). */
+  const clearHangupTimer = () => {
+    if (hangupTimer) {
+      clearTimeout(hangupTimer);
+      hangupTimer = null;
+    }
+  };
+
+  /**
+   * (Re)arms the hangup long-stop, replacing any timer already pending.
+   *
+   * `reason` distinguishes the two ways this timer legitimately fires: a plain
+   * silent hangup (nothing was pending, so there was never going to be a
+   * "listening" edge) is an ordinary agent-initiated end and must record as
+   * one; firing while speech was outstanding means the state machine went
+   * quiet without ever reaching "listening", which is the stuck case and is
+   * recorded distinctly so it stays visible in call records.
+   */
+  const armHangupTimer = (delayMs: number, reason: string) => {
+    clearHangupTimer();
+    hangupTimer = setTimeout(() => {
+      hangupTimer = null;
+      // cleanupAndClose is idempotent (isCleaningUp), so losing the race to the
+      // state-change handler is a no-op rather than a double teardown.
+      void cleanupAndClose(reason).catch((e) =>
+        logger.error({ e }, "error closing call after hangup"),
+      );
+    }, delayMs);
+    // Never hold the process open on this timer alone.
+    hangupTimer.unref?.();
+  };
+
+  /**
+   * Drives an agent-initiated hangup to completion. Called by the worker's
+   * `onHangup` the moment the latch is set, rather than waiting on a state
+   * transition that may never arrive.
+   *
+   * The AgentStateChanged → "listening" handler still runs and will usually
+   * win the race — that is the path that lets a goodbye finish. This exists so
+   * that when it does not fire, the call still ends.
+   */
+  const executeHangup = () => {
+    if (hangupArmed) return;
+    hangupArmed = true;
+
+    // If the session is mid-generation there IS a closing utterance to wait
+    // for, and the "listening" edge will arrive when it finishes. If it is idle
+    // there is nothing to wait for and that edge will never come — the stuck
+    // case — so fall back to the short grace. Either way the timer is a
+    // long-stop: noteAgentState below pushes it out on every transition, and
+    // the normal listening-edge handler still does the actual close first.
+    const speechPending =
+      lastAgentState === "speaking" || lastAgentState === "thinking";
+    const delay = speechPending ? HANGUP_WATCHDOG_MS : HANGUP_IDLE_GRACE_MS;
+
+    logger.info(
+      { callId: call.id, lastAgentState, speechPending, delayMs: delay },
+      speechPending
+        ? "agent hangup requested; waiting for speech to finish (watchdog armed)"
+        : "agent hangup requested with nothing pending; closing on grace timer",
+    );
+    armHangupTimer(
+      delay,
+      speechPending
+        ? DISCONNECT_REASONS.HANGUP_WATCHDOG
+        : DISCONNECT_REASONS.AGENT_INITIATED_HANGUP,
+    );
+  };
+
+  /**
+   * Records the session's agent state and, while a hangup is outstanding,
+   * re-arms the long-stop. A session that is still transitioning is still
+   * working — pushing the timer out is what keeps a long goodbye from being
+   * cut off mid-sentence, and what lets a generation that starts just after
+   * the hangup call (state still "listening" at request time) complete.
+   */
+  const noteAgentState = (state: string) => {
+    lastAgentState = state;
+    if (!hangupArmed) return;
+    // "listening" is handled by the AgentStateChanged handlers, which close the
+    // call outright; re-arming there would only delay the long-stop behind it.
+    if (state === "listening") return;
+    // Reaching here means speech is outstanding: if it never lands us back in
+    // "listening" the call is stuck, so this arming records as the watchdog.
+    armHangupTimer(HANGUP_WATCHDOG_MS, DISCONNECT_REASONS.HANGUP_WATCHDOG);
+  };
+
+  /**
+   * Forced teardown after the tool breaker sees a tool spinning past its kill
+   * threshold. At that point the model has demonstrated it will not stop, so
+   * the only way to stop the spend is to end the call.
+   */
+  const onToolLoopDetected = ({
+    tool,
+    calls,
+    windowMs,
+  }: {
+    tool: string;
+    calls: number;
+    windowMs: number;
+  }) => {
+    logger.error(
+      { callId: call.id, tool, calls, windowMs },
+      "terminating call: runaway tool-call loop",
+    );
+    void cleanupAndClose(DISCONNECT_REASONS.TOOL_LOOP_DETECTED).catch((e) =>
+      logger.error({ e }, "error closing call after tool loop"),
+    );
   };
 
   // ---- Agent-to-agent transfer (builtin transfer_agent) ----
@@ -835,6 +979,7 @@ export async function runAgentWorker({
       voice.AgentSessionEventTypes.AgentStateChanged,
       async (ev: voice.AgentStateChangedEvent) => {
         if (isStaleSession(s)) return;
+        noteAgentState(ev.newState);
         // The incoming agent has produced audio — the handover gap is over, so
         // stop any comfort tone covering it (idempotent / no-op otherwise).
         if (ev.newState === "speaking") {
@@ -1266,7 +1411,13 @@ export async function runAgentWorker({
       getTransferState,
       onAgentTransfer,
       onSendDtmf,
+      onToolLoopDetected,
     });
+
+  // Give the worker's hangup latch a way to close the call itself. Registered
+  // before the session starts so a hangup on the very first turn is covered,
+  // and cleared in cleanupAndClose alongside registerBridgedTakeover.
+  registerHangupExecutor?.(executeHangup);
 
   // ---- Bridged human→agent takeover (options.bridgedTransferToAgent) ----
   // Expose the live handover machinery to the transfer handler: when a
@@ -1393,6 +1544,7 @@ export async function runAgentWorker({
           voice.AgentSessionEventTypes.AgentStateChanged,
           async (ev: voice.AgentStateChangedEvent) => {
             if (isStaleSession(setupSession)) return;
+            noteAgentState(ev.newState);
             logger.debug({ ev, checkForHangup: checkForHangup(), roomName: room.name }, "agent state changed");
             sendMessage({ status: ev.newState });
             if (ev.newState === "listening" && checkForHangup() && room.name) {

--- a/agents/livekit/lib/worker.ts
+++ b/agents/livekit/lib/worker.ts
@@ -61,6 +61,8 @@ import type {
   SetupCallParams,
   TransferArgs,
   MessageData,
+  HangupResult,
+  HangupExecutor,
 } from "./types.js";
 
 dotenv.config();
@@ -276,6 +278,7 @@ export default defineAgent({
         startHandoverTone,
         stopHandoverTone,
         registerBridgedTakeover,
+        registerHangupExecutor,
       } = await setupCallAndUtilities({
         ctx,
         room,
@@ -443,6 +446,7 @@ export default defineAgent({
             startHandoverTone,
             stopHandoverTone,
             registerBridgedTakeover,
+            registerHangupExecutor,
             endTransferActivityIfNeeded: endTransferActivityFn,
             getTransferState,
             recordingOptions: activeRecordingOptions,
@@ -1237,6 +1241,13 @@ async function setupCallAndUtilities({
   );
 
   let wantHangup = false;
+  // Set by the voice runtime once its stack is up (see registerHangupExecutor);
+  // null before that and after teardown. onHangup calls it to close the call
+  // itself instead of waiting for a state-change edge that may never come.
+  let hangupExecutor: HangupExecutor | null = null;
+  const registerHangupExecutor = (execute: HangupExecutor | null) => {
+    hangupExecutor = execute;
+  };
   let currentBridged: SipParticipant | null = null;
   let bridgedCallRecord: Call | null = null;
   const setBridgedCallRecord = (call: Call | null) => {
@@ -1503,8 +1514,32 @@ async function setupCallAndUtilities({
     return wantHangup;
   };
 
-  async function onHangup() {
+  async function onHangup(): Promise<HangupResult> {
+    // Idempotent: a model that calls hangup twice must not re-arm teardown,
+    // and must be told plainly that the first call was accepted. Returning the
+    // same cheerful "call is ending" for a repeat invites another repeat.
+    if (wantHangup) {
+      return {
+        status: "OK",
+        detail:
+          "hangup is already in progress and the call is ending — do not call hangup again",
+      };
+    }
     wantHangup = true;
+
+    // Drive teardown directly rather than relying solely on the runtime's
+    // AgentStateChanged → "listening" edge. That edge only fires on a state
+    // TRANSITION, so a hangup issued while the session is already listening —
+    // e.g. a tool-call-only turn with no closing utterance — never fires it,
+    // the latch is never read, and the call stays up and billed until the far
+    // end drops. Not awaited: teardown must not block this tool's result, and
+    // the executor applies its own grace period so the result still flushes.
+    hangupExecutor?.();
+
+    return {
+      status: "OK",
+      detail: "the call is ending now — say nothing further",
+    };
   }
 
   // Helper function to destroy any in-progress transfer when original caller disconnects
@@ -1536,6 +1571,9 @@ async function setupCallAndUtilities({
     // Registration point for the runtime's bridged human→agent takeover
     // capability (options.bridgedTransferToAgent).
     registerBridgedTakeover,
+    // Registration point for the runtime's direct teardown path, used by
+    // onHangup so an agent-initiated hangup cannot strand the call.
+    registerHangupExecutor,
     // expose helper to check the currently active call for logging
     getActiveCall: () => bridgedCallRecord || activeAgentCall,
     // The agent's own call WITHOUT the bridge override — usage attribution must


### PR DESCRIPTION
## What changed
- `hangup` is terminal rather than a latch: the voice runtime registers a teardown executor into the worker scope (mirroring `registerBridgedTakeover`) and `onHangup` drives it directly, instead of depending solely on the `AgentStateChanged → "listening"` edge.
- `hangup` returns a real, non-empty result and is idempotent — a repeat call while one is in flight is told so explicitly.
- New generic runaway-tool breaker at the tool-dispatch choke point (`agent-tools.ts`), keyed per tool name per session, plus an event-tagged `tool_loop` ERROR log and distinct `HANGUP_WATCHDOG` / `TOOL_LOOP_DETECTED` disconnect reasons.

## Why
Observed on `agent-runner-staging` called `hangup` **337 times over 2m28s** at ~2.5 calls/sec, and only stopped when the far end dropped the call. The eval scored the case as **passed** — this was invisible to the suite.

Root cause: `onHangup` only set `wantHangup = true`. The latch was read in exactly one place — the `AgentStateChanged` handler, gated on the *transition edge* into `listening`. The model issued `hangup` from a tool-call-only turn while the session was already `listening`, so no further state change ever fired, the latch was never read, and the call stayed up and billed. During the whole 2.5 minutes the process emitted nothing but hangup calls — no `generation_created`, no transcript, no `Status` event.

Compounding it, `onHangup` returned `void`, which serialises to an empty tool result; a realtime model reads that as "my request went nowhere" and retries as fast as it can generate.

Pipecat does not have this bug — `call_session.py:853` ends the call inline and returns `{"ok": true}`. This is a LiveKit-only divergence dating to `e96c91e` (Oct 2025).

The trigger is not test-specific: it covers any agent that hangs up without a closing utterance (ending silently once the caller says goodbye, hanging up in reaction to a tool result). The usual case only works because agents normally speak first, which supplies the edge.

### Design note
The latch exists for a good reason — it lets a closing utterance finish before the line drops — so a naive "close immediately" would regress the good path. The long-stop is therefore measured from the **last state change, not from the hangup request**: while the session keeps transitioning it is alive and working, so the timer is pushed out. Idle at request time → 2s grace; speech pending → 15s long-stop, re-armed on each transition. A generation that starts just after the hangup call re-arms it too, so a late goodbye is not clipped. The existing `listening`-edge close still runs and usually wins; `cleanupAndClose` is already idempotent, so the loser is a no-op.

Breaker thresholds are per tool **name** (>10 calls/20s refuses and returns a hard error to the model, >25 tears the call down), which leaves sequential tool chaining (`docs/tool-call-chaining-metadata-priming.md`) unaffected — that pattern chains *different* tools.

Replaying the incident against this branch: hangup at 14:35:13 with `lastAgentState === "listening"` → 2s grace → call ends ~14:35:15. ~2 seconds and ~4 tool calls instead of 148 seconds and 337. The breaker never engages, which is the intended layering.

## Lane(s) / files touched
`agents/livekit/lib/` only — `worker.ts`, `voice-agent-runtime.ts`, `agent-tools.ts`, `types.ts`, `tool-log.ts`, `livekit-constants.ts`.

No hot files touched (no `index.mjs`, `api/api-doc.yaml`, `lib/ws-handler.js`, `lib/handlers/*`, `lib/database.js`, `lib/models/index.js`, `package.json`). No public API surface change, so no `api/api-doc.yaml` update needed.

## How verified
Repo gate per docs/CONTEXT.md §4 (`cd agents/livekit && yarn build`), plus a standalone typecheck:

```
$ cd agents/livekit && npx tsc --noEmit -p tsconfig.json
exit=0

$ cd agents/livekit && yarn build
ESM ⚡️ Build success in 26ms
Done in 0.81s.
exit=0
```

