### PR TITLE
fix(livekit): let the consult leg hear the target it dialled

### DIFF
--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -30,6 +30,7 @@ import {
 } from "./voice-session-resources.js";
 import { userOwnsPhoneNumber, userOwnsRow } from "./scope.js";
 import { deleteRoomWithRetry } from "./livekit-helpers.js";
+import type { UltravoxFirstSpeakerSettings } from "../plugins/ultravox/src/realtime/api_proto.js";
 import {
   parseBridgedTransferMap,
   armBridgedTransferWatch,
@@ -63,6 +64,38 @@ export type TransferState =
  * dropped/errored consult's meter is collected with its Call.
  */
 const consultUsageMeters = new WeakMap<Call, UsageMeter>();
+
+/**
+ * How long the TransferAgent waits for the dialled target to speak before opening
+ * the conversation itself. Comfortably inside the eval target's 6s inactivity
+ * timeout, and long enough to cover answer-to-greeting latency on a carrier trunk
+ * (~1.5s observed) without leaving a live person listening to silence.
+ */
+const CONSULT_FIRST_SPEAKER_FALLBACK_DELAY = "3s";
+
+/**
+ * `firstSpeakerSettings` is an Ultravox-realtime concept. The consult session
+ * inherits whatever LLM the primary call uses, which may be another realtime
+ * provider or a plain text LLM, so both helpers are no-ops unless the model
+ * actually implements the one-shot override.
+ */
+type ConsultFirstSpeakerCapable = {
+  setNextSessionFirstSpeaker?: (s: UltravoxFirstSpeakerSettings) => void;
+  clearNextSessionFirstSpeaker?: () => void;
+};
+
+function setNextSessionFirstSpeaker(
+  consultLlm: unknown,
+  firstSpeakerSettings: UltravoxFirstSpeakerSettings
+): void {
+  (consultLlm as ConsultFirstSpeakerCapable)?.setNextSessionFirstSpeaker?.(
+    firstSpeakerSettings
+  );
+}
+
+function clearNextSessionFirstSpeaker(consultLlm: unknown): void {
+  (consultLlm as ConsultFirstSpeakerCapable)?.clearNextSessionFirstSpeaker?.();
+}
 
 export interface TransferContext {
   ctx: any; // JobContext
@@ -905,6 +938,9 @@ async function startConsultativeTransfer(
 
 You are now speaking with the person that it has been decided to transfer the call to based on the previous Conversation, and you should act as if you were 
 the agent involved in this conversation with full knowledge of the conversation history.
+
+You have just dialled this person and they have only this second answered. Let them speak first - wait until you have heard them greet you before you say anything. If they stay silent for a few seconds, open with a brief greeting yourself.
+
 Your role is to:
 1. Summarize the call history for the transfer target
 2. Ask if they want to accept the transfer and speak with the caller
@@ -997,9 +1033,8 @@ Be helpful, informal, but respectful and concise as if talking to a colleague in
     });
 
     // Step 6: Create TransferAgent session and connect to consultation room
-    const transferSession = new voice.AgentSession({
-      llm: getLlmForTransferSession(session),
-    });
+    const consultLlm = getLlmForTransferSession(session);
+    const transferSession = new voice.AgentSession({ llm: consultLlm });
     setTransferSession(transferSession);
 
     // Persist the consultation conversation onto the consult CALL RECORD.
@@ -1053,12 +1088,40 @@ Be helpful, informal, but respectful and concise as if talking to a colleague in
     });
     consultUsageMeter.wire(transferSession);
 
-    await transferSession.start({
-      room: consultRoom,
-      agent: transferAgent,
-      // Don't try to record the transfer session as this causes the start to throw due to recording primary session in parallel
-      record: false,
+    // The consult leg DIALS the target, so the target answers and greets first —
+    // the opposite posture to the inbound primary call whose model instance this
+    // session shares. Left on the model default (FIRST_SPEAKER_AGENT) the
+    // TransferAgent opens its own turn ~0.5s after connect, straight over the
+    // target's greeting, which Ultravox then discards as barge-in: the consult
+    // transcript loses that turn and the agent never hears who it is talking to.
+    // Ultravox owns the opening turn, so express it there, for THIS session only.
+    // `fallback` keeps a silent target (voicemail, IVR, someone waiting for us to
+    // speak) from producing dead air; `prompt` rather than `text` so the greeting is
+    // generated in the TransferAgent's own voice and is not echoed back to us as a
+    // synthetic user turn.
+    setNextSessionFirstSpeaker(consultLlm, {
+      user: {
+        fallback: {
+          delay: CONSULT_FIRST_SPEAKER_FALLBACK_DELAY,
+          prompt:
+            "The person you dialled has not said anything yet. Greet them briefly and explain that you are calling about transferring a caller to them.",
+        },
+      },
     });
+
+    try {
+      await transferSession.start({
+        room: consultRoom,
+        agent: transferAgent,
+        // Don't try to record the transfer session as this causes the start to throw due to recording primary session in parallel
+        record: false,
+      });
+    } finally {
+      // start() consumes the one-shot when it builds the realtime session; if it
+      // threw before that, drop the override so it cannot land on an unrelated
+      // session later (e.g. a primary-agent handover on the same model).
+      clearNextSessionFirstSpeaker(consultLlm);
+    }
 
     logger.info({}, "transfer agent started in consultation room");
 

--- a/agents/livekit/plugins/ultravox/src/realtime/realtime_model.ts
+++ b/agents/livekit/plugins/ultravox/src/realtime/realtime_model.ts
@@ -243,6 +243,57 @@ class Response {
   }
 }
 
+/**
+ * Return `base` with `firstSpeakerSettings` REPLACED by `override`, or `base`
+ * shallow-copied when there is no override.
+ *
+ * Replace, never merge: an agent carrying `options.greeting` arrives here with
+ * `firstSpeakerSettings.agent.text` already set (see voice-session-factory), and the
+ * Ultravox API expects exactly one of `user` / `agent` — a merge would leave both
+ * populated. The `vendorSpecific` containers are rebuilt rather than mutated so the
+ * model's defaults, shared with every other session it creates and with the caller's
+ * own options object, are left untouched.
+ */
+export function withFirstSpeakerOverride(
+  base: ModelOptions,
+  override?: api_proto.UltravoxFirstSpeakerSettings
+): ModelOptions {
+  const opts: ModelOptions = { ...base };
+  if (!override) {
+    return opts;
+  }
+  opts.vendorSpecific = {
+    ...opts.vendorSpecific,
+    ultravox: {
+      ...opts.vendorSpecific?.ultravox,
+      firstSpeakerSettings: override,
+    },
+  };
+  return opts;
+}
+
+/**
+ * Fold one transcript frame into the turn accumulated so far.
+ *
+ * `text` is an authoritative snapshot of the whole turn when present; otherwise the
+ * frame carries an incremental `delta`. Ultravox does not guarantee `text` on the
+ * final frame of a turn — see `#handleAgentTranscript`, which has buffered deltas for
+ * that reason since inception — so a consumer that reads only `text` silently drops
+ * any turn delivered purely as deltas.
+ */
+export function foldTranscriptFrame(
+  buffer: string,
+  frame: { text?: string; delta?: string }
+): string {
+  if (frame.text) {
+    return frame.text;
+  }
+  if (frame.delta) {
+    return buffer + frame.delta;
+  }
+  return buffer;
+}
+
 export class RealtimeModel extends llm.RealtimeModel {
   sampleRate = api_proto.SAMPLE_RATE;
   numChannels = api_proto.NUM_CHANNELS;
@@ -254,6 +305,11 @@ export class RealtimeModel extends llm.RealtimeModel {
 
   #defaultOpts: ModelOptions;
   #sessions: RealtimeSession[] = [];
+  /**
+   * One-shot `firstSpeakerSettings` override for the NEXT session created from
+   * this model. See `setNextSessionFirstSpeaker`.
+   */
+  #nextSessionFirstSpeaker?: api_proto.UltravoxFirstSpeakerSettings;
   #client: UltravoxClient;
   constructor({
     modalities = ["text", "audio"],
@@ -355,8 +411,52 @@ export class RealtimeModel extends llm.RealtimeModel {
     return this.#sessions.length > 0 ? this.#sessions[0] : undefined;
   }
 
+  /**
+   * Shape the opening turn of the NEXT session created from this model, and only
+   * that one.
+   *
+   * Used by the consultative-transfer consult leg: it shares the primary call's
+   * model instance but has the opposite conversational posture — it DIALS its peer,
+   * so the peer answers and greets first. Without this the model's default
+   * `FIRST_SPEAKER_AGENT` makes the TransferAgent open its own turn immediately and
+   * talk over the target's greeting, which Ultravox then discards as barge-in.
+   *
+   * Consumed and cleared by the next `session()` call. Call
+   * `clearNextSessionFirstSpeaker()` if the session is never started, so the
+   * override cannot leak onto an unrelated session (e.g. an agent handover).
+   */
+  setNextSessionFirstSpeaker(
+    firstSpeakerSettings: api_proto.UltravoxFirstSpeakerSettings
+  ): void {
+    this.#nextSessionFirstSpeaker = firstSpeakerSettings;
+  }
+
+  /** Discard a pending {@link setNextSessionFirstSpeaker} override. */
+  clearNextSessionFirstSpeaker(): void {
+    this.#nextSessionFirstSpeaker = undefined;
+  }
+
+  /** The override awaiting the next `session()`, if any. Diagnostics/tests. */
+  get pendingFirstSpeakerOverride():
+    | api_proto.UltravoxFirstSpeakerSettings
+    | undefined {
+    return this.#nextSessionFirstSpeaker;
+  }
+
   session(): RealtimeSession {
-    const opts: ModelOptions = { ...this.#defaultOpts };
+    const firstSpeakerOverride = this.#nextSessionFirstSpeaker;
+    this.#nextSessionFirstSpeaker = undefined;
+    const opts: ModelOptions = withFirstSpeakerOverride(
+      this.#defaultOpts,
+      firstSpeakerOverride
+    );
+    if (firstSpeakerOverride) {
+      // Resolved lazily: RealtimeModel may be constructed before initializeLogger().
+      log().info(
+        { firstSpeakerSettings: firstSpeakerOverride },
+        "applying one-shot firstSpeakerSettings override to new session"
+      );
+    }
 
     const newSession = new RealtimeSession(this, opts, this.#client, {
       chatCtx: new llm.ChatContext(),
@@ -423,6 +523,15 @@ export class RealtimeSession extends llm.RealtimeSession {
   public instructions?: string;
   // Agent transcript buffer for accumulating deltas
   #agentTranscriptBuffer: string = "";
+  // User transcript buffer for accumulating deltas. Ultravox does not guarantee a
+  // `text` property on the final frame of a turn (see #handleAgentTranscript, which
+  // has buffered deltas for that reason since inception); without the same buffer on
+  // the user side a delta-only turn is dropped outright and never reaches the chat
+  // context, so the turn is absent from the transcript AND from the agent's history.
+  #userTranscriptBuffer: string = "";
+  // Ordinal of the user turn #userTranscriptBuffer belongs to, so a turn abandoned
+  // without a final frame (barge-in, interruption) cannot prefix the next one.
+  #userTranscriptOrdinal: number | undefined = undefined;
   // Track last item ID for proper insertion order
   #lastItemId: string | undefined = undefined;
   // Track message IDs that have been sent to Ultravox (to avoid duplicates)
@@ -1431,35 +1540,83 @@ export class RealtimeSession extends llm.RealtimeSession {
 
   #handleTranscript(event: api_proto.UltravoxTranscriptMessage): void {
     event.final && this.#logger.debug(
-      { event },
+      { event, ordinal: event.ordinal },
       "handleTranscript - received final transcript event"
     );
 
     if (event.role === "user") {
+      // A new ordinal is a new turn: drop anything left over from a turn that was
+      // abandoned without a final frame rather than prefixing it onto this one.
+      if (
+        event.ordinal !== undefined &&
+        event.ordinal !== this.#userTranscriptOrdinal
+      ) {
+        this.#userTranscriptBuffer = "";
+        this.#userTranscriptOrdinal = event.ordinal;
+      }
+
+      // Accumulate the turn the same way the agent side does: `text` is an
+      // authoritative snapshot when present, otherwise fold in the delta. A final
+      // frame carrying only `delta` used to fall through to "Skipping empty
+      // transcript event" and the whole user turn was lost silently.
+      this.#userTranscriptBuffer = foldTranscriptFrame(
+        this.#userTranscriptBuffer,
+        event
+      );
+      const transcript = this.#userTranscriptBuffer;
+
       // Emit input_speech_started when we first detect user speech (non-final transcript)
       // This interrupts any ongoing agent generation
-      if (!this.userSpeechStartedEmitted && !event.final && event.text && event.text.trim().length > 0) {
+      if (!this.userSpeechStartedEmitted && !event.final && transcript.trim().length > 0) {
         this.#logger.debug("Emitting input_speech_started on first user transcript");
         this.emit("input_speech_started", {
           itemId: "ultravox-user-input",
         } as InputSpeechStarted);
         this.userSpeechStartedEmitted = true;
       }
-      
+
       // Only emit transcription events when there's actual text content
-      if (event.text && event.text.trim().length > 0) {
+      if (transcript.trim().length > 0) {
         const transcriptionEvent = {
           itemId: shortuuid("user-transcript-"),
-          transcript: event.text,
+          transcript,
           isFinal: event.final,
         };
-        this.#logger.debug(
-          { transcriptionEvent, event },
-          "Emitting input_audio_transcription_completed event"
-        );
+        // Finals log at info: at production log level this is the only positive
+        // evidence that a user turn reached us, and its absence is the signature of
+        // a transcript the provider never sent. Interim frames stay at debug so the
+        // volume tracks turns rather than frames.
+        const emitted = {
+          transcriptionEvent,
+          ordinal: event.ordinal,
+          fromDeltaBuffer: !event.text,
+        };
+        if (event.final) {
+          this.#logger.info(
+            emitted,
+            "Emitting input_audio_transcription_completed event"
+          );
+        } else {
+          this.#logger.debug(
+            { ...emitted, event },
+            "Emitting input_audio_transcription_completed event"
+          );
+        }
         this.emit("input_audio_transcription_completed", transcriptionEvent);
       } else {
-        this.#logger.debug({ event }, "Skipping empty transcript event");
+        // Info, not debug: this is a DROPPED user turn. It should be unreachable now
+        // that deltas are buffered, so if it appears the provider sent us a frame
+        // with neither `text` nor `delta` and the turn is gone.
+        this.#logger.info(
+          { event, ordinal: event.ordinal },
+          "Skipping empty transcript event"
+        );
+      }
+
+      if (event.final) {
+        // Keep the ordinal: it stays the boundary marker for any further frame on
+        // this same turn, and the next turn's ordinal resets the buffer anyway.
+        this.#userTranscriptBuffer = "";
       }
     } else if (event.role === "agent") {
       // Handle agent transcript through the generation stream

--- a/agents/livekit/test/ultravox-first-speaker.test.ts
+++ b/agents/livekit/test/ultravox-first-speaker.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { initializeLogger } from "@livekit/agents";
+import {
+  RealtimeModel,
+  withFirstSpeakerOverride,
+} from "../plugins/ultravox/src/realtime/realtime_model.js";
+
+// Covers the one-shot `firstSpeakerSettings` override used by the consultative
+// transfer consult leg, which shares the primary call's RealtimeModel but DIALS its
+// peer (so the peer answers and greets first) instead of being dialled.
+// run: npx tsx --test test/ultravox-first-speaker.test.ts
+
+// The SDK's RealtimeSession base class resolves the logger at construction.
+initializeLogger({ pretty: false, level: "fatal" });
+
+const AGENT_FIRST = { agent: { text: "Hi, how can I help?", uninterruptible: true } };
+const USER_FIRST = { user: { fallback: { delay: "3s", prompt: "say something" } } };
+
+const baseOpts = (ultravox?: Record<string, unknown>) =>
+  ({ instructions: "test agent", ...(ultravox ? { vendorSpecific: { ultravox } } : {}) }) as any;
+
+const makeModel = (ultravox?: Record<string, unknown>) =>
+  new RealtimeModel({
+    instructions: "test agent",
+    apiKey: "test-key",
+    ...(ultravox ? { vendorSpecific: { ultravox } } : {}),
+  } as any);
+
+// --- merge semantics -------------------------------------------------------
+
+test("no override: options pass through with firstSpeakerSettings intact", () => {
+  const base = baseOpts({ firstSpeakerSettings: AGENT_FIRST });
+  const opts = withFirstSpeakerOverride(base, undefined);
+  assert.deepEqual(opts.vendorSpecific.ultravox.firstSpeakerSettings, AGENT_FIRST);
+});
+
+test("override REPLACES rather than merges an agent-first greeting", () => {
+  const opts = withFirstSpeakerOverride(baseOpts({ firstSpeakerSettings: AGENT_FIRST }), USER_FIRST as any);
+  const fs = opts.vendorSpecific!.ultravox!.firstSpeakerSettings as any;
+  assert.deepEqual(fs, USER_FIRST);
+  // Both `agent` and `user` populated is ambiguous to the Ultravox API.
+  assert.equal(fs.agent, undefined, "agent-first greeting must not survive the override");
+});
+
+test("override applies when the model had no firstSpeakerSettings at all", () => {
+  const opts = withFirstSpeakerOverride(baseOpts(), USER_FIRST as any);
+  assert.deepEqual(opts.vendorSpecific!.ultravox!.firstSpeakerSettings, USER_FIRST);
+});
+
+test("override preserves sibling vendor options", () => {
+  const base = baseOpts({
+    firstSpeakerSettings: AGENT_FIRST,
+    vadSettings: { turnEndpointDelay: "0.5s" },
+    experimentalSettings: { transcriptionProvider: "whisper" },
+  });
+  const opts = withFirstSpeakerOverride(base, USER_FIRST as any);
+  assert.deepEqual(opts.vendorSpecific!.ultravox!.vadSettings, { turnEndpointDelay: "0.5s" });
+  assert.deepEqual(opts.vendorSpecific!.ultravox!.experimentalSettings, {
+    transcriptionProvider: "whisper",
+  });
+});
+
+test("override does not mutate the caller's options object", () => {
+  const ultravox = { firstSpeakerSettings: AGENT_FIRST };
+  const base = baseOpts(ultravox);
+  withFirstSpeakerOverride(base, USER_FIRST as any);
+  assert.deepEqual(
+    ultravox.firstSpeakerSettings,
+    AGENT_FIRST,
+    "the model's shared defaults must be untouched",
+  );
+  assert.deepEqual(base.vendorSpecific.ultravox.firstSpeakerSettings, AGENT_FIRST);
+});
+
+// --- one-shot lifecycle ----------------------------------------------------
+
+test("set then session(): the override is consumed exactly once", () => {
+  const model = makeModel({ firstSpeakerSettings: AGENT_FIRST });
+  model.setNextSessionFirstSpeaker(USER_FIRST as any);
+  assert.deepEqual(model.pendingFirstSpeakerOverride, USER_FIRST);
+
+  model.session();
+  assert.equal(
+    model.pendingFirstSpeakerOverride,
+    undefined,
+    "a later session — e.g. a primary-agent handover — must not inherit the consult posture",
+  );
+});
+
+test("clearNextSessionFirstSpeaker discards a pending override", () => {
+  const model = makeModel();
+  model.setNextSessionFirstSpeaker(USER_FIRST as any);
+  model.clearNextSessionFirstSpeaker();
+  assert.equal(model.pendingFirstSpeakerOverride, undefined);
+});
+
+test("no override pending by default", () => {
+  assert.equal(makeModel().pendingFirstSpeakerOverride, undefined);
+});

--- a/agents/livekit/test/ultravox-user-transcript.test.ts
+++ b/agents/livekit/test/ultravox-user-transcript.test.ts
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { foldTranscriptFrame } from "../plugins/ultravox/src/realtime/realtime_model.js";
+
+// Covers user-transcript accumulation in the Ultravox realtime plugin. Before this,
+// the user branch of #handleTranscript read `event.text` only, so a turn Ultravox
+// delivered as `delta` fragments with no `text` on the final frame was dropped
+// outright — no ConversationItemAdded, so the turn reached neither the transcript nor
+// the agent's own history. The agent branch has buffered deltas from the start.
+// run: npx tsx --test test/ultravox-user-transcript.test.ts
+
+/** Replay a turn's frames the way #handleTranscript does, returning the final text. */
+const replay = (frames: Array<{ text?: string; delta?: string }>) =>
+  frames.reduce((buffer, frame) => foldTranscriptFrame(buffer, frame), "");
+
+test("text-only frames: the final snapshot wins (existing Ultravox behaviour)", () => {
+  assert.equal(
+    replay([{ text: "Yes, I will" }, { text: "Yes, I will take the call." }]),
+    "Yes, I will take the call.",
+  );
+});
+
+test("delta-only turn is accumulated rather than dropped", () => {
+  assert.equal(
+    replay([{ delta: "Yes," }, { delta: " I will take" }, { delta: " the call." }]),
+    "Yes, I will take the call.",
+  );
+});
+
+test("final frame carrying only a delta still completes the turn", () => {
+  // The reported failure shape: interim deltas, then a final with no `text`.
+  assert.equal(replay([{ delta: "Yes, I will take" }, { delta: " the call." }]), "Yes, I will take the call.");
+});
+
+test("a text snapshot supersedes anything accumulated so far", () => {
+  assert.equal(
+    replay([{ delta: "Yess I wil" }, { text: "Yes, I will take the call." }]),
+    "Yes, I will take the call.",
+  );
+});
+
+test("frames with neither text nor delta leave the buffer untouched", () => {
+  assert.equal(replay([{ delta: "Hello" }, {}, { delta: " there" }]), "Hello there");
+});
+
+test("an entirely empty turn stays empty (still reported as skipped)", () => {
+  assert.equal(replay([{}]), "");
+  assert.equal(replay([{ text: "" }]), "");
+  assert.equal(replay([{ delta: "" }]), "");
+});
+
+test("empty string text does not clobber an accumulated turn", () => {
+  // `text: ""` is falsy, so it must not be treated as an authoritative snapshot.
+  assert.equal(replay([{ delta: "Hello there" }, { text: "" }]), "Hello there");
+});
+
+// --- turn boundaries -------------------------------------------------------
+// #handleTranscript resets the buffer when `ordinal` changes, so a turn abandoned
+// without a final frame (barge-in) cannot prefix the next one. Replayed here the
+// same way the handler sequences it.
+
+const replayWithOrdinals = (
+  frames: Array<{ text?: string; delta?: string; final?: boolean; ordinal?: number }>,
+) => {
+  let buffer = "";
+  let ordinal: number | undefined;
+  const emitted: string[] = [];
+  for (const frame of frames) {
+    if (frame.ordinal !== undefined && frame.ordinal !== ordinal) {
+      buffer = "";
+      ordinal = frame.ordinal;
+    }
+    buffer = foldTranscriptFrame(buffer, frame);
+    if (frame.final) {
+      emitted.push(buffer);
+      buffer = "";
+    }
+  }
+  return { emitted, buffer };
+};
+
+test("an abandoned turn does not prefix the next one", () => {
+  const { emitted } = replayWithOrdinals([
+    // Turn 1: user starts speaking, gets cut off — no final frame ever arrives.
+    { ordinal: 1, delta: "Sorry can you" },
+    // Turn 2: a complete delta-only turn.
+    { ordinal: 3, delta: "Yes, I will take" },
+    { ordinal: 3, delta: " the call.", final: true },
+  ]);
+  assert.deepEqual(emitted, ["Yes, I will take the call."]);
+});
+
+test("consecutive complete turns are emitted independently", () => {
+  const { emitted, buffer } = replayWithOrdinals([
+    { ordinal: 1, delta: "James", final: false },
+    { ordinal: 1, text: "James speaking.", final: true },
+    { ordinal: 3, delta: "Yes, I will take the call.", final: true },
+  ]);
+  assert.deepEqual(emitted, ["James speaking.", "Yes, I will take the call."]);
+  assert.equal(buffer, "", "buffer is drained after the last final");
+});


### PR DESCRIPTION
## Problem

Eval case for some consult transfers fails intermittently with `consult_transcript_two_way` — the consult leg's transaction log held 3 rows (`start`, one **agent** turn, `hangup`) and **zero user turns** — while the call itself fully succeeded: REFER+Replaces went through, A↔C bridged, handshake verified on the caller leg.

Traced on `agent-runner-staging` to two independent defects in the Ultravox realtime path. Neither is the teardown/flush race it first looked like: `transferSession.close()` is unawaited and the SDK closes the websocket last, so the socket was still open when `call.end()` took its snapshot. Nothing was in flight — the transcript was never delivered.

## 1. The consult leg talks over the target's greeting

The consult session shares the primary call's `RealtimeModel` and inherits its `FIRST_SPEAKER_AGENT` default. But the consult leg **dials** its peer — the target answers and greets first. Staging timeline:

```
15:54:47.549  transfer agent started in consultation room
15:54:47.822  Ultravox "Call started"
15:54:48.412  consult session Status -> speaking     <- opens its own turn
15:54:48.914  target's session: agent final "James speaking."
15:55:02.450  consult session: agent final (13.4s monologue)
```

The greeting was swallowed as barge-in and never transcribed. In the two consult cases that **passed** in the same run the TransferAgent stayed quiet, received `user: " James speaking."` ~1.7 s later, and only then replied.

`RealtimeModel` gains a one-shot `setNextSessionFirstSpeaker()`, consumed and cleared by the next `session()`, so the consult leg declares `firstSpeakerSettings.user` without disturbing the primary call or any later session on the same model (an agent handover would otherwise inherit it). It **replaces** rather than merges — an agent carrying `options.greeting` arrives with `firstSpeakerSettings.agent` already set, and the Ultravox API expects exactly one of `user`/`agent`.

A `user.fallback` (3 s) keeps a silent target — voicemail, IVR, someone waiting for us to speak — from producing dead air, using `prompt` rather than `text` so the greeting is generated in the TransferAgent's own voice and is not echoed back as a synthetic user turn (`voice-agent-runtime` filters that echo on the primary path; the consult capture has no such filter).

## 2. Delta-only user transcripts were dropped

The user branch of `#handleTranscript` read `event.text` only. A turn Ultravox delivers as `delta` fragments with no `text` on the final frame fell through to `Skipping empty transcript event` and was dropped — no `ConversationItemAdded`, so the turn reached neither the transcript **nor the agent's own chat history**.

`#handleAgentTranscript` has buffered deltas since inception, with a comment saying why:

> `// It isn't 100% clear that Ultravox will always send a final transcript with a "text" property, so we buffer deltas just in case`

The user side now does the same, with `ordinal` as the turn boundary so a turn abandoned without a final frame (barge-in) cannot prefix the next one.

## 3. Observability

The two user-transcript log lines move from `debug` to `info`, and log `event.ordinal` (already typed, never read). At production log level "arrived and was dropped" and "never arrived" were indistinguishable — which is exactly what made defect 2 impossible to rule out from the staging logs. Finals only; interim frames stay at `debug` so volume tracks turns, not frames.

## Verification

- `tsc --noEmit` clean, `tsup` build clean.
- 66/66 tests pass (`npx tsx --test test/*.test.ts`) — 49 pre-existing plus 17 new across two files covering replace-not-merge, one-shot consumption, no mutation of the model's shared defaults, delta accumulation, and turn boundaries.
- Merge and fold semantics extracted as pure exported functions (`withFirstSpeakerOverride`, `foldTranscriptFrame`) so they are testable without standing up a session.