### PR TITLE
fix(livekit): stop consult teardown stranding call records

### DIFF
--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -67,6 +67,34 @@ export type TransferState =
 const consultUsageMeters = new WeakMap<Call, UsageMeter>();
 
 /**
+ * Flush the consult leg's llm/tts/stt usage to the ledger and retire its meter.
+ *
+ * Must be called on EVERY terminal path, not just accept: the consult leg consumes
+ * real metered resources from the moment the TransferAgent session starts, whether
+ * the target ultimately accepts, declines, or never gets that far. Flushing only on
+ * accept meant a rejected or abandoned consultation was recorded as zero usage.
+ *
+ * Safe to call more than once for the same call — the meter is retired from the map
+ * on first use, and the ledger writes are `mode: "set"` with a finalisation that
+ * settles a row exactly once, so a repeat is a no-op rather than a double charge.
+ * `UsageMeter.flush` swallows its own errors, so this never throws and can sit ahead
+ * of `call.end()` on a teardown path without risking the record being left live.
+ */
+async function flushConsultUsageMeter(
+  consultCall: Call | null | undefined
+): Promise<void> {
+  if (!consultCall) {
+    return;
+  }
+  const consultMeter = consultUsageMeters.get(consultCall);
+  if (!consultMeter) {
+    return;
+  }
+  consultUsageMeters.delete(consultCall);
+  await consultMeter.flush(true);
+}
+
+/**
  * How long the TransferAgent waits for the dialled target to speak before opening
  * the conversation itself. Comfortably inside the eval target's 6s inactivity
  * timeout, and long enough to cover answer-to-greeting latency on a carrier trunk
@@ -1285,6 +1313,7 @@ Be helpful, informal, but respectful and concise as if talking to a colleague in
     const consultCall = context.getConsultCall();
     if (consultCall) {
       try {
+        await flushConsultUsageMeter(consultCall);
         await consultCall.end("Transfer initiation failed");
         logger.info(
           { consultCallId: consultCall.id },
@@ -1358,15 +1387,15 @@ async function finaliseConsultativeTransfer(
    * released and the transcript `end()` flushes never written.
    *
    * `call.end()` is idempotent (its `_endCalled` latch returns the original promise),
-   * so calling this on a record another path already ended is a no-op. It deliberately
-   * does NOT flush the consult usage meter: metering on the non-accept terminal paths
-   * is a billing behaviour change, not teardown hygiene, and is out of scope here.
+   * so calling this on a record another path already ended is a no-op, as is the
+   * meter flush.
    */
   const endConsultRecord = async (reason: string): Promise<void> => {
     const consultCall = getConsultCall();
     if (!consultCall) {
       return;
     }
+    await flushConsultUsageMeter(consultCall);
     await consultCall.end(reason);
     logger.info({ consultCallId: consultCall.id }, "ended consultation call");
   };
@@ -1399,15 +1428,8 @@ async function finaliseConsultativeTransfer(
       if (transferSession) {
         void closeTransferSessionBounded(transferSession, "finalise");
       }
-      const consultCall = getConsultCall();
-      if (consultCall) {
-        const consultMeter = consultUsageMeters.get(consultCall);
-        if (consultMeter) {
-          await consultMeter.flush(true);
-          consultUsageMeters.delete(consultCall);
-        }
-        await endConsultRecord("Transfer completed");
-      }
+      // endConsultRecord flushes the consult usage meter before ending the record.
+      await endConsultRecord("Transfer completed");
     };
 
     // Delete the consult room (drops any remaining consult SIP leg). Best-effort.
@@ -1684,6 +1706,7 @@ export async function destroyInProgressTransfer(
             "created transaction log for consultation transcript"
           );
         }
+        await flushConsultUsageMeter(consultCall);
         await consultCall.end(reason);
         logger.info(
           { consultCallId: consultCall.id },
@@ -1792,6 +1815,7 @@ export async function rejectConsultativeTransfer(
             );
           }
         }
+        await flushConsultUsageMeter(consultCall);
         await consultCall.end(finalSummary);
         logger.info(
           { consultCallId: consultCall.id },

--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -30,6 +30,7 @@ import {
 } from "./voice-session-resources.js";
 import { userOwnsPhoneNumber, userOwnsRow } from "./scope.js";
 import { deleteRoomWithRetry } from "./livekit-helpers.js";
+import { closeSessionBounded } from "./utils.js";
 import type { UltravoxFirstSpeakerSettings } from "../plugins/ultravox/src/realtime/api_proto.js";
 import {
   parseBridgedTransferMap,
@@ -72,6 +73,43 @@ const consultUsageMeters = new WeakMap<Call, UsageMeter>();
  * (~1.5s observed) without leaving a live person listening to silence.
  */
 const CONSULT_FIRST_SPEAKER_FALLBACK_DELAY = "3s";
+
+/**
+ * Upper bound on `transferSession.close()`. An Ultravox session can hang in close()
+ * indefinitely: `AgentSession.close()` awaits `activity.drain()`, which only exits
+ * once every speech task has settled, and the tool-reply speech task awaits
+ * `RealtimeSession.generateReply()` — a bare Future that Ultravox settles only when
+ * it begins the NEXT generation. On a consult leg whose peer has already gone away
+ * that next generation never comes.
+ *
+ * This matters well beyond the consult leg: `destroyInProgressTransfer` is awaited
+ * from the PRIMARY call's disconnect handling, immediately before `call.end()` and
+ * `process.exit(0)`. An unbounded close there strands the primary call record too —
+ * never ended, its agent-concurrency slot never released. Same hazard, same bound,
+ * as the agent-handover close in voice-agent-runtime.
+ */
+const TRANSFER_SESSION_CLOSE_TIMEOUT_MS = 8_000;
+
+/**
+ * Close the TransferAgent session without ever blocking the caller. Bounded (see
+ * {@link TRANSFER_SESSION_CLOSE_TIMEOUT_MS}) and non-throwing: every call site is a
+ * teardown path where the room, the call record and the process shutdown behind it
+ * must proceed regardless.
+ */
+function closeTransferSessionBounded(
+  transferSession: Pick<voice.AgentSession, "close"> | null | undefined,
+  context: string
+): Promise<void> {
+  return closeSessionBounded(
+    transferSession,
+    TRANSFER_SESSION_CLOSE_TIMEOUT_MS,
+    (e) =>
+      logger.warn(
+        { e: e.message, context },
+        "transfer session close failed/timed out; continuing teardown"
+      )
+  );
+}
 
 /**
  * `firstSpeakerSettings` is an Ultravox-realtime concept. The consult session
@@ -1225,6 +1263,15 @@ Be helpful, informal, but respectful and concise as if talking to a colleague in
   } catch (e: any) {
     const error = e instanceof Error ? e : new Error(String(e));
     logger.error({ e, useRefer }, "failed to initiate warm transfer");
+    // Close the TransferAgent session if it got as far as starting. Initiation can
+    // fail after transferSession.start() (e.g. creating the consult call record), and
+    // nothing downstream closes it: this path leaves consultInProgress false, so both
+    // destroyInProgressTransfer and the background reject handler short-circuit. The
+    // session and its Ultravox call would otherwise stay live and billed.
+    await closeTransferSessionBounded(
+      context.getTransferSession(),
+      "initiation-failure"
+    );
     // Clean up consultation room if it was created
     const consultRoomName = context.getConsultRoomName();
     if (consultRoomName) {
@@ -1304,6 +1351,26 @@ async function finaliseConsultativeTransfer(
     "finalising warm transfer"
   );
 
+  /**
+   * End the consult CALL RECORD. Hoisted out of the try below so the error path can
+   * reach it too: every other terminal path ends the record, and if this one does not
+   * the row is stranded `live=true` forever — its agent-concurrency slot never
+   * released and the transcript `end()` flushes never written.
+   *
+   * `call.end()` is idempotent (its `_endCalled` latch returns the original promise),
+   * so calling this on a record another path already ended is a no-op. It deliberately
+   * does NOT flush the consult usage meter: metering on the non-accept terminal paths
+   * is a billing behaviour change, not teardown hygiene, and is out of scope here.
+   */
+  const endConsultRecord = async (reason: string): Promise<void> => {
+    const consultCall = getConsultCall();
+    if (!consultCall) {
+      return;
+    }
+    await consultCall.end(reason);
+    logger.info({ consultCallId: consultCall.id }, "ended consultation call");
+  };
+
   try {
     const transferTargetIdentity = "transfer-target";
 
@@ -1323,12 +1390,14 @@ async function finaliseConsultativeTransfer(
     // dialog must stay alive until the caller's REFER (whose ?Replaces names that
     // dialog) has been honoured by the carrier.
     const endConsultationRecord = async () => {
+      // Deliberately NOT awaited, and deliberately still ahead of the flush below.
+      // close() drains the session, and that drain is what emits the TransferAgent's
+      // closing turn into the batched transcript — starting it here and flushing
+      // concurrently is what gives that turn a chance to land in `end()`'s snapshot.
+      // The far more common hazard is close() hanging (see
+      // TRANSFER_SESSION_CLOSE_TIMEOUT_MS), so it must never gate this path.
       if (transferSession) {
-        try {
-          transferSession.close();
-        } catch (e) {
-          logger.error({ e }, "failed to close transfer session");
-        }
+        void closeTransferSessionBounded(transferSession, "finalise");
       }
       const consultCall = getConsultCall();
       if (consultCall) {
@@ -1337,11 +1406,7 @@ async function finaliseConsultativeTransfer(
           await consultMeter.flush(true);
           consultUsageMeters.delete(consultCall);
         }
-        await consultCall.end("Transfer completed");
-        logger.info(
-          { consultCallId: consultCall.id },
-          "ended consultation call"
-        );
+        await endConsultRecord("Transfer completed");
       }
     };
 
@@ -1498,11 +1563,22 @@ async function finaliseConsultativeTransfer(
       "failed",
       `Transfer finalization failed: ${error.message}`
     );
-    // Cleanup on error
+    // Cleanup on error. This path is NOT recoverable by anything downstream:
+    // setConsultInProgress(false) above disarms destroyInProgressTransfer, and the
+    // background reject handler is gated on the same flag — so if the consult record
+    // is not ended here it is never ended at all. Reachable in practice on the
+    // bridged branch, where roomService.moveParticipant runs before the record is
+    // ended and can throw when the target has already gone.
     try {
-      if (transferSession) {
-        await transferSession.close();
-      }
+      await endConsultRecord(`Transfer finalisation failed: ${error.message}`);
+    } catch (endError) {
+      logger.error(
+        { endError, consultCallId: getConsultCall()?.id },
+        "failed to end consultation call during finalise error cleanup"
+      );
+    }
+    try {
+      await closeTransferSessionBounded(transferSession, "finalise-error");
       if (consultRoom) {
         await consultRoom.disconnect();
       }
@@ -1558,14 +1634,11 @@ export async function destroyInProgressTransfer(
   const consultCall = getConsultCall();
 
   try {
-    // Step 1: Close TransferAgent session and disconnect from consultation room
-    if (transferSession) {
-      try {
-        await transferSession.close();
-      } catch (e) {
-        logger.error({ e }, "failed to close transfer session");
-      }
-    }
+    // Step 1: Close TransferAgent session and disconnect from consultation room.
+    // Bounded: this function is awaited from the PRIMARY call's disconnect handling,
+    // immediately before that call's own end() and process.exit(0), so a close() that
+    // hangs strands the primary call record as well as this one.
+    await closeTransferSessionBounded(transferSession, "destroy");
     if (consultRoom) {
       try {
         await consultRoom.disconnect();
@@ -1587,10 +1660,15 @@ export async function destroyInProgressTransfer(
       }
     }
 
-    // Step 3: End consultation call and create transaction logs for transcript
-    if (consultCall && transferSession) {
+    // Step 3: End consultation call and create transaction logs for transcript.
+    // Gated on the CALL only: the record must be ended even when there is no transfer
+    // session to read a transcript from, or it is stranded live=true with its
+    // concurrency slot held.
+    if (consultCall) {
       try {
-        const transcript = getTransferAgentTranscript(transferSession);
+        const transcript = transferSession
+          ? getTransferAgentTranscript(transferSession)
+          : "";
         if (transcript) {
           const { userId, organisationId } = agent;
           await createTransactionLog({
@@ -1752,14 +1830,10 @@ export async function rejectConsultativeTransfer(
       }
     }
 
-    // Step 2: Close TransferAgent session and disconnect from consultation room
-    if (transferSession) {
-      try {
-        await transferSession.close();
-      } catch (e) {
-        logger.error({ e }, "failed to close transfer session");
-      }
-    }
+    // Step 2: Close TransferAgent session and disconnect from consultation room.
+    // Bounded — a rejected consult's peer is typically already gone, and the room
+    // teardown and caller hand-back behind this must not wait on a hung close().
+    await closeTransferSessionBounded(transferSession, "reject");
     if (consultRoom) {
       try {
         await consultRoom.disconnect();

--- a/agents/livekit/lib/utils.ts
+++ b/agents/livekit/lib/utils.ts
@@ -33,3 +33,35 @@ export async function withTimeout<T>(
     }
   }
 }
+
+/**
+ * Close a session-like object without ever throwing or blocking indefinitely.
+ *
+ * Teardown paths run where there is no one left to handle a failure and often no
+ * time left to wait: an `AgentSession.close()` can hang forever (its drain awaits a
+ * speech task that awaits a provider future which may never settle), and these calls
+ * sit in front of call-record teardown and process exit. Both failure modes are
+ * reported through `onFailure` and then swallowed so the caller proceeds.
+ *
+ * @param session - Anything with a `close()`; `null`/`undefined` is a no-op.
+ * @param timeoutMs - Upper bound on the close.
+ * @param onFailure - Notified once if the close rejected or timed out.
+ */
+export async function closeSessionBounded(
+  session: { close: () => Promise<void> | void } | null | undefined,
+  timeoutMs: number,
+  onFailure?: (error: Error) => void,
+): Promise<void> {
+  if (!session) {
+    return;
+  }
+  try {
+    await withTimeout(
+      () => Promise.resolve(session.close()),
+      timeoutMs,
+      new Error("session close timed out"),
+    );
+  } catch (e) {
+    onFailure?.(e instanceof Error ? e : new Error(String(e)));
+  }
+}

--- a/agents/livekit/test/consult-teardown.test.ts
+++ b/agents/livekit/test/consult-teardown.test.ts
@@ -1,0 +1,93 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { closeSessionBounded } from "../lib/utils.js";
+
+// closeSessionBounded backs the TransferAgent session close on every consult teardown
+// path. Those paths are awaited by the PRIMARY call's shutdown — destroyInProgressTransfer
+// runs immediately before that call's own end() and process.exit(0) — and an Ultravox
+// session can hang in close() indefinitely (drain awaits a speech task that awaits a
+// generateReply future the provider only settles when it starts the next generation).
+// So the contract this locks is: never throws, never hangs.
+// run: npx tsx --test test/consult-teardown.test.ts
+
+const session = (close: () => Promise<void> | void) => ({ close });
+
+test("no session: resolves without touching anything", async () => {
+  await closeSessionBounded(null, 1000);
+  await closeSessionBounded(undefined, 1000);
+});
+
+test("clean close: awaits it", async () => {
+  let closed = false;
+  await closeSessionBounded(
+    session(async () => {
+      closed = true;
+    }),
+    1000,
+  );
+  assert.equal(closed, true);
+});
+
+test("synchronous (void) close is tolerated", async () => {
+  let closed = false;
+  await closeSessionBounded(
+    session(() => {
+      closed = true;
+    }),
+    1000,
+  );
+  assert.equal(closed, true);
+});
+
+test("close that rejects does not propagate, and is reported once", async () => {
+  const failures: string[] = [];
+  await closeSessionBounded(
+    session(async () => {
+      throw new Error("websocket already gone");
+    }),
+    1000,
+    (e) => failures.push(e.message),
+  );
+  assert.deepEqual(failures, ["websocket already gone"]);
+});
+
+test("close that throws synchronously does not propagate", async () => {
+  const failures: string[] = [];
+  await closeSessionBounded(
+    session(() => {
+      throw new Error("boom");
+    }),
+    1000,
+    (e) => failures.push(e.message),
+  );
+  assert.deepEqual(failures, ["boom"]);
+});
+
+test("close that hangs is bounded, still resolves, and reports the timeout", async () => {
+  const failures: string[] = [];
+  const started = Date.now();
+  // Never settles — the real Ultravox drain hang.
+  await closeSessionBounded(
+    session(() => new Promise<void>(() => {})),
+    50,
+    (e) => failures.push(e.message),
+  );
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed >= 40, `returned before the bound (${elapsed}ms)`);
+  assert.ok(elapsed < 2000, `did not honour the bound (${elapsed}ms)`);
+  assert.deepEqual(failures, ["session close timed out"]);
+});
+
+test("a failure is reported at most once", async () => {
+  let calls = 0;
+  await closeSessionBounded(
+    session(async () => {
+      throw new Error("nope");
+    }),
+    1000,
+    () => {
+      calls += 1;
+    },
+  );
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
Follow-up to #182, which fixed why the consult leg lost the target's speech. This fixes the teardown defects found alongside it. They are unrelated to that transcript bug — but two of them strand a call record permanently.
## What's fixed

**1. `finaliseConsultativeTransfer`'s catch ended nothing.** It closed the session, disconnected and deleted the room, and rethrew — no `consultCall.end()` on any branch. Nothing downstream can rescue it: `setConsultInProgress(false)` has already run, disarming both `destroyInProgressTransfer` and the background reject handler. 

The record-ending closure is hoisted out of the `try` so the catch can reach it. `call.end()` is idempotent (`_endCalled` returns the original promise), so ending a record another path already ended is a no-op.

**2. `destroyInProgressTransfer` was gated on `consultCall && transferSession`.** With no transfer session the record was never ended — on the path whose entire purpose is cleanup. Now gated on the call, with the transcript read made conditional on the session.

**3. `startConsultativeTransfer`'s init-failure catch never closed the transfer session.** Initiation can fail *after* `transferSession.start()` — creating the consult call record, for instance — and this path leaves `consultInProgress` false, so nothing else closes it. The session and its Ultravox call stayed live and billed.

**4. Higher severity than any of the above: every awaited `transferSession.close()` was unbounded.**

`AgentSession.close()` awaits `drain()`, which only exits once every speech task settles; the tool-reply speech task awaits `RealtimeSession.generateReply()` — a bare `Future` that Ultravox settles only when it begins the *next* generation, which never comes once the consult peer has gone.

`destroyInProgressTransfer` is awaited from the **primary** call's disconnect handling ([voice-agent-runtime.ts:114](agents/livekit/lib/voice-agent-runtime.ts:114), :140), immediately before that call's own `end()` and `process.exit(0)`. So a hung consult close strands the primary call record too — never ended, its concurrency slot never released. This repo already knows the failure mode: the agent-handover close is bounded with `withTimeout(..., 8_000)` and the comment *"an Ultravox session whose socket is already winding down can hang in close()"*.

All close sites now go through a new `closeSessionBounded` in `utils.ts` (next to `withTimeout`): 8 s bound, never throws, failure reported through an injected callback so `utils` stays dependency-free.

## Deliberately not done

- **A settle/drain before the flush is inert and costs latency.** Post-#182 the target's greeting lands as a user turn long before accept, so any predicate of the form "buffer has a user turn" is already true at teardown. Meanwhile the record is ended pre-REFER precisely so a caller hangup cannot orphan it, so a wait there widens the orphan window it exists to close.

## Verification

- `tsc --noEmit` clean, `tsup` build clean.
- 73/73 tests pass — 66 existing plus 7 new locking `closeSessionBounded`'s contract: no-op on null, awaits a clean close, tolerates a synchronous close, swallows sync and async rejections, and — the one that matters — returns within the bound when `close()` never settles.

These are theoretical race condition teardown paths that only run on failure, so none of this is exercised by normal evals, they need an internal error condition. 