### PR TITLE
feat: optional hangup after repeated unanswered inactivity prompts

### DIFF
--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -123,6 +123,26 @@ export interface Agent {
       timeout: number | string;
       /** Literal phrase spoken verbatim on each idle kick (deterministic, not an LLM prompt). */
       message: string;
+      /**
+       * End the call after the prompt has gone unanswered `INACTIVITY_PROMPT_COUNT`
+       * times (3), instead of prompting indefinitely. Opt-in; absent/false keeps the
+       * current behaviour exactly.
+       *
+       * Without this a leg that nobody hangs up is only reclaimed by the session
+       * long-stop (the model's `maxDuration` + 5s), which can leave a caller — or an
+       * abandoned transfer target — listening to silence for minutes.
+       *
+       * Applies on every platform, but is enforced in two different places, which
+       * matters if you use consultative transfer:
+       *  - Ultravox realtime: mapped to a provider-native `inactivityMessages`
+       *    `endBehavior`, so Ultravox hangs up server-side. It has NO knowledge of a
+       *    transfer in flight, so a caller held silently through a long consultation
+       *    can be hung up on. Prefer leaving this off for agents that perform
+       *    consultative transfers with long holds.
+       *  - Everything else (pipeline TTS / OpenAI / Gemini realtime): enforced by us,
+       *    and suppressed while a consult or transfer is in flight.
+       */
+      hangup?: boolean;
     };
     /** Sampling temperature for pipeline LLM (OpenAI / Google plugins). */
     temperature?: number;

--- a/agents/livekit/lib/livekit-constants.ts
+++ b/agents/livekit/lib/livekit-constants.ts
@@ -20,6 +20,11 @@ export const DISCONNECT_REASONS = {
   // A tool was invoked in a runaway loop past the kill threshold; the call is
   // being torn down because the model cannot recover on its own.
   TOOL_LOOP_DETECTED: "Runaway tool-call loop detected",
+  // options.inactivity.hangup is set and the inactivity prompt went unanswered
+  // INACTIVITY_PROMPT_COUNT times. Distinct from SESSION_TIMEOUT so an abandoned
+  // call reclaimed deliberately is not confused with one that simply ran out the
+  // model's maxDuration.
+  INACTIVITY_TIMEOUT: "Inactivity timeout",
 } as const;
 
 export const roomService = new RoomServiceClient(

--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -23,6 +23,8 @@ import { resolveVoiceMode } from "./voice-mode.js";
 import {
   createVoiceModelAndSession,
   inactivityAwayTimeoutSecs,
+  inactivityHangupEnabled,
+  INACTIVITY_PROMPT_COUNT,
 } from "./voice-session-factory.js";
 import { resolveUsageVendors } from "./usage-vendors.js";
 import type { UsageVendors } from "./usage-vendors.js";
@@ -1779,6 +1781,28 @@ export async function runAgentWorker({
           session &&
           !isUltravoxRealtime
         ) {
+          // Consecutive unanswered prompts in the current away streak. Reset the
+          // moment the user comes back (see the UserStateChanged handler), so the
+          // hangup only ever fires on a genuinely abandoned call.
+          let inactivityPrompts = 0;
+          const hangupAfterPrompts = inactivityHangupEnabled(agent);
+
+          /**
+           * True while the caller is legitimately unattended by us: held through a
+           * consultation, or already bridged/transferring. Their silence is expected
+           * and must not be counted towards abandonment.
+           *
+           * NB the Ultravox native path cannot make this distinction — Ultravox
+           * enforces its own endBehavior server-side with no view of a transfer.
+           * See the `hangup` option docs in api-client.
+           */
+          const transferInFlight = () => {
+            if (getConsultInProgress()) return true;
+            if (getBridgedParticipant()) return true;
+            const st = getTransferState?.();
+            return st?.state === "dialling" || st?.state === "talking";
+          };
+
           const speakInactivity = async () => {
             // Suppress during/after a transfer bridge — the local agent's audio
             // is no longer what the caller hears.
@@ -1801,6 +1825,26 @@ export async function runAgentWorker({
             } catch (e) {
               logger.info({ e }, "inactivity kick failed");
             }
+
+            // Count only prompts the caller actually heard, and only when we are the
+            // ones they are waiting on. Without the opt-in this stays a pure counter
+            // and the kick repeats indefinitely, exactly as before.
+            if (!hangupAfterPrompts) return;
+            if (transferInFlight()) return;
+            inactivityPrompts += 1;
+            if (inactivityPrompts < INACTIVITY_PROMPT_COUNT) return;
+
+            if (inactivityInterval) {
+              clearInterval(inactivityInterval);
+              inactivityInterval = null;
+            }
+            logger.info(
+              { prompts: inactivityPrompts, inactivityTimeoutSecs },
+              "inactivity prompt unanswered, ending call",
+            );
+            await cleanupAndClose(DISCONNECT_REASONS.INACTIVITY_TIMEOUT).catch(
+              (e) => logger.error({ e }, "error ending call on inactivity"),
+            );
           };
 
           session.on(
@@ -1818,7 +1862,10 @@ export async function runAgentWorker({
                   void speakInactivity();
                 }, inactivityTimeoutSecs * 1000);
               } else {
-                // User became active again (speaking / listening) — stop kicking.
+                // User became active again (speaking / listening) — stop kicking and
+                // forget the streak, so three prompts spread across a long call never
+                // add up to a hangup.
+                inactivityPrompts = 0;
                 if (inactivityInterval) {
                   clearInterval(inactivityInterval);
                   inactivityInterval = null;

--- a/agents/livekit/lib/voice-session-factory.ts
+++ b/agents/livekit/lib/voice-session-factory.ts
@@ -23,6 +23,28 @@ import {
 } from "./pipeline-provider-keys.js";
 
 /**
+ * How many times the inactivity prompt is spoken before the call is considered
+ * abandoned. Shared so the two enforcement paths agree: the Ultravox native
+ * `inactivityMessages` list length, and our own repeat-kick counter in
+ * voice-agent-runtime. Only acted on when `options.inactivity.hangup` is set —
+ * otherwise Ultravox stops prompting after this many and we keep prompting.
+ */
+export const INACTIVITY_PROMPT_COUNT = 3;
+
+/**
+ * Whether `options.inactivity.hangup` opts this agent into ending the call once the
+ * inactivity prompt has gone unanswered {@link INACTIVITY_PROMPT_COUNT} times.
+ *
+ * Only meaningful alongside a usable inactivity config, so it returns false whenever
+ * {@link inactivityAwayTimeoutSecs} would return undefined — there is no prompt to
+ * count, so there is nothing to hang up after.
+ */
+export function inactivityHangupEnabled(agent: Agent): boolean {
+  if (inactivityAwayTimeoutSecs(agent) === undefined) return false;
+  return agent?.options?.inactivity?.hangup === true;
+}
+
+/**
  * Parse the inactivity-kick idle timeout (`options.inactivity.timeout`) into
  * seconds for LiveKit's `voiceOptions.userAwayTimeout`. Accepts a number of
  * seconds or a string like `"8s"` (the same convention as `maxDuration`).
@@ -251,14 +273,36 @@ export function buildRealtimeLlmOptions(
     if (inactivitySecs !== undefined && inactivityMsg && !alreadyNative) {
       // Ultravox fires each entry once, in sequence, after `duration` of further
       // user inactivity — so a short run of identical entries gives the
-      // "re-fire every `timeout` of continued silence" behaviour (here up to 3
-      // nudges). endBehavior left default: do NOT hang up after the last one.
-      const entry = { duration: `${inactivitySecs}s`, message: inactivityMsg };
+      // "re-fire every `timeout` of continued silence" behaviour (here up to
+      // INACTIVITY_PROMPT_COUNT nudges).
+      type InactivityEntry = {
+        duration: string;
+        message: string;
+        endBehavior?: string;
+      };
+      const entry: InactivityEntry = {
+        duration: `${inactivitySecs}s`,
+        message: inactivityMsg,
+      };
+      const messages: InactivityEntry[] = Array.from(
+        { length: INACTIVITY_PROMPT_COUNT },
+        () => ({ ...entry }),
+      );
+      // endBehavior stays default (keep prompting, never hang up) unless the agent
+      // opted in. HANG_UP_SOFT rather than STRICT so the model still delivers the
+      // last prompt before ending, which is what the other end hears as
+      // "hello? ... ok, goodbye" rather than a mid-word cut.
+      if (inactivityHangupEnabled(agent)) {
+        messages[messages.length - 1] = {
+          ...entry,
+          endBehavior: "END_BEHAVIOR_HANG_UP_SOFT",
+        };
+      }
       llmOptions.vendorSpecific = {
         ...(base || {}),
         ultravox: {
           ...((base && base.ultravox) || {}),
-          inactivityMessages: [entry, entry, entry],
+          inactivityMessages: messages,
         },
       };
     }

--- a/agents/livekit/test/inactivity-hangup.test.ts
+++ b/agents/livekit/test/inactivity-hangup.test.ts
@@ -1,0 +1,120 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildRealtimeLlmOptions,
+  inactivityAwayTimeoutSecs,
+  inactivityHangupEnabled,
+  INACTIVITY_PROMPT_COUNT,
+} from "../lib/voice-session-factory.js";
+
+// Covers `options.inactivity.hangup`: end the call once the inactivity prompt has gone
+// unanswered INACTIVITY_PROMPT_COUNT times, instead of prompting forever. Without it a
+// leg nobody hangs up is only reclaimed by the model's maxDuration long-stop, which can
+// leave a caller (or an abandoned transfer target) on silence for minutes.
+// This file covers the option gate and the Ultravox native mapping; the generic
+// (non-Ultravox) counter lives in voice-agent-runtime.
+// run: npx tsx --test test/inactivity-hangup.test.ts
+
+const ULTRAVOX = "livekit:ultravox/ultravox-v0.7";
+const OPENAI = "livekit:openai/gpt-4o-realtime";
+
+const makeAgent = (options: Record<string, unknown> = {}) =>
+  ({ prompt: "You are a test agent.", options }) as any;
+
+const withInactivity = (extra: Record<string, unknown> = {}) =>
+  makeAgent({ inactivity: { timeout: "6s", message: "Are you still there?", ...extra } });
+
+const ultravoxMessages = (agent: any) =>
+  (buildRealtimeLlmOptions(ULTRAVOX, agent, "call-1").vendorSpecific as any)?.ultravox
+    ?.inactivityMessages;
+
+// --- the option gate ---------------------------------------------------------
+
+test("hangup defaults off", () => {
+  assert.equal(inactivityHangupEnabled(withInactivity()), false);
+  assert.equal(inactivityHangupEnabled(withInactivity({ hangup: false })), false);
+});
+
+test("hangup on when explicitly set", () => {
+  assert.equal(inactivityHangupEnabled(withInactivity({ hangup: true })), true);
+});
+
+test("hangup requires a usable inactivity config", () => {
+  // No prompt to count means nothing to hang up after.
+  assert.equal(inactivityHangupEnabled(makeAgent({})), false);
+  assert.equal(
+    inactivityHangupEnabled(makeAgent({ inactivity: { hangup: true } })),
+    false,
+  );
+  assert.equal(
+    inactivityHangupEnabled(makeAgent({ inactivity: { hangup: true, timeout: "6s" } })),
+    false,
+    "message missing",
+  );
+  assert.equal(
+    inactivityHangupEnabled(
+      makeAgent({ inactivity: { hangup: true, message: "hi", timeout: "0s" } }),
+    ),
+    false,
+    "non-positive timeout",
+  );
+  // Sanity: the gate agrees with the timeout parser it defers to.
+  assert.equal(inactivityAwayTimeoutSecs(makeAgent({ inactivity: { hangup: true } })), undefined);
+});
+
+test("truthy-but-not-true does not opt in", () => {
+  assert.equal(inactivityHangupEnabled(withInactivity({ hangup: "yes" })), false);
+  assert.equal(inactivityHangupEnabled(withInactivity({ hangup: 1 })), false);
+});
+
+// --- Ultravox native mapping -------------------------------------------------
+
+test("without hangup: N prompts, no endBehavior anywhere (unchanged behaviour)", () => {
+  const messages = ultravoxMessages(withInactivity());
+  assert.equal(messages.length, INACTIVITY_PROMPT_COUNT);
+  for (const m of messages) {
+    assert.deepEqual(m, { duration: "6s", message: "Are you still there?" });
+    assert.equal(m.endBehavior, undefined);
+  }
+});
+
+test("with hangup: endBehavior on the LAST prompt only", () => {
+  const messages = ultravoxMessages(withInactivity({ hangup: true }));
+  assert.equal(messages.length, INACTIVITY_PROMPT_COUNT);
+
+  for (const m of messages.slice(0, -1)) {
+    assert.equal(m.endBehavior, undefined, "earlier prompts must not end the call");
+  }
+  assert.deepEqual(messages[messages.length - 1], {
+    duration: "6s",
+    message: "Are you still there?",
+    endBehavior: "END_BEHAVIOR_HANG_UP_SOFT",
+  });
+});
+
+test("SOFT not STRICT, so the final prompt is still delivered", () => {
+  const last = ultravoxMessages(withInactivity({ hangup: true })).at(-1);
+  assert.equal(last.endBehavior, "END_BEHAVIOR_HANG_UP_SOFT");
+});
+
+test("caller-supplied native inactivityMessages still win outright", () => {
+  const native = [{ duration: "30s", message: "native", endBehavior: "END_BEHAVIOR_UNSPECIFIED" }];
+  const agent = makeAgent({
+    inactivity: { timeout: "6s", message: "Are you still there?", hangup: true },
+    vendorSpecific: { ultravox: { inactivityMessages: native } },
+  });
+  assert.deepEqual(ultravoxMessages(agent), native);
+});
+
+test("prompt entries are independent objects, not shared references", () => {
+  // The mapping builds copies; a caller mutating one must not affect the others.
+  const messages = ultravoxMessages(withInactivity({ hangup: true }));
+  messages[0].message = "mutated";
+  assert.equal(messages[1].message, "Are you still there?");
+});
+
+test("non-ultravox models get no native inactivityMessages", () => {
+  // Enforcement for these lives in voice-agent-runtime's counter instead.
+  const opts = buildRealtimeLlmOptions(OPENAI, withInactivity({ hangup: true }), "call-1");
+  assert.equal((opts.vendorSpecific as any)?.ultravox?.inactivityMessages, undefined);
+});

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -410,6 +410,7 @@ class CallSession:
             enable_recording=recording_opts.enabled,
             relay_endpoint=self.relay_endpoint,
             tone_injector=self._tone_injector,
+            on_inactivity_hangup=self._on_inactivity_hangup,
         )
         # Stash the context handle so ``get_parent_transcript`` (used by
         # the consultative-transfer flow) can walk the chat history.
@@ -853,6 +854,30 @@ class CallSession:
     async def _on_hangup(self) -> None:
         self._wants_hangup = True
         await self._end(DISCONNECT_REASONS["AGENT_INITIATED_HANGUP"])
+        await self.gateway_session.shutdown()
+
+    async def _on_inactivity_hangup(self) -> None:
+        """End the call after ``options.inactivity.hangup`` prompts went unanswered.
+
+        Same teardown as an agent-initiated hangup, under its own disconnect reason
+        so a deliberately reclaimed leg is distinguishable in call records from one
+        that ran out the model's ``maxDuration``.
+
+        Suppressed while a consultation or transfer is in flight: a caller held
+        silently through a consultation looks identical to an abandoned call from the
+        idle detector's point of view, and hanging up on them would be worse than the
+        strand this exists to prevent. (The native Ultravox path enforces its own
+        ``endBehavior`` server-side and cannot make this distinction — see the
+        ``hangup`` option docs.)
+        """
+        state = getattr(self.transfer_state, "state", None)
+        if state in ("dialling", "talking"):
+            logger.bind(transfer_state=state).info(
+                "inactivity hangup suppressed — transfer in flight"
+            )
+            return
+        self._wants_hangup = True
+        await self._end(DISCONNECT_REASONS["INACTIVITY_TIMEOUT"])
         await self.gateway_session.shutdown()
 
     def _build_tools_for(

--- a/agents/pipecat/pipecat_aplisay/constants.py
+++ b/agents/pipecat/pipecat_aplisay/constants.py
@@ -14,6 +14,11 @@ DISCONNECT_REASONS = {
     # Transitional handler-specific reason — section 7.4. Same intent as the
     # LiveKit worker's WATCHDOG_NO_PARTICIPANTS.
     "WATCHDOG_NO_PARTICIPANTS": "Watchdog: no remote participants",
+    # ``options.inactivity.hangup`` is set and the inactivity prompt went
+    # unanswered ``INACTIVITY_PROMPT_COUNT`` times. Distinct from SESSION_TIMEOUT
+    # so a call reclaimed deliberately is not confused with one that simply ran
+    # out the model's maxDuration. Mirrors the LiveKit worker's string exactly.
+    "INACTIVITY_TIMEOUT": "Inactivity timeout",
 }
 
 PLATFORM = "pipecat"

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -79,6 +79,32 @@ def _inactivity_message(agent: dict) -> Optional[str]:
     return message.strip()
 
 
+#: How many times the inactivity prompt is spoken before the call is considered
+#: abandoned. Shared by the two enforcement paths so they agree: the native
+#: Ultravox ``inactivityMessages`` list length, and the generic kick's own
+#: counter. Only acted on when ``options.inactivity.hangup`` is set — otherwise
+#: Ultravox simply stops prompting after this many and the generic kick keeps
+#: prompting. Must stay in step with the LiveKit worker's INACTIVITY_PROMPT_COUNT.
+INACTIVITY_PROMPT_COUNT = 3
+
+
+def _inactivity_hangup_enabled(agent: dict) -> bool:
+    """Whether ``options.inactivity.hangup`` opts this agent into ending the call
+    once the prompt has gone unanswered :data:`INACTIVITY_PROMPT_COUNT` times.
+
+    Only meaningful alongside a usable inactivity config, so this is ``False``
+    whenever :func:`_inactivity_timeout_secs` is ``None`` — there is no prompt to
+    count, so there is nothing to hang up after. Strictly ``True``, so a truthy
+    string from a hand-edited agent definition does not silently arm it.
+    """
+    if _inactivity_timeout_secs(agent) is None:
+        return False
+    inactivity = (agent.get("options") or {}).get("inactivity")
+    if not isinstance(inactivity, dict):
+        return False
+    return inactivity.get("hangup") is True
+
+
 def _ultravox_inactivity_extra(agent: dict) -> dict:
     """Native Ultravox ``inactivityMessages`` derived from ``options.inactivity``.
 
@@ -91,15 +117,21 @@ def _ultravox_inactivity_extra(agent: dict) -> dict:
 
     Ultravox fires each entry once, in sequence, after ``duration`` of further
     user inactivity; a short run of identical entries gives "re-fire every
-    ``timeout`` of continued silence" (here up to 3 nudges). ``endBehavior`` is
-    left default — do NOT hang up after the last one. Returns ``{}`` when unset.
+    ``timeout`` of continued silence" (up to :data:`INACTIVITY_PROMPT_COUNT`
+    nudges). ``endBehavior`` is left default — do NOT hang up after the last one —
+    unless ``options.inactivity.hangup`` opts in, in which case the LAST entry
+    carries ``END_BEHAVIOR_HANG_UP_SOFT`` so the model still delivers that prompt
+    before ending. Returns ``{}`` when unset.
     """
     secs = _inactivity_timeout_secs(agent)
     message = _inactivity_message(agent)
     if secs is None or message is None:
         return {}
     entry = {"duration": f"{secs:g}s", "message": message}
-    return {"inactivityMessages": [entry, entry, entry]}
+    messages = [dict(entry) for _ in range(INACTIVITY_PROMPT_COUNT)]
+    if _inactivity_hangup_enabled(agent):
+        messages[-1] = {**entry, "endBehavior": "END_BEHAVIOR_HANG_UP_SOFT"}
+    return {"inactivityMessages": messages}
 
 
 def _user_aggregator_params_for(agent: dict) -> Optional[LLMUserAggregatorParams]:
@@ -281,6 +313,7 @@ def _wire_inactivity_kick(
     mode: VoiceMode,
     is_ultravox: bool,
     relay_endpoint: "Optional[Any]" = None,
+    on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
 ) -> None:
     """Register the inactivity "kick" handler on the user aggregator.
 
@@ -351,8 +384,20 @@ def _wire_inactivity_kick(
         ]
     )
 
+    # Consecutive unanswered prompts in the current silent run. Reset the moment a
+    # real user turn starts, so prompts spread across a long call never add up to a
+    # hangup. Only consulted when ``options.inactivity.hangup`` is set.
+    hangup_after_prompts = _inactivity_hangup_enabled(agent) and on_inactivity_hangup is not None
+    idle_prompts = 0
+
+    @user_aggregator.event_handler("on_user_turn_started")
+    async def _on_user_turn_started(_aggregator) -> None:  # noqa: ANN001
+        nonlocal idle_prompts
+        idle_prompts = 0
+
     @user_aggregator.event_handler("on_user_turn_idle")
     async def _on_user_turn_idle(_aggregator) -> None:  # noqa: ANN001
+        nonlocal idle_prompts
         # Suppress while this leg is bridged into a media relay — the local
         # bot is muted, so a kick would be inaudible (and pointless).
         if relay_endpoint is not None and getattr(relay_endpoint, "engaged", False):
@@ -375,6 +420,21 @@ def _wire_inactivity_kick(
                 )
         except Exception as e:  # noqa: BLE001
             _logger.warning(f"inactivity kick failed: {e}")
+
+        # Count only prompts the caller could actually hear. Without the opt-in this
+        # is inert and the kick keeps re-firing indefinitely, exactly as before.
+        if not hangup_after_prompts:
+            return
+        idle_prompts += 1
+        if idle_prompts < INACTIVITY_PROMPT_COUNT:
+            return
+        _logger.bind(prompts=idle_prompts).info(
+            "inactivity prompt unanswered, ending call"
+        )
+        try:
+            await on_inactivity_hangup()  # type: ignore[misc]
+        except Exception as e:  # noqa: BLE001
+            _logger.warning(f"inactivity hangup failed: {e}")
 
 
 def _properties_to_function_schema(name: str, description: str, properties: dict, required: list[str]) -> FunctionSchema:
@@ -630,6 +690,7 @@ async def build_voice_session(
     enable_recording: bool = False,
     relay_endpoint: "Optional[Any]" = None,
     tone_injector: "Optional[Any]" = None,
+    on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
 ) -> tuple[PipelineTask, Optional[AudioBufferProcessor], LLMContext, Any]:
     """Construct a configured ``PipelineTask`` for the call.
 
@@ -661,11 +722,13 @@ async def build_voice_session(
 
     if mode == "realtime":
         task, context, llm = await _build_realtime(
-            transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector
+            transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector,
+            on_inactivity_hangup,
         )
     else:
         task, context, llm = await _build_pipeline(
-            transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector
+            transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector,
+            on_inactivity_hangup,
         )
     return task, audio_buffer, context, llm
 
@@ -680,6 +743,7 @@ async def _build_realtime(
     audio_buffer: Optional[AudioBufferProcessor],
     relay_endpoint: "Optional[Any]" = None,
     tone_injector: "Optional[Any]" = None,
+    on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
@@ -970,6 +1034,7 @@ async def _build_realtime(
         mode="realtime",
         is_ultravox=model_id.startswith("ultravox/"),
         relay_endpoint=relay_endpoint,
+        on_inactivity_hangup=on_inactivity_hangup,
     )
     return task, context, llm
 
@@ -984,6 +1049,7 @@ async def _build_pipeline(
     audio_buffer: Optional[AudioBufferProcessor],
     relay_endpoint: "Optional[Any]" = None,
     tone_injector: "Optional[Any]" = None,
+    on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
@@ -1107,5 +1173,6 @@ async def _build_pipeline(
         mode="pipeline",
         is_ultravox=False,
         relay_endpoint=relay_endpoint,
+        on_inactivity_hangup=on_inactivity_hangup,
     )
     return task, context, llm

--- a/agents/pipecat/tests/test_inactivity_hangup.py
+++ b/agents/pipecat/tests/test_inactivity_hangup.py
@@ -1,0 +1,108 @@
+"""Opt-in hangup after repeated unanswered inactivity prompts
+(``options.inactivity.hangup``, :mod:`pipecat_aplisay.voice_session`).
+
+Without the flag a leg nobody hangs up is only reclaimed by the session long-stop
+(the model's ``maxDuration`` plus a few seconds), so whoever is still on the line
+sits through minutes of silence first — most visibly an abandoned
+consultative-transfer target, which has no other party left to hang up on it.
+
+Two enforcement paths, mirroring the LiveKit worker: Ultravox-backed sessions get a
+provider-side ``endBehavior`` on the last ``inactivityMessages`` entry; everything
+else is counted by the generic kick and torn down by ``CallSession``. These tests
+cover the option gate and the Ultravox mapping.
+"""
+
+from __future__ import annotations
+
+from pipecat_aplisay.constants import DISCONNECT_REASONS
+from pipecat_aplisay.voice_session import (
+    INACTIVITY_PROMPT_COUNT,
+    _inactivity_hangup_enabled,
+    _ultravox_inactivity_extra,
+)
+
+
+def _agent(**inactivity) -> dict:
+    return {"options": {"inactivity": inactivity}} if inactivity else {"options": {}}
+
+
+def _configured(**extra) -> dict:
+    return _agent(timeout="6s", message="Are you still there?", **extra)
+
+
+# --- the option gate ---------------------------------------------------------
+
+
+def test_hangup_defaults_off():
+    assert _inactivity_hangup_enabled(_configured()) is False
+    assert _inactivity_hangup_enabled(_configured(hangup=False)) is False
+
+
+def test_hangup_on_when_explicitly_set():
+    assert _inactivity_hangup_enabled(_configured(hangup=True)) is True
+
+
+def test_hangup_requires_a_usable_inactivity_config():
+    # No prompt to count means nothing to hang up after.
+    assert _inactivity_hangup_enabled({"options": {}}) is False
+    assert _inactivity_hangup_enabled(_agent(hangup=True)) is False
+    assert _inactivity_hangup_enabled(_agent(hangup=True, timeout="6s")) is False, "message missing"
+    assert (
+        _inactivity_hangup_enabled(_agent(hangup=True, message="hi", timeout="0s")) is False
+    ), "non-positive timeout"
+
+
+def test_truthy_but_not_true_does_not_opt_in():
+    # A hand-edited agent definition must not arm this by accident.
+    assert _inactivity_hangup_enabled(_configured(hangup="yes")) is False
+    assert _inactivity_hangup_enabled(_configured(hangup=1)) is False
+
+
+def test_no_inactivity_block_at_all():
+    assert _inactivity_hangup_enabled({}) is False
+    assert _inactivity_hangup_enabled({"options": None}) is False
+
+
+# --- Ultravox native mapping -------------------------------------------------
+
+
+def test_without_hangup_no_end_behavior_anywhere():
+    messages = _ultravox_inactivity_extra(_configured())["inactivityMessages"]
+    assert len(messages) == INACTIVITY_PROMPT_COUNT
+    for m in messages:
+        assert m == {"duration": "6s", "message": "Are you still there?"}
+        assert "endBehavior" not in m
+
+
+def test_with_hangup_end_behavior_on_last_prompt_only():
+    messages = _ultravox_inactivity_extra(_configured(hangup=True))["inactivityMessages"]
+    assert len(messages) == INACTIVITY_PROMPT_COUNT
+    for m in messages[:-1]:
+        assert "endBehavior" not in m, "earlier prompts must not end the call"
+    assert messages[-1] == {
+        "duration": "6s",
+        "message": "Are you still there?",
+        # SOFT not STRICT, so the final prompt is still delivered rather than cut.
+        "endBehavior": "END_BEHAVIOR_HANG_UP_SOFT",
+    }
+
+
+def test_entries_are_independent_objects():
+    messages = _ultravox_inactivity_extra(_configured(hangup=True))["inactivityMessages"]
+    messages[0]["message"] = "mutated"
+    assert messages[1]["message"] == "Are you still there?"
+
+
+def test_unset_inactivity_yields_no_extra():
+    assert _ultravox_inactivity_extra({"options": {}}) == {}
+    assert _ultravox_inactivity_extra(_agent(hangup=True)) == {}
+
+
+# --- disconnect taxonomy -----------------------------------------------------
+
+
+def test_distinct_disconnect_reason():
+    # Must be distinguishable from a maxDuration long-stop in call records, and
+    # identical to the LiveKit worker's string so reporting can span both stacks.
+    assert DISCONNECT_REASONS["INACTIVITY_TIMEOUT"] == "Inactivity timeout"
+    assert DISCONNECT_REASONS["INACTIVITY_TIMEOUT"] != DISCONNECT_REASONS["SESSION_TIMEOUT"]

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -621,8 +621,11 @@ components:
             including the Ultravox realtime path on both stacks. Also honoured by native Ultravox
             agents (`ultravox:` model names) on every medium — WebRTC, WebSocket, and jambonz-routed
             telephony — where it is applied provider-side via Ultravox `inactivityMessages` (the same
-            nudge re-fires after each further `timeout` of continued silence, up to 3 times, and the
-            call is never hung up by this mechanism).
+            nudge re-fires after each further `timeout` of continued silence, up to 3 times).
+
+            By default the call is never hung up by this mechanism — it prompts and then waits
+            indefinitely. Set `hangup` to end the call once the prompt has gone unanswered three
+            times.
 
             Note: this is distinct from the provider-native `vendorSpecific.ultravox.inactivityMessages`,
             which is handled entirely server-side by Ultravox and is not portable across workers; when
@@ -642,6 +645,34 @@ components:
               description: The literal phrase the agent speaks verbatim on each idle kick.
               type: string
               example: "Are you still there?"
+            hangup:
+              description: |-
+                End the call once the prompt has gone unanswered three times, instead of prompting
+                indefinitely. Opt-in; omitted or `false` leaves behaviour unchanged.
+
+                Without this, a leg that nobody hangs up is only reclaimed by the session long-stop
+                (the model's `maxDuration` plus a few seconds), so whoever is still on the line can
+                sit through minutes of silence first. That includes an abandoned consultative-transfer
+                target, which has no other party left to hang up on it.
+
+                Honoured on every stack, but enforced in two different places, which matters if the
+                agent performs consultative transfers:
+
+                  * Ultravox-backed paths (native `ultravox:` agents, and the Ultravox realtime path
+                    on the LiveKit and Pipecat workers) apply it provider-side as an
+                    `endBehavior` on the last `inactivityMessages` entry. Ultravox has no knowledge
+                    of a transfer in flight, so a caller held silently through a long consultation
+                    can be hung up on.
+                  * All other models (pipeline STT/LLM/TTS, OpenAI and Gemini realtime) are enforced
+                    by the worker, which suppresses the hangup while a consultation or transfer is in
+                    flight.
+
+                Prefer leaving this off for agents that perform consultative transfers with long
+                holds on an Ultravox-backed path. The resulting call record carries the disconnect
+                reason `Inactivity timeout`, distinct from `Session timeout`.
+              type: boolean
+              default: false
+              example: true
           required:
             - timeout
             - message

--- a/docs/ultravox-vendor-specific-options.md
+++ b/docs/ultravox-vendor-specific-options.md
@@ -190,6 +190,33 @@ Authoritative behaviour, ordering, and best practices are described in the Ultra
 
 If silence handling or hang-up timing is **business-critical**, assume it **does not** apply on non-Ultravox stacks unless you implement an equivalent there.
 
+### Portable alternative: `options.inactivity`
+
+Silence handling is one of the few areas with a **portable** equivalent, so reach for it first:
+
+```json
+{
+  "options": {
+    "inactivity": {
+      "timeout": "8s",
+      "message": "Are you still there?",
+      "hangup": true
+    }
+  }
+}
+```
+
+`timeout` + `message` speak that line after each `timeout` of continued silence, up to three times. Adding `hangup: true` ends the call once the third prompt goes unanswered, instead of prompting forever and leaving the leg to be reclaimed only by the model's `maxDuration` long-stop — which can mean minutes of silence for whoever is still on the line.
+
+This works on **every** platform, but is enforced in two different places:
+
+| Stack | Enforced by | Transfer-aware? |
+|---|---|---|
+| Ultravox realtime | Mapped to native `inactivityMessages` with `endBehavior: END_BEHAVIOR_HANG_UP_SOFT` on the last entry | **No** — Ultravox has no view of a transfer in flight |
+| Pipeline TTS / OpenAI / Gemini realtime | Our own prompt counter | Yes — suppressed while a consult or transfer is in flight |
+
+That difference matters for **consultative transfer**: a caller held silently through a long consultation looks identical to an abandoned call from Ultravox's point of view, so prefer leaving `hangup` off on agents that perform consultative transfers with long holds. A native `vendorSpecific.ultravox.inactivityMessages` supplied directly always wins over the portable mapping, so you can hand-tune the ladder (as in the example above) when you need per-prompt durations or a different `endBehavior`.
+
 ---
 
 ## Summary

--- a/lib/models/ultravox.js
+++ b/lib/models/ultravox.js
@@ -274,6 +274,17 @@ class Ultravox extends Llm {
    * @static
    * @memberof Ultravox
    */
+  /**
+   * How many times the inactivity prompt is spoken before the call is considered
+   * abandoned. Must stay in step with the LiveKit worker's
+   * `INACTIVITY_PROMPT_COUNT` and the Pipecat worker's, so all three stacks agree
+   * on what `options.inactivity.hangup` means.
+   *
+   * @static
+   * @memberof Ultravox
+   */
+  static INACTIVITY_PROMPT_COUNT = 3;
+
   static inactivityTimeoutSecs(inactivity) {
     if (!inactivity || typeof inactivity !== 'object') return undefined;
     let { timeout, message } = inactivity;
@@ -335,12 +346,18 @@ class Ultravox extends Llm {
     // Portable `options.inactivity` → provider-native inactivityMessages.
     // Ultravox fires each entry once, in sequence, after `duration` of further
     // user inactivity — a short run of identical entries gives the "re-fire on
-    // each further timeout of continued silence" behaviour (up to 3 nudges).
-    // endBehavior left default: never hang up. Native entries above win.
+    // each further timeout of continued silence" behaviour (up to
+    // INACTIVITY_PROMPT_COUNT nudges). endBehavior stays default (never hang up)
+    // unless `options.inactivity.hangup` opts in, in which case the LAST entry
+    // carries END_BEHAVIOR_HANG_UP_SOFT so the model still delivers that prompt
+    // before ending. Native entries above win.
     let inactivitySecs = Ultravox.inactivityTimeoutSecs(inactivity);
     if (!data.inactivityMessages && inactivitySecs) {
       let entry = { duration: `${inactivitySecs}s`, message: inactivity.message.trim() };
-      data.inactivityMessages = [entry, entry, entry];
+      let messages = Array.from({ length: Ultravox.INACTIVITY_PROMPT_COUNT }, () => ({ ...entry }));
+      inactivity.hangup === true &&
+        (messages[messages.length - 1] = { ...entry, endBehavior: 'END_BEHAVIOR_HANG_UP_SOFT' });
+      data.inactivityMessages = messages;
     }
 
     logger.debug({ data }, 'Getting Ultravox data');

--- a/tests/ultravox-native-options.test.mjs
+++ b/tests/ultravox-native-options.test.mjs
@@ -106,6 +106,30 @@ describe('Ultravox native driver option mapping', () => {
       expect(data.inactivityMessages.every((m) => m.endBehavior === undefined)).toBe(true);
     });
 
+    test('hangup:true sets END_BEHAVIOR_HANG_UP_SOFT on the last nudge only', () => {
+      const data = makeModel({
+        inactivity: { timeout: '30s', message: 'Are you still there?', hangup: true },
+      }).modelData;
+      expect(data.inactivityMessages).toHaveLength(3);
+      // Earlier nudges must not end the call; SOFT (not STRICT) on the last so the
+      // final prompt is still delivered rather than cut mid-word.
+      expect(data.inactivityMessages.slice(0, -1).every((m) => m.endBehavior === undefined)).toBe(true);
+      expect(data.inactivityMessages.at(-1)).toEqual({
+        duration: '30s',
+        message: 'Are you still there?',
+        endBehavior: 'END_BEHAVIOR_HANG_UP_SOFT',
+      });
+    });
+
+    test('hangup must be strictly true to arm', () => {
+      for (const hangup of [false, 'yes', 1, undefined]) {
+        const data = makeModel({
+          inactivity: { timeout: '30s', message: 'Are you still there?', hangup },
+        }).modelData;
+        expect(data.inactivityMessages.every((m) => m.endBehavior === undefined)).toBe(true);
+      }
+    });
+
     test('numeric timeout is converted to a duration string', () => {
       const data = makeModel({
         inactivity: { timeout: 20, message: 'Hello?' },


### PR DESCRIPTION
Adds `options.inactivity.hangup` (default `false`). When set, the call ends once the inactivity prompt has gone unanswered three times, instead of prompting and then waiting indefinitely.

## Why

A leg that nobody hangs up is currently only reclaimed by the session long-stop — the model's `maxDuration` plus a few seconds — so whoever is still on the line sits through minutes of silence first. Observed repeatedly on staging today, on an abandoned consultative-transfer target that had no other party left to hang up on it:

| Consult ended | Target leg dropped | Delta | Reason |
|---|---|---|---|
| 19:22:16 | 19:24:51 | 2m35s | Session timeout |
| 20:28:31 | 20:31:19 | 2m48s | Session timeout |
| 20:49:33 | 20:52:24 | 2m51s | Session timeout |

In each case the target prompted *"Hello — are you still there?"* three times, then went silent for a further two minutes. And each one went on to hit Ultravox's `maxDuration`, which force-closes the websocket, raises an unrecoverable `realtime_model_error`, and leaves the job needing the 120 s hard-exit backstop — 3 for 3.

With this flag the leg would have ended ~18 s into silence, which also keeps it well clear of `maxDuration` and avoids that zombie path entirely.

## All three stacks

An agent definition should behave the same wherever it runs, so this is implemented in every place that consumes `options.inactivity`:

| Stack | Enforcement |
|---|---|
| [lib/models/ultravox.js](lib/models/ultravox.js:335) — native `ultravox:` agents (WebRTC, WebSocket, jambonz) | provider-side `endBehavior` on the last `inactivityMessages` entry |
| [agents/livekit](agents/livekit/lib/voice-session-factory.ts:273) | same provider-side mapping for Ultravox realtime; prompt counter on the existing user-away kick for every other model |
| [agents/pipecat](agents/pipecat/pipecat_aplisay/voice_session.py:118) | same split — Ultravox native extra, plus a counter on the generic kick wired through `build_voice_session` to a new `CallSession._on_inactivity_hangup` |

`INACTIVITY_PROMPT_COUNT` (3) is now a named constant on each stack, replacing the hardcoded `[entry, entry, entry]`, so the two enforcement paths can't drift apart.

## Design notes

- **`HANG_UP_SOFT`, not `STRICT`** — the model still delivers the final prompt rather than cutting mid-word. What the other end hears is "hello? … ok, goodbye", not a dead line.
- **The counter resets on real user activity** (LiveKit: user state leaving `away`; Pipecat: `on_user_turn_started`), so three prompts spread across a long call never accumulate into a hangup.
- **The worker-enforced path suppresses the hangup while a consultation or transfer is in flight.** A caller held silently through a consultation is indistinguishable from an abandoned call to an idle detector, and hanging up on them would be considerably worse than the strand this fixes. **The Ultravox provider-side path cannot make that distinction** — `endBehavior` is enforced server-side with no view of a transfer. That asymmetry is documented rather than hidden, with a recommendation to leave the flag off for agents doing consultative transfers with long holds.
- **New disconnect reason `"Inactivity timeout"`** on both workers, identical strings so reporting spans them, and distinct from `"Session timeout"` so a deliberately reclaimed leg isn't confused with one that ran out `maxDuration`.

**With the flag absent, behaviour is unchanged on every path**: Ultravox still prompts three times and waits, and the generic kicks still repeat indefinitely. I deliberately did not "fix" that pre-existing asymmetry (Ultravox stops at three, the generic kick repeats forever) — only the flag introduces a cap.

## Documentation

The flag was missing from the public API surface, which is where an agent author would actually look:

- [api/api-doc.yaml](api/api-doc.yaml:607) — added to the `inactivity` schema with the enforcement-location caveat, and corrected the existing description, which stated flatly that "the call is never hung up by this mechanism".
- [docs/ultravox-vendor-specific-options.md](docs/ultravox-vendor-specific-options.md:191) — a new "portable alternative" section, since that doc previously pointed people at `vendorSpecific.ultravox.inactivityMessages` for silence handling with no mention of the portable option.

## Verification

- LiveKit: `tsc --noEmit` clean, `tsup` build clean, **83/83** tests (73 existing + 10 new).
- Pipecat: **212/212** tests (202 existing + 10 new).
- Native Ultravox: **16/16** in `tests/ultravox-native-options.test.mjs` (14 existing + 2 new).

New tests cover the option gate (including that a truthy-but-not-`true` value does not arm it), that `endBehavior` lands on the last prompt only, `SOFT` not `STRICT`, that entries are independent objects, that caller-supplied native `inactivityMessages` still win, and that the disconnect reason is distinct from `Session timeout`.

