### PR TITLE
Bill per-minute time in 6-second increments (round up)

### DIFF
--- a/lib/rates.js
+++ b/lib/rates.js
@@ -15,6 +15,9 @@
  *  - **Match = key omission is wildcard.** A line matches a row iff every
  *    *specified* `match` key equals the row's field; the most-specific (most keys)
  *    line wins within each dimension. `media` is only meaningful on voice rows.
+ *  - **6-second increments.** Time-metered quantities priced per minute round the
+ *    duration UP to the next {@link BILLING_INCREMENT_SECONDS} multiple before
+ *    rating (matching destination tariffs' rounding) — the published billing claim.
  *  - **Never throws.** A costing failure must never become a metering failure, so
  *    every public entry point is best-effort: a resolver throw stamps
  *    `costStatus='errored'` and leaves the quantity untouched.
@@ -37,11 +40,19 @@ import {
   Tariff as DefaultTariff,
   TariffPrefix as DefaultTariffPrefix,
 } from './database.js';
-import { resolveTariff, matchTariffPrefix, computeDestinationCost, normaliseDestination } from './tariffs.js';
+import { resolveTariff, matchTariffPrefix, computeDestinationCost, normaliseDestination, roundUpSeconds } from './tariffs.js';
 import { maybeFireBalanceCallbacks } from './balance-callback.js';
 import defaultLogger from './logger.js';
 
-const MS_PER_MINUTE = 60000;
+/**
+ * Billing increment for ANY time-metered quantity priced per minute: duration is
+ * rounded UP to the next 6-second multiple before rating. This is the published
+ * customer claim ("billed in 6-second increments" — docs/documentation-site-design.md
+ * in polite-ai), so it applies to the headline per-minute dimensions here exactly as
+ * it already does to destination tariffs (Tariff.roundingSeconds defaults to the
+ * same 6). Changing it changes what customers are charged versus what the docs say.
+ */
+export const BILLING_INCREMENT_SECONDS = 6;
 
 /**
  * Money scale: balances and costs are stored internally in **micro-pence**
@@ -104,13 +115,18 @@ export function validateRateLines(detail) {
  * character counts are 1:1 with their billing unit (a line matches a specific
  * token unit, e.g. `output_tokens`, priced per `token`).
  *
+ * Time → minute conversions round the duration UP to the next
+ * {@link BILLING_INCREMENT_SECONDS} multiple first, so every per-minute-priced
+ * line bills in 6-second increments (any non-zero duration bills at least one
+ * increment). A quantity already in minutes is trusted as-is.
+ *
  * @returns {number} quantity expressed in `lineUnit` (may be fractional)
  */
 export function toLineUnits(quantity, rowUnit, lineUnit) {
   const q = Number(quantity) || 0;
   if (lineUnit === 'minute') {
-    if (rowUnit === 'milliseconds') return q / MS_PER_MINUTE;
-    if (rowUnit === 'seconds') return q / 60;
+    if (rowUnit === 'milliseconds') return roundUpSeconds(q / 1000, BILLING_INCREMENT_SECONDS) / 60;
+    if (rowUnit === 'seconds') return roundUpSeconds(q, BILLING_INCREMENT_SECONDS) / 60;
     return q; // already minutes
   }
   return q;

--- a/tests/rates.test.mjs
+++ b/tests/rates.test.mjs
@@ -6,6 +6,7 @@ import { randomUUID } from 'crypto';
 import {
   resolveRowCost, toLineUnits, lineMatchesRow, resolveOrgRateName,
   resolveRateCard, settle, costUsageRow, sweepUncostedRows,
+  BILLING_INCREMENT_SECONDS,
 } from '../lib/rates.js';
 import { recordUsage, finaliseSession } from '../lib/usage.js';
 
@@ -42,6 +43,25 @@ describe('rates: pure additive resolver', () => {
     expect(toLineUnits(120, 'seconds', 'minute')).toBe(2);
     expect(toLineUnits(42, 'output_tokens', 'token')).toBe(42);
     expect(toLineUnits(900, 'characters', 'character')).toBe(900);
+  });
+
+  // Pins the published customer claim: calls are "billed in 6-second increments"
+  // (docs/documentation-site-design.md in polite-ai). If this test breaks, the
+  // docs are lying — change the docs claim before changing the behaviour.
+  it('bills per-minute time in 6-second increments, rounding UP', () => {
+    expect(BILLING_INCREMENT_SECONDS).toBe(6);
+    // 61s → 66 billed seconds → 1.1 minutes, from either meter unit.
+    expect(toLineUnits(61_000, 'milliseconds', 'minute')).toBeCloseTo(1.1);
+    expect(toLineUnits(61, 'seconds', 'minute')).toBeCloseTo(1.1);
+    // Exact multiples don't over-round; zero stays zero.
+    expect(toLineUnits(66_000, 'milliseconds', 'minute')).toBeCloseTo(1.1);
+    expect(toLineUnits(0, 'milliseconds', 'minute')).toBe(0);
+    // Any non-zero duration bills at least one increment (0.1 min).
+    expect(toLineUnits(1, 'milliseconds', 'minute')).toBeCloseTo(0.1);
+    // End-to-end through the resolver: a 61s realtime call is rated as 1.1 min on
+    // BOTH per-minute dimensions: 1.1 × (500_000 + 6_000_000) = 7_150_000.
+    const { costMicros } = resolveRowCost(voiceRow({ quantity: 61_000 }), ULTRAVOX_CARD);
+    expect(costMicros).toBe(7_150_000);
   });
 
   it('lineMatchesRow: key omission is wildcard; specified keys must equal', () => {
@@ -107,7 +127,7 @@ describe('rates: pure additive resolver', () => {
     const card = { detail: { lines: [
       { dim: 'audio-path', match: { technology: 'voice' }, unit: 'minute', priceMicros: 7 },
     ] } };
-    // 10_000ms = 1/6 min; 7 * 1/6 = 1.166… -> 1
+    // 10_000ms rounds up to 12 billed seconds = 0.2 min; 7 * 0.2 = 1.4 -> 1
     expect(resolveRowCost(voiceRow({ quantity: 10_000 }), card).costMicros).toBe(1);
   });
 });


### PR DESCRIPTION
## Why

The customer docs (documentation site, agreed 29 Jul) state as fact that call billing uses **6-second increments**. Today only destination tariffs round up to 6-second increments (`Tariff.roundingSeconds`, default 6); the headline per-minute dimensions (`audio-path`, `model`, `tts`, `stt`) rated raw milliseconds/seconds as fractional minutes — i.e. per-second billing.

## What

- `toLineUnits` now rounds any time→minute conversion **UP** to the next `BILLING_INCREMENT_SECONDS` (6) multiple, reusing `roundUpSeconds` from the tariff engine so both paths share one policy.
- New exported constant `BILLING_INCREMENT_SECONDS = 6` documents that this is the published claim.
- Test pins the increment end-to-end (61 s → 66 billed seconds → 1.1 min on both per-minute dimensions), plus edge cases (exact multiples, zero, minimum one increment).

## Consistency audit

- **Settlement** (`costUsageRow` → `resolveRowCost` → `toLineUnits`): covered by this change.
- **Destination tariffs** (`computeDestinationCost`): already round up to 6 s — unchanged.
- **`/usage` aggregation + tariff quote endpoint**: sum frozen `costMicros` / use the tariff engine — no independent duration→cost math, consistent by construction.
- **Frozen history**: `matched` rows are cost-at-write and never re-valued; this applies to rows costed from deploy onward.

## Tests

All rate/tariff/billing/balance/usage suites pass (104 tests across 12 suites) against the test Postgres.