### PR TITLE
fix(livekit): fix issues which prevent a normal call ending when Ultravox inititiates

### DIFF
--- a/agents/livekit/lib/livekit-constants.ts
+++ b/agents/livekit/lib/livekit-constants.ts
@@ -25,6 +25,13 @@ export const DISCONNECT_REASONS = {
   // call reclaimed deliberately is not confused with one that simply ran out the
   // model's maxDuration.
   INACTIVITY_TIMEOUT: "Inactivity timeout",
+  // The realtime provider ended the session without being asked to — Ultravox's own
+  // maxDuration, an inactivityMessages endBehavior hangup, or an outage. Distinct from
+  // SESSION_TIMEOUT: that one means OUR long-stop reclaimed a leg nobody ended, which
+  // is precisely the symptom this reason exists to stop being mistaken for a cause.
+  // NB Call.end discards `reason` for `status` (always "ended normally") — this string
+  // is durable in the hangup transaction-log row and the invocation log, not in status.
+  REALTIME_PROVIDER_ENDED: "Realtime provider ended session",
 } as const;
 
 export const roomService = new RoomServiceClient(

--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -1572,6 +1572,39 @@ export async function runAgentWorker({
           },
         );
 
+        // When the realtime provider ends the session itself — Ultravox's own
+        // maxDuration, an options.inactivity.hangup endBehavior hangup, or a genuine
+        // outage — the agent is dead but the SIP leg is still up. Nothing else notices:
+        // the SDK turns it into an unrecoverable error whose `recoverable` flag is
+        // stripped before any listener sees it (see setProviderEndedCallback), and the
+        // Close event never arrives because closeImpl blocks in drain(). Observed on
+        // staging: 2m10s of dead air on a live leg, then teardown under the unrelated
+        // "Session timeout" long-stop, then a 120s forced process exit.
+        //
+        // The callback fires for the PRIMARY session only, so a consult TransferAgent
+        // session or a post-handover session ending cannot reach here. The guards below
+        // cover the cases where the primary model is deliberately dead but the call is
+        // healthy or already coming down.
+        (
+          model as unknown as {
+            setProviderEndedCallback?: (cb: (i: unknown) => void) => void;
+          } | null
+        )?.setProviderEndedCallback?.((info: unknown) => {
+          if (isCleaningUp) return;
+          if (agentHandoverInProgress) return;
+          // Bridged/transferred out: the caller no longer hears this agent, so its
+          // model dying is expected and must not end the bridged call.
+          if (getBridgedParticipant()) return;
+          if (getConsultInProgress()) return;
+          logger.warn(
+            { info, callId: call.id },
+            "realtime provider ended the session; ending call",
+          );
+          void cleanupAndClose(DISCONNECT_REASONS.REALTIME_PROVIDER_ENDED).catch(
+            (e) => logger.error({ e }, "error ending call after provider end"),
+          );
+        });
+
         // Watch for any non-recoverable model/STT/TTS errors that occur while
         // the session is still starting. If we see one before callStarted is
         // set, we treat it as a setup failure so the outer fallback loop can

--- a/agents/livekit/plugins/ultravox/src/realtime/realtime_model.ts
+++ b/agents/livekit/plugins/ultravox/src/realtime/realtime_model.ts
@@ -310,6 +310,8 @@ export class RealtimeModel extends llm.RealtimeModel {
    * this model. See `setNextSessionFirstSpeaker`.
    */
   #nextSessionFirstSpeaker?: api_proto.UltravoxFirstSpeakerSettings;
+  /** See {@link setProviderEndedCallback}. */
+  #providerEndedCallback?: (info: { code?: number; reason?: string }) => void;
   #client: UltravoxClient;
   constructor({
     modalities = ["text", "audio"],
@@ -434,6 +436,39 @@ export class RealtimeModel extends llm.RealtimeModel {
   /** Discard a pending {@link setNextSessionFirstSpeaker} override. */
   clearNextSessionFirstSpeaker(): void {
     this.#nextSessionFirstSpeaker = undefined;
+  }
+
+  /**
+   * Called when Ultravox ends a session we did not ask it to end — its own
+   * `maxDuration`, an `inactivityMessages` `endBehavior` hangup, or a genuine outage.
+   *
+   * Exists because the SDK's `AgentSession.Error` event is lossy: `agent_activity`'s
+   * `onError` forwards `createErrorEvent(ev.error, …)`, i.e. the INNER `Error`, so the
+   * `RealtimeModelError` wrapper's `type` and `recoverable` never reach a listener.
+   * A subscriber therefore cannot distinguish a terminal provider hangup from a
+   * routine recoverable reconnect, and guessing in either direction is harmful —
+   * treating reconnects as fatal hangs up live calls, treating hangups as transient
+   * leaves the caller on a dead line until an unrelated long-stop fires.
+   *
+   * Fires for the PRIMARY session only (the first this model creates). A consult
+   * TransferAgent session and post-handover sessions share the model instance but
+   * their ending must never tear down the primary call.
+   */
+  setProviderEndedCallback(
+    cb: (info: { code?: number; reason?: string }) => void
+  ): void {
+    this.#providerEndedCallback = cb;
+  }
+
+  /** @internal Invoked by a RealtimeSession whose socket closed provider-side. */
+  _notifyProviderEnded(
+    session: RealtimeSession,
+    info: { code?: number; reason?: string }
+  ): void {
+    if (this.#sessions[0] !== session) {
+      return;
+    }
+    this.#providerEndedCallback?.(info);
   }
 
   /** The override awaiting the next `session()`, if any. Diagnostics/tests. */
@@ -1137,8 +1172,22 @@ export class RealtimeSession extends llm.RealtimeSession {
 
         this.#ws.onerror = (error) => {
           const errorMsg = "Ultravox WebSocket error: " + error.message;
+          // Mirror onclose's #closing guard. Without it a socket that errors during a
+          // teardown WE initiated — agent handover closing the outgoing session, the
+          // consult session closing after accept/reject, ordinary call cleanup — is
+          // reported as an unrecoverable failure of a live session. That is a false
+          // positive today (it only mislabels a log line) but becomes a call-killer
+          // once the runtime acts on provider-ended, so guard it at the source.
+          if (this.#closing) {
+            this.#logger.info(
+              { error, callId: this.#callId },
+              "Ultravox WebSocket error during local close; ignoring"
+            );
+            return;
+          }
           this.#logger.error({ error }, "Ultravox WebSocket error occurred");
           this.#sessionFailed = true;
+          this.#notifyProviderEnded({ reason: error.message });
           this.emitError({ error: new Error(errorMsg), recoverable: false });
           reject(new Error(errorMsg));
         };
@@ -1308,20 +1357,39 @@ export class RealtimeSession extends llm.RealtimeSession {
           this.emitError({ error, recoverable: true });
         });
 
-        this.#ws.onclose = () => {
-          if (this.#expiresAt && Date.now() >= this.#expiresAt) {
-            this.#closing = true;
-          }
+        this.#ws.onclose = (event?: { code?: number; reason?: string }) => {
+          // NB no #expiresAt short-circuit here. It used to set #closing = true once
+          // Date.now() passed a HARDCODED start+5min (see #expiresAt assignment), which
+          // silently swallowed every provider-side close after that point — no error,
+          // no signal, and the SIP leg left up with a dead agent. Deriving it from
+          // maxDuration would be worse still: it would suppress exactly the provider
+          // hangups we now need to act on (Ultravox maxDuration, and the
+          // inactivityMessages endBehavior hangup). #expiresAt remains for the session
+          // -update payloads that report it; it is not a close classifier.
+          const code = event?.code;
+          const reason = event?.reason || undefined;
           if (!this.#closing) {
             const errorMsg = "Ultravox connection closed unexpectedly";
             this.#logger.error(
-              { callId: this.#callId },
+              { callId: this.#callId, code, reason },
               "Ultravox WebSocket closed unexpectedly"
             );
             this.#sessionFailed = true;
+            // The provider ended this session and we did not ask it to. The SDK's
+            // AgentSession.Error event cannot carry this: it forwards the INNER Error
+            // (agent_activity onError -> createErrorEvent(ev.error, …)), so `type` and
+            // `recoverable` are stripped and a listener cannot tell a terminal death
+            // from a routine reconnect. Report it out-of-band instead, so the runtime
+            // can end the call rather than leaving the caller on a dead line.
+            this.#notifyProviderEnded({ code, reason });
             const error = new Error(errorMsg);
             this.emitError({ error, recoverable: false });
             reject(error);
+          } else {
+            this.#logger.info(
+              { callId: this.#callId, code, reason },
+              "Ultravox WebSocket closed (initiated locally)"
+            );
           }
           this.#closing = true;
           this.#ws = null;
@@ -1536,6 +1604,19 @@ export class RealtimeSession extends llm.RealtimeSession {
 
     }
 
+  }
+
+  /**
+   * Tell the model this session was ended by the provider, so it can notify the
+   * runtime (primary session only — see `RealtimeModel.setProviderEndedCallback`).
+   * Best-effort: a failure here must never mask the error we are already reporting.
+   */
+  #notifyProviderEnded(info: { code?: number; reason?: string }): void {
+    try {
+      (this.realtimeModel as RealtimeModel)._notifyProviderEnded?.(this, info);
+    } catch (e) {
+      this.#logger.warn({ e }, "provider-ended notification failed");
+    }
   }
 
   #handleTranscript(event: api_proto.UltravoxTranscriptMessage): void {

--- a/agents/livekit/test/ultravox-provider-ended.test.ts
+++ b/agents/livekit/test/ultravox-provider-ended.test.ts
@@ -1,0 +1,108 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { initializeLogger } from "@livekit/agents";
+import { RealtimeModel } from "../plugins/ultravox/src/realtime/realtime_model.js";
+
+// When Ultravox ends a session we did not ask it to end — its own maxDuration, an
+// options.inactivity.hangup endBehavior hangup, or an outage — the agent is dead but
+// the SIP leg is still up. The SDK cannot tell us: AgentSession.Error forwards the
+// INNER Error, so the RealtimeModelError wrapper's `recoverable` is stripped before any
+// listener sees it, and the Close event never arrives because closeImpl blocks in
+// drain(). Hence the out-of-band provider-ended callback these tests lock down.
+//
+// The dangerous failure mode is a FALSE POSITIVE — ending a healthy call — so the
+// primary-session scoping is what most of this file is about.
+// run: npx tsx --test test/ultravox-provider-ended.test.ts
+
+initializeLogger({ pretty: false, level: "fatal" });
+
+const makeModel = () =>
+  new RealtimeModel({ instructions: "test", apiKey: "test-key" } as any);
+
+/** Model internals under test are keyed off session identity, not call state. */
+const notify = (model: any, session: unknown, info = { code: 1000 }) =>
+  model._notifyProviderEnded(session, info);
+
+test("no callback registered: notifying is a no-op, not a throw", () => {
+  const model = makeModel();
+  const s = model.session();
+  notify(model, s);
+});
+
+test("primary session: the callback fires with the close info", () => {
+  const model = makeModel();
+  const seen: unknown[] = [];
+  model.setProviderEndedCallback((i: unknown) => seen.push(i));
+
+  const primary = model.session();
+  notify(model, primary, { code: 1000, reason: "Time limit reached" } as any);
+
+  assert.deepEqual(seen, [{ code: 1000, reason: "Time limit reached" }]);
+});
+
+test("consult/handover sessions must NOT fire it", () => {
+  // The consult TransferAgent session and post-handover sessions share the model
+  // instance. Their ending is routine; tearing down the primary call would be a
+  // catastrophic false positive.
+  const model = makeModel();
+  let calls = 0;
+  model.setProviderEndedCallback(() => {
+    calls += 1;
+  });
+
+  model.session(); // primary
+  const consult = model.session(); // consult TransferAgent
+  const handover = model.session(); // later full-stack handover
+
+  notify(model, consult);
+  notify(model, handover);
+  assert.equal(calls, 0, "only the primary session may end the call");
+});
+
+test("primary stays the FIRST session even after later sessions exist", () => {
+  const model = makeModel();
+  const seen: unknown[] = [];
+  model.setProviderEndedCallback((i: unknown) => seen.push(i));
+
+  const primary = model.session();
+  model.session();
+  model.session();
+
+  notify(model, primary, { code: 1006 } as any);
+  assert.deepEqual(seen, [{ code: 1006 }]);
+});
+
+test("an unknown session object is ignored", () => {
+  const model = makeModel();
+  let calls = 0;
+  model.setProviderEndedCallback(() => {
+    calls += 1;
+  });
+  model.session();
+  notify(model, { not: "a session" });
+  assert.equal(calls, 0);
+});
+
+test("callback is replaceable and only the latest fires", () => {
+  const model = makeModel();
+  const first: unknown[] = [];
+  const second: unknown[] = [];
+  model.setProviderEndedCallback((i: unknown) => first.push(i));
+  model.setProviderEndedCallback((i: unknown) => second.push(i));
+
+  const primary = model.session();
+  notify(model, primary);
+
+  assert.equal(first.length, 0);
+  assert.equal(second.length, 1);
+});
+
+test("notifying before any session exists is a no-op", () => {
+  const model = makeModel();
+  let calls = 0;
+  model.setProviderEndedCallback(() => {
+    calls += 1;
+  });
+  notify(model, { anything: true });
+  assert.equal(calls, 0);
+});


### PR DESCRIPTION
Follow-up to #184. That PR made `options.inactivity.hangup` work — Ultravox does hang up. 

Resolves an issue exposed in staging testing after this landed:

**1. `onclose` silently swallowed provider-side closes.** It short-circuited on `#expiresAt` — hardcoded to `start + 5min` — setting `#closing = true` so no error was emitted at all. Removed.

**2. `onerror` had no `#closing` guard**, unlike `onclose`. A socket erroring during a teardown *we* initiated — handover closing the outgoing session, the consult session closing after accept/reject, ordinary cleanup — was reported as an unrecoverable failure of a live session. Harmless while nothing acted on it; a call-killer the moment something does. Guarded at the source, which is what makes the runtime hook safe.

Adds new `REALTIME_PROVIDER_ENDED`, distinct from `SESSION_TIMEOUT`

Note `Call.end` discards `reason` for `status` (always `"ended normally"`), so the string is durable in the `hangup` transaction-log row and the invocation log, not in `status`. Which also means the eval's `leg_status_ended_normally` check only catches this defect via its sampling window — worth remembering when judging whether a future regression would be visible.

Close code and reason are now captured and logged on both paths (1000 vs 1006 distinguishes a clean provider end from an abrupt drop). The `CloseEvent` was previously discarded entirely, which is why the `maxDuration` incident couldn't be diagnosed from logs at all.