### PR TITLE
fix(livekit): hook provider-ended on session.llm, not the returned model

### DIFF
--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -1585,25 +1585,45 @@ export async function runAgentWorker({
         // session or a post-handover session ending cannot reach here. The guards below
         // cover the cases where the primary model is deliberately dead but the call is
         // healthy or already coming down.
-        (
-          model as unknown as {
-            setProviderEndedCallback?: (cb: (i: unknown) => void) => void;
-          } | null
-        )?.setProviderEndedCallback?.((info: unknown) => {
-          if (isCleaningUp) return;
-          if (agentHandoverInProgress) return;
-          // Bridged/transferred out: the caller no longer hears this agent, so its
-          // model dying is expected and must not end the bridged call.
-          if (getBridgedParticipant()) return;
-          if (getConsultInProgress()) return;
-          logger.warn(
-            { info, callId: call.id },
-            "realtime provider ended the session; ending call",
+        // NB the realtime model is `session.llm`, NOT the `model` this factory returns
+        // — that one is the voice.Agent (behaviour/instructions). The RealtimeModel is
+        // constructed inline inside createVoiceModelAndSession and is reachable only
+        // through the session, the same way getLlmForTransferSession does it.
+        const realtimeModel = session.llm as unknown as {
+          setProviderEndedCallback?: (cb: (i: unknown) => void) => void;
+        } | null;
+        if (typeof realtimeModel?.setProviderEndedCallback === "function") {
+          realtimeModel.setProviderEndedCallback((info: unknown) => {
+            if (isCleaningUp) return;
+            if (agentHandoverInProgress) return;
+            // Bridged/transferred out: the caller no longer hears this agent, so its
+            // model dying is expected and must not end the bridged call.
+            if (getBridgedParticipant()) return;
+            if (getConsultInProgress()) return;
+            logger.warn(
+              { info, callId: call.id },
+              "realtime provider ended the session; ending call",
+            );
+            void cleanupAndClose(
+              DISCONNECT_REASONS.REALTIME_PROVIDER_ENDED,
+            ).catch((e) =>
+              logger.error({ e }, "error ending call after provider end"),
+            );
+          });
+          // Logged at INFO deliberately: app-level debug is invisible inside job
+          // processes, so a silently-unregistered hook is exactly how this shipped
+          // broken once already (it was wired to the wrong object and the optional
+          // call no-opped). If this line is absent, the hook is NOT armed.
+          logger.info(
+            { callId: call.id, modelName },
+            "provider-ended teardown hook armed",
           );
-          void cleanupAndClose(DISCONNECT_REASONS.REALTIME_PROVIDER_ENDED).catch(
-            (e) => logger.error({ e }, "error ending call after provider end"),
+        } else {
+          logger.info(
+            { callId: call.id, modelName },
+            "realtime model does not report provider-ended; teardown hook not armed",
           );
-        });
+        }
 
         // Watch for any non-recoverable model/STT/TTS errors that occur while
         // the session is still starting. If we see one before callStarted is

--- a/agents/livekit/test/ultravox-provider-ended.test.ts
+++ b/agents/livekit/test/ultravox-provider-ended.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { initializeLogger } from "@livekit/agents";
 import { RealtimeModel } from "../plugins/ultravox/src/realtime/realtime_model.js";
+import { createVoiceModelAndSession } from "../lib/voice-session-factory.js";
 
 // When Ultravox ends a session we did not ask it to end — its own maxDuration, an
 // options.inactivity.hangup endBehavior hangup, or an outage — the agent is dead but
@@ -95,6 +96,47 @@ test("callback is replaceable and only the latest fires", () => {
 
   assert.equal(first.length, 0);
   assert.equal(second.length, 1);
+});
+
+// --- the wiring contract ---------------------------------------------------
+// This is the test that was missing. The hook shipped once bound to the wrong
+// object: createVoiceModelAndSession returns `model` as the voice.Agent (behaviour),
+// while the RealtimeModel is constructed inline and reachable ONLY via session.llm.
+// The runtime called setProviderEndedCallback on the Agent through an optional call,
+// so it silently no-opped and the defect looked unfixed in production. Assert the
+// exact object the runtime reaches for.
+
+const evalAgent = () =>
+  ({
+    id: "agent-1",
+    userId: "u",
+    organisationId: "o",
+    modelName: "livekit:ultravox/ultravox-v0.6",
+    prompt: "You are a test agent.",
+    options: { tts: { vendor: "ultravox", voice: "Eanna" } },
+  }) as any;
+
+test("session.llm — not the returned model — carries setProviderEndedCallback", () => {
+  // The plugin's constructor requires a key; nothing here reaches the network.
+  process.env.ULTRAVOX_API_KEY ||= "test-key";
+  const { session, model } = createVoiceModelAndSession({
+    voiceMode: "realtime",
+    modelName: "livekit:ultravox/ultravox-v0.6",
+    agent: evalAgent(),
+    call: { id: "call-1" } as any,
+    tools: {} as any,
+  });
+
+  assert.equal(
+    typeof (session.llm as any)?.setProviderEndedCallback,
+    "function",
+    "the runtime hooks session.llm; it must expose the callback",
+  );
+  assert.equal(
+    typeof (model as any)?.setProviderEndedCallback,
+    "undefined",
+    "`model` is the voice.Agent — hooking it is the bug this test exists to catch",
+  );
 });
 
 test("notifying before any session exists is a no-op", () => {


### PR DESCRIPTION
**#186 merged one commit early.** `c3f1c7c` took only `a8c9dec`; my follow-up `2e7ea73` landed on the branch just after the merge, so `next` currently has the version of the hook that is bound to the wrong object and silently does nothing.

