### PR TITLE
fix(livekit): stop a >250ms SYN failing outbound API calls outright

### DIFF
--- a/agents/livekit/lib/net-defaults.ts
+++ b/agents/livekit/lib/net-defaults.ts
@@ -1,0 +1,68 @@
+import dns from "node:dns";
+import net from "node:net";
+
+/**
+ * Process-wide outbound connection defaults. Applied as an import side effect so they
+ * are in place before anything opens a socket; `realtime.ts` imports this first.
+ *
+ * ## Why
+ *
+ * Node ≥20 enables happy-eyeballs (`autoSelectFamily`) with an
+ * `autoSelectFamilyAttemptTimeout` of **250 ms**. It resolves a hostname to every
+ * address and walks them, giving each 250 ms to connect before moving on; when the
+ * list is exhausted it throws `AggregateError [ETIMEDOUT]`, surfacing as
+ * `TypeError: fetch failed`.
+ *
+ * The agent runner resolves the platform API to both an A and an AAAA record, but the
+ * VM has **no IPv6 route** — a v6 connect returns `ENETUNREACH` in ~1 ms. So every
+ * request walks a two-address list of which one is dead on arrival, leaving the IPv4
+ * attempt a 250 ms budget. IPv4 normally connects in ~2 ms, which is why this almost
+ * always works; but a SYN occasionally taking longer than 250 ms — entirely plausible
+ * on a box that logs "worker is at full capacity" under eval load — exhausts the list
+ * and fails the request outright, before it ever reaches the server. Observed on
+ * staging as a consult-leg `POST /api/agent-db/call` failing in ~300 ms with no
+ * corresponding Cloud Run request log, which aborted the whole warm transfer, and
+ * separately on `POST /api/agent-db/transaction-log`: it is not endpoint-specific.
+ *
+ * ## What
+ *
+ * 1. `ipv4first` DNS ordering, so the address that actually works is tried first and
+ *    the doomed IPv6 attempt never delays anything.
+ * 2. A 5 s per-address budget instead of 250 ms, so a slow SYN degrades into a slow
+ *    request rather than a hard failure.
+ *
+ * NB happy-eyeballs is deliberately left ENABLED. Disabling it
+ * (`--no-network-family-autoselection`) would drop back to a single address and make
+ * (2) inert — the attempt timeout only governs the multi-address walk — and would turn
+ * any future IPv4 problem into an immediate hard failure instead of a v6 fallback.
+ * Ordering achieves the "don't wait on IPv6" goal without giving up the fallback.
+ *
+ * Both settings are module-level defaults that `net.connect` reads when a caller does
+ * not pass the option, and Node's built-in `fetch` does not pass either — the observed
+ * failure stack runs `fetch` → `node:net` `internalConnectMultipleTimeout`, i.e. the
+ * same code path that consults these defaults.
+ */
+export const OUTBOUND_DNS_RESULT_ORDER = "ipv4first" as const;
+
+/**
+ * Per-address connect budget. Chosen to prefer a slow worker over a hard fail; well
+ * inside undici's own ~10 s connect timeout, which remains the real backstop.
+ */
+export const OUTBOUND_CONNECT_ATTEMPT_TIMEOUT_MS = 5_000;
+
+dns.setDefaultResultOrder(OUTBOUND_DNS_RESULT_ORDER);
+net.setDefaultAutoSelectFamilyAttemptTimeout(OUTBOUND_CONNECT_ATTEMPT_TIMEOUT_MS);
+
+/** The defaults actually in force, for logging at startup. */
+export function outboundNetworkDefaults(): {
+  dnsResultOrder: string;
+  autoSelectFamily: boolean;
+  autoSelectFamilyAttemptTimeoutMs: number;
+} {
+  return {
+    dnsResultOrder: OUTBOUND_DNS_RESULT_ORDER,
+    autoSelectFamily: net.getDefaultAutoSelectFamily(),
+    autoSelectFamilyAttemptTimeoutMs:
+      net.getDefaultAutoSelectFamilyAttemptTimeout(),
+  };
+}

--- a/agents/livekit/realtime.ts
+++ b/agents/livekit/realtime.ts
@@ -1,3 +1,7 @@
+// FIRST import: applies process-wide outbound connect defaults as a side effect, so
+// they are in force before anything can open a socket. See net-defaults.ts — without it
+// a >250ms SYN fails the request outright.
+import { outboundNetworkDefaults } from './lib/net-defaults.js';
 import { fileURLToPath } from 'node:url';
 import { ServerOptions, cli } from '@livekit/agents';
 import * as loggerModule from './agent-lib/logger.js';
@@ -6,7 +10,13 @@ import worker from './lib/worker.js';
 
 const logger = loggerModule.default;
 
-logger.info({ argv: process.argv }, 'worker started');
+// Logged so the settings are verifiable in production rather than assumed. This entry
+// runs in the parent worker AND in every spawned job process, which is where the
+// outbound API calls actually happen.
+logger.info(
+  { argv: process.argv, net: outboundNetworkDefaults() },
+  'worker started',
+);
 Error.stackTraceLimit = 40;
 
 if (process.argv[2] === 'setup') {

--- a/agents/livekit/test/net-defaults.test.ts
+++ b/agents/livekit/test/net-defaults.test.ts
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import dns from "node:dns";
+import {
+  OUTBOUND_CONNECT_ATTEMPT_TIMEOUT_MS,
+  OUTBOUND_DNS_RESULT_ORDER,
+  outboundNetworkDefaults,
+} from "../lib/net-defaults.js";
+
+// Node ≥20 walks every resolved address with a 250ms per-address connect budget and
+// throws AggregateError [ETIMEDOUT] when the list is exhausted — surfacing as
+// "TypeError: fetch failed". The runner's API host advertises an AAAA the VM cannot
+// route (ENETUNREACH in ~1ms), so IPv4 was left a 250ms budget; a SYN slower than that
+// failed the request before it reached the server. Observed on staging on both
+// /api/agent-db/call (aborting a warm transfer) and /api/agent-db/transaction-log.
+// run: npx tsx --test test/net-defaults.test.ts
+
+test("importing the module applies the attempt timeout as a side effect", () => {
+  // Load order matters: realtime.ts imports this first so the default is in force
+  // before anything opens a socket.
+  assert.equal(
+    net.getDefaultAutoSelectFamilyAttemptTimeout(),
+    OUTBOUND_CONNECT_ATTEMPT_TIMEOUT_MS,
+  );
+});
+
+test("the budget is 5s — slow request, not hard failure", () => {
+  assert.equal(OUTBOUND_CONNECT_ATTEMPT_TIMEOUT_MS, 5_000);
+  // Comfortably above the 250ms default that caused the failures...
+  assert.ok(OUTBOUND_CONNECT_ATTEMPT_TIMEOUT_MS > 250);
+  // ...and inside undici's own ~10s connect timeout, which stays the real backstop.
+  assert.ok(OUTBOUND_CONNECT_ATTEMPT_TIMEOUT_MS < 10_000);
+});
+
+test("IPv4 is preferred, so the unroutable AAAA never delays a request", () => {
+  assert.equal(OUTBOUND_DNS_RESULT_ORDER, "ipv4first");
+  assert.equal(dns.getDefaultResultOrder(), "ipv4first");
+});
+
+test("happy-eyeballs stays ENABLED", () => {
+  // Load-bearing. Disabling autoSelectFamily would make the attempt timeout inert —
+  // it only governs the multi-address walk — and would turn any future IPv4 problem
+  // into an immediate hard failure instead of falling back to IPv6.
+  assert.equal(net.getDefaultAutoSelectFamily(), true);
+});
+
+test("outboundNetworkDefaults reports what is actually in force", () => {
+  // Read back from node:net rather than echoing our own constants, so the startup log
+  // cannot claim a setting that was not applied.
+  assert.deepEqual(outboundNetworkDefaults(), {
+    dnsResultOrder: "ipv4first",
+    autoSelectFamily: true,
+    autoSelectFamilyAttemptTimeoutMs: 5_000,
+  });
+});


### PR DESCRIPTION
api-client requests sometimes fail with: 
```
TypeError: fetch failed
caused by: AggregateError [ETIMEDOUT]
    at internalConnectMultiple (node:net:1194)
    at Timeout.internalConnectMultipleTimeout (node:net:1811)
```

Connection **establishment** timing out — not a reset on a reused socket. Measured from inside the running container:

## Fix

Two process-wide defaults in a new `lib/net-defaults.ts`, applied as an import side effect from the **first** import in `realtime.ts` so they are in force before anything opens a socket:

1. **`ipv4first` DNS ordering** — the address that works is tried first, so the doomed IPv6 attempt never delays anything.
2. **`autoSelectFamilyAttemptTimeout` 250 ms → 5 s** — a slow SYN degrades into a slow request rather than a hard failure.

