### PR TITLE
Client-driven call-artifact retention: bulk prune endpoint + spend-policy limit on the billing PATCH

### DIFF
--- a/api/paths/calls/prune.js
+++ b/api/paths/calls/prune.js
@@ -1,0 +1,233 @@
+import { Call, TransactionLog, InvocationLog, Organisation, Op, Sequelize } from '../../../lib/database.js';
+import { Storage } from '@google-cloud/storage';
+import { requirePermission, can } from '../../../lib/auth/permissions.js';
+import { parseGcsPath, defaultRecordingBaseUrl } from '../../../lib/recording/index.js';
+
+/**
+ * POST /api/calls/prune — org-scoped bulk pruning of stored call ARTIFACTS
+ * (recordings / transcripts / invocation logs) older than a cut-off date, so a
+ * client system can apply its own retention policies. The call rows themselves
+ * (caller, duration, status, billing linkage) are NEVER deleted — pruning only
+ * removes the artifacts and nulls the recording metadata columns. `usage_records`
+ * and `call_recording_downloads` are never touched.
+ *
+ * Gated on `call:prune` (superAdmin + the billingService seam). Tenancy: callers
+ * are confined to their OWN organisation unless they hold the cross-tenant
+ * billing-service seam permission `organisation:billing` (see the
+ * /organisations/{id}/billing handler, whose permission "implies cross-tenant
+ * service use") — mirroring the balance endpoint's own-org-unless-marker
+ * pattern. An out-of-scope organisationId gets a 404, never data (same
+ * existence-hiding rule as lib/auth/admin-scope.js).
+ *
+ * Matching is ARTIFACT-AWARE, which is what makes a drain loop terminate:
+ * destroying transcript/invocation rows (and nulling recordingId) does not stop
+ * the call row matching a naive `createdAt < before` WHERE, so an already-pruned
+ * call would be re-matched forever and `remaining` could never go false. We
+ * therefore only select calls where at least one REQUESTED artifact still
+ * exists (recordingId NOT NULL, or an EXISTS against the relevant log table);
+ * each pass removes those artifacts, the call drops out of the match set, and
+ * a second identical request reports `matched: 0, remaining: false`.
+ */
+
+// Test seam: unit tests substitute a stub client here; production always uses
+// a real GCS client (the same pattern as the per-call recording DELETE).
+let makeStorage = () => new Storage();
+export function _setStorageFactory(factory) {
+  makeStorage = factory || (() => new Storage());
+}
+
+const ARTIFACTS = ['recording', 'transcript', 'invocationLog'];
+
+export default function (logger) {
+  const pruneCalls = async (req, res) => {
+    if (!requirePermission(res, 'call', 'prune')) return;
+    const log = req.log || logger;
+    const { before, artifacts, limit, organisationId } = req.body || {};
+
+    const beforeDate = typeof before === 'string' ? new Date(before) : null;
+    if (!beforeDate || Number.isNaN(beforeDate.valueOf())) {
+      return res.status(400).send({ message: 'before must be an ISO date-time string' });
+    }
+
+    let wanted = ARTIFACTS;
+    if (artifacts !== undefined) {
+      if (!Array.isArray(artifacts) || artifacts.length === 0 || artifacts.some((a) => !ARTIFACTS.includes(a))) {
+        return res.status(400).send({ message: `artifacts must be a non-empty array drawn from ${ARTIFACTS.join(', ')}` });
+      }
+      wanted = [...new Set(artifacts)];
+    }
+
+    let batchLimit = 200;
+    if (limit !== undefined) {
+      if (!Number.isInteger(limit)) {
+        return res.status(400).send({ message: 'limit must be an integer' });
+      }
+      batchLimit = Math.min(Math.max(limit, 1), 500);
+    }
+
+    if (organisationId !== undefined && typeof organisationId !== 'string') {
+      return res.status(400).send({ message: 'organisationId must be a string' });
+    }
+
+    // Tenancy: own org by default; a cross-tenant service caller (the billing
+    // seam / system principal) may name any org. Out-of-scope target -> 404.
+    const user = res.locals.user;
+    const crossTenant = user?.isSystem === true || can(user, 'organisation', 'billing');
+    const targetOrgId = organisationId ?? user?.organisationId ?? null;
+    if (!targetOrgId) {
+      return res.status(400).send({ message: 'organisationId is required when the caller has no organisation' });
+    }
+    if (!crossTenant && targetOrgId !== user?.organisationId) {
+      return res.status(404).send({ message: `Organisation ${targetOrgId} not found` });
+    }
+    const org = await Organisation.findByPk(targetOrgId);
+    if (!org) {
+      return res.status(404).send({ message: `Organisation ${targetOrgId} not found` });
+    }
+
+    // Only finished calls are ever pruned: never live, and only once an end
+    // time has been stamped (an unended row is either in flight or under
+    // investigation — leave its artifacts alone).
+    // The [Op.or] leg is the artifact-aware match described above.
+    const artifactConditions = [];
+    if (wanted.includes('recording')) {
+      artifactConditions.push({ recordingId: { [Op.ne]: null } });
+    }
+    if (wanted.includes('transcript')) {
+      artifactConditions.push(Sequelize.literal('EXISTS (SELECT 1 FROM transaction_logs WHERE transaction_logs.call_id = "Call"."id")'));
+    }
+    if (wanted.includes('invocationLog')) {
+      artifactConditions.push(Sequelize.literal('EXISTS (SELECT 1 FROM invocation_logs WHERE invocation_logs.call_id = "Call"."id")'));
+    }
+
+    const where = {
+      [Op.and]: [
+        { organisationId: targetOrgId },
+        { live: false },
+        { endedAt: { [Op.ne]: null } },
+        { createdAt: { [Op.lt]: beforeDate } },
+        { [Op.or]: artifactConditions },
+      ],
+    };
+
+    try {
+      const calls = await Call.findAll({ where, order: [['createdAt', 'ASC']], limit: batchLimit });
+
+      let prunedRecordings = 0;
+      let prunedTranscripts = 0;
+      let prunedInvocationLogs = 0;
+      const storage = wanted.includes('recording') ? makeStorage() : null;
+      const { bucket } = wanted.includes('recording') ? parseGcsPath(defaultRecordingBaseUrl()) : {};
+
+      for (const call of calls) {
+        if (wanted.includes('recording') && call.recordingId) {
+          const objectName = call.recordingId;
+          try {
+            // Best-effort object delete, exactly as DELETE /calls/{id}/recording:
+            // a missing object is fine, and a storage failure still clears the
+            // metadata so the call stops advertising a recording.
+            await storage.bucket(bucket).file(objectName).delete({ ignoreNotFound: true });
+          } catch (err) {
+            log.error({ err, callId: call.id, objectName }, 'prune: error deleting recording object from storage');
+          }
+          call.recordingId = null;
+          call.encryptionKey = null;
+          await call.save();
+          prunedRecordings += 1;
+        }
+        if (wanted.includes('transcript')) {
+          const n = await TransactionLog.destroy({ where: { callId: call.id } });
+          if (n > 0) prunedTranscripts += 1;
+        }
+        if (wanted.includes('invocationLog')) {
+          const n = await InvocationLog.destroy({ where: { callId: call.id } });
+          if (n > 0) prunedInvocationLogs += 1;
+        }
+      }
+
+      return res.send({
+        matched: calls.length,
+        prunedRecordings,
+        prunedTranscripts,
+        prunedInvocationLogs,
+        // A full batch means there may be more matching calls: the caller
+        // loops until remaining is false (guaranteed to happen — see above).
+        remaining: calls.length === batchLimit,
+      });
+    } catch (err) {
+      log.error({ err }, 'prune calls failed');
+      return res.status(500).send({ error: err.message });
+    }
+  };
+
+  pruneCalls.apiDoc = {
+    summary: 'Bulk-prune stored call artifacts (recordings / transcripts / invocation logs) older than a date.',
+    description:
+      'Retention seam for client systems: deletes the selected artifacts of finished calls created before `before`, '
+      + 'one bounded batch per request. Call rows themselves are never deleted (only the recording metadata columns are '
+      + 'nulled), and usage/billing records are untouched. Matching is artifact-aware — only calls that still hold at '
+      + 'least one requested artifact are selected — so repeating the request drains to `matched: 0, remaining: false` '
+      + 'and the operation is idempotent. Callers are confined to their own organisation unless they hold the '
+      + 'cross-tenant billing-service permission.',
+    operationId: 'pruneCalls',
+    tags: ['Calls'],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['before'],
+            properties: {
+              before: {
+                type: 'string',
+                format: 'date-time',
+                description: 'Prune artifacts of calls created strictly before this instant.',
+              },
+              artifacts: {
+                type: 'array',
+                minItems: 1,
+                items: { type: 'string', enum: ARTIFACTS },
+                description: 'Which artifacts to prune (default: all three).',
+              },
+              limit: {
+                type: 'integer',
+                default: 200,
+                description: 'Calls to process this batch (clamped 1–500); loop while `remaining` is true.',
+              },
+              organisationId: {
+                type: 'string',
+                description: 'Target organisation (cross-tenant service callers only; defaults to the caller’s own organisation).',
+              },
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'Batch report.',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                matched: { type: 'integer', description: 'Calls in this batch that still held a requested artifact.' },
+                prunedRecordings: { type: 'integer', description: 'Calls whose recording was deleted.' },
+                prunedTranscripts: { type: 'integer', description: 'Calls whose transcript rows were deleted.' },
+                prunedInvocationLogs: { type: 'integer', description: 'Calls whose invocation-log rows were deleted.' },
+                remaining: { type: 'boolean', description: 'True when the batch was full — call again to continue draining.' },
+              },
+            },
+          },
+        },
+      },
+      400: { description: 'Invalid before / artifacts / limit', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+      403: { description: 'Requires call:prune', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+      404: { description: 'Organisation not found (or out of scope)', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
+      default: { description: 'An error occurred', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    },
+  };
+
+  return { POST: pruneCalls };
+}

--- a/api/paths/calls/{callId}/recording.js
+++ b/api/paths/calls/{callId}/recording.js
@@ -210,3 +210,46 @@ async function deleteCallRecording(req, res) {
     return res.status(500).send({ error: 'Internal server error' });
   }
 }
+
+deleteCallRecording.apiDoc = {
+  summary: 'Delete a call recording',
+  description:
+    'Deletes the stored recording object (best-effort, tolerating an already-missing object) and clears the call’s '
+    + 'recording metadata (recordingId + encryptionKey). The call row itself is retained.',
+  tags: ['Calls'],
+  operationId: 'deleteCallRecording',
+  parameters: [
+    {
+      name: 'callId',
+      in: 'path',
+      description: 'The call ID',
+      required: true,
+      schema: {
+        type: 'string',
+      },
+    },
+  ],
+  responses: {
+    204: {
+      description: 'Recording deleted and metadata cleared.',
+    },
+    404: {
+      description: 'Call or recording not found',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              error: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    },
+    500: {
+      description: 'Internal server error',
+    },
+  },
+};

--- a/api/paths/organisations/{organisationId}/billing.js
+++ b/api/paths/organisations/{organisationId}/billing.js
@@ -15,7 +15,8 @@ import { isSafeCallbackUrl } from '../../../../lib/balance-callback.js';
  *          own stricter `organisation:setRate` gate for this field.
  *
  * Gated on `organisation:billing` — held by superAdmin and the least-privilege
- * `billingService` role (polite-ai's server-side seam, like `credit`). The
+ * `billingService` role (the client billing system's server-side seam, like
+ * `credit`). The
  * permission implies cross-tenant service use, so like the credit endpoint this
  * does no tenancy scoping.
  */

--- a/api/paths/organisations/{organisationId}/billing.js
+++ b/api/paths/organisations/{organisationId}/billing.js
@@ -4,11 +4,15 @@ import { isSafeCallbackUrl } from '../../../../lib/balance-callback.js';
 
 /**
  * /api/organisations/{id}/billing — the org's billing CONTROLS (not money):
- *   GET    read `billingBlocked` + `billingConfig`.
- *   PATCH  set either/both. `billingConfig` is validated whole (callbackUrl must
+ *   GET    read `billingBlocked` + `billingConfig` + `chargeableNumberLimit`.
+ *   PATCH  set any of them. `billingConfig` is validated whole (callbackUrl must
  *          pass the SSRF guard, hashKey ≥ 16 chars, balanceLowPennies ≥ 0) or
  *          cleared with null; `billingBlocked` is the hard call-refusal lever
- *          that Call.start() enforces.
+ *          that Call.start() enforces; `chargeableNumberLimit` is the generic
+ *          spend-policy cap on numbers held on chargeable (non-owned) trunks
+ *          (null = unlimited) that a client billing service sets alongside the
+ *          rest of the billing config — the direct org-PATCH route keeps its
+ *          own stricter `organisation:setRate` gate for this field.
  *
  * Gated on `organisation:billing` — held by superAdmin and the least-privilege
  * `billingService` role (polite-ai's server-side seam, like `credit`). The
@@ -19,6 +23,7 @@ export default function (logger) {
   const shape = (org) => ({
     billingBlocked: !!org.billingBlocked,
     billingConfig: org.billingConfig ?? null,
+    chargeableNumberLimit: org.chargeableNumberLimit ?? null,
   });
 
   const get = async (req, res) => {
@@ -45,8 +50,16 @@ export default function (logger) {
     if (!org) return res.status(404).send({ message: `Organisation ${req.params.organisationId} not found` });
 
     const body = req.body || {};
-    if (!('billingBlocked' in body) && !('billingConfig' in body)) {
-      return res.status(400).send({ message: 'Provide billingBlocked and/or billingConfig' });
+    if (!('billingBlocked' in body) && !('billingConfig' in body) && !('chargeableNumberLimit' in body)) {
+      return res.status(400).send({ message: 'Provide billingBlocked, billingConfig and/or chargeableNumberLimit' });
+    }
+
+    if ('chargeableNumberLimit' in body) {
+      const limit = body.chargeableNumberLimit;
+      if (limit !== null && (!Number.isInteger(limit) || limit < 0)) {
+        return res.status(400).send({ message: 'chargeableNumberLimit must be a non-negative integer or null (unlimited)' });
+      }
+      org.chargeableNumberLimit = limit;
     }
 
     if ('billingBlocked' in body) {
@@ -88,7 +101,7 @@ export default function (logger) {
     return res.send(shape(org));
   };
   update.apiDoc = {
-    summary: 'Set an organisation’s billing controls (billingBlocked / billingConfig).',
+    summary: 'Set an organisation’s billing controls (billingBlocked / billingConfig / chargeableNumberLimit).',
     operationId: 'updateOrganisationBilling',
     tags: ['Organisations', 'Billing'],
     parameters: [{ in: 'path', name: 'organisationId', required: true, schema: { type: 'string' } }],
@@ -109,6 +122,12 @@ export default function (logger) {
                   hashKey: { type: 'string', description: 'Shared HMAC secret (≥ 16 chars).' },
                   balanceLowPennies: { type: 'number', nullable: true, description: 'Low-balance threshold in pennies (null = no balanceLow events).' },
                 },
+              },
+              chargeableNumberLimit: {
+                type: 'integer',
+                nullable: true,
+                minimum: 0,
+                description: 'Spend-policy cap: max numbers the org may hold on chargeable (non-owned) trunks; null = unlimited. A client billing service sets this alongside the other billing controls.',
               },
             },
           },

--- a/lib/auth/permissions.js
+++ b/lib/auth/permissions.js
@@ -33,7 +33,11 @@ export const statements = {
   // Telephony / calls / billing
   phoneEndpoint: ['claim', 'read', 'update', 'release'],
   trunk: ['read', 'assign', 'create'],
-  call: ['read', 'listen'],
+  // `prune` = bulk-delete stored call ARTIFACTS (recordings / transcripts /
+  // invocation logs) past a retention horizon — the call rows themselves are
+  // never deleted. Held by superAdmin and the billingService seam so a client
+  // system can apply its own retention policies.
+  call: ['read', 'listen', 'prune'],
   recording: ['read', 'download', 'delete'],
   usage: ['read', 'readAll'], // readAll = cross-tenant
   // Pricing rate cards (Phase 2/3 billing). Platform pricing config — superAdmin
@@ -140,6 +144,7 @@ export const roles = {
   superAdmin: {
     statements: {
       ...OWNER_STATEMENTS,
+      call: ['read', 'listen', 'prune'],
       usage: ['read', 'readAll'],
       rate: ['read', 'readAll', 'create', 'update', 'delete'],
       tariff: ['read', 'readAll', 'create', 'update', 'delete'],
@@ -158,6 +163,10 @@ export const roles = {
   billingService: {
     statements: {
       organisation: ['credit', 'billing'],
+      // Retention seam: the client's billing service applies its own
+      // call-artifact retention policies via POST /calls/prune. Artifact
+      // deletion only — no call read/listen, no product access.
+      call: ['prune'],
     },
   },
 

--- a/tests/balance-api.test.mjs
+++ b/tests/balance-api.test.mjs
@@ -52,7 +52,7 @@ describe('Phase 3: rate-history + balance + balance/credit', () => {
   afterEach(async () => {
     await BalanceCredit.destroy({ where: { organisationId: orgId } });
     await Organisation.update(
-      { balance: null, rateHistory: null, billingBlocked: false, billingConfig: null },
+      { balance: null, rateHistory: null, billingBlocked: false, billingConfig: null, chargeableNumberLimit: 3 },
       { where: { id: orgId } },
     );
   });
@@ -186,7 +186,7 @@ describe('Phase 3: rate-history + balance + balance/credit', () => {
 
     const read = mockReqRes({ role: 'billingService', params: { organisationId: orgId } });
     await billingGET(read.req, read.res);
-    expect(read.res.body).toEqual({ billingBlocked: true, billingConfig: cfg });
+    expect(read.res.body).toEqual({ billingBlocked: true, billingConfig: cfg, chargeableNumberLimit: 3 });
 
     // balance read (own-org member) surfaces the block flag
     const bal = mockReqRes({ role: 'owner', organisationId: orgId, params: { organisationId: orgId } });
@@ -194,7 +194,42 @@ describe('Phase 3: rate-history + balance + balance/credit', () => {
     expect(bal.res.body.blocked).toBe(true);
 
     const cleared = await patch({ billingBlocked: false, billingConfig: null });
-    expect(cleared.body).toEqual({ billingBlocked: false, billingConfig: null });
+    expect(cleared.body).toEqual({ billingBlocked: false, billingConfig: null, chargeableNumberLimit: 3 });
+  });
+
+  it('billing PATCH sets chargeableNumberLimit (integer >= 0, null = unlimited) and validates it', async () => {
+    const patch = (body, role = 'billingService') => {
+      const { req, res } = mockReqRes({ role, params: { organisationId: orgId }, body });
+      return billingPATCH(req, res).then(() => res);
+    };
+
+    const raised = await patch({ chargeableNumberLimit: 10 });
+    expect(raised.statusCode).toBe(200);
+    expect(raised.body.chargeableNumberLimit).toBe(10);
+    expect((await Organisation.findByPk(orgId)).chargeableNumberLimit).toBe(10);
+
+    const zero = await patch({ chargeableNumberLimit: 0 });
+    expect(zero.statusCode).toBe(200);
+    expect((await Organisation.findByPk(orgId)).chargeableNumberLimit).toBe(0);
+
+    const unlimited = await patch({ chargeableNumberLimit: null });
+    expect(unlimited.statusCode).toBe(200);
+    expect(unlimited.body.chargeableNumberLimit).toBeNull();
+    expect((await Organisation.findByPk(orgId)).chargeableNumberLimit).toBeNull();
+
+    // Settable alongside the other billing controls in one PATCH.
+    const combined = await patch({ billingBlocked: true, chargeableNumberLimit: 1 });
+    expect(combined.statusCode).toBe(200);
+    expect(combined.body).toMatchObject({ billingBlocked: true, chargeableNumberLimit: 1 });
+
+    // Invalid values reject without persisting anything.
+    expect((await patch({ chargeableNumberLimit: -1 })).statusCode).toBe(400);
+    expect((await patch({ chargeableNumberLimit: 1.5 })).statusCode).toBe(400);
+    expect((await patch({ chargeableNumberLimit: '3' })).statusCode).toBe(400);
+    expect((await Organisation.findByPk(orgId)).chargeableNumberLimit).toBe(1);
+
+    // Same gate as the rest of the billing controls.
+    expect((await patch({ chargeableNumberLimit: 99 }, 'owner')).statusCode).toBe(403);
   });
 
   it('billing PATCH validates: unsafe URL, short hashKey, bad types, empty body, owner 403', async () => {

--- a/tests/calls-prune.test.mjs
+++ b/tests/calls-prune.test.mjs
@@ -1,0 +1,297 @@
+import {
+  setupRealDatabase,
+  teardownRealDatabase,
+  databaseStarted,
+  Call,
+  TransactionLog,
+  InvocationLog,
+  UsageRecord,
+  Organisation,
+  User,
+} from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+// POST /calls/prune — org-scoped bulk artifact pruning (retention seam for
+// client systems). Covers: artifact-aware matching + idempotency, live/unended
+// exclusion, call-row + usage-record preservation, batching, tenancy scoping
+// and body validation. GCS is stubbed via the module's storage-factory seam.
+
+const mockLogger = { info() { }, error() { }, warn() { }, debug() { }, trace() { }, child() { return mockLogger; } };
+
+const FUTURE = '2100-01-01T00:00:00Z';
+
+describe('POST /calls/prune', () => {
+  let prunePOST;
+  let setStorageFactory;
+  let userId;
+  let idx = 1;
+  const deletedObjects = [];
+  const fakeStorage = {
+    bucket: (bucket) => ({
+      file: (objectName) => ({
+        delete: async () => { deletedObjects.push({ bucket, objectName }); },
+      }),
+    }),
+  };
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    await databaseStarted;
+    const mod = await import('../api/paths/calls/prune.js');
+    prunePOST = mod.default(mockLogger).POST;
+    setStorageFactory = mod._setStorageFactory;
+    setStorageFactory(() => fakeStorage);
+
+    userId = randomUUID();
+    await User.upsert({
+      id: userId,
+      name: 'Prune Tester',
+      email: `prune-${userId}@example.com`,
+      emailVerified: true,
+      phone: '0000',
+      phoneVerified: false,
+      picture: '',
+      role: 'owner',
+    });
+  }, 30000);
+
+  afterAll(async () => {
+    setStorageFactory(null);
+    await teardownRealDatabase();
+  }, 60000);
+
+  function mockReqRes(user, body = {}) {
+    const req = { params: {}, body, query: {}, log: mockLogger };
+    const res = { locals: { user }, statusCode: 200, body: undefined };
+    res.status = (c) => { res.statusCode = c; return res; };
+    res.send = (b) => { res.body = b; return res; };
+    res.json = (b) => { res.body = b; return res; };
+    return { req, res };
+  }
+
+  const prune = async (user, body) => {
+    const { req, res } = mockReqRes(user, body);
+    await prunePOST(req, res);
+    return res;
+  };
+
+  const mkOrg = async () => {
+    const id = randomUUID();
+    await Organisation.create({ id, name: `Prune Org ${id.slice(0, 8)}` });
+    return id;
+  };
+
+  const mkCall = async (orgId, {
+    live = false,
+    endedAt = new Date('2026-01-01T01:00:00Z'),
+    recording = false,
+    transcript = false,
+    invocation = false,
+  } = {}) => {
+    const call = await Call.create({
+      organisationId: orgId,
+      userId,
+      index: idx++,
+      calledId: '+442080996945',
+      callerId: '+443300889471',
+      status: live ? 'in progress' : 'ended normally',
+      platform: 'test',
+      live,
+      startedAt: new Date('2026-01-01T00:00:00Z'),
+      endedAt,
+      ...(recording ? { recordingId: `test-recordings/${randomUUID()}.ogg`, encryptionKey: 'k'.repeat(32) } : {}),
+    }, { hooks: false });
+    if (transcript) {
+      await TransactionLog.create({ callId: call.id, organisationId: orgId, userId, type: 'user', data: { text: 'hello' }, isFinal: true }, { hooks: false });
+      await TransactionLog.create({ callId: call.id, organisationId: orgId, userId, type: 'agent', data: { text: 'hi' }, isFinal: true }, { hooks: false });
+    }
+    if (invocation) {
+      await InvocationLog.create({ callId: call.id, organisationId: orgId, userId, subsystem: 'livekit-agent', log: { encoding: 'none', data: 'x' } });
+    }
+    return call;
+  };
+
+  test('prunes all artifact types, keeps call rows + usage records, deletes storage objects, and is idempotent', async () => {
+    const orgId = await mkOrg();
+    const c1 = await mkCall(orgId, { recording: true, transcript: true, invocation: true });
+    const c2 = await mkCall(orgId, { transcript: true });
+    const c3 = await mkCall(orgId, { recording: true });
+    const c1Recording = c1.recordingId;
+    const c3Recording = c3.recordingId;
+
+    await UsageRecord.create({
+      sessionId: c1.id,
+      meterKey: 'llm:test:1',
+      callId: c1.id,
+      organisationId: orgId,
+      technology: 'llm',
+      unit: 'input_tokens',
+      quantity: 10,
+    });
+
+    const user = { id: userId, role: 'superAdmin', organisationId: orgId };
+    const res = await prune(user, { before: FUTURE });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      matched: 3,
+      prunedRecordings: 2,
+      prunedTranscripts: 2,
+      prunedInvocationLogs: 1,
+      remaining: false,
+    });
+
+    // Call rows survive, with only the recording metadata columns nulled.
+    for (const call of [c1, c2, c3]) {
+      const row = await Call.findByPk(call.id);
+      expect(row).not.toBeNull();
+      expect(row.recordingId).toBeNull();
+      expect(row.getDataValue('encryptionKey')).toBeNull();
+      expect(row.status).toBe('ended normally');
+    }
+
+    // Artifacts gone; the usage (billing) record is untouched.
+    expect(await TransactionLog.count({ where: { callId: [c1.id, c2.id, c3.id] } })).toBe(0);
+    expect(await InvocationLog.count({ where: { callId: [c1.id, c2.id, c3.id] } })).toBe(0);
+    expect(await UsageRecord.count({ where: { callId: c1.id } })).toBe(1);
+
+    // The stub storage saw exactly the two recording objects.
+    const objectNames = deletedObjects.map((d) => d.objectName);
+    expect(objectNames).toContain(c1Recording);
+    expect(objectNames).toContain(c3Recording);
+
+    // Second identical request: everything already pruned -> nothing matches.
+    const again = await prune(user, { before: FUTURE });
+    expect(again.statusCode).toBe(200);
+    expect(again.body).toEqual({
+      matched: 0,
+      prunedRecordings: 0,
+      prunedTranscripts: 0,
+      prunedInvocationLogs: 0,
+      remaining: false,
+    });
+  });
+
+  test('matching is artifact-aware: only calls holding a REQUESTED artifact are selected', async () => {
+    const orgId = await mkOrg();
+    const recOnly = await mkCall(orgId, { recording: true });
+    const txOnly = await mkCall(orgId, { transcript: true });
+    const user = { id: userId, role: 'superAdmin', organisationId: orgId };
+
+    const txPass = await prune(user, { before: FUTURE, artifacts: ['transcript'] });
+    expect(txPass.statusCode).toBe(200);
+    expect(txPass.body.matched).toBe(1);
+    expect(txPass.body.prunedTranscripts).toBe(1);
+    expect(txPass.body.prunedRecordings).toBe(0);
+
+    // The recording-only call was not touched by a transcript-only prune.
+    expect((await Call.findByPk(recOnly.id)).recordingId).not.toBeNull();
+    // ... and a repeat transcript pass finds nothing (terminating).
+    expect((await prune(user, { before: FUTURE, artifacts: ['transcript'] })).body.matched).toBe(0);
+
+    const recPass = await prune(user, { before: FUTURE, artifacts: ['recording'] });
+    expect(recPass.body).toMatchObject({ matched: 1, prunedRecordings: 1, remaining: false });
+    expect((await Call.findByPk(recOnly.id)).recordingId).toBeNull();
+    expect((await Call.findByPk(txOnly.id)).id).toBe(txOnly.id);
+  });
+
+  test('never touches live or unended calls', async () => {
+    const orgId = await mkOrg();
+    const liveCall = await mkCall(orgId, { live: true, endedAt: null, recording: true, transcript: true });
+    const unended = await mkCall(orgId, { live: false, endedAt: null, recording: true });
+    const user = { id: userId, role: 'superAdmin', organisationId: orgId };
+
+    const res = await prune(user, { before: FUTURE });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.matched).toBe(0);
+
+    expect((await Call.findByPk(liveCall.id)).recordingId).not.toBeNull();
+    expect((await Call.findByPk(unended.id)).recordingId).not.toBeNull();
+    expect(await TransactionLog.count({ where: { callId: liveCall.id } })).toBe(2);
+  });
+
+  test('a cut-off in the past matches nothing', async () => {
+    const orgId = await mkOrg();
+    await mkCall(orgId, { transcript: true });
+    const user = { id: userId, role: 'superAdmin', organisationId: orgId };
+    const res = await prune(user, { before: '1970-01-01T00:00:00Z' });
+    expect(res.body.matched).toBe(0);
+  });
+
+  test('batches by limit (clamped) and reports remaining until drained', async () => {
+    const orgId = await mkOrg();
+    await mkCall(orgId, { transcript: true });
+    await mkCall(orgId, { transcript: true });
+    await mkCall(orgId, { transcript: true });
+    const user = { id: userId, role: 'superAdmin', organisationId: orgId };
+
+    const first = await prune(user, { before: FUTURE, limit: 2 });
+    expect(first.body).toMatchObject({ matched: 2, prunedTranscripts: 2, remaining: true });
+
+    // limit: 0 clamps up to 1 — the last call drains and the loop terminates.
+    const second = await prune(user, { before: FUTURE, limit: 0 });
+    expect(second.body).toMatchObject({ matched: 1, prunedTranscripts: 1, remaining: true });
+
+    const third = await prune(user, { before: FUTURE, limit: 2 });
+    expect(third.body).toEqual({ matched: 0, prunedRecordings: 0, prunedTranscripts: 0, prunedInvocationLogs: 0, remaining: false });
+  });
+
+  test('tenancy: org-scoped callers are confined to their own organisation', async () => {
+    const orgA = await mkOrg();
+    const orgB = await mkOrg();
+    await mkCall(orgA, { transcript: true });
+    const foreign = await mkCall(orgB, { transcript: true });
+
+    // An org-scoped principal holding call:prune via a permissions override.
+    const scoped = { id: userId, role: 'owner', organisationId: orgA, permissions: { call: ['prune'] } };
+
+    // Naming someone else's organisation: 404, and their data is untouched.
+    const denied = await prune(scoped, { before: FUTURE, organisationId: orgB });
+    expect(denied.statusCode).toBe(404);
+    expect(await TransactionLog.count({ where: { callId: foreign.id } })).toBe(2);
+
+    // Explicitly naming their OWN organisation is fine.
+    const own = await prune(scoped, { before: FUTURE, organisationId: orgA });
+    expect(own.statusCode).toBe(200);
+    expect(own.body.matched).toBe(1);
+
+    // Defaulting to their own organisation also works (already drained -> 0).
+    const defaulted = await prune(scoped, { before: FUTURE });
+    expect(defaulted.statusCode).toBe(200);
+    expect(defaulted.body.matched).toBe(0);
+  });
+
+  test('tenancy: the billing-service role prunes cross-org; unknown orgs 404; no permission 403', async () => {
+    const serviceOrg = await mkOrg();
+    const orgB = await mkOrg();
+    const foreign = await mkCall(orgB, { transcript: true, invocation: true });
+
+    const service = { id: userId, role: 'billingService', organisationId: serviceOrg };
+    const res = await prune(service, { before: FUTURE, organisationId: orgB });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ matched: 1, prunedTranscripts: 1, prunedInvocationLogs: 1 });
+    expect(await TransactionLog.count({ where: { callId: foreign.id } })).toBe(0);
+    expect((await Call.findByPk(foreign.id))).not.toBeNull();
+
+    const missing = await prune(service, { before: FUTURE, organisationId: randomUUID() });
+    expect(missing.statusCode).toBe(404);
+
+    const noPerm = await prune({ id: userId, role: 'owner', organisationId: orgB }, { before: FUTURE });
+    expect(noPerm.statusCode).toBe(403);
+  });
+
+  test('validates before, artifacts, limit and organisationId', async () => {
+    const orgId = await mkOrg();
+    const user = { id: userId, role: 'superAdmin', organisationId: orgId };
+
+    expect((await prune(user, {})).statusCode).toBe(400);
+    expect((await prune(user, { before: 'not-a-date' })).statusCode).toBe(400);
+    expect((await prune(user, { before: 42 })).statusCode).toBe(400);
+    expect((await prune(user, { before: FUTURE, artifacts: [] })).statusCode).toBe(400);
+    expect((await prune(user, { before: FUTURE, artifacts: ['bogus'] })).statusCode).toBe(400);
+    expect((await prune(user, { before: FUTURE, artifacts: 'recording' })).statusCode).toBe(400);
+    expect((await prune(user, { before: FUTURE, limit: 1.5 })).statusCode).toBe(400);
+    expect((await prune(user, { before: FUTURE, limit: 'ten' })).statusCode).toBe(400);
+    expect((await prune(user, { before: FUTURE, organisationId: 42 })).statusCode).toBe(400);
+  });
+});

--- a/tests/setup/database-test-wrapper.js
+++ b/tests/setup/database-test-wrapper.js
@@ -78,6 +78,7 @@ export async function setupRealDatabase() {
       Instance: dbModule.Instance,
       Call: dbModule.Call,
       TransactionLog: dbModule.TransactionLog,
+      InvocationLog: dbModule.InvocationLog,
       UsageRecord: dbModule.UsageRecord,
       RateCard: dbModule.RateCard,
       BalanceCredit: dbModule.BalanceCredit,
@@ -100,6 +101,7 @@ export async function setupRealDatabase() {
   PhoneRegistration = dbModule.PhoneRegistration;
   Call = dbModule.Call;
   TransactionLog = dbModule.TransactionLog;
+  InvocationLog = dbModule.InvocationLog;
   UsageRecord = dbModule.UsageRecord;
   RateCard = dbModule.RateCard;
   BalanceCredit = dbModule.BalanceCredit;
@@ -135,6 +137,7 @@ export async function teardownRealDatabase() {
     PhoneRegistration = undefined;
     Call = undefined;
     TransactionLog = undefined;
+    InvocationLog = undefined;
     UsageRecord = undefined;
     RateCard = undefined;
     BalanceCredit = undefined;
@@ -163,6 +166,6 @@ export function getRealDatabase() {
 
 // Export the same objects as database.js for drop-in replacement
 // These will be populated after setupRealDatabase() is called
-export let Metadata, Agent, AgentSet, Instance, PhoneNumber, PhoneRegistration, Call, TransactionLog, UsageRecord, RateCard, BalanceCredit, Tariff, TariffPrefix, User, Organisation, AuthKey, Trunk;
+export let Metadata, Agent, AgentSet, Instance, PhoneNumber, PhoneRegistration, Call, TransactionLog, InvocationLog, UsageRecord, RateCard, BalanceCredit, Tariff, TariffPrefix, User, Organisation, AuthKey, Trunk;
 export let Op, Sequelize;
 export let databaseStarted, stopDatabase;


### PR DESCRIPTION
## What

Two small, generic additions letting client systems apply their own retention and spend policies:

- **`POST /calls/prune`** — org-scoped bulk pruning of call *artifacts* older than a client-supplied date: recording (GCS object deleted, `recordingId`/`encryptionKey` nulled), transcript rows, and invocation-log rows. **Call rows (CDR), `usage_records` and `call_recording_downloads` are never touched.** Matching is artifact-aware (only calls that still hold a requested artifact are selected), so a drain loop is guaranteed to terminate at `matched: 0, remaining: false` and repeat runs are no-ops. Guards: `live: false`, `endedAt` NOT NULL, `createdAt < before`; batches clamped 1–500. New `call:prune` action, granted to superAdmin and the `billingService` role; callers without cross-org scope are confined to their own organisation.
- **`PATCH /organisations/{id}/billing` accepts `chargeableNumberLimit`** (integer ≥ 0, null = unlimited) — the spend-policy allowance a client's billing service sets alongside billing config, behind the existing `organisation:billing` gate. The direct org-PATCH field gate (`organisation:setRate`, superAdmin-only) is unchanged, so organisations still cannot raise their own limit.
- Housekeeping: the pre-existing `DELETE /calls/{callId}/recording` gains its missing apiDoc (it mounted undocumented and unvalidated).

## Verification

- 58/58 across `calls-prune`, `balance-api`, `rbac-permissions` suites (test PG :5433); RBAC model-access suite also run green during review (62/62).
- Full express-openapi mount verified: apiDoc validates; static `/calls/prune` sorts ahead of `/calls/{callId}` (no shadowing).

## Notes

- Additive API-shape change: billing GET/PATCH responses now include `chargeableNumberLimit`; exact-equality assertions elsewhere may need the field added.
- Deliberately conservative: calls with `live=false` but no `endedAt` (early refusal paths) are never pruned; best-effort storage deletion mirrors the existing per-call DELETE (a transient GCS failure can orphan an encrypted object — a future hardening could count storage failures separately).