### PR TITLE
sipbridge: pace RTP egress + route transfer legs (beta PSTN fixes)

### DIFF
--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -173,6 +173,15 @@ class CallSession:
     # X-Aplisay-Origin-Caller-Id on transfer legs so the B2BUA can assert it as
     # P-Asserted-Identity toward the gateway. Mirrors LiveKit's originCallerId.
     origin_caller_id: Optional[str] = None
+    # Egress routing tuple for gateway-originated transfer legs (dial_bridge /
+    # consult): the trunk the call arrived on, or the registration's B2BUA —
+    # threaded from InboundCallContext / OutboundCallParams so a transfer
+    # dials out the same way the call came in. See TransferRequest in
+    # ``sip_gateway/base.py``.
+    aplisay_id: Optional[str] = None
+    registration_endpoint_id: Optional[str] = None
+    b2bua_gateway_ip: Optional[str] = None
+    b2bua_gateway_transport: Optional[str] = None
     # Resolved REFER-vs-bridge decision for the in-flight consultative
     # transfer, recorded when ``_on_transfer`` starts the consult leg so the
     # accept tool finalises via the same mode (attended REFER vs media bridge).
@@ -1501,6 +1510,10 @@ class CallSession:
             force_refer=use_refer,
             monitor_dtmf=bool(self._bta_targets),
             tap_audio=bool(self._bta_transcribe),
+            aplisay_id=self.aplisay_id,
+            registration_endpoint_id=self.registration_endpoint_id,
+            b2bua_gateway_ip=self.b2bua_gateway_ip,
+            b2bua_gateway_transport=self.b2bua_gateway_transport,
         )
 
         if op == "consultative":
@@ -2321,6 +2334,10 @@ async def setup_inbound_call(
         force_bridged_transfer=inbound.force_bridged_transfer,
         registration_username=inbound.registration_username,
         origin_caller_id=inbound.caller_id,
+        aplisay_id=inbound.aplisay_id,
+        registration_endpoint_id=inbound.phone_registration,
+        b2bua_gateway_ip=inbound.b2bua_gateway_ip,
+        b2bua_gateway_transport=inbound.b2bua_gateway_transport,
     )
 
 
@@ -2622,4 +2639,6 @@ async def setup_outbound_call(
         sip_gateway=sip_gateway,
         gateway_session=gw_session,
         call=call,
+        origin_caller_id=caller_id,
+        aplisay_id=aplisay_id,
     )

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/base.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/base.py
@@ -173,6 +173,20 @@ class TransferRequest:
     can_refer: bool = False  # if False, force blind-bridge per section 6.7
     force_bridged: bool = False
 
+    # Egress routing for the legs the gateway *originates* (dial_bridge and
+    # the consultative consult leg). Same tuple as OutboundCallParams, for the
+    # same reason: the bridge has no outbound proxy, so a bare-number
+    # destination must be resolved to a routable URI — registration origin →
+    # the registration's B2BUA gateway, trunk origin → the global outbound
+    # SBC — and the upstream SBC picks the carrier route off
+    # X-Aplisay-Trunk / X-Aplisay-PhoneRegistration. Populated by the call
+    # session from the origin call's context; all-None falls through to the
+    # outbound-SBC default with no trunk header (IP-gated SBCs).
+    aplisay_id: Optional[str] = None
+    registration_endpoint_id: Optional[str] = None
+    b2bua_gateway_ip: Optional[str] = None
+    b2bua_gateway_transport: Optional[str] = None
+
     # Force the final hop to be completed via SIP REFER (with ?Replaces for
     # the consultative finalize) regardless of the origin default. Takes
     # precedence over ``force_bridged`` when both are set. Mirrors the

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
@@ -183,14 +183,33 @@ class _SbGatewaySession(GatewaySession):
             self._gateway.clear_consult_call_id(self.session_id)
 
         # force_bridged (typically a registration endpoint that can't
-        # honour REFER) takes the native dial+relay path: the bridge
-        # dials the target as a fresh agent-less leg and relays media
-        # between it and the caller, keeping media inside the bridge.
-        # Otherwise we REFER and let the upstream B2BUA reroute.
+        # honour REFER, or a trunk-origin call — the trunk default) takes
+        # the native dial+relay path: the bridge dials the target as a
+        # fresh agent-less leg and relays media between it and the caller,
+        # keeping media inside the bridge. Otherwise we REFER and let the
+        # upstream B2BUA reroute.
         if req.force_bridged:
+            # The bridge has no outbound proxy: a bare-number target must be
+            # resolved to a routable URI here (the Go side hard-rejects it
+            # with "invalid uri scheme" otherwise), exactly as the outbound
+            # originate path does via _outbound_target_uri.
+            target = _routable_leg_uri(
+                req.destination,
+                registration_endpoint_id=req.registration_endpoint_id,
+                b2bua_gateway_ip=req.b2bua_gateway_ip,
+                b2bua_gateway_transport=req.b2bua_gateway_transport,
+                outbound_sbc=self._gateway.outbound_sbc,
+                purpose="bridged transfer",
+            )
+            # From toward the gateway: explicit override, else the genuine
+            # origin caller (LiveKit: fromNumber = registrationUsername ||
+            # origin). Without a From user the bridge falls back to sipgo's
+            # synthetic From (user@localhost) and the SBC's handler-domain
+            # gate drops the leg.
+            caller_id = req.caller_id_override or req.origin_caller_id or ""
             logger.bind(
                 call_id=self.bridge_call_id,
-                target=req.destination,
+                target=target,
                 mode="dial_bridge",
                 monitor_dtmf=req.monitor_dtmf,
             ).info("sipbridge transfer (native dial+bridge)")
@@ -198,9 +217,10 @@ class _SbGatewaySession(GatewaySession):
                 "POST",
                 f"/v1/calls/{self.bridge_call_id}/transfer",
                 {
-                    "target": req.destination,
+                    "target": target,
                     "mode": "dial_bridge",
-                    "caller_id": req.caller_id_override or "",
+                    "caller_id": caller_id,
+                    "custom_headers": _transfer_egress_headers(req),
                     "monitor_dtmf": req.monitor_dtmf,
                     "tap_audio": req.tap_audio,
                 },
@@ -236,6 +256,19 @@ class _SbGatewaySession(GatewaySession):
         stashed in step 2. Accept/reject tools on the consult bot
         drive the parent's ``transfer_state`` from then on.
         """
+        # Resolve the routable URI BEFORE registering the consult session so a
+        # no-route failure propagates cleanly without leaking a registration.
+        # Same normalisation as dial_bridge / outbound originate: the consult
+        # leg also lands in ``Manager.Originate``.
+        destination_uri = _routable_leg_uri(
+            req.destination,
+            registration_endpoint_id=req.registration_endpoint_id,
+            b2bua_gateway_ip=req.b2bua_gateway_ip,
+            b2bua_gateway_transport=req.b2bua_gateway_transport,
+            outbound_sbc=self._gateway.outbound_sbc,
+            purpose="consult transfer",
+        )
+
         consult_session_id = f"sb-consult-{uuid.uuid4()}"
         # Stash the TransferAgent payload for the WS handler.
         self._gateway.register_consult_session(
@@ -245,17 +278,14 @@ class _SbGatewaySession(GatewaySession):
             parent_transcript=req.parent_transcript or "",
         )
 
-        # Assert the genuine origin to the gateway: the From toward the gateway
-        # is the trunk username (for call admission), so we surface the real
-        # caller as X-Aplisay-Origin-Caller-Id; the B2BUA maps it into a
-        # P-Asserted-Identity. Mirrors LiveKit's X-Aplisay-Origin-Caller-Id.
-        custom_headers: dict[str, str] = {}
-        if req.origin_caller_id:
-            custom_headers["X-Aplisay-Origin-Caller-Id"] = req.origin_caller_id
+        # Trunk / registration egress routing plus the genuine-origin
+        # assertion (X-Aplisay-Origin-Caller-Id → P-Asserted-Identity at the
+        # B2BUA). Mirrors the outbound originate header contract.
+        custom_headers = _transfer_egress_headers(req)
 
         body: dict[str, Any] = {
-            "destination": req.destination,
-            "caller_id": req.caller_id_override or "",
+            "destination": destination_uri,
+            "caller_id": req.caller_id_override or req.origin_caller_id or "",
             "agent_ws_session_id": consult_session_id,
             "custom_headers": custom_headers,
             "metadata": {},
@@ -648,19 +678,45 @@ def _outbound_target_uri(params: OutboundCallParams, outbound_sbc: Optional[str]
     A ``destination`` that is already a ``sip:``/``sips:`` URI is passed through
     unchanged.
     """
-    dest = (params.called_id or "").strip()
+    return _routable_leg_uri(
+        params.called_id,
+        registration_endpoint_id=params.registration_endpoint_id,
+        b2bua_gateway_ip=params.b2bua_gateway_ip,
+        b2bua_gateway_transport=params.b2bua_gateway_transport,
+        outbound_sbc=outbound_sbc,
+        purpose="outbound originate",
+    )
+
+
+def _routable_leg_uri(
+    destination: str,
+    *,
+    registration_endpoint_id: Optional[str] = None,
+    b2bua_gateway_ip: Optional[str] = None,
+    b2bua_gateway_transport: Optional[str] = None,
+    outbound_sbc: Optional[str] = None,
+    purpose: str = "originate",
+) -> str:
+    """Resolve a dial target to a URI the Go bridge can route.
+
+    Shared by outbound originates AND gateway-originated transfer legs
+    (dial_bridge / consult) — all three end in ``Manager.Originate``, whose
+    ``sip.ParseUri`` rejects a bare number with ``invalid uri scheme``.
+    ``purpose`` only flavours the no-route error message.
+    """
+    dest = (destination or "").strip()
     if dest.lower().startswith(("sip:", "sips:")):
         return dest
-    if params.registration_endpoint_id and params.b2bua_gateway_ip:
+    if registration_endpoint_id and b2bua_gateway_ip:
         # ``host[:port]`` — append the B2BUA SIP port (5070) only when the
         # configured value doesn't already carry one.
-        host = _strip_sip_scheme(params.b2bua_gateway_ip)
+        host = _strip_sip_scheme(b2bua_gateway_ip)
         authority = host if ":" in host else f"{host}:5070"
-        transport = params.b2bua_gateway_transport or "tcp"
+        transport = b2bua_gateway_transport or "tcp"
         return f"sip:{dest}@{authority};transport={transport}"
     if not outbound_sbc:
         raise RuntimeError(
-            "sipbridge outbound originate has no route for a trunk-origin call: "
+            f"sipbridge {purpose} has no route for a trunk-origin call: "
             "set PIPECAT_SIP_OUTBOUND (host[:port][;transport=...]) to the "
             "Aplisay outbound SBC, or originate with a registration endpoint as "
             "the caller-ID"
@@ -668,6 +724,28 @@ def _outbound_target_uri(params: OutboundCallParams, outbound_sbc: Optional[str]
     # The SBC value is an authority (``host[:port][;transport=...]``). Tolerate
     # an operator who included a ``sip:`` scheme — we add our own.
     return f"sip:{dest}@{_strip_sip_scheme(outbound_sbc)}"
+
+
+def _transfer_egress_headers(req: TransferRequest) -> dict[str, str]:
+    """The X-Aplisay-*/X-Lk-* routing contract for a gateway-originated
+    transfer leg — the same section-6 header set ``_custom_headers_for``
+    stamps on outbound originates (minus the call id: bridged transfer legs
+    live only inside the bridge), sourced from the TransferRequest's egress
+    tuple, plus the origin-caller assertion the consult path has always
+    sent. Without X-Aplisay-Trunk the upstream SBC 403s a trunk-egress
+    INVITE."""
+    h: dict[str, str] = {}
+    if req.aplisay_id:
+        h["X-Aplisay-Trunk"] = req.aplisay_id
+    if req.registration_endpoint_id:
+        h["X-Aplisay-PhoneRegistration"] = req.registration_endpoint_id
+    if req.b2bua_gateway_ip:
+        h["X-Lk-RealIp"] = req.b2bua_gateway_ip
+    if req.b2bua_gateway_transport:
+        h["X-Lk-Transport"] = req.b2bua_gateway_transport
+    if req.origin_caller_id:
+        h["X-Aplisay-Origin-Caller-Id"] = req.origin_caller_id
+    return h
 
 
 def _strip_sip_scheme(authority: str) -> str:

--- a/agents/pipecat/sipbridge/internal/call/manager.go
+++ b/agents/pipecat/sipbridge/internal/call/manager.go
@@ -402,6 +402,7 @@ func (m *Manager) Originate(ctx context.Context, p OriginateParams) (string, err
 	releaseCtx, releaseCancel := context.WithCancel(context.Background())
 	c.releaseStop = releaseCancel
 	c.startJitterRelease(releaseCtx)
+	c.startPacer(releaseCtx)
 	outCallID := c.callID
 	c.startMediaTimeoutWatchdog(m.cfg.RTPTimeoutSeconds, func() {
 		_ = m.Hangup(context.Background(), outCallID)
@@ -409,6 +410,7 @@ func (m *Manager) Originate(ctx context.Context, p OriginateParams) (string, err
 
 	c.rtp.SetPayloadHandler(c.onRTPPayload)
 	pc.SetAudioHandler(c.onWSAudio)
+	pc.SetInterruptionHandler(c.clearPacedAudio)
 	pc.SetCloseHandler(func(err error) {
 		// In relay mode the worker WS is expected to go away (SetPeer
 		// stops it, or a monitoring worker restarts) — the bridged
@@ -715,6 +717,7 @@ func (m *Manager) Unbridge(ctx context.Context, p UnbridgeParams) error {
 	pc := pcclient.NewClient(wsURL)
 	unbridgedID := c.callID
 	pc.SetAudioHandler(c.onWSAudio)
+	pc.SetInterruptionHandler(c.clearPacedAudio)
 	pc.SetCloseHandler(func(err error) {
 		if c.hasPeer() {
 			log.Info().Str("call_id", unbridgedID).Err(err).Msg("call: ws closed while bridged — call stays up")
@@ -736,7 +739,8 @@ func (m *Manager) Unbridge(ctx context.Context, p UnbridgeParams) error {
 	}
 
 	// 4. Swap the WS in and restart the decode path (jitter buffer +
-	// release loop) that SetPeer stopped when the relay engaged.
+	// release loop) that SetPeer stopped when the relay engaged, plus a
+	// fresh egress pacer (the old one died with the relay's ctx).
 	c.mu.Lock()
 	c.ws = pc
 	c.sessionID = p.AgentSessionID
@@ -749,6 +753,7 @@ func (m *Manager) Unbridge(ctx context.Context, p UnbridgeParams) error {
 	releaseCtx, releaseCancel := context.WithCancel(context.Background())
 	c.releaseStop = releaseCancel
 	c.startJitterRelease(releaseCtx)
+	c.startPacer(releaseCtx)
 
 	log.Info().
 		Str("call_id", c.callID).
@@ -885,6 +890,7 @@ func (m *Manager) onInvite(
 	releaseCtx, releaseCancel := context.WithCancel(context.Background())
 	c.releaseStop = releaseCancel
 	c.startJitterRelease(releaseCtx)
+	c.startPacer(releaseCtx)
 	inCallID := callID
 	c.startMediaTimeoutWatchdog(m.cfg.RTPTimeoutSeconds, func() {
 		_ = m.Hangup(context.Background(), inCallID)
@@ -893,6 +899,7 @@ func (m *Manager) onInvite(
 	// 4. Wire callbacks. Both directions go through the codec layer.
 	rtpSess.SetPayloadHandler(c.onRTPPayload)
 	pc.SetAudioHandler(c.onWSAudio)
+	pc.SetInterruptionHandler(c.clearPacedAudio)
 	pc.SetCloseHandler(func(err error) {
 		// See the outbound handler: a bridged call must survive its
 		// worker WS going away (SetPeer stop or monitor-worker loss).
@@ -1496,6 +1503,15 @@ type Call struct {
 	jb           *rtp.JitterBuffer
 	releaseStop  context.CancelFunc
 
+	// outPacer is the egress mirror of jb: worker WS audio arrives at up
+	// to 2× real-time (Pipecat's transport design), so onWSAudio enqueues
+	// encoded 20 ms payloads here and the pacer's loop puts exactly one on
+	// the wire per 20 ms with wall-clock timestamps and talkspurt markers.
+	// Runs on the same context as the jitter release loop (releaseStop
+	// cancels both; SetPeer therefore stops it when a relay engages).
+	// Guarded by mu; recreated on unbridge re-attach.
+	outPacer *pacer
+
 	mu     sync.Mutex
 	closed chan struct{}
 	done   bool
@@ -1851,14 +1867,49 @@ func (c *Call) startJitterRelease(ctx context.Context) {
 	}()
 }
 
+// startPacer starts the paced egress loop that drains onWSAudio's queue at
+// one 20 ms packet per 20 ms (see pacer.go for why the WS arrival cadence
+// cannot be trusted). Shares ctx with the jitter release loop so SetPeer /
+// Close cancel both together.
+func (c *Call) startPacer(ctx context.Context) {
+	p := &pacer{
+		sendFn:    c.rtp.SendPayloadPaced,
+		suspended: c.hasPeer,
+		onSendError: func(err error) {
+			log.Warn().Err(err).Str("call_id", c.callID).Msg("call: rtp send failed")
+			c.Close()
+		},
+	}
+	c.mu.Lock()
+	c.outPacer = p
+	c.mu.Unlock()
+	go p.run(ctx)
+}
+
+// clearPacedAudio drops any queued-but-unsent bot audio (worker
+// interruption: the caller barged in, and the tail of the utterance the
+// worker already shipped at 2× must not keep playing over them).
+func (c *Call) clearPacedAudio() {
+	c.mu.Lock()
+	p := c.outPacer
+	c.mu.Unlock()
+	if p == nil {
+		return
+	}
+	if n := p.clear(); n > 0 {
+		log.Debug().Int("packets", n).Str("call_id", c.callID).
+			Msg("call: interruption — dropped queued bot audio")
+	}
+}
+
 // onWSAudio is called when the worker pushes a bot-side AudioRawFrame
 // down the WS. PCM16LE @ 16 kHz mono in, RTP-encoded at 8 kHz on the
 // wire.
 //
-// Pipecat batches its audio output in roughly-20-ms chunks (320
-// samples), which happens to be exactly one downsampled RTP frame at
-// 8 kHz. Larger chunks are split into 160-sample (20 ms) RTP packets
-// to match the negotiated ptime — most carriers and SBCs enforce this.
+// Chunks are split into 160-sample (20 ms) G.711 payloads and ENQUEUED on
+// the egress pacer, never sent inline: Pipecat's websocket transport
+// deliberately sends at up to 2× real-time when it has a backlog, and the
+// PSTN side needs an isochronous 20 ms cadence (see pacer.go).
 func (c *Call) onWSAudio(pcm16LEbytes []byte) {
 	if c.isClosed() {
 		return
@@ -1869,10 +1920,19 @@ func (c *Call) onWSAudio(pcm16LEbytes []byte) {
 	if c.hasPeer() {
 		return
 	}
+	c.mu.Lock()
+	p := c.outPacer
+	c.mu.Unlock()
+	if p == nil {
+		// No pacer running (should not happen outside teardown races —
+		// the pacer starts before the worker WS connects).
+		return
+	}
 	samples16k := codec.BytesToPCMS16LE(pcm16LEbytes)
 	samples8k := codec.Downsample16To8(samples16k)
 
 	const samplesPerPacket = 160 // 20 ms at 8 kHz
+	payloads := make([][]byte, 0, (len(samples8k)+samplesPerPacket-1)/samplesPerPacket)
 	for i := 0; i < len(samples8k); i += samplesPerPacket {
 		end := i + samplesPerPacket
 		if end > len(samples8k) {
@@ -1888,12 +1948,9 @@ func (c *Call) onWSAudio(pcm16LEbytes []byte) {
 		default:
 			return
 		}
-		if err := c.rtp.SendPayload(payload); err != nil {
-			log.Warn().Err(err).Str("call_id", c.callID).Msg("call: rtp send failed")
-			c.Close()
-			return
-		}
+		payloads = append(payloads, payload)
 	}
+	p.enqueue(payloads)
 }
 
 // Close tears down RTP + WS + jitter buffer release loop. Idempotent.

--- a/agents/pipecat/sipbridge/internal/call/pacer.go
+++ b/agents/pipecat/sipbridge/internal/call/pacer.go
@@ -1,0 +1,189 @@
+package call
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// pacer smooths the worker→caller audio path onto a real-time RTP cadence.
+//
+// Why it exists: Pipecat's websocket output transport deliberately sends
+// audio at up to 2× real-time when it has a backlog (its send interval is
+// half the chunk duration — a buffer-priming strategy for browser clients).
+// The bridge used to forward each WS chunk to RTP the moment it arrived, so
+// during any long utterance the wire carried ~20 ms of audio every ~10 ms.
+// A carrier-side jitter buffer plays at 1×, overflows within a few hundred
+// milliseconds, and discards the rest — heard as garbled/chopped speech at
+// the handset while the worker-side recording (tapped before the WS) stays
+// perfect. The pacer restores the invariant the PSTN expects: one 20 ms
+// packet every 20 ms, timestamps that track the wall clock across silence,
+// and a marker bit on each talkspurt start (RFC 3550 §5.1).
+//
+// Shape: onWSAudio enqueues encoded 20 ms G.711 payloads; a single goroutine
+// (run) pops one payload per 20 ms frame slot and hands it to sendFn together
+// with the accumulated silence gap (in frames) and the talkspurt marker.
+// Empty slots while a stream is live count toward the next packet's timestamp
+// jump, so playout timing survives bot pauses without sending silence
+// packets. clear() drops queued-but-unsent audio (barge-in — the worker has
+// already shipped the rest of the utterance at 2×, and it must not play over
+// the caller).
+type pacer struct {
+	// sendFn writes one payload to the wire. gapFrames is how many whole
+	// 20 ms frames of silence preceded this packet (0 = contiguous speech);
+	// marker flags a talkspurt start.
+	sendFn func(payload []byte, gapFrames uint32, marker bool) error
+	// suspended reports whether sending must be withheld (relay mode owns
+	// the media path). Queued audio is discarded while suspended.
+	suspended func() bool
+	// onSendError is invoked once if sendFn fails; the run loop exits after.
+	onSendError func(err error)
+
+	mu      sync.Mutex
+	queue   [][]byte
+	idle    uint32 // empty frame slots since the last send (pending ts jump)
+	started bool   // at least one packet sent (first ever packet gets marker)
+	dropped int    // payloads discarded by overflow/clear/suspend since last log
+}
+
+const (
+	// paceFrame is the RTP packetisation interval: 160 samples at 8 kHz.
+	paceFrame = 20 * time.Millisecond
+	// maxPaceLag bounds the catch-up burst after a scheduler stall: if the
+	// loop falls further behind than this it re-anchors to the wall clock
+	// and accounts the skipped slots as silence instead of bursting them.
+	maxPaceLag = 200 * time.Millisecond
+	// maxPaceQueue bounds queue growth (60 s of audio). At the design 2×
+	// ingress rate the depth peaks at half the utterance length, so this
+	// only trips on runaway input; overflow drops the newest audio.
+	maxPaceQueue = 3000
+)
+
+// enqueue appends encoded payloads for paced sending. Payloads beyond the
+// queue bound are dropped (newest-first) with a rate-limited warning.
+func (p *pacer) enqueue(payloads [][]byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	room := maxPaceQueue - len(p.queue)
+	if room <= 0 {
+		p.dropped += len(payloads)
+		p.warnDroppedLocked("overflow")
+		return
+	}
+	if len(payloads) > room {
+		p.dropped += len(payloads) - room
+		payloads = payloads[:room]
+		p.warnDroppedLocked("overflow")
+	}
+	p.queue = append(p.queue, payloads...)
+}
+
+// clear drops all queued-but-unsent audio (barge-in / relay engage) and
+// returns how many packets were discarded. The pacing clock keeps running,
+// so the next enqueued audio starts a fresh talkspurt with a wall-clock-
+// correct timestamp jump.
+func (p *pacer) clear() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := len(p.queue)
+	p.queue = nil
+	return n
+}
+
+// depth reports the current queue depth (packets).
+func (p *pacer) depth() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.queue)
+}
+
+func (p *pacer) warnDroppedLocked(reason string) {
+	// Rate-limit: log every 250 drops (~5 s of audio) rather than per packet.
+	if p.dropped == 1 || p.dropped%250 == 0 {
+		log.Warn().Int("dropped", p.dropped).Str("reason", reason).
+			Msg("pacer: dropping bot audio")
+	}
+}
+
+// run is the pacing loop. One frame slot per paceFrame: a queued payload is
+// sent with the pending gap/marker state; an empty slot just extends the gap.
+// After a scheduler stall the loop sends back-to-back until it has caught up
+// with the wall clock (bounded by maxPaceLag, past which it re-anchors and
+// converts the lost slots into silence gap).
+func (p *pacer) run(ctx context.Context) {
+	next := time.Now()
+	for {
+		d := time.Until(next)
+		if d > 0 {
+			t := time.NewTimer(d)
+			select {
+			case <-ctx.Done():
+				t.Stop()
+				return
+			case <-t.C:
+			}
+		} else {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			if -d > maxPaceLag {
+				skipped := uint32(-d / paceFrame)
+				p.mu.Lock()
+				if p.started {
+					p.idle += skipped
+				}
+				p.mu.Unlock()
+				next = time.Now()
+			}
+		}
+
+		if p.suspended != nil && p.suspended() {
+			// Relay mode owns the media path; stale bot audio must not be
+			// mixed onto the caller's RTP stream.
+			p.mu.Lock()
+			if n := len(p.queue); n > 0 {
+				p.dropped += n
+				p.queue = nil
+				p.warnDroppedLocked("suspended")
+			}
+			if p.started {
+				p.idle++
+			}
+			p.mu.Unlock()
+			next = next.Add(paceFrame)
+			continue
+		}
+
+		p.mu.Lock()
+		var payload []byte
+		if len(p.queue) > 0 {
+			payload = p.queue[0]
+			p.queue = p.queue[1:]
+		}
+		if payload == nil {
+			if p.started {
+				p.idle++
+			}
+			p.mu.Unlock()
+			next = next.Add(paceFrame)
+			continue
+		}
+		gap := p.idle
+		marker := !p.started || gap > 0
+		p.idle = 0
+		p.started = true
+		p.mu.Unlock()
+
+		if err := p.sendFn(payload, gap, marker); err != nil {
+			if p.onSendError != nil {
+				p.onSendError(err)
+			}
+			return
+		}
+		next = next.Add(paceFrame)
+	}
+}

--- a/agents/pipecat/sipbridge/internal/call/pacer_test.go
+++ b/agents/pipecat/sipbridge/internal/call/pacer_test.go
@@ -1,0 +1,205 @@
+package call
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// sendRecorder collects sendFn invocations with their wall-clock times.
+type sendRecorder struct {
+	mu    sync.Mutex
+	sends []recordedSend
+}
+
+type recordedSend struct {
+	payload []byte
+	gap     uint32
+	marker  bool
+	at      time.Time
+}
+
+func (r *sendRecorder) send(payload []byte, gap uint32, marker bool) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sends = append(r.sends, recordedSend{payload, gap, marker, time.Now()})
+	return nil
+}
+
+func (r *sendRecorder) snapshot() []recordedSend {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedSend, len(r.sends))
+	copy(out, r.sends)
+	return out
+}
+
+func payloadsN(n int) [][]byte {
+	out := make([][]byte, n)
+	for i := range out {
+		out[i] = []byte{byte(i)}
+	}
+	return out
+}
+
+func startTestPacer(t *testing.T, rec *sendRecorder, suspended func() bool) (*pacer, context.CancelFunc) {
+	t.Helper()
+	if suspended == nil {
+		suspended = func() bool { return false }
+	}
+	p := &pacer{sendFn: rec.send, suspended: suspended}
+	ctx, cancel := context.WithCancel(context.Background())
+	go p.run(ctx)
+	return p, cancel
+}
+
+// A burst of enqueued payloads must leave at ~real-time (one per 20 ms),
+// not back-to-back: 10 packets span at least 9 inter-send frames.
+func TestPacerSmoothsBurstToRealTime(t *testing.T) {
+	rec := &sendRecorder{}
+	p, cancel := startTestPacer(t, rec, nil)
+	defer cancel()
+
+	start := time.Now()
+	p.enqueue(payloadsN(10))
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if len(rec.snapshot()) == 10 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out: only %d/10 packets sent", len(rec.snapshot()))
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	elapsed := time.Since(start)
+	// 10 packets = 9 full frame intervals minimum (first may go ~immediately).
+	// Generous lower bound to stay robust on loaded CI machines: the old
+	// unpaced path shipped all 10 within a millisecond.
+	if elapsed < 150*time.Millisecond {
+		t.Fatalf("10 packets sent in %v — egress is not paced", elapsed)
+	}
+
+	sends := rec.snapshot()
+	if !sends[0].marker {
+		t.Error("first packet of the stream must carry the talkspurt marker")
+	}
+	for i, s := range sends {
+		if i == 0 {
+			continue
+		}
+		if s.marker || s.gap != 0 {
+			t.Errorf("packet %d: contiguous speech must have marker=false gap=0 (got marker=%v gap=%d)", i, s.marker, s.gap)
+		}
+	}
+	// Payload order preserved.
+	for i, s := range sends {
+		if s.payload[0] != byte(i) {
+			t.Fatalf("packet %d: payload out of order (got %d)", i, s.payload[0])
+		}
+	}
+}
+
+// Silence between talkspurts must surface as a timestamp gap plus a marker
+// on the resuming packet — not as contiguous timestamps.
+func TestPacerGapAndMarkerAcrossSilence(t *testing.T) {
+	rec := &sendRecorder{}
+	p, cancel := startTestPacer(t, rec, nil)
+	defer cancel()
+
+	p.enqueue(payloadsN(2))
+	time.Sleep(100 * time.Millisecond) // let both go out
+	pause := 200 * time.Millisecond
+	time.Sleep(pause)
+	p.enqueue(payloadsN(1))
+
+	deadline := time.After(2 * time.Second)
+	for len(rec.snapshot()) < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out: %d/3 packets sent", len(rec.snapshot()))
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	sends := rec.snapshot()
+	last := sends[2]
+	if !last.marker {
+		t.Error("first packet after silence must carry the talkspurt marker")
+	}
+	// ~300 ms of idle ≈ 15 frames; allow wide scheduling slack either side.
+	if last.gap < 5 || last.gap > 30 {
+		t.Errorf("timestamp gap after ~300 ms silence should be roughly 15 frames, got %d", last.gap)
+	}
+}
+
+// clear() must drop queued audio: nothing else is sent after it, and the
+// next talkspurt re-opens with a marker.
+func TestPacerClearDropsQueuedAudio(t *testing.T) {
+	rec := &sendRecorder{}
+	p, cancel := startTestPacer(t, rec, nil)
+	defer cancel()
+
+	p.enqueue(payloadsN(50)) // ~1 s of queued audio
+	time.Sleep(90 * time.Millisecond)
+	dropped := p.clear()
+	sentAtClear := len(rec.snapshot())
+	if dropped == 0 {
+		t.Fatal("clear() dropped nothing — queue was expected to hold a backlog")
+	}
+	if sentAtClear+dropped != 50 {
+		t.Errorf("sent(%d) + dropped(%d) != enqueued(50)", sentAtClear, dropped)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if n := len(rec.snapshot()); n != sentAtClear {
+		t.Fatalf("packets kept flowing after clear(): %d -> %d", sentAtClear, n)
+	}
+
+	p.enqueue(payloadsN(1))
+	deadline := time.After(time.Second)
+	for len(rec.snapshot()) < sentAtClear+1 {
+		select {
+		case <-deadline:
+			t.Fatal("post-clear packet never sent")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	if s := rec.snapshot(); !s[len(s)-1].marker {
+		t.Error("first packet after clear() must open a fresh talkspurt (marker)")
+	}
+}
+
+// While suspended (relay mode), queued audio is discarded and nothing is
+// sent.
+func TestPacerSuspendedDiscards(t *testing.T) {
+	rec := &sendRecorder{}
+	p, cancel := startTestPacer(t, rec, func() bool { return true })
+	defer cancel()
+
+	p.enqueue(payloadsN(5))
+	time.Sleep(120 * time.Millisecond)
+	if n := len(rec.snapshot()); n != 0 {
+		t.Fatalf("suspended pacer sent %d packets", n)
+	}
+	if d := p.depth(); d != 0 {
+		t.Fatalf("suspended pacer kept %d packets queued (must discard)", d)
+	}
+}
+
+// Overflow beyond the queue bound drops the newest payloads instead of
+// growing without bound.
+func TestPacerOverflowBounded(t *testing.T) {
+	rec := &sendRecorder{}
+	p := &pacer{sendFn: rec.send, suspended: func() bool { return false }}
+	// No run loop: depth inspection only.
+	p.enqueue(payloadsN(maxPaceQueue + 100))
+	if d := p.depth(); d != maxPaceQueue {
+		t.Fatalf("queue depth %d, want cap %d", d, maxPaceQueue)
+	}
+	p.enqueue(payloadsN(1))
+	if d := p.depth(); d != maxPaceQueue {
+		t.Fatalf("queue grew past cap: %d", d)
+	}
+}

--- a/agents/pipecat/sipbridge/internal/pipecat/client.go
+++ b/agents/pipecat/sipbridge/internal/pipecat/client.go
@@ -36,10 +36,11 @@ type Client struct {
 	mu   sync.Mutex // protects Write — concurrent writes on a single
 	// WebSocket are unsafe.
 
-	onAudio   func(samplesS16LE []byte)
-	onText    func(TextFrame)
-	onTscript func(TranscriptionFrame)
-	onClose   func(err error)
+	onAudio        func(samplesS16LE []byte)
+	onText         func(TextFrame)
+	onTscript      func(TranscriptionFrame)
+	onInterruption func()
+	onClose        func(err error)
 
 	cancel  context.CancelFunc
 	done    chan struct{}
@@ -84,6 +85,15 @@ func (c *Client) SetTextHandler(fn func(TextFrame)) {
 // SetTranscriptionHandler registers an optional callback for STT output.
 func (c *Client) SetTranscriptionHandler(fn func(TranscriptionFrame)) {
 	c.onTscript = fn
+}
+
+// SetInterruptionHandler registers an optional callback fired when the
+// worker serializes an InterruptionFrame (caller barge-in — Pipecat's
+// ProtobufFrameSerializer ships it as the Frame oneof's ``interruption``
+// branch). The bridge uses it to drop queued-but-unsent bot audio so the
+// tail of an interrupted utterance doesn't keep playing over the caller.
+func (c *Client) SetInterruptionHandler(fn func()) {
+	c.onInterruption = fn
 }
 
 // SetCloseHandler registers a callback fired exactly once when the
@@ -353,5 +363,9 @@ func (c *Client) dispatch(frame *IncomingFrame) {
 		// Unused on this path — Pipecat application messages travel via
 		// a different channel in our worker. Log at debug.
 		log.Debug().Str("data", frame.Message.Data).Msg("pipecat ws: message frame ignored")
+	case frame.Interruption:
+		if c.onInterruption != nil {
+			c.onInterruption()
+		}
 	}
 }

--- a/agents/pipecat/sipbridge/internal/pipecat/wire.go
+++ b/agents/pipecat/sipbridge/internal/pipecat/wire.go
@@ -60,6 +60,7 @@ const (
 	frameTagAudio         = 2
 	frameTagTranscription = 3
 	frameTagMessage       = 4
+	frameTagInterruption  = 5
 )
 
 // AudioRawFrame is the Go equivalent of pipecat.AudioRawFrame.
@@ -100,12 +101,17 @@ type MessageFrame struct {
 }
 
 // IncomingFrame is what DecodeFrame produces — exactly one of its
-// pointer fields is non-nil, matching the proto3 oneof semantics.
+// pointer fields is non-nil (or Interruption is true), matching the
+// proto3 oneof semantics.
 type IncomingFrame struct {
 	Audio         *AudioRawFrame
 	Text          *TextFrame
 	Transcription *TranscriptionFrame
 	Message       *MessageFrame
+	// Interruption mirrors pipecat.InterruptionFrame (oneof branch 5):
+	// caller barge-in. The frame's id/name fields carry nothing the
+	// bridge needs, so it is surfaced as a plain flag.
+	Interruption bool
 }
 
 // EncodeAudio returns the bytes of a wire `Frame{audio: AudioRawFrame{...}}`.
@@ -193,6 +199,10 @@ func DecodeFrame(b []byte) (*IncomingFrame, error) {
 				return nil, fmt.Errorf("message: %w", err)
 			}
 			out.Message = m
+		case frameTagInterruption:
+			// InterruptionFrame carries only id/name — presence is the
+			// whole signal, so the inner payload is not decoded.
+			out.Interruption = true
 		default:
 			// Forward-compatible: ignore unknown oneof branches.
 		}

--- a/agents/pipecat/sipbridge/internal/pipecat/wire_test.go
+++ b/agents/pipecat/sipbridge/internal/pipecat/wire_test.go
@@ -1,0 +1,46 @@
+package pipecat
+
+import "testing"
+
+// The worker's ProtobufFrameSerializer ships caller barge-in as the Frame
+// oneof's ``interruption`` branch (field 5, length-delimited InterruptionFrame
+// carrying only id/name). DecodeFrame must surface it as a flag — this is the
+// signal the bridge uses to drop queued-but-unsent paced bot audio.
+func TestDecodeFrameInterruption(t *testing.T) {
+	// Frame{interruption: InterruptionFrame{}} — field 5, wire type 2,
+	// zero-length inner message.
+	b := []byte{0x2a, 0x00}
+	f, err := DecodeFrame(b)
+	if err != nil {
+		t.Fatalf("DecodeFrame: %v", err)
+	}
+	if !f.Interruption {
+		t.Fatal("Interruption flag not set for oneof branch 5")
+	}
+	if f.Audio != nil || f.Text != nil || f.Transcription != nil || f.Message != nil {
+		t.Fatal("unexpected sibling branches set")
+	}
+
+	// Inner id/name fields present (id=7, name="x") — still just a flag.
+	inner := []byte{0x08, 0x07, 0x12, 0x01, 'x'}
+	b = append([]byte{0x2a, byte(len(inner))}, inner...)
+	f, err = DecodeFrame(b)
+	if err != nil {
+		t.Fatalf("DecodeFrame (populated inner): %v", err)
+	}
+	if !f.Interruption {
+		t.Fatal("Interruption flag not set when inner fields are populated")
+	}
+}
+
+// Unknown future oneof branches must still be skipped without error.
+func TestDecodeFrameUnknownBranchIgnored(t *testing.T) {
+	b := []byte{0x32, 0x00} // field 6, wire type 2, empty
+	f, err := DecodeFrame(b)
+	if err != nil {
+		t.Fatalf("DecodeFrame: %v", err)
+	}
+	if f.Interruption || f.Audio != nil || f.Text != nil || f.Transcription != nil || f.Message != nil {
+		t.Fatal("unknown branch must decode to an empty IncomingFrame")
+	}
+}

--- a/agents/pipecat/sipbridge/internal/rtp/session.go
+++ b/agents/pipecat/sipbridge/internal/rtp/session.go
@@ -266,6 +266,16 @@ func (s *Session) SendPayload(payload []byte) error {
 	return s.writeRTP(uint8(s.payloadType.Load()), s.ts.Add(tsIncrement), false, payload)
 }
 
+// SendPayloadPaced is SendPayload for a silence-suppressed paced stream:
+// the packet's sampling instant is gapFrames whole frames after the
+// previous packet (0 = contiguous speech), so the RTP timestamp tracks the
+// wall clock across bot pauses without silence packets; marker flags the
+// first packet of a talkspurt (RFC 3550 §5.1). Shares the sequence/ts
+// space with SendPayload and SendTelephoneEvent.
+func (s *Session) SendPayloadPaced(payload []byte, gapFrames uint32, marker bool) error {
+	return s.writeRTP(uint8(s.payloadType.Load()), s.ts.Add(tsIncrement*(1+gapFrames)), marker, payload)
+}
+
 // SetDTMFPayloadType overrides the payload type used for outbound RFC 4733
 // telephone-event packets (default PayloadDTMF / 101). A caller that has
 // parsed the peer's telephone-event rtpmap may install the negotiated value

--- a/agents/pipecat/sipbridge/proto/frames.proto
+++ b/agents/pipecat/sipbridge/proto/frames.proto
@@ -48,11 +48,17 @@ message MessageFrame {
   string data = 1;
 }
 
+message InterruptionFrame {
+  uint64 id = 1;
+  string name = 2;
+}
+
 message Frame {
   oneof frame {
     TextFrame text = 1;
     AudioRawFrame audio = 2;
     TranscriptionFrame transcription = 3;
     MessageFrame message = 4;
+    InterruptionFrame interruption = 5;
   }
 }

--- a/agents/pipecat/tests/test_sipbridge_transfer_target.py
+++ b/agents/pipecat/tests/test_sipbridge_transfer_target.py
@@ -1,0 +1,180 @@
+"""Tests for transfer-leg target normalisation on the sipbridge gateway.
+
+Root cause pinned here (beta 2026-08-04): a trunk-origin blind transfer takes
+the dial_bridge path, which POSTed the agent-configured bare number verbatim;
+the Go bridge's ``Manager.Originate`` → ``sip.ParseUri`` then 502s with
+``invalid target URI "44...": invalid uri scheme``. The outbound-originate
+path already solved this (``_outbound_target_uri``); these tests pin the
+shared ``_routable_leg_uri`` helper and the dial_bridge / consult POST bodies
+(routable target, caller-ID fallback, X-Aplisay-* egress headers).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+import pytest
+
+from pipecat_aplisay.sip_gateway.base import TransferRequest
+from pipecat_aplisay.sip_gateway.sipbridge_gateway import (
+    _routable_leg_uri,
+    _transfer_egress_headers,
+    _SbGatewaySession,
+)
+
+
+# ---- _routable_leg_uri ----------------------------------------------------
+
+
+def test_bare_number_routes_to_outbound_sbc():
+    assert (
+        _routable_leg_uri("443300889471", outbound_sbc="sbc.example:5061;transport=tls")
+        == "sip:443300889471@sbc.example:5061;transport=tls"
+    )
+
+
+def test_sip_uri_passes_through_unchanged():
+    uri = "sips:+441234@carrier.example;transport=tls"
+    assert _routable_leg_uri(uri, outbound_sbc="sbc.example") == uri
+
+
+def test_registration_origin_routes_to_b2bua_gateway():
+    assert (
+        _routable_leg_uri(
+            "8093",
+            registration_endpoint_id="reg-1",
+            b2bua_gateway_ip="10.0.0.5",
+            b2bua_gateway_transport=None,
+            outbound_sbc="sbc.example",
+        )
+        == "sip:8093@10.0.0.5:5070;transport=tcp"
+    )
+
+
+def test_bare_number_without_route_raises():
+    with pytest.raises(RuntimeError, match="PIPECAT_SIP_OUTBOUND"):
+        _routable_leg_uri("443300889471", outbound_sbc=None)
+
+
+# ---- _transfer_egress_headers ---------------------------------------------
+
+
+def _req(**kw: Any) -> TransferRequest:
+    base = dict(destination="443300889471", operation="blind")
+    base.update(kw)
+    return TransferRequest(**base)
+
+
+def test_trunk_egress_headers():
+    req = _req(aplisay_id="magrathea", origin_caller_id="07970939456")
+    assert _transfer_egress_headers(req) == {
+        "X-Aplisay-Trunk": "magrathea",
+        "X-Aplisay-Origin-Caller-Id": "07970939456",
+    }
+
+
+def test_registration_egress_headers():
+    req = _req(
+        registration_endpoint_id="reg-1",
+        b2bua_gateway_ip="10.0.0.5",
+        b2bua_gateway_transport="tcp",
+    )
+    assert _transfer_egress_headers(req) == {
+        "X-Aplisay-PhoneRegistration": "reg-1",
+        "X-Lk-RealIp": "10.0.0.5",
+        "X-Lk-Transport": "tcp",
+    }
+
+
+# ---- dial_bridge POST body ------------------------------------------------
+
+
+class _FakeGateway:
+    """Captures _call_api invocations; quacks like SipBridgeSipGateway for the
+    slices _do_blind touches."""
+
+    def __init__(self, outbound_sbc: Optional[str] = "sbc.example:5061;transport=tls"):
+        self.outbound_sbc = outbound_sbc
+        self.calls: list[tuple[str, str, Optional[dict]]] = []
+
+    async def _call_api(self, method: str, path: str, body: Optional[dict], **kw: Any):
+        self.calls.append((method, path, body))
+        return {}
+
+    # consult-leg bookkeeping used by _do_blind's preamble
+    def get_consult_call_id(self, session_id: str) -> Optional[str]:
+        return None
+
+    def clear_consult_call_id(self, session_id: str) -> None:  # pragma: no cover
+        pass
+
+
+def _session(gateway: _FakeGateway) -> _SbGatewaySession:
+    return _SbGatewaySession(
+        transport=None,  # not touched by transfer()
+        session_id="sess-1",
+        bridge_call_id="call-1",
+        _gateway=gateway,
+    )
+
+
+def test_dial_bridge_posts_routable_target_and_egress_headers():
+    gw = _FakeGateway()
+    session = _session(gw)
+    req = _req(
+        force_bridged=True,
+        aplisay_id="magrathea",
+        origin_caller_id="07970939456",
+    )
+    asyncio.run(session.transfer(req))
+
+    assert len(gw.calls) == 1
+    method, path, body = gw.calls[0]
+    assert (method, path) == ("POST", "/v1/calls/call-1/transfer")
+    assert body == {
+        "target": "sip:443300889471@sbc.example:5061;transport=tls",
+        "mode": "dial_bridge",
+        # no explicit override -> falls back to the genuine origin caller
+        "caller_id": "07970939456",
+        "custom_headers": {
+            "X-Aplisay-Trunk": "magrathea",
+            "X-Aplisay-Origin-Caller-Id": "07970939456",
+        },
+        "monitor_dtmf": False,
+        "tap_audio": False,
+    }
+
+
+def test_dial_bridge_caller_id_override_wins():
+    gw = _FakeGateway()
+    session = _session(gw)
+    req = _req(
+        force_bridged=True,
+        caller_id_override="8092",
+        origin_caller_id="07970939456",
+    )
+    asyncio.run(session.transfer(req))
+    _, _, body = gw.calls[0]
+    assert body["caller_id"] == "8092"
+
+
+def test_dial_bridge_bare_number_without_sbc_fails_before_posting():
+    gw = _FakeGateway(outbound_sbc=None)
+    session = _session(gw)
+    req = _req(force_bridged=True)
+    with pytest.raises(RuntimeError, match="bridged transfer has no route"):
+        asyncio.run(session.transfer(req))
+    assert gw.calls == []  # nothing hit the bridge API
+
+
+def test_refer_path_unchanged_for_bare_numbers():
+    """Blind REFER keeps the raw target: the Go side builds the Refer-To
+    (bare numbers are normalised there against the bridge's signal IP and
+    rewritten by the upstream B2BUA)."""
+    gw = _FakeGateway()
+    session = _session(gw)
+    req = _req(force_bridged=False)
+    asyncio.run(session.transfer(req))
+    _, _, body = gw.calls[0]
+    assert body == {"target": "443300889471", "mode": "blind"}


### PR DESCRIPTION
## Summary

Fixes the two faults diagnosed on the 2026-08-04 beta PSTN test calls plus the barge-in interaction the audio fix introduces.

### 1. Transfer failures
Trunk-origin blind transfers default to the `dial_bridge` path, which POSTed the agent's configured bare number verbatim to the bridge; `Manager.Originate → sip.ParseUri` rejects anything without a scheme. The outbound-originate path already solved exactly this (`_outbound_target_uri`), and blind-REFER normalises in Go — the two transfer paths were the only ones missing it.

- `_do_blind` (dial_bridge) and `_do_consultative` now resolve destinations through a shared `_routable_leg_uri` (bare number → `sip:<num>@PIPECAT_SIP_OUTBOUND`, or the registration's B2BUA gateway; `sip:`/`sips:` URIs pass through).
- The origin call's egress tuple (trunk `aplisay_id` / registration + B2BUA fields) is threaded `InboundCallContext → CallSession → TransferRequest`, and the transfer POST now stamps the `X-Aplisay-Trunk` / `X-Aplisay-PhoneRegistration` / `X-Lk-*` headers — kamailio 403s trunk egress without `X-Aplisay-Trunk` (`$sht(outbound=>$var(trunk_id))` lookup).
- The leg's CLI falls back `caller_id_override → origin_caller_id` so the INVITE carries a real From user; kamailio's handler-domain suffix gate drops sipgo's synthetic `From: <sip:ua@localhost>` otherwise.

### 2. Bot audio garbled at the handset (call recording clean) — unpaced RTP egress

Pipecat's websocket output transport deliberately sends audio at up to **2× real-time** when backlogged (`_send_interval = chunk/2`), and the bridge forwarded every WS chunk to RTP the instant it arrived — so the wire carried 20 ms of audio every ~10 ms for the length of each utterance. The carrier-side jitter buffer plays at 1×, overflows within a few hundred ms, and discards the rest; the recording taps the worker before the WS, so it stayed perfect.

- New `pacer` (egress mirror of the inbound jitter-release loop): `onWSAudio` enqueues encoded 20 ms G.711 payloads; a per-call loop puts exactly one on the wire per 20 ms.
- RTP timestamps now track the wall clock across bot pauses (`SendPayloadPaced` advances by the observed silence gap) and each talkspurt opens with the marker bit (RFC 3550 §5.1) — previously timestamps were contiguous across every pause and the marker was never set.
- Bounded queue (60 s) with rate-limited overflow logging; relay engage (`SetPeer`) stops the pacer via the shared release context and discards stale bot audio.

### 3. Barge-in: drop the queued utterance tail

With 2× ingress, at barge-in the bridge holds the unplayed remainder of the utterance — without a clear it would keep playing over the caller. The worker already ships `InterruptionFrame` on interruption (Ultravox `playback_clear_buffer` → `InterruptionFrame` → transport → protobuf oneof branch 5); the bridge previously ignored that branch. `DecodeFrame` now surfaces it, and the new `SetInterruptionHandler` drops queued-but-unsent audio. No worker/serializer changes needed.

## Testing

- `go build ./... && go vet ./... && go test ./...` (golang:1.25 container) — all green, including new pacer tests (cadence, gap/marker across silence, clear-on-barge-in, suspended-discard, overflow bound) and wire decode tests for the interruption branch.
- `pytest agents/pipecat/tests` — 270 passed (260 existing + 10 new covering `_routable_leg_uri`, egress headers, dial_bridge body shape, REFER passthrough, and fail-before-POST when no route exists).

