### PR TITLE
sipbridge: downgrade SRTP offers smoothly on 415/606 + remember per route

### DIFF
--- a/agents/pipecat/sipbridge/internal/call/manager.go
+++ b/agents/pipecat/sipbridge/internal/call/manager.go
@@ -90,6 +90,17 @@ type Manager struct {
 
 	mu    sync.Mutex
 	calls map[string]*Call // keyed by SIP Call-ID
+
+	// srtpAvoid remembers egress routes (trunk / registration / destination)
+	// whose gateway rejected an SRTP offer with a media-type error (415 /
+	// 488 / 606), so subsequent originates skip the doomed SRTP first
+	// attempt and offer plaintext immediately — the dynamic downgrade still
+	// works without it, but each first attempt costs a full INVITE round
+	// trip (Magrathea's gateway takes ~1 s to 415). Entries expire after
+	// srtpAvoidTTL so a trunk that gains SRTP support gets re-probed.
+	// Guarded by srtpAvoidMu.
+	srtpAvoidMu sync.Mutex
+	srtpAvoid   map[string]time.Time
 }
 
 // New returns a Manager. Caller is responsible for calling
@@ -108,8 +119,9 @@ func New(cfg Config) *Manager {
 		cfg.RTPTimeoutSeconds = 10
 	}
 	return &Manager{
-		cfg:   cfg,
-		calls: make(map[string]*Call),
+		cfg:       cfg,
+		calls:     make(map[string]*Call),
+		srtpAvoid: make(map[string]time.Time),
 	}
 }
 
@@ -237,6 +249,57 @@ func (m *Manager) buildOutboundOffer(
 	return sipx.BuildOffer(rtpSess, m.cfg.MediaIP, encOffer), ourOfferedSDES, nil
 }
 
+// srtpAvoidTTL is how long a route stays in the plaintext-first cache after
+// its gateway rejected an SRTP offer. Long enough that back-to-back transfers
+// don't re-pay the rejection round trip; short enough that a trunk which
+// gains SRTP support is re-probed within the hour.
+const srtpAvoidTTL = time.Hour
+
+// isSRTPMediaReject reports whether a final INVITE response code plausibly
+// means "your RTP/SAVP offer is unacceptable": 488 Not Acceptable Here
+// (Twilio Elastic SIP Trunks), 415 Unsupported Media Type (Magrathea's
+// gateway), 606 Not Acceptable.
+func isSRTPMediaReject(code int) bool {
+	return code == 415 || code == 488 || code == 606
+}
+
+// srtpRouteKey identifies the egress route for the SRTP avoid-cache. Every
+// trunk call is dialled through the same upstream SBC, so the destination
+// host alone cannot distinguish carriers — prefer the routing headers that
+// do, falling back to the destination URI for direct dials.
+func srtpRouteKey(custom map[string]string, destination string) string {
+	if v := custom["X-Aplisay-Trunk"]; v != "" {
+		return "trunk:" + v
+	}
+	if v := custom["X-Aplisay-PhoneRegistration"]; v != "" {
+		return "reg:" + v
+	}
+	return "dest:" + destination
+}
+
+// srtpRecentlyRejected reports whether the route rejected an SRTP offer
+// within srtpAvoidTTL (expired entries are pruned on read).
+func (m *Manager) srtpRecentlyRejected(key string) bool {
+	m.srtpAvoidMu.Lock()
+	defer m.srtpAvoidMu.Unlock()
+	at, ok := m.srtpAvoid[key]
+	if !ok {
+		return false
+	}
+	if time.Since(at) > srtpAvoidTTL {
+		delete(m.srtpAvoid, key)
+		return false
+	}
+	return true
+}
+
+// noteSRTPRejected records that the route just rejected an SRTP offer.
+func (m *Manager) noteSRTPRejected(key string) {
+	m.srtpAvoidMu.Lock()
+	defer m.srtpAvoidMu.Unlock()
+	m.srtpAvoid[key] = time.Now()
+}
+
 // dialAndWireRTP performs the SIP-dial + RTP-socket + codec/SRTP
 // negotiation shared by every outbound leg (agent originate, consult
 // leg, and the agent-less relay leg of a native bridged transfer). It
@@ -262,18 +325,9 @@ func (m *Manager) dialAndWireRTP(ctx context.Context, p OriginateParams) (*Call,
 		return nil, nil, fmt.Errorf("call: rtp: %w", err)
 	}
 
-	// Outbound encryption offer. When SRTPOutbound + SRTPEnabled we offer SDES
-	// SRTP (RTP/SAVP). ``ourOfferedSDES`` maps tag → master material so we can
-	// install the outbound SRTP context once the peer picks a tag in its 200 OK.
-	offeringSDES := m.cfg.SRTPEnabled && m.cfg.SRTPOutbound
-	offer, ourOfferedSDES, err := m.buildOutboundOffer(rtpSess, offeringSDES)
-	if err != nil {
-		rtpSess.Close()
-		return nil, nil, err
-	}
-
 	// Inject X-Aplisay-Call-Id from metadata if present — the upstream
-	// B2BUA uses this as the platform-wide call correlator.
+	// B2BUA uses this as the platform-wide call correlator. Built before the
+	// offer because the routing headers also key the SRTP avoid-cache.
 	custom := map[string]string{}
 	for k, v := range p.CustomHeaders {
 		custom[k] = v
@@ -282,21 +336,45 @@ func (m *Manager) dialAndWireRTP(ctx context.Context, p OriginateParams) (*Call,
 		custom["X-Aplisay-Call-Id"] = v
 	}
 
+	// Outbound encryption offer. When SRTPOutbound + SRTPEnabled we offer SDES
+	// SRTP (RTP/SAVP). ``ourOfferedSDES`` maps tag → master material so we can
+	// install the outbound SRTP context once the peer picks a tag in its 200 OK.
+	// A route that rejected SRTP within srtpAvoidTTL goes straight to
+	// plaintext — the downgrade below still works without this, but each
+	// first attempt costs a full INVITE round trip.
+	offeringSDES := m.cfg.SRTPEnabled && m.cfg.SRTPOutbound
+	routeKey := srtpRouteKey(custom, p.Destination)
+	if offeringSDES && !m.cfg.SRTPRequired && m.srtpRecentlyRejected(routeKey) {
+		log.Debug().
+			Str("route", routeKey).
+			Msg("call: route rejected SRTP recently — offering plaintext RTP/AVP directly")
+		offeringSDES = false
+	}
+	offer, ourOfferedSDES, err := m.buildOutboundOffer(rtpSess, offeringSDES)
+	if err != nil {
+		rtpSess.Close()
+		return nil, nil, err
+	}
+
 	// 2. Send INVITE and wait for the 200 OK + SDP answer.
 	out, _, err := m.sip.Originate(ctx, p.Destination, p.CallerID, offer, custom)
 	if err != nil {
-		// Some carriers (notably Twilio Elastic SIP Trunks unless explicitly
-		// configured for secure media) reject an SRTP offer with 488 Not
-		// Acceptable Here. When we offered SRTP and SRTP isn't strictly
-		// required, retry once with a plaintext RTP/AVP offer so the call still
-		// completes. Trunks that accept SRTP never hit this path, so secure
-		// media is preserved everywhere it's supported.
+		// Some carriers reject an SRTP offer outright: Twilio Elastic SIP
+		// Trunks (unless explicitly configured for secure media) answer 488
+		// Not Acceptable Here; Magrathea's gateway answers 415 Unsupported
+		// Media Type. When we offered SRTP and SRTP isn't strictly required,
+		// retry once with a plaintext RTP/AVP offer so the call still
+		// completes, and remember the route so the next originate skips the
+		// doomed attempt. Trunks that accept SRTP never hit this path, so
+		// secure media is preserved everywhere it's supported.
 		var se *sipx.SIPResponseError
-		if offeringSDES && !m.cfg.SRTPRequired && errors.As(err, &se) && se.Code == 488 {
+		if offeringSDES && !m.cfg.SRTPRequired && errors.As(err, &se) && isSRTPMediaReject(se.Code) {
 			log.Warn().
 				Str("destination", p.Destination).
+				Str("route", routeKey).
 				Int("code", se.Code).
-				Msg("call: peer rejected SRTP offer (488); retrying with plaintext RTP/AVP")
+				Msg("call: peer rejected SRTP offer; retrying with plaintext RTP/AVP")
+			m.noteSRTPRejected(routeKey)
 			offeringSDES = false
 			offer, ourOfferedSDES, err = m.buildOutboundOffer(rtpSess, false)
 			if err != nil {

--- a/agents/pipecat/sipbridge/internal/call/srtp_downgrade_test.go
+++ b/agents/pipecat/sipbridge/internal/call/srtp_downgrade_test.go
@@ -1,0 +1,74 @@
+package call
+
+import (
+	"testing"
+	"time"
+)
+
+// Magrathea's gateway answers 415 to an RTP/SAVP offer; Twilio answers 488.
+// Both (plus 606) must trigger the plaintext downgrade; unrelated failures
+// (busy, not found, server error) must not.
+func TestIsSRTPMediaReject(t *testing.T) {
+	for _, code := range []int{415, 488, 606} {
+		if !isSRTPMediaReject(code) {
+			t.Errorf("code %d must trigger the SRTP downgrade", code)
+		}
+	}
+	for _, code := range []int{404, 403, 486, 480, 500, 503, 401, 407} {
+		if isSRTPMediaReject(code) {
+			t.Errorf("code %d must NOT trigger the SRTP downgrade", code)
+		}
+	}
+}
+
+// Every trunk call is dialled through the same upstream SBC host, so the
+// avoid-cache must key on the routing headers, not the destination.
+func TestSRTPRouteKeyPreference(t *testing.T) {
+	dest := "sip:443300889471@outbound.sbc.example:5060"
+	if k := srtpRouteKey(map[string]string{"X-Aplisay-Trunk": "magrathea"}, dest); k != "trunk:magrathea" {
+		t.Errorf("trunk header must win: got %q", k)
+	}
+	if k := srtpRouteKey(map[string]string{"X-Aplisay-PhoneRegistration": "reg-1"}, dest); k != "reg:reg-1" {
+		t.Errorf("registration header must be used when no trunk: got %q", k)
+	}
+	if k := srtpRouteKey(map[string]string{}, dest); k != "dest:"+dest {
+		t.Errorf("destination fallback: got %q", k)
+	}
+	// Trunk beats registration when both are present (trunk identifies the
+	// carrier hop, which is what rejects the SDP).
+	both := map[string]string{"X-Aplisay-Trunk": "magrathea", "X-Aplisay-PhoneRegistration": "reg-1"}
+	if k := srtpRouteKey(both, dest); k != "trunk:magrathea" {
+		t.Errorf("trunk must take precedence: got %q", k)
+	}
+}
+
+func TestSRTPAvoidCacheRememberAndExpire(t *testing.T) {
+	m := New(Config{MediaIP: "127.0.0.1"})
+	key := "trunk:magrathea"
+
+	if m.srtpRecentlyRejected(key) {
+		t.Fatal("fresh manager must not remember any rejection")
+	}
+	m.noteSRTPRejected(key)
+	if !m.srtpRecentlyRejected(key) {
+		t.Fatal("rejection must be remembered inside the TTL")
+	}
+	// Different routes are independent.
+	if m.srtpRecentlyRejected("trunk:other") {
+		t.Fatal("unrelated route must not be affected")
+	}
+
+	// Age the entry past the TTL: it must read as expired AND be pruned.
+	m.srtpAvoidMu.Lock()
+	m.srtpAvoid[key] = time.Now().Add(-srtpAvoidTTL - time.Minute)
+	m.srtpAvoidMu.Unlock()
+	if m.srtpRecentlyRejected(key) {
+		t.Fatal("expired rejection must not be remembered")
+	}
+	m.srtpAvoidMu.Lock()
+	_, still := m.srtpAvoid[key]
+	m.srtpAvoidMu.Unlock()
+	if still {
+		t.Fatal("expired entry must be pruned on read")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #191, from the first live transfer test to Magrathea: the dial_bridge leg now routes end-to-end, but Magrathea's gateway answers **`415 Unsupported Media Type`** to the bridge's `RTP/SAVP` + `a=crypto` offer. The existing plaintext-downgrade retry only matched Twilio's `488 Not Acceptable Here`, so the transfer failed — and would keep re-offering SRTP on every attempt.

## Changes

- **Extend the downgrade trigger** to `415` and `606` alongside `488` (`isSRTPMediaReject`). Behaviour is unchanged when `SIPBRIDGE_SRTP_REQUIRED` is set or when the peer accepts SRTP — trunks that support secure media keep it; only a media-type rejection of an SRTP offer falls back to plaintext `RTP/AVP`.
- **Remember rejecting routes for an hour** (`srtpAvoid` cache) so repeat calls skip the doomed first INVITE round trip — Magrathea takes ~1 s to send the 415, which would otherwise be added to every transfer. Keyed by `X-Aplisay-Trunk` / `X-Aplisay-PhoneRegistration` / destination URI (every trunk call is dialled through the same upstream SBC host, so the destination alone can't distinguish carriers). Entries expire after `srtpAvoidTTL` (1 h) so a trunk that gains SRTP support is re-probed.

## Wire evidence

```
m=audio 16654 RTP/SAVP 0 8 101
a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:…
   →  SIP/2.0 415 Unsupported Media Type   (User-Agent: Avon v1.0)
```
## Testing

- `go build ./... && go vet ./... && go test` (golang:1.25 container) — green.
- New unit tests: downgrade trigger set (415/488/606 yes; 404/403/486/480/5xx/auth no), route-key preference order, avoid-cache remember/expire/prune.
