### PR TITLE
pipecat: gate transport builds behind ONLY_TRANSPORTS

### DIFF
--- a/agents/pipecat/Dockerfile
+++ b/agents/pipecat/Dockerfile
@@ -17,7 +17,20 @@ RUN pip install --no-cache-dir uv
 WORKDIR /usr/src/app
 COPY agents/pipecat /usr/src/app
 
-RUN uv sync --frozen --no-cache || uv sync --no-cache
+# ONLY_TRANSPORTS: comma-separated allow-list (no spaces) of transports this
+# image should carry, matching the cloudbuild _ONLY_TRANSPORTS substitution.
+# Empty (the default) = all. The only transport with a worker-side install
+# cost is "daily": daily-python is a ~14 MB native wheel nothing else uses, so
+# the gate skips that single package and leaves the uv.lock resolution alone.
+ARG ONLY_TRANSPORTS=
+RUN case ",$ONLY_TRANSPORTS," in \
+        ",,"|*",daily,"*) \
+            uv sync --frozen --no-cache || uv sync --no-cache ;; \
+        *) \
+            echo "ONLY_TRANSPORTS=$ONLY_TRANSPORTS: skipping daily-python"; \
+            uv sync --frozen --no-cache --no-install-package daily-python \
+                || uv sync --no-cache --no-install-package daily-python ;; \
+    esac
 
 # Build identity — baked from Cloud Build's COMMIT_SHA / BRANCH_NAME / TAG_NAME
 # and logged at startup by pipecat_aplisay.build_info (mirrors the Node image's
@@ -33,4 +46,7 @@ ENV BUILD_COMMIT=$COMMIT_SHA \
 EXPOSE 8082
 ENV PORT=8082
 
-ENTRYPOINT ["uv", "run", "python", "-m", "pipecat_aplisay"]
+# --no-sync: the environment was fully materialised at build time; without it
+# `uv run` re-syncs against the lock at container start, which would reinstall
+# a daily-python that an ONLY_TRANSPORTS build deliberately excluded.
+ENTRYPOINT ["uv", "run", "--no-sync", "python", "-m", "pipecat_aplisay"]

--- a/agents/pipecat/deploy/gcp/README.md
+++ b/agents/pipecat/deploy/gcp/README.md
@@ -1,8 +1,8 @@
 # GCP deployment — Aplisay Pipecat agent
 
-Cloud Build + GCP Compute Engine deployment tooling for the three-container
-Pipecat agent stack (`freeswitch`, `esl-poller`, `pipecat-worker`). Adapted
-from `aplisay-b2bua/deploy/gcp/`.
+Cloud Build + GCP Compute Engine deployment tooling for the five-image
+Pipecat agent stack (`freeswitch`, `esl-poller`, `sipbridge`,
+`secretenv-exec`, `pipecat-worker`). Adapted from `aplisay-b2bua/deploy/gcp/`.
 
 ## Files
 
@@ -58,13 +58,45 @@ gcloud builds submit \
 
 Production `:latest` is **not** produced here. A versioned release tag on main
 runs the top-level [`cloudbuild-release.yaml`](../../../../cloudbuild-release.yaml),
-which verifies that every image (the five Pipecat images plus the Cloud Run
-services) exists at the release `:$COMMIT_SHA`, **aborts if any is missing**, and
-then promotes them all to `:latest` / `:$TAG_NAME` as a group before deploying.
+which verifies that every image in its `_RELEASE_IMAGES` group (the
+non-gated Pipecat images plus the Cloud Run services) exists at the release
+`:$COMMIT_SHA`, **aborts if any is missing**, and then promotes them all to
+`:latest` / `:$TAG_NAME` as a group before deploying.
 
 The build runs from the repo root so the `pipecat-worker` Dockerfile can pull
 in `agents/pipecat/` files. Both other services have self-contained build
 contexts under `agents/pipecat/freeswitch/` and `agents/pipecat/esl-poller/`.
+
+### `_ONLY_TRANSPORTS` — build only the transports you deploy
+
+All three pipelines (`cloudbuild.yaml`, `cloudbuild-staging.yaml`,
+`cloudbuild-beta.yaml`) accept an `_ONLY_TRANSPORTS` substitution: a
+comma-separated allow-list — no spaces — of the SIP transports to build.
+Empty or unset means **build everything** (the pre-flag behaviour, and what a
+plain `gcloud builds submit` of these configs does). When set,
+transport-specific artifacts outside the list are skipped:
+
+| name         | gates                                                              |
+| ------------ | ------------------------------------------------------------------ |
+| `freeswitch` | the `freeswitch` + `esl-poller` images                             |
+| `sipbridge`  | the `sipbridge` image                                              |
+| `daily`      | the `daily-python` wheel inside `pipecat-worker` (the image itself always builds; `SIP_GATEWAY=daily` then fails with a clear error at boot) |
+
+`secretenv-exec` and `pipecat-worker` are always built. The
+`pipecat-prod` / `pipecat-staging` / `pipecat-beta` Cloud Build triggers set
+`_ONLY_TRANSPORTS=sipbridge`, since neither the FreeSWITCH nor the Daily
+transport is in any deployed scenario — the FreeSWITCH image build (base
+image pull + `mod_audio_stream` compile) is the big per-CI win. To re-enable
+a transport, extend the substitution on the triggers **and** re-add
+`freeswitch esl-poller` to `_RELEASE_IMAGES` in the top-level
+[`cloudbuild-release.yaml`](../../../../cloudbuild-release.yaml) (its Verify
+step aborts a release when a listed image was never built; the gated ones
+are therefore delisted there).
+
+Note the gate skips beta promotion too: a gated-out image's `:beta` /
+`:beta-n.n.n` tags simply stop moving. Skipping the `esl-poller` build also
+skips its in-Dockerfile jest suite — the freeswitch transport is only
+compiled and tested again when the flag re-enables it.
 
 ## Deploying to a VM
 

--- a/agents/pipecat/deploy/gcp/cloudbuild-beta.yaml
+++ b/agents/pipecat/deploy/gcp/cloudbuild-beta.yaml
@@ -30,6 +30,14 @@
 # gated independently. No `images:` provenance list: Cloud Build fails the
 # build when a listed image wasn't produced locally, which is exactly the
 # skip path.
+#
+# _ONLY_TRANSPORTS (set on the trigger; empty / unset = everything):
+# comma-separated allow-list — no spaces — of the SIP transports in this
+# channel. Same semantics as the staging / per-commit builds: freeswitch →
+# freeswitch + esl-poller images, sipbridge → sipbridge image, daily → the
+# daily-python wheel inside pipecat-worker (that image itself always builds).
+# Gated-out images are neither checked, promoted, built nor pushed — their
+# :beta / :$TAG_NAME tags are simply not moved.
 steps:
   - name: gcr.io/cloud-builders/docker
     id: Check
@@ -39,7 +47,19 @@ steps:
       - |
         set -euo pipefail
         REG="$_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME"
-        for img in freeswitch esl-poller sipbridge secretenv-exec pipecat-worker; do
+        # _ONLY_TRANSPORTS gate: images of transports outside the allow-list
+        # are neither checked nor promoted (their Build/Push steps carry the
+        # same gate).
+        imgs="secretenv-exec pipecat-worker"
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) imgs="freeswitch esl-poller $$imgs";;
+          *) echo "[gate] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch (+esl-poller)";;
+        esac
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",sipbridge,"*) imgs="sipbridge $$imgs";;
+          *) echo "[gate] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes sipbridge";;
+        esac
+        for img in $$imgs; do
           # NB parse the Digest: line — the GCB builder's buildx ignores
           # `imagetools inspect --format` and prints the human output anyway.
           digest=$$(docker buildx imagetools inspect "$$REG/$$img:$COMMIT_SHA" 2>/dev/null \
@@ -66,6 +86,10 @@ steps:
     args:
       - -c
       - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch"; exit 0;;
+        esac
         [ -f /workspace/skip-freeswitch ] && { echo "[skip] promoted existing image"; exit 0; }
         exec docker build --no-cache \
           --build-arg BUILD_ENV=production \
@@ -79,6 +103,10 @@ steps:
     args:
       - -c
       - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch"; exit 0;;
+        esac
         [ -f /workspace/skip-freeswitch ] && { echo "[skip] promoted existing image"; exit 0; }
         exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch
 
@@ -89,6 +117,10 @@ steps:
     args:
       - -c
       - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch (esl-poller)"; exit 0;;
+        esac
         [ -f /workspace/skip-esl-poller ] && { echo "[skip] promoted existing image"; exit 0; }
         exec docker build --no-cache \
           -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA \
@@ -101,6 +133,10 @@ steps:
     args:
       - -c
       - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch (esl-poller)"; exit 0;;
+        esac
         [ -f /workspace/skip-esl-poller ] && { echo "[skip] promoted existing image"; exit 0; }
         exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller
 
@@ -113,6 +149,10 @@ steps:
     args:
       - -c
       - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",sipbridge,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes sipbridge"; exit 0;;
+        esac
         [ -f /workspace/skip-sipbridge ] && { echo "[skip] promoted existing image"; exit 0; }
         exec docker build --no-cache \
           -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA \
@@ -125,6 +165,10 @@ steps:
     args:
       - -c
       - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",sipbridge,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes sipbridge"; exit 0;;
+        esac
         [ -f /workspace/skip-sipbridge ] && { echo "[skip] promoted existing image"; exit 0; }
         exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge
 
@@ -167,6 +211,7 @@ steps:
           --build-arg COMMIT_SHA=$COMMIT_SHA \
           --build-arg BRANCH_NAME=$BRANCH_NAME \
           --build-arg TAG_NAME=$TAG_NAME \
+          --build-arg ONLY_TRANSPORTS=$_ONLY_TRANSPORTS \
           -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$COMMIT_SHA \
           -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:beta \
           -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$TAG_NAME \
@@ -188,6 +233,7 @@ options:
 
 substitutions:
   _AR_HOSTNAME: europe-west1-docker.pkg.dev
+  _ONLY_TRANSPORTS: ''
 
 tags:
   - pipecat-agent-beta

--- a/agents/pipecat/deploy/gcp/cloudbuild-staging.yaml
+++ b/agents/pipecat/deploy/gcp/cloudbuild-staging.yaml
@@ -12,85 +12,107 @@
 #                       the repo root because the worker Dockerfile COPYs
 #                       agents/pipecat into the image)
 #
+# _ONLY_TRANSPORTS (set on the trigger; empty / unset = build everything):
+# comma-separated allow-list — no spaces — of the SIP transports to build.
+# Transport-specific artifacts outside the list are skipped:
+#   freeswitch → the freeswitch + esl-poller images
+#   sipbridge  → the sipbridge image
+#   daily      → the daily-python wheel inside pipecat-worker (that image
+#                itself always builds)
+# secretenv-exec and pipecat-worker are always built. The `images:` provenance
+# list below holds only the unconditional images: Cloud Build fails any build
+# whose listed image was not produced, which is exactly the skip path.
+#
 # Adapted from aplisay-b2bua/deploy/gcp/cloudbuild-staging.yaml.
 steps:
-  # ----- FreeSWITCH -----
+  # ----- FreeSWITCH (gated: built only when _ONLY_TRANSPORTS is empty or lists freeswitch) -----
   - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '--no-cache'
-      - '--build-arg'
-      - BUILD_ENV=production
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:next
-      - '-f'
-      - './agents/pipecat/freeswitch/Dockerfile'
-      - './agents/pipecat/freeswitch'
     id: Build-freeswitch
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch"; exit 0;;
+        esac
+        exec docker build --no-cache \
+          --build-arg BUILD_ENV=production \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:next \
+          -f ./agents/pipecat/freeswitch/Dockerfile ./agents/pipecat/freeswitch
 
   - name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch
     id: Push-freeswitch
-
-  # ----- esl-poller -----
-  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - build
-      - '--no-cache'
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:next
-      - '-f'
-      - './agents/pipecat/esl-poller/Dockerfile'
-      - './agents/pipecat/esl-poller'
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch"; exit 0;;
+        esac
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch
+
+  # ----- esl-poller (part of the freeswitch transport, same gate) -----
+  - name: gcr.io/cloud-builders/docker
     id: Build-esl-poller
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch (esl-poller)"; exit 0;;
+        esac
+        exec docker build --no-cache \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:next \
+          -f ./agents/pipecat/esl-poller/Dockerfile ./agents/pipecat/esl-poller
 
   - name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller
     id: Push-esl-poller
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch (esl-poller)"; exit 0;;
+        esac
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller
 
-  # ----- sipbridge -----
+  # ----- sipbridge (gated on its own name) -----
   # Build context is the repo root (.) because the Dockerfile COPYs
   # agents/pipecat/sipbridge into the image.
   - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '--no-cache'
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:next
-      - '-f'
-      - './agents/pipecat/sipbridge/Dockerfile'
-      - '.'
     id: Build-sipbridge
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",sipbridge,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes sipbridge"; exit 0;;
+        esac
+        exec docker build --no-cache \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:next \
+          -f ./agents/pipecat/sipbridge/Dockerfile .
 
   - name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - '--all-tags'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge
     id: Push-sipbridge
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",sipbridge,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes sipbridge"; exit 0;;
+        esac
+        exec docker push --all-tags $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge
 
-  # ----- secretenv-exec -----
+  # ----- secretenv-exec (always built) -----
   # Tiny static decrypt-and-exec wrapper (reuses the sipbridge Go module).
   # Used by the Kubernetes freeswitch / voiceblender overlays so those
   # containers can share the single SECRETENV_KEY + SECRETENV_BUNDLE secret.
@@ -117,7 +139,7 @@ steps:
         $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec
     id: Push-secretenv-exec
 
-  # ----- pipecat-worker -----
+  # ----- pipecat-worker (always built; ONLY_TRANSPORTS gates its daily extra) -----
   # Build context is the repo root (.) because the Dockerfile COPYs
   # agents/pipecat into the image.
   - name: gcr.io/cloud-builders/docker
@@ -130,6 +152,8 @@ steps:
       - BRANCH_NAME=$BRANCH_NAME
       - '--build-arg'
       - TAG_NAME=$TAG_NAME
+      - '--build-arg'
+      - ONLY_TRANSPORTS=$_ONLY_TRANSPORTS
       - '-t'
       - >-
         $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$COMMIT_SHA
@@ -149,13 +173,11 @@ steps:
         $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker
     id: Push-pipecat-worker
 
+# Unconditional images only — the transport images (freeswitch, esl-poller,
+# sipbridge) are pushed by their own steps and may be skipped entirely by
+# _ONLY_TRANSPORTS, and Cloud Build fails a build whose listed image was not
+# produced.
 images:
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA
   - >-
     $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:$COMMIT_SHA
   - >-
@@ -169,6 +191,7 @@ options:
 
 substitutions:
   _AR_HOSTNAME: $LOCATION-docker.pkg.dev
+  _ONLY_TRANSPORTS: ''
 
 tags:
   - pipecat-agent-staging

--- a/agents/pipecat/deploy/gcp/cloudbuild.yaml
+++ b/agents/pipecat/deploy/gcp/cloudbuild.yaml
@@ -9,69 +9,106 @@
 # is their deploy path. The :next staging tag is produced separately by
 # cloudbuild-staging.yaml.
 #
+# _ONLY_TRANSPORTS (set on the trigger; empty / unset = build everything):
+# comma-separated allow-list — no spaces — of the SIP transports to build.
+# Transport-specific artifacts outside the list are skipped:
+#   freeswitch → the freeswitch + esl-poller images
+#   sipbridge  → the sipbridge image
+#   daily      → the daily-python wheel inside pipecat-worker (that image
+#                itself always builds)
+# secretenv-exec and pipecat-worker are always built. The `images:` provenance
+# list below holds only the unconditional images: Cloud Build fails any build
+# whose listed image was not produced, which is exactly the skip path.
+# NB: the top-level cloudbuild-release.yaml's _RELEASE_IMAGES must agree with
+# what this build produces — a release verifies every listed image at
+# :$COMMIT_SHA and aborts on any missing one.
+#
 # Adapted from aplisay-b2bua/deploy/gcp/cloudbuild.yaml.
 steps:
+  # ----- FreeSWITCH (gated: built only when _ONLY_TRANSPORTS is empty or lists freeswitch) -----
   - name: gcr.io/cloud-builders/docker
-    args:
-      - build
-      - '--no-cache'
-      - '--build-arg'
-      - BUILD_ENV=production
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA
-      - '-f'
-      - './agents/pipecat/freeswitch/Dockerfile'
-      - './agents/pipecat/freeswitch'
     id: Build-freeswitch
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch"; exit 0;;
+        esac
+        exec docker build --no-cache \
+          --build-arg BUILD_ENV=production \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA \
+          -f ./agents/pipecat/freeswitch/Dockerfile ./agents/pipecat/freeswitch
 
   - name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA
     id: Push-freeswitch
-
-  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - build
-      - '--no-cache'
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA
-      - '-f'
-      - './agents/pipecat/esl-poller/Dockerfile'
-      - './agents/pipecat/esl-poller'
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch"; exit 0;;
+        esac
+        exec docker push $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA
+
+  # ----- esl-poller (part of the freeswitch transport, same gate) -----
+  - name: gcr.io/cloud-builders/docker
     id: Build-esl-poller
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch (esl-poller)"; exit 0;;
+        esac
+        exec docker build --no-cache \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA \
+          -f ./agents/pipecat/esl-poller/Dockerfile ./agents/pipecat/esl-poller
 
   - name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA
     id: Push-esl-poller
-
-  # ----- sipbridge -----
-  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
     args:
-      - build
-      - '--no-cache'
-      - '-t'
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA
-      - '-f'
-      - './agents/pipecat/sipbridge/Dockerfile'
-      - '.'
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",freeswitch,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes freeswitch (esl-poller)"; exit 0;;
+        esac
+        exec docker push $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA
+
+  # ----- sipbridge (gated on its own name; build context is the repo root
+  # because the Dockerfile COPYs agents/pipecat/sipbridge into the image) -----
+  - name: gcr.io/cloud-builders/docker
     id: Build-sipbridge
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",sipbridge,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes sipbridge"; exit 0;;
+        esac
+        exec docker build --no-cache \
+          -t $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA \
+          -f ./agents/pipecat/sipbridge/Dockerfile .
 
   - name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - >-
-        $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA
     id: Push-sipbridge
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        case ",$_ONLY_TRANSPORTS," in
+          ",,"|*",sipbridge,"*) ;;
+          *) echo "[skip] _ONLY_TRANSPORTS='$_ONLY_TRANSPORTS' excludes sipbridge"; exit 0;;
+        esac
+        exec docker push $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA
 
-  # ----- secretenv-exec -----
+  # ----- secretenv-exec (always built) -----
   # Tiny static decrypt-and-exec wrapper (reuses the sipbridge Go module).
   # Used by the Kubernetes freeswitch / voiceblender overlays so those
   # containers can share the single SECRETENV_KEY + SECRETENV_BUNDLE secret.
@@ -94,6 +131,7 @@ steps:
         $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:$COMMIT_SHA
     id: Push-secretenv-exec
 
+  # ----- pipecat-worker (always built; ONLY_TRANSPORTS gates its daily extra) -----
   - name: gcr.io/cloud-builders/docker
     args:
       - build
@@ -104,6 +142,8 @@ steps:
       - BRANCH_NAME=$BRANCH_NAME
       - '--build-arg'
       - TAG_NAME=$TAG_NAME
+      - '--build-arg'
+      - ONLY_TRANSPORTS=$_ONLY_TRANSPORTS
       - '-t'
       - >-
         $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$COMMIT_SHA
@@ -119,13 +159,11 @@ steps:
         $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/pipecat-worker:$COMMIT_SHA
     id: Push-pipecat-worker
 
+# Unconditional images only — the transport images (freeswitch, esl-poller,
+# sipbridge) are pushed by their own steps and may be skipped entirely by
+# _ONLY_TRANSPORTS, and Cloud Build fails a build whose listed image was not
+# produced.
 images:
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/freeswitch:$COMMIT_SHA
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/esl-poller:$COMMIT_SHA
-  - >-
-    $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/sipbridge:$COMMIT_SHA
   - >-
     $_AR_HOSTNAME/$PROJECT_ID/containers/$REPO_NAME/secretenv-exec:$COMMIT_SHA
   - >-
@@ -139,6 +177,7 @@ options:
 
 substitutions:
   _AR_HOSTNAME: $LOCATION-docker.pkg.dev
+  _ONLY_TRANSPORTS: ''
 
 tags:
   - pipecat-agent

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -1738,7 +1738,10 @@ class CallSession:
     def _reject_daily(self) -> Optional[dict]:
         """WebRTC relay needs a bare ``originate``; the Daily gateway requires
         room pre-provisioning we don't do here. Reject explicitly."""
-        from .sip_gateway.daily_gateway import DailySipGateway
+        # Package-level import: resolves to the placeholder class when the
+        # daily transport is not installed (ONLY_TRANSPORTS build); importing
+        # the submodule directly would raise ImportError there.
+        from .sip_gateway import DailySipGateway
 
         if isinstance(self.sip_gateway, DailySipGateway):
             return self._transfer_failed(

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/__init__.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/__init__.py
@@ -18,7 +18,31 @@ from .base import (
     GatewaySessionParams,
     collect_sip_headers,
 )
-from .daily_gateway import DailySipGateway
+try:
+    from .daily_gateway import DailySipGateway
+except ImportError as exc:
+    # Images built with ONLY_TRANSPORTS excluding "daily" omit the
+    # daily-python wheel, so the Daily gateway module cannot import. Keep a
+    # placeholder class: isinstance() checks against DailySipGateway elsewhere
+    # in the worker still work (nothing is ever an instance of it), and
+    # selecting SIP_GATEWAY=daily fails with a clear error at gateway
+    # construction instead of an import crash at boot.
+    from loguru import logger
+
+    _daily_import_error = exc
+    logger.info(f"daily gateway unavailable in this build: {exc}")
+
+    class DailySipGateway:  # type: ignore[no-redef]
+        """Placeholder for images built without the daily transport."""
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            raise RuntimeError(
+                "SIP_GATEWAY=daily requested but the daily transport is not "
+                "installed in this image (built with ONLY_TRANSPORTS "
+                f"excluding 'daily'): {_daily_import_error}"
+            )
+
+
 from .freeswitch_gateway import FreeswitchSipGateway
 from .sipbridge_gateway import SipBridgeSipGateway
 from .voiceblender_gateway import VoiceblenderSipGateway

--- a/cloudbuild-release.yaml
+++ b/cloudbuild-release.yaml
@@ -120,10 +120,15 @@ substitutions:
   _JAMBONZ_SERVICE: jambonz-agent
   # Every image promoted + (where applicable) deployed as one release group.
   # Cloud Run / GCE: llm-agent jambonz-agent livekit-agent
-  # Pipecat / K8s:   freeswitch esl-poller sipbridge secretenv-exec pipecat-worker
+  # Pipecat / K8s:   sipbridge secretenv-exec pipecat-worker
+  # NOT listed: freeswitch + esl-poller — the pipecat builds gate them behind
+  # _ONLY_TRANSPORTS (agents/pipecat/deploy/gcp/cloudbuild*.yaml) and the
+  # triggers exclude them, so per-commit builds no longer produce them and
+  # Verify above would abort every release. Re-add them here in the same
+  # change that re-enables the freeswitch transport on those triggers.
   _RELEASE_IMAGES: >-
-    llm-agent jambonz-agent livekit-agent freeswitch esl-poller sipbridge
-    secretenv-exec pipecat-worker
+    llm-agent jambonz-agent livekit-agent sipbridge secretenv-exec
+    pipecat-worker
 
 tags:
   - release


### PR DESCRIPTION
## What

`_ONLY_TRANSPORTS` — a comma-separated allow-list (no spaces) on the three pipecat cloudbuilds (staging / per-commit / beta), passed through from the Cloud Build triggers. Empty or unset = build everything (pre-flag behaviour). When set, transport-specific artifacts outside the list are skipped:

| name | gates |
|---|---|
| `freeswitch` | `freeswitch` + `esl-poller` images |
| `sipbridge` | `sipbridge` image |
| `daily` | `daily-python` wheel inside `pipecat-worker` (image itself always builds) |

`secretenv-exec` and `pipecat-worker` are always built. Neither the FreeSWITCH nor the Daily transport is in any deployed scenario, so building them every CI run (freeswitch base pull + mod_audio_stream cmake compile, esl-poller yarn install/test/build, the ~14 MB daily-python native wheel) was pure waste.

## Details

- Gated build/push steps become bash-guarded (the skip-marker style cloudbuild-beta already used). `images:` provenance lists keep only unconditional images — Cloud Build fails a build whose listed image was not produced.
- Beta: the Check step neither checks nor promotes gated-out images, so their `:beta` / `:beta-n.n.n` tags simply stop moving; skipping esl-poller also skips its in-Dockerfile jest suite.
- **cloudbuild-release.yaml**: `freeswitch` + `esl-poller` delisted from `_RELEASE_IMAGES` — Verify aborts a release on any missing `:$COMMIT_SHA` image, and per-commit builds no longer produce them. Re-enabling freeswitch = extend the trigger substitution **and** re-add both images there (commented in both files + README).
- Worker: `ONLY_TRANSPORTS` build-arg drives `uv sync --no-install-package daily-python` (uv.lock untouched); entrypoint gains `uv run --no-sync` so runtime cannot re-install the excluded wheel; `sip_gateway` exports a placeholder `DailySipGateway` when daily-python is absent — isinstance checks keep working and `SIP_GATEWAY=daily` fails with a clear boot error instead of an import crash.

## Trigger state (already applied)

`pipecat-prod`, `pipecat-staging`, `pipecat-beta` in llm-voice already carry `_ONLY_TRANSPORTS=sipbridge` (no-op against the old YAMLs via ALLOW_LOOSE; takes effect when this lands).

## Verification

- All four YAMLs parse; every embedded script passes `bash -n`; gate matrix (5 flag values × build/push steps × 3 files + beta Check list) exercised against the real scripts with docker stubbed — all correct.
- `uv sync --dry-run` confirms the exclusion drops daily-python and nothing else.
- Full worker module imports with daily blocked (INFO line confirms exclusion); 260 pipecat tests green from this branch.
- Not yet exercised in a real Cloud Build — the first staging run after merge is the live test.