### PR TITLE
pipecat: fix consult-leg crash reading callerId off the CallRecord

### DIFF
--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -353,6 +353,20 @@ def _voiceblender_session_lookup(app: FastAPI, session_id: str):
     return None
 
 
+def _aplisay_caller_id(call: api_client.CallRecord) -> Optional[str]:
+    """Origin caller id as seeded at ``metadata.aplisay.callerId``.
+
+    ``CallRecord`` deliberately has no top-level ``callerId`` field — the
+    number lives only in the aplisay metadata blob (see the create_call
+    payloads), and attribute access on the pydantic model raises
+    AttributeError. Beta 2026-08-05: the sipbridge consult arm did exactly
+    that, killing the TransferAgent WS the moment the transfer target
+    answered — they heard silence while the bridge held the leg open.
+    """
+    meta = call.metadata if isinstance(call.metadata, dict) else {}
+    return (meta.get("aplisay") or {}).get("callerId")
+
+
 # X- headers on the sipbridge WS handshake that are sipbridge's own transport
 # metadata, NOT part of the inbound INVITE — excluded from aplisay.sipHeaders.
 # (``x-forwarded-*`` is a defensive guard against any future reverse proxy; today
@@ -1112,7 +1126,7 @@ async def freeswitch_audio(websocket: WebSocket) -> None:
         ctx = InboundCallContext(
             session_id=start.channel_uuid,
             called_id=start.called_id,
-            caller_id=parent.call.callerId,
+            caller_id=_aplisay_caller_id(parent.call),
             aplisay_id=None,
             phone_registration=None,
             b2bua_gateway_ip=None,
@@ -1716,7 +1730,7 @@ async def sipbridge_agent(websocket: WebSocket, session_id: str) -> None:
             ctx = InboundCallContext(
                 session_id=session_id,
                 called_id=None,
-                caller_id=consult_parent.call.callerId,
+                caller_id=_aplisay_caller_id(consult_parent.call),
                 aplisay_id=None,
                 phone_registration=None,
                 b2bua_gateway_ip=None,

--- a/agents/pipecat/tests/test_sipbridge_consult_ws_routing.py
+++ b/agents/pipecat/tests/test_sipbridge_consult_ws_routing.py
@@ -18,7 +18,11 @@ channel:
   (here it then closes 1011 because no live parent session exists — the
   regression under test is the handshake-level 404 denial);
 - an unknown session id must still take the inbound path and be denied
-  (guard against over-routing).
+  (guard against over-routing);
+- with a live parent, flow (b) must reach ``_run_session`` with the consult
+  context's caller id sourced from ``metadata.aplisay.callerId`` (the
+  ``CallRecord`` pydantic model has no ``callerId`` attribute — reading one
+  crashed the handler and left the answered transfer target in silence).
 """
 
 from __future__ import annotations
@@ -28,13 +32,22 @@ from types import SimpleNamespace
 
 from starlette.websockets import WebSocket
 
-from pipecat_aplisay import worker
+from pipecat_aplisay import api_client, worker
+from pipecat_aplisay.call_session import TransferState
 from pipecat_aplisay.sip_gateway.sipbridge_gateway import SipBridgeSipGateway
 
 
-def _drive_handler(gateway: SipBridgeSipGateway, session_id: str) -> list[dict]:
+def _drive_handler(
+    gateway: SipBridgeSipGateway,
+    session_id: str,
+    live_calls: dict | None = None,
+) -> list[dict]:
     """Run ``sipbridge_agent`` against a scripted WS; return the frames it sent."""
-    app = SimpleNamespace(state=SimpleNamespace(sip_gateway=gateway, live_calls={}))
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            sip_gateway=gateway, live_calls=live_calls if live_calls is not None else {}
+        )
+    )
     scope = {
         "type": "websocket",
         "path": f"/sipbridge/agent/{session_id}",
@@ -100,3 +113,78 @@ def test_unknown_session_ws_still_takes_inbound_path(monkeypatch):
     assert sent[0]["type"] == "websocket.http.response.start"
     assert sent[0]["status"] == 404
     assert not any(m["type"] == "websocket.accept" for m in sent)
+
+
+def test_consult_ws_reaches_run_session_with_metadata_caller_id(monkeypatch):
+    """Drive flow (b) with a LIVE parent all the way to ``_run_session``.
+
+    Regression (beta 2026-08-05, second incarnation): with routing fixed,
+    the handler crashed building the consult ``InboundCallContext`` —
+    ``consult_parent.call.callerId`` on a pydantic ``CallRecord`` that has
+    no such field (AttributeError). The Go bridge held the answered leg
+    open with no bot attached, so the transfer target heard silence. The
+    parent's ``call`` here is a REAL CallRecord so any attribute-access
+    regression re-raises; the caller id must come from
+    ``metadata.aplisay.callerId``.
+    """
+    gateway = SipBridgeSipGateway()
+    session_id = "sb-consult-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    gateway.register_consult_session(
+        consult_session_id=session_id,
+        parent_session_id="parent-session",
+        transfer_prompt_template="Consult prompt. ${parentTranscript}",
+        parent_transcript="caller: hello",
+    )
+
+    parent_call = api_client.CallRecord(
+        id="parent-call",
+        userId="user-1",
+        organisationId="org-1",
+        instanceId="instance-1",
+        agentId="agent-1",
+        metadata={"aplisay": {"callerId": "07970939456", "calledId": "+441539454616"}},
+    )
+    parent = SimpleNamespace(
+        session_id="parent-session",
+        call=parent_call,
+        agent={
+            "id": "agent-1",
+            "userId": "user-1",
+            "organisationId": "org-1",
+            "modelName": "pipecat:ultravox",
+            "options": {},
+        },
+        instance={"id": "instance-1"},
+        transfer_state=TransferState("dialling", "Dialling transfer target..."),
+    )
+
+    captured: dict = {}
+
+    async def fake_setup_consult_call(sip_gateway, ctx, *, instance, transfer_agent, parent):
+        captured["ctx"] = ctx
+        captured["instance"] = instance
+        captured["transfer_agent"] = transfer_agent
+        return SimpleNamespace(call=SimpleNamespace(id="consult-call-1"))
+
+    async def fake_run_session(app, session, call_id):
+        captured["ran_call_id"] = call_id
+
+    monkeypatch.setattr(worker, "setup_consult_call", fake_setup_consult_call)
+    monkeypatch.setattr(worker, "_run_session", fake_run_session)
+
+    sent = _drive_handler(gateway, session_id, live_calls={"parent-call": parent})
+
+    assert sent[0]["type"] == "websocket.accept"
+    assert not any(m["type"] == "websocket.http.response.start" for m in sent)
+    # The crash line: caller id must be read from the aplisay metadata.
+    assert captured["ctx"].caller_id == "07970939456"
+    assert captured["ctx"].raw["consult_of"] == "parent-session"
+    # The TransferAgent inherits the parent's model with the consult prompt.
+    assert captured["transfer_agent"]["modelName"] == "pipecat:ultravox"
+    assert "caller: hello" in captured["transfer_agent"]["prompt"]
+    # The consult bot's pipeline actually ran.
+    assert captured["ran_call_id"] == "consult-call-1"
+    # No accept_transfer fired before the WS ended → parent marked rejected.
+    assert parent.transfer_state.state == "rejected"
+    # Consult registration cleaned up on exit.
+    assert gateway.consult_payload(session_id) is None


### PR DESCRIPTION
## Symptom

Follow-up to #194. Latest beta test call (07970 939456, 19:36Z): the call no longer drops on answer, but the consult-leg transfer recipient never hears the agent.

## Root cause

With routing fixed, the sipbridge consult arm now runs — and crashes building the TransferAgent's `InboundCallContext`:

```
File "worker.py", line 1719, in sipbridge_agent
    caller_id=consult_parent.call.callerId,
AttributeError: 'CallRecord' object has no attribute 'callerId'
```

`CallRecord` has no top-level `callerId` — the number lives at `metadata.aplisay.callerId` (where every other arm reads it). The exception killed the ASGI handler immediately after the WS handshake, and the Go bridge's tolerant "ws closed while call up" handling kept the freshly-answered consult leg alive with **no bot attached**: the transfer target answered to silence (sipbridge log: `pipecat ws read ended: EOF` one line after `pipecat ws connected`), and the parent's `transfer_state` stayed `dialling` because the crash landed before the `talking` transition.

The freeswitch consult arm had the identical latent crash at its ctx build; voiceblender reuses its pending inbound ctx and was unaffected.

## Fix

Shared `_aplisay_caller_id()` helper reads `metadata.aplisay.callerId`; both consult arms use it.

## Tests

Extended `test_sipbridge_consult_ws_routing.py`: drives flow (b) with a live parent whose `call` is a **real pydantic CallRecord** all the way to `_run_session` — fails on the old code with the AttributeError — pinning the metadata-sourced caller id, TransferAgent composition, and the rejected-on-disconnect parent transition.

Full pipecat suite: **295 passed** (was 292).