### PR TITLE
pipecat: give the sipbridge consult record a real calledId

### DIFF
--- a/agents/pipecat/pipecat_aplisay/sip_gateway/base.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/base.py
@@ -332,11 +332,20 @@ class ConsultPayload:
     voiceblender gateways. Each gateway's ``_do_consultative`` calls
     ``register_consult_session`` to stash it and the worker's per-
     gateway WS handler reads it via ``consult_payload``.
+
+    ``destination`` is the transfer target as requested (pre URI
+    normalisation) — the consult call record's ``calledId``. Gateways
+    whose WS arrival carries the dialled number natively (FreeSWITCH
+    ``start.called_id``, voiceblender's pending inbound ctx) may leave
+    it empty; sipbridge has nothing else to read it from (the bridge
+    dials us back with only the session id in the URL), and the
+    agent-db API rejects a null calledId outright.
     """
 
     parent_session_id: str
     transfer_prompt_template: str
     parent_transcript: str
+    destination: str = ""
 
 
 class ConsultStateMixin:
@@ -384,11 +393,13 @@ class ConsultStateMixin:
         parent_session_id: str,
         transfer_prompt_template: str,
         parent_transcript: str,
+        destination: str = "",
     ) -> None:
         self._consult_payloads[consult_session_id] = ConsultPayload(
             parent_session_id=parent_session_id,
             transfer_prompt_template=transfer_prompt_template,
             parent_transcript=parent_transcript,
+            destination=destination,
         )
 
     def consult_payload(self, session_id: str) -> Optional[ConsultPayload]:

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
@@ -270,12 +270,16 @@ class _SbGatewaySession(GatewaySession):
         )
 
         consult_session_id = f"sb-consult-{uuid.uuid4()}"
-        # Stash the TransferAgent payload for the WS handler.
+        # Stash the TransferAgent payload for the WS handler. ``destination``
+        # rides along because the bridge's callback WS carries only the
+        # session id in the URL — the WS arm needs it for the consult call
+        # record's calledId (a null calledId is a 400 at the agent-db API).
         self._gateway.register_consult_session(
             consult_session_id=consult_session_id,
             parent_session_id=self.session_id,
             transfer_prompt_template=req.transfer_prompt_template or "",
             parent_transcript=req.parent_transcript or "",
+            destination=req.destination or "",
         )
 
         # Trunk / registration egress routing plus the genuine-origin

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -1729,8 +1729,15 @@ async def sipbridge_agent(websocket: WebSocket, session_id: str) -> None:
 
             ctx = InboundCallContext(
                 session_id=session_id,
-                called_id=None,
-                caller_id=_aplisay_caller_id(consult_parent.call),
+                # The consult record's calledId/callerId must be real strings
+                # — the agent-db API 400s a null (beta 2026-08-05: calledId=
+                # None failed every consult-record POST, so the TransferAgent
+                # never spawned and the answered target heard silence).
+                # calledId = the transfer destination, stashed on the
+                # ConsultPayload at _do_consultative time; callerId = the
+                # origin caller from the parent's aplisay metadata.
+                called_id=payload.destination or "unknown",
+                caller_id=_aplisay_caller_id(consult_parent.call) or "unknown",
                 aplisay_id=None,
                 phone_registration=None,
                 b2bua_gateway_ip=None,

--- a/agents/pipecat/tests/test_sipbridge_consult_ws_routing.py
+++ b/agents/pipecat/tests/test_sipbridge_consult_ws_routing.py
@@ -134,6 +134,7 @@ def test_consult_ws_reaches_run_session_with_metadata_caller_id(monkeypatch):
         parent_session_id="parent-session",
         transfer_prompt_template="Consult prompt. ${parentTranscript}",
         parent_transcript="caller: hello",
+        destination="443300889471",
     )
 
     parent_call = api_client.CallRecord(
@@ -178,6 +179,9 @@ def test_consult_ws_reaches_run_session_with_metadata_caller_id(monkeypatch):
     assert not any(m["type"] == "websocket.http.response.start" for m in sent)
     # The crash line: caller id must be read from the aplisay metadata.
     assert captured["ctx"].caller_id == "07970939456"
+    # calledId = the transfer destination stashed on the ConsultPayload
+    # (None here 400s the consult call-record POST — see the payload test).
+    assert captured["ctx"].called_id == "443300889471"
     assert captured["ctx"].raw["consult_of"] == "parent-session"
     # The TransferAgent inherits the parent's model with the consult prompt.
     assert captured["transfer_agent"]["modelName"] == "pipecat:ultravox"
@@ -188,3 +192,82 @@ def test_consult_ws_reaches_run_session_with_metadata_caller_id(monkeypatch):
     assert parent.transfer_state.state == "rejected"
     # Consult registration cleaned up on exit.
     assert gateway.consult_payload(session_id) is None
+
+
+def test_consult_call_record_posts_string_called_and_caller_ids(monkeypatch):
+    """Drive flow (b) through the REAL ``setup_consult_call`` to the
+    agent-db POST.
+
+    Regression (beta 2026-08-05, third incarnation): the sipbridge arm
+    built its consult ctx with ``called_id=None``, and the agent-db API's
+    OpenAPI validation 400s a null calledId ("must be string") — so the
+    consult call record was never created, setup failed, and the answered
+    transfer target heard silence. The record's calledId must be the
+    transfer destination and callerId the origin caller, both strings.
+    """
+    gateway = SipBridgeSipGateway()
+    session_id = "sb-consult-99999999-8888-7777-6666-555555555555"
+    gateway.register_consult_session(
+        consult_session_id=session_id,
+        parent_session_id="parent-session",
+        transfer_prompt_template="Consult prompt. ${parentTranscript}",
+        parent_transcript="caller: hello",
+        destination="443300889471",
+    )
+
+    parent_call = api_client.CallRecord(
+        id="parent-call",
+        userId="user-1",
+        organisationId="org-1",
+        instanceId="instance-1",
+        agentId="agent-1",
+        metadata={"aplisay": {"callerId": "07970939456", "calledId": "+441539454616"}},
+    )
+    parent = SimpleNamespace(
+        session_id="parent-session",
+        call=parent_call,
+        agent={
+            "id": "agent-1",
+            "userId": "user-1",
+            "organisationId": "org-1",
+            "modelName": "pipecat:ultravox",
+            "options": {},
+        },
+        instance={"id": "instance-1"},
+        transfer_state=TransferState("dialling", "Dialling transfer target..."),
+    )
+
+    posted: dict = {}
+
+    async def fake_create_call(call_data: dict):
+        posted.update(call_data)
+        return api_client.CallRecord(
+            id="consult-call-rec",
+            userId=call_data["userId"],
+            organisationId=call_data["organisationId"],
+            instanceId=call_data["instanceId"],
+            agentId=call_data["agentId"],
+            metadata=call_data.get("metadata") or {},
+            options=call_data.get("options") or {},
+        )
+
+    async def fake_start_call(call):
+        return call
+
+    async def fake_run_session(app, session, call_id):
+        posted["ran_call_id"] = call_id
+
+    monkeypatch.setattr(api_client, "create_call", fake_create_call)
+    monkeypatch.setattr(api_client, "start_call", fake_start_call)
+    monkeypatch.setattr(worker, "_run_session", fake_run_session)
+
+    sent = _drive_handler(gateway, session_id, live_calls={"parent-call": parent})
+
+    assert sent[0]["type"] == "websocket.accept"
+    # The 400 killer: both ids must be non-empty strings on the wire.
+    assert posted["calledId"] == "443300889471"
+    assert posted["callerId"] == "07970939456"
+    assert posted["metadata"]["aplisay"]["transferConsultation"] is True
+    assert posted["parentId"] == "parent-call"
+    # The real setup_consult_call completed and the pipeline ran.
+    assert posted["ran_call_id"] == "consult-call-rec"


### PR DESCRIPTION
## Symptom

After the v57 migration, calls connect and the consult leg dials — but the transfer recipient still hears no agent. Latest call (20:02Z):

```
POST /api/agent-db/call -> 400 {"errors":[{"path":"calledId","message":"must be string"}]}
sipbridge consult setup failed: API request failed: 400
```

## Root cause

Third link in the consult chain (after #194 routing, #196 callerId): the sipbridge consult arm hardcodes `called_id=None` into its `InboundCallContext`; `setup_consult_call` posts that as `calledId: null`, the API's OpenAPI validation rejects it, setup fails, the WS closes 1011, and the answered target sits in silence again.

The correct `calledId` is the transfer destination — but the bridge's callback WS carries only the session id in the URL, so the WS arm had nowhere to read it from.

## Fix

- `ConsultPayload` / `register_consult_session` gain a `destination` field (default `""` — freeswitch/voiceblender registrations unchanged; freeswitch reads the dialled number natively from `start.called_id`).
- sipbridge `_do_consultative` stashes `req.destination` at register time.
- The sipbridge WS arm uses `payload.destination` for `called_id`, with `"unknown"` fallbacks on both ids (the API schema requires strings).

## Tests

- Flow (b) handler test now pins `ctx.called_id == destination`.
- New test drives the **real** `setup_consult_call` (api_client patched) and asserts the posted `calledId`/`callerId` strings — both fail on the old code.

Full pipecat suite: **296 passed** (was 295).