### PR TITLE
fix(auth): per-client email rate limits + swallow send-hook errors (enumeration oracle)

### DIFF
--- a/api/paths/users/signup.js
+++ b/api/paths/users/signup.js
@@ -103,7 +103,16 @@ export default function (logger) {
       // Double opt-in for the credential-less new row and any existing-unverified
       // re-submit. Enumeration-safe (no-ops for missing/verified user), so the row
       // MUST exist by here. No request headers => not session-scoped.
-      await auth.api.sendVerificationEmail({ body: { email, callbackURL } });
+      try {
+        await auth.api.sendVerificationEmail({ body: { email, callbackURL } });
+      } catch (err) {
+        // The auth hooks 429 a re-submit once the address's send budget is
+        // spent (lib/auth/send-budget.js) — earlier emails already went out, so
+        // the neutral 'pending' answer below stays truthful. Anything else is a
+        // real failure for the outer catch.
+        if (err?.statusCode !== 429) throw err;
+        logger.warn({ email }, 'signup verification email suppressed by send budget');
+      }
       return res.json({ ok: true, status: 'pending', message: 'Check your inbox to confirm.' });
     } catch (err) {
       logger.error({ err: err?.message }, 'signup failed');

--- a/environment-example
+++ b/environment-example
@@ -40,6 +40,21 @@ BETTER_AUTH_GOOGLE_CLIENT_SECRET=<GOOGLE OAUTH CLIENT SECRET>
 # /confirmed page is the waitlist verification callbackURL (e.g.
 # http://localhost:5173 in dev, https://polite.ai in prod) or the post-verify
 # redirect is origin-rejected.
+#
+# Per-user rate limiting for BFF-proxied auth traffic: the polite-ai BFF
+# forwards the END-USER's IP as `x-client-ip`, authenticated by this shared
+# secret in `x-auth-proxy-secret` (same value in polite-ai's AUTH_PROXY_SECRET).
+# Unset => the header is always stripped and BFF traffic shares one rate bucket.
+# AUTH_PROXY_SECRET=<RANDOM SECRET, `openssl rand -base64 32`>
+#
+# Budgets for the endpoints that send email (/request-password-reset,
+# /send-verification-email): per submitted ADDRESS (hourly/daily, the
+# inbox-bombing guard) and a GLOBAL hourly circuit-breaker for the smtp2go
+# quota. Enforced pre-lookup, uniform 429 — never an enumeration oracle.
+# Counter table is auto-created on the auth DB; no migration step. Defaults:
+# AUTH_EMAIL_PER_ADDRESS_HOURLY=3
+# AUTH_EMAIL_PER_ADDRESS_DAILY=10
+# AUTH_EMAIL_GLOBAL_HOURLY=250
 
 # ── Waitlist (polite.ai coming-soon) ────────────────────────────────────────
 # Where better-auth redirects after the waitlist confirmation link is clicked

--- a/index.mjs
+++ b/index.mjs
@@ -62,10 +62,20 @@ server.use(cors({
 
 // Better-Auth (parallel to Firebase) must mount BEFORE express.json — its node
 // handler reads the raw request body. Inert unless BETTER_AUTH_ENABLED=true.
+// The client-ip gate runs first: it strips `x-client-ip` unless the request
+// carries the AUTH_PROXY_SECRET the polite-ai BFF uses to forward the real
+// end-user IP — that header is what better-auth keys its per-client rate
+// limits on (advanced.ipAddress in lib/auth/index.js), so it must never be
+// spoofable by a direct caller.
 const { auth: betterAuth } = await import('./lib/auth/index.js');
 if (betterAuth) {
   const { toNodeHandler } = await import('better-auth/node');
-  server.all('/api/auth/*', toNodeHandler(betterAuth));
+  const { createClientIpGate } = await import('./lib/auth/client-ip-gate.js');
+  server.all(
+    '/api/auth/*',
+    createClientIpGate({ secret: process.env.AUTH_PROXY_SECRET, logger }),
+    toNodeHandler(betterAuth),
+  );
   logger.info('mounted better-auth at /api/auth/*');
 }
 

--- a/lib/auth/client-ip-gate.js
+++ b/lib/auth/client-ip-gate.js
@@ -1,0 +1,54 @@
+/**
+ * Express gate for the `x-client-ip` header on /api/auth/*.
+ *
+ * polite-ai's BFF proxies the public auth endpoints server-to-server, so the
+ * IP better-auth's rate limiter would otherwise see is the BFF's egress — one
+ * bucket for every user on the platform (the 5/hour platform-wide reset cap).
+ * The BFF therefore forwards the END-USER's IP as `x-client-ip`, authenticated
+ * by the shared secret in `x-auth-proxy-secret`, and better-auth is configured
+ * to read `x-client-ip` ahead of `x-forwarded-for`
+ * (advanced.ipAddress.ipAddressHeaders in lib/auth/index.js).
+ *
+ * This middleware makes that trustworthy: unless the request carries the
+ * matching secret AND a single syntactically-valid IP, `x-client-ip` is
+ * STRIPPED before better-auth can read it — a direct caller cannot spoof
+ * per-client buckets, and with no secret configured the feature is entirely
+ * off. The secret header itself is always removed so it can never leak into
+ * downstream logging.
+ */
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { isIP } from 'node:net';
+
+const CLIENT_IP_HEADER = 'x-client-ip';
+const SECRET_HEADER = 'x-auth-proxy-secret';
+
+// Compare via digests: constant-time and length-blind.
+const digest = (value) => createHash('sha256').update(String(value)).digest();
+
+export function createClientIpGate({ secret, logger }) {
+  const secretHash = secret ? digest(secret) : null;
+  if (!secretHash) {
+    logger?.info('client-ip gate: AUTH_PROXY_SECRET unset — x-client-ip is always stripped');
+  }
+  return function clientIpGate(req, _res, next) {
+    const provided = req.headers[SECRET_HEADER];
+    delete req.headers[SECRET_HEADER];
+
+    const claimed = req.headers[CLIENT_IP_HEADER];
+    const authorised = Boolean(
+      secretHash
+      && typeof provided === 'string'
+      && provided.length > 0
+      && timingSafeEqual(digest(provided), secretHash),
+    );
+    const ip = typeof claimed === 'string' ? claimed.trim() : '';
+    if (authorised && isIP(ip) !== 0) {
+      req.headers[CLIENT_IP_HEADER] = ip;
+    } else {
+      delete req.headers[CLIENT_IP_HEADER];
+    }
+    next();
+  };
+}
+
+export default createClientIpGate;

--- a/lib/auth/email-hooks.js
+++ b/lib/auth/email-hooks.js
@@ -1,0 +1,77 @@
+/**
+ * The outbound-email hooks for better-auth (password reset + verification),
+ * factored out of index.js so their contract is testable in isolation.
+ *
+ * CONTRACT: a send failure is logged and SWALLOWED — never rethrown. better-auth
+ * runs `sendResetPassword` through `runInBackgroundOrAwait` (which swallows),
+ * but AWAITS `sendVerificationEmail` bare on `/send-verification-email`, where
+ * it reaches the hook ONLY for a registered-and-unverified address. A rethrow
+ * there becomes better-call's bare 500 — so during any smtp2go outage the
+ * status code says exactly "this address is registered and unverified": an
+ * account-enumeration oracle on the very handler better-auth gives a 500ms
+ * constant-time floor to hide the same distinction on the timing channel
+ * (polite-ai-website PR #197 findings). Swallowing on BOTH paths keeps every
+ * response account-blind; a mail outage is an OPERATOR signal, carried by the
+ * `… email send FAILED` error logs below — alert on those, they are the only
+ * signal left by design.
+ */
+
+export function createSendHooks({ emailClient, logger }) {
+  return {
+    // Enabling sendResetPassword also turns on the Firebase->Better-Auth bridge
+    // for PASSWORD users: a migrating Firebase row has no Better-Auth credential,
+    // and resetPassword *creates* a `credential` account on that existing row
+    // when none exists — so setting a password lands on the existing user
+    // (id + data preserved), never a dup.
+    sendResetPassword: async ({ user, url }) => {
+      try {
+        const info = await emailClient.send({
+          to: user.email,
+          subject: 'Set your polite.ai password',
+          text: [
+            'Open this link to set your polite.ai password:',
+            '',
+            url,
+            '',
+            "If you didn't request this, you can safely ignore this email.",
+          ].join('\n'),
+        });
+        logger.info({ to: user.email, transport: emailClient.provider, id: info?.id }, 'reset-password email sent');
+      } catch (err) {
+        logger.error({ err: err?.message, to: user.email, transport: emailClient.provider }, 'reset-password email send FAILED');
+      }
+    },
+
+    sendVerificationEmail: async ({ user, url }, request) => {
+      // Invite-completion signups (polite-ai onboarding) already proved address
+      // ownership via the emailed invite link — skip the redundant double opt-in
+      // mail. Spoofing the header only suppresses the sender's own email; the
+      // account is provisional-gated regardless.
+      if (request?.headers?.get('x-onboarding-invite') === 'complete') {
+        logger.info({ to: user.email }, 'verification email suppressed (invite-completion signup)');
+        return;
+      }
+      try {
+        const info = await emailClient.send({
+          to: user.email,
+          subject: 'Confirm your polite.ai subscription',
+          text: [
+            'Thanks for registering your interest in polite.ai.',
+            '',
+            'Please confirm your subscription by opening this link:',
+            url,
+            '',
+            "If you didn't request this, you can safely ignore this email.",
+            '',
+            '— polite.ai · Communication, reimagined.',
+          ].join('\n'),
+        });
+        logger.info({ to: user.email, transport: emailClient.provider, id: info?.id }, 'verification email sent');
+      } catch (err) {
+        logger.error({ err: err?.message, to: user.email, transport: emailClient.provider }, 'verification email send FAILED');
+      }
+    },
+  };
+}
+
+export default createSendHooks;

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -28,6 +28,9 @@ const {
   BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION,
   BETTER_AUTH_GOOGLE_CLIENT_ID,
   BETTER_AUTH_GOOGLE_CLIENT_SECRET,
+  AUTH_EMAIL_PER_ADDRESS_HOURLY,
+  AUTH_EMAIL_PER_ADDRESS_DAILY,
+  AUTH_EMAIL_GLOBAL_HOURLY,
   POSTGRES_DB,
   POSTGRES_USER,
   POSTGRES_HOST,
@@ -46,8 +49,11 @@ let auth = null;
 if (enabled) {
   const { betterAuth } = await import('better-auth');
   const { bearer, oneTimeToken } = await import('better-auth/plugins');
+  const { createAuthMiddleware, APIError } = await import('better-auth/api');
   const { Pool } = await import('pg');
   const { createEmailClient } = await import('@aplisay/email');
+  const { createSendBudget } = await import('./send-budget.js');
+  const { createSendHooks } = await import('./email-hooks.js');
 
   if (!BETTER_AUTH_SECRET) {
     logger.error('BETTER_AUTH_ENABLED=true but BETTER_AUTH_SECRET is unset — refusing to boot with broken token signing');
@@ -73,6 +79,8 @@ if (enabled) {
     );
   }
 
+  const sendHooks = createSendHooks({ emailClient, logger });
+
   // Its own pool to the same database (Better-Auth uses the Kysely adapter; it
   // cannot share Sequelize's pool). Mirrors the SSL config in lib/database.js.
   const pool = new Pool({
@@ -95,6 +103,21 @@ if (enabled) {
     ? BETTER_AUTH_TRUSTED_ORIGINS.split(',').map((s) => s.trim()).filter(Boolean)
     : ['http://localhost:3000', 'http://localhost:3001', 'http://localhost:3030', 'http://localhost:5173']);
 
+  // Budgets for the endpoints that cause outbound email. Enforced pre-lookup in
+  // hooks.before (below), keyed on the SUBMITTED address + a global breaker, so
+  // rejection can never reveal whether an account exists. Counters live on the
+  // auth pool (table auto-created; no migration to forget).
+  const posNum = (v, dflt) => (Number.isFinite(Number(v)) && Number(v) > 0 ? Number(v) : dflt);
+  const sendBudget = createSendBudget({
+    pool,
+    logger,
+    caps: {
+      addressHourly: posNum(AUTH_EMAIL_PER_ADDRESS_HOURLY, 3),
+      addressDaily: posNum(AUTH_EMAIL_PER_ADDRESS_DAILY, 10),
+      globalHourly: posNum(AUTH_EMAIL_GLOBAL_HOURLY, 250),
+    },
+  });
+
   auth = betterAuth({
     database: pool,
     baseURL: BETTER_AUTH_URL || `http://localhost:${process.env.WS_PORT || 4000}`,
@@ -102,32 +125,82 @@ if (enabled) {
     secret: BETTER_AUTH_SECRET,
     trustedOrigins,
 
-    // Rate limiting. better-auth ships sensible per-IP, per-path defaults
-    // (/sign-in & /sign-up: 3 per 10s; password-reset & verification-email
-    // sends: 3 per 60s) but ENABLES them only when NODE_ENV=production — so they
-    // are off in staging/feature. Turn them on in every environment, and tighten
-    // the email-sending endpoints to an hourly cap: each call hits
-    // emailClient.send (real cost + inbox-bombing risk). Client IP is taken from
-    // the leftmost X-Forwarded-For (Cloud Run) by better-auth's getIp.
-    // NB: storage is in-memory, so caps are per process — the effective limit is
-    // max × running instances under Cloud Run autoscaling. Switch storage to
-    // 'database' (needs an auth migration) for a hard cluster-wide limit.
+    // Rate limiting, three layers deep on the email-sending endpoints:
+    //
+    //  1. better-auth's per-IP limiter (this block). The IP is resolved from
+    //     `x-client-ip` first — which only survives the client-ip-gate in
+    //     index.mjs when the polite-ai BFF authenticated it with
+    //     AUTH_PROXY_SECRET — then `x-forwarded-for` under getIp's own rules.
+    //     With the BFF forwarding end-user IPs these buckets are genuinely
+    //     per-person; before that they collapsed to ONE bucket for all BFF
+    //     traffic (a platform-wide 5/hour reset ceiling — the 6th user in any
+    //     hour could not reset their password).
+    //  2. per-ADDRESS budgets (hooks.before, below): hourly + daily caps on the
+    //     submitted address, IP-independent, so no inbox can be bombed through
+    //     us from a botnet.
+    //  3. a GLOBAL hourly breaker (same hook) guarding the smtp2go quota and
+    //     sender reputation; tripping it is an incident, and the error log it
+    //     emits is the alert.
+    //
+    // better-auth ships per-IP defaults but ENABLES them only when
+    // NODE_ENV=production; turn them on in every environment.
+    // NB: this layer's storage is in-memory, so ITS caps are per process
+    // (max × running instances under autoscaling). That is acceptable for a
+    // UX-shaping per-person limit; the security-critical bounds (layers 2-3)
+    // are database-backed and cluster-wide. Switching this layer to
+    // storage:'database' needs an auth migration wired into deploy first — the
+    // satellite-tables incident is what happens when that step is manual.
     rateLimit: {
       enabled: true,
       customRules: {
-        '/forget-password': { window: 3600, max: 5 },
-        '/request-password-reset': { window: 3600, max: 5 },
-        '/send-verification-email': { window: 3600, max: 5 },
+        '/forget-password': { window: 3600, max: 10 },
+        '/request-password-reset': { window: 3600, max: 10 },
+        '/send-verification-email': { window: 3600, max: 10 },
         // OTT hand-off (Google sign-in → polite-ai BFF session capture, see
         // lib/auth/oauth-handoff.js). verify is PUBLIC but called SERVER-side by
-        // the polite-ai BFF, so per-IP here means per-BFF-egress-IP — i.e. a
-        // PLATFORM-WIDE Google-sign-in ceiling, not per-user. Size it for burst
-        // headroom; the real brute-force guard is the 32-char single-use token
-        // with a 1-minute TTL, hashed at rest. generate is session-gated and
-        // blocked for direct client calls (disableClientRequest) but capped anyway.
+        // the polite-ai BFF; once the BFF forwards end-user IPs (x-client-ip)
+        // these buckets become per-user too — until then per-BFF-egress-IP.
+        // Size for burst headroom; the real brute-force guard is the 32-char
+        // single-use token with a 1-minute TTL, hashed at rest. generate is
+        // session-gated and blocked for direct client calls
+        // (disableClientRequest) but capped anyway.
         '/one-time-token/verify': { window: 60, max: 120 },
         '/one-time-token/generate': { window: 60, max: 10 },
       },
+    },
+
+    // `x-client-ip` FIRST: it can only be present when the client-ip-gate
+    // verified the BFF's shared secret (index.mjs strips it otherwise), so it
+    // outranks x-forwarded-for. Browsers can never supply it (CORS never
+    // allows the header and the gate drops it regardless).
+    advanced: {
+      ipAddress: { ipAddressHeaders: ['x-client-ip', 'x-forwarded-for'] },
+    },
+
+    // Pre-lookup send budgets (layers 2-3 above). Runs for every dispatch of
+    // the three email endpoints — HTTP and server-side auth.api calls alike —
+    // BEFORE any user lookup, on the SUBMITTED address only, with identical
+    // work whether or not an account exists: a 429 here is uniform and
+    // therefore not an account-enumeration oracle. Malformed bodies fall
+    // through to the endpoint's own validation.
+    hooks: {
+      before: createAuthMiddleware(async (ctx) => {
+        const kind = { '/request-password-reset': 'reset', '/forget-password': 'reset', '/send-verification-email': 'verify' }[ctx.path];
+        const email = typeof ctx.body?.email === 'string' ? ctx.body.email : null;
+        if (!kind || !email) return;
+        const verdict = await sendBudget.consume({ kind, email });
+        if (!verdict.allowed) {
+          // Global-scope trips are the platform email circuit-breaker — the
+          // error log is the pager signal. Address-scope trips are routine.
+          logger[verdict.scope === 'global-hour' ? 'error' : 'warn'](
+            { kind, scope: verdict.scope, to: email },
+            'email send budget exhausted — request rejected 429',
+          );
+          throw new APIError('TOO_MANY_REQUESTS', {
+            message: 'Too many email requests. Please wait a while before trying again.',
+          });
+        }
+      }),
     },
 
     // Mirror the Firebase methods: email/password + Google.
@@ -138,30 +211,10 @@ if (enabled) {
       // Off by default for easy WIP testing; flip to mirror Firebase's verified-
       // email gate (the SPA AuthProvider already maps emailVerified -> status).
       requireEmailVerification: BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION === 'true',
-      // WIP email transport: log the reset link. Enabling sendResetPassword also
-      // turns on the Firebase->Better-Auth bridge for PASSWORD users: a migrating
-      // Firebase row has no Better-Auth credential, and resetPassword *creates* a
-      // `credential` account on that existing row when none exists — so setting a
-      // password lands on the existing user (id + data preserved), never a dup.
-      sendResetPassword: async ({ user, url }) => {
-        try {
-          const info = await emailClient.send({
-            to: user.email,
-            subject: 'Set your polite.ai password',
-            text: [
-              'Open this link to set your polite.ai password:',
-              '',
-              url,
-              '',
-              "If you didn't request this, you can safely ignore this email.",
-            ].join('\n'),
-          });
-          logger.info({ to: user.email, transport: emailClient.provider, id: info?.id }, 'reset-password email sent');
-        } catch (err) {
-          logger.error({ err: err?.message, to: user.email, transport: emailClient.provider }, 'reset-password email send FAILED');
-          throw err;
-        }
-      },
+      // Send hooks live in email-hooks.js. CONTRACT: they log-and-swallow send
+      // failures (never rethrow) so no response status can depend on whether an
+      // address is registered — see that module for the full rationale.
+      sendResetPassword: sendHooks.sendResetPassword,
     },
     socialProviders: (BETTER_AUTH_GOOGLE_CLIENT_ID && BETTER_AUTH_GOOGLE_CLIENT_SECRET)
       ? {
@@ -206,36 +259,11 @@ if (enabled) {
     emailVerification: {
       sendOnSignUp: true,
       expiresIn: 60 * 60 * 24 * 7, // 7 days
-      sendVerificationEmail: async ({ user, url }, request) => {
-        // Invite-completion signups (polite-ai onboarding) already proved address
-        // ownership via the emailed invite link — skip the redundant double opt-in
-        // mail. Spoofing the header only suppresses the sender's own email; the
-        // account is provisional-gated regardless.
-        if (request?.headers?.get('x-onboarding-invite') === 'complete') {
-          logger.info({ to: user.email }, 'verification email suppressed (invite-completion signup)');
-          return;
-        }
-        try {
-          const info = await emailClient.send({
-            to: user.email,
-            subject: 'Confirm your polite.ai subscription',
-            text: [
-              'Thanks for registering your interest in polite.ai.',
-              '',
-              'Please confirm your subscription by opening this link:',
-              url,
-              '',
-              "If you didn't request this, you can safely ignore this email.",
-              '',
-              '— polite.ai · Communication, reimagined.',
-            ].join('\n'),
-          });
-          logger.info({ to: user.email, transport: emailClient.provider, id: info?.id }, 'verification email sent');
-        } catch (err) {
-          logger.error({ err: err?.message, to: user.email, transport: emailClient.provider }, 'verification email send FAILED');
-          throw err;
-        }
-      },
+      // Log-and-swallow, same contract as sendResetPassword above: a rethrow
+      // here used to become a bare 500 that fired ONLY for registered-and-
+      // unverified addresses (better-auth awaits this hook, unlike the reset
+      // one) — an enumeration oracle during any mail outage. See email-hooks.js.
+      sendVerificationEmail: sendHooks.sendVerificationEmail,
     },
 
     // Carry the session token as Authorization: Bearer, like the Firebase flow.

--- a/lib/auth/send-budget.js
+++ b/lib/auth/send-budget.js
@@ -1,0 +1,104 @@
+/**
+ * Email-send budgets for the public better-auth endpoints that cause outbound
+ * mail (`/request-password-reset`, `/forget-password`, `/send-verification-email`).
+ *
+ * Three fixed-window counters, checked in order with short-circuit:
+ *   1. per submitted address, hourly  — a person re-requesting their own email;
+ *   2. per submitted address, daily   — inbox-bombing guard: nobody's mailbox can
+ *      be flooded through us, however many IPs the requests come from;
+ *   3. global, hourly                 — circuit-breaker for the smtp2go quota /
+ *      sender reputation under distributed abuse.
+ *
+ * The caller enforces these BEFORE any account lookup, keyed only on the
+ * SUBMITTED address — identical work and identical outcome whether or not an
+ * account exists — so a rejection is safe to surface as a 429 without becoming
+ * an account-enumeration oracle. (Inherent trade, accepted: anyone can spend a
+ * given address's budget, so a determined attacker can force a specific victim
+ * to the support channel. Every per-address cap has this property.)
+ *
+ * Counters live in their own table on the better-auth pool, created lazily
+ * (CREATE TABLE IF NOT EXISTS) so no migration step is needed — see the
+ * satellite-tables deploy incident for why auth migrations must not be load-
+ * bearing. Windows are anchored at the first request and do NOT slide on
+ * rejection. On any storage error the check FAILS OPEN: sending email must not
+ * depend on the limiter's availability.
+ */
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const CLEANUP_EVERY = 1000;
+
+const CREATE_SQL = `
+  CREATE TABLE IF NOT EXISTS auth_send_limits (
+    key          text PRIMARY KEY,
+    window_start bigint  NOT NULL,
+    count        integer NOT NULL
+  )`;
+
+// Atomic bump-and-read: reset the window if it has expired, else increment.
+// Always increments (an over-cap request still counts), so `count <= cap` is
+// the allow test and a hammered bucket stays closed for a full window from its
+// first request.
+const BUMP_SQL = `
+  INSERT INTO auth_send_limits (key, window_start, count) VALUES ($1, $2, 1)
+  ON CONFLICT (key) DO UPDATE SET
+    count        = CASE WHEN auth_send_limits.window_start <= $3 THEN 1 ELSE auth_send_limits.count + 1 END,
+    window_start = CASE WHEN auth_send_limits.window_start <= $3 THEN $2 ELSE auth_send_limits.window_start END
+  RETURNING count`;
+
+export function createSendBudget({ pool, logger, caps }) {
+  const { addressHourly, addressDaily, globalHourly } = caps;
+  let ensured = null;
+  let calls = 0;
+
+  function ensure() {
+    if (!ensured) {
+      ensured = pool.query(CREATE_SQL).catch((err) => {
+        ensured = null; // retry on the next consume
+        throw err;
+      });
+    }
+    return ensured;
+  }
+
+  async function bump(key, windowMs, now) {
+    const { rows } = await pool.query(BUMP_SQL, [key, now, now - windowMs]);
+    return rows[0].count;
+  }
+
+  /**
+   * Spend one unit of budget for a send request. Returns
+   * `{ allowed: boolean, scope?: 'address-hour'|'address-day'|'global-hour' }`.
+   * Never throws.
+   */
+  async function consume({ kind, email }) {
+    const now = Date.now();
+    const addr = String(email).trim().toLowerCase();
+    try {
+      await ensure();
+      if ((++calls % CLEANUP_EVERY) === 0) {
+        // Opportunistic sweep of long-dead windows; failure is irrelevant.
+        pool.query('DELETE FROM auth_send_limits WHERE window_start < $1', [now - 7 * DAY_MS])
+          .catch(() => { });
+      }
+      if (await bump(`h:${kind}:${addr}`, HOUR_MS, now) > addressHourly) {
+        return { allowed: false, scope: 'address-hour' };
+      }
+      if (await bump(`d:${kind}:${addr}`, DAY_MS, now) > addressDaily) {
+        return { allowed: false, scope: 'address-day' };
+      }
+      // Global last, so per-address abuse can't spend the platform's budget.
+      if (await bump('g:sends', HOUR_MS, now) > globalHourly) {
+        return { allowed: false, scope: 'global-hour' };
+      }
+      return { allowed: true };
+    } catch (err) {
+      logger.error({ err: err?.message }, 'send-budget check failed — failing OPEN (send allowed)');
+      return { allowed: true, degraded: true };
+    }
+  }
+
+  return { consume };
+}
+
+export default createSendBudget;

--- a/tests/auth-client-ip-gate.test.mjs
+++ b/tests/auth-client-ip-gate.test.mjs
@@ -1,0 +1,69 @@
+// client-ip-gate (lib/auth/client-ip-gate.js): `x-client-ip` survives ONLY when
+// the request carries the matching AUTH_PROXY_SECRET and a single valid IP;
+// the secret header itself never survives. No DB needed.
+import { createClientIpGate } from '../lib/auth/client-ip-gate.js';
+
+const quietLogger = { info() { }, warn() { }, error() { } };
+
+function run(gate, headers) {
+  const req = { headers: { ...headers } };
+  let nexted = false;
+  gate(req, {}, () => { nexted = true; });
+  expect(nexted).toBe(true);
+  return req.headers;
+}
+
+describe('client-ip gate', () => {
+  const SECRET = 'squeamish-ossifrage';
+  const gate = createClientIpGate({ secret: SECRET, logger: quietLogger });
+
+  it('keeps a valid IP when the secret matches, and strips the secret header', () => {
+    const headers = run(gate, {
+      'x-client-ip': ' 203.0.113.9 ',
+      'x-auth-proxy-secret': SECRET,
+      'x-forwarded-for': '10.0.0.1',
+    });
+    expect(headers['x-client-ip']).toBe('203.0.113.9');
+    expect(headers['x-auth-proxy-secret']).toBeUndefined();
+    expect(headers['x-forwarded-for']).toBe('10.0.0.1'); // untouched
+  });
+
+  it('keeps a valid IPv6 address', () => {
+    const headers = run(gate, { 'x-client-ip': '2001:db8::1', 'x-auth-proxy-secret': SECRET });
+    expect(headers['x-client-ip']).toBe('2001:db8::1');
+  });
+
+  it('strips the IP on a wrong secret', () => {
+    const headers = run(gate, { 'x-client-ip': '203.0.113.9', 'x-auth-proxy-secret': 'nope' });
+    expect(headers['x-client-ip']).toBeUndefined();
+    expect(headers['x-auth-proxy-secret']).toBeUndefined();
+  });
+
+  it('strips the IP when no secret is presented', () => {
+    const headers = run(gate, { 'x-client-ip': '203.0.113.9' });
+    expect(headers['x-client-ip']).toBeUndefined();
+  });
+
+  it.each([
+    ['not an IP', 'localhost'],
+    ['truncated IPv4', '1.2.3'],
+    ['a list', '203.0.113.9, 198.51.100.2'],
+  ])('strips %s even with the right secret', (_label, value) => {
+    const headers = run(gate, { 'x-client-ip': value, 'x-auth-proxy-secret': SECRET });
+    expect(headers['x-client-ip']).toBeUndefined();
+  });
+
+  it('strips a repeated (array) header', () => {
+    const headers = run(gate, {
+      'x-client-ip': ['203.0.113.9', '198.51.100.2'],
+      'x-auth-proxy-secret': SECRET,
+    });
+    expect(headers['x-client-ip']).toBeUndefined();
+  });
+
+  it('always strips when no secret is configured (feature off)', () => {
+    const off = createClientIpGate({ secret: undefined, logger: quietLogger });
+    const headers = run(off, { 'x-client-ip': '203.0.113.9', 'x-auth-proxy-secret': '' });
+    expect(headers['x-client-ip']).toBeUndefined();
+  });
+});

--- a/tests/auth-email-hooks.test.mjs
+++ b/tests/auth-email-hooks.test.mjs
@@ -1,0 +1,69 @@
+// Send hooks (lib/auth/email-hooks.js). The load-bearing contract: a send
+// failure is logged and SWALLOWED — a rethrow from sendVerificationEmail
+// becomes better-call's bare 500, which fires only for registered-and-
+// unverified addresses (an enumeration oracle during any mail outage).
+import { createSendHooks } from '../lib/auth/email-hooks.js';
+
+function harness({ sendFails = false } = {}) {
+  const sent = [];
+  const logs = { info: [], error: [] };
+  const emailClient = {
+    provider: 'test',
+    send: async (msg) => {
+      if (sendFails) throw new Error('smtp2go down');
+      sent.push(msg);
+      return { id: 'msg-1' };
+    },
+  };
+  const logger = {
+    info: (...a) => logs.info.push(a),
+    error: (...a) => logs.error.push(a),
+  };
+  return { hooks: createSendHooks({ emailClient, logger }), sent, logs };
+}
+
+const user = { email: 'someone@example.com' };
+
+describe('sendResetPassword', () => {
+  it('sends and logs on success', async () => {
+    const { hooks, sent, logs } = harness();
+    await hooks.sendResetPassword({ user, url: 'https://x/reset?token=t' });
+    expect(sent).toHaveLength(1);
+    expect(sent[0].to).toBe(user.email);
+    expect(sent[0].text).toContain('https://x/reset?token=t');
+    expect(logs.error).toHaveLength(0);
+  });
+
+  it('RESOLVES (never rejects) when the send fails, logging the failure', async () => {
+    const { hooks, logs } = harness({ sendFails: true });
+    await expect(hooks.sendResetPassword({ user, url: 'https://x/r' })).resolves.toBeUndefined();
+    expect(logs.error).toHaveLength(1);
+    expect(logs.error[0][1]).toBe('reset-password email send FAILED');
+  });
+});
+
+describe('sendVerificationEmail', () => {
+  it('sends and logs on success', async () => {
+    const { hooks, sent } = harness();
+    await hooks.sendVerificationEmail({ user, url: 'https://x/verify?token=t' }, undefined);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].text).toContain('https://x/verify?token=t');
+  });
+
+  it('RESOLVES (never rejects) when the send fails, logging the failure', async () => {
+    const { hooks, logs } = harness({ sendFails: true });
+    await expect(
+      hooks.sendVerificationEmail({ user, url: 'https://x/v' }, undefined),
+    ).resolves.toBeUndefined();
+    expect(logs.error).toHaveLength(1);
+    expect(logs.error[0][1]).toBe('verification email send FAILED');
+  });
+
+  it('suppresses the email for invite-completion signups', async () => {
+    const { hooks, sent, logs } = harness();
+    const request = { headers: new Headers({ 'x-onboarding-invite': 'complete' }) };
+    await hooks.sendVerificationEmail({ user, url: 'https://x/v' }, request);
+    expect(sent).toHaveLength(0);
+    expect(logs.info.some(([, msg]) => String(msg).includes('suppressed'))).toBe(true);
+  });
+});

--- a/tests/auth-send-budget.test.mjs
+++ b/tests/auth-send-budget.test.mjs
@@ -1,0 +1,130 @@
+// Email send-budget counters (lib/auth/send-budget.js): per-address hour/day
+// caps + global hourly breaker, fixed windows anchored at first request,
+// fail-OPEN on storage errors. Uses the test Postgres directly (same container
+// the wrapper points every suite at) — the helper owns its own table.
+import './setup/database-test-wrapper.js'; // sets POSTGRES_* to the test container
+import { randomUUID } from 'node:crypto';
+import pg from 'pg';
+import { createSendBudget } from '../lib/auth/send-budget.js';
+
+const quietLogger = { info() { }, warn() { }, debug() { }, trace() { }, error() { } };
+
+let pool;
+
+const addr = () => `${randomUUID()}@example.com`;
+const budget = (caps) => createSendBudget({
+  pool,
+  logger: quietLogger,
+  caps: { addressHourly: 3, addressDaily: 10, globalHourly: 10_000, ...caps },
+});
+
+beforeAll(async () => {
+  pool = new pg.Pool({
+    host: process.env.POSTGRES_HOST,
+    port: Number(process.env.POSTGRES_PORT),
+    database: process.env.POSTGRES_DB,
+    user: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD,
+  });
+  await pool.query('SELECT 1'); // fail fast if the test DB is down
+});
+
+afterAll(async () => {
+  await pool?.end();
+});
+
+describe('send-budget per-address hourly cap', () => {
+  it('allows up to the cap then denies with scope address-hour', async () => {
+    const b = budget({});
+    const email = addr();
+    for (let i = 0; i < 3; i++) {
+      expect(await b.consume({ kind: 'reset', email })).toEqual({ allowed: true });
+    }
+    expect(await b.consume({ kind: 'reset', email }))
+      .toEqual({ allowed: false, scope: 'address-hour' });
+  });
+
+  it('normalises case and whitespace into one bucket', async () => {
+    const b = budget({ addressHourly: 1 });
+    const email = addr();
+    expect((await b.consume({ kind: 'reset', email })).allowed).toBe(true);
+    const shouted = ` ${email.toUpperCase()} `;
+    expect(await b.consume({ kind: 'reset', email: shouted }))
+      .toEqual({ allowed: false, scope: 'address-hour' });
+  });
+
+  it('keeps kinds in separate buckets', async () => {
+    const b = budget({ addressHourly: 1 });
+    const email = addr();
+    expect((await b.consume({ kind: 'reset', email })).allowed).toBe(true);
+    expect((await b.consume({ kind: 'verify', email })).allowed).toBe(true);
+    expect((await b.consume({ kind: 'reset', email })).allowed).toBe(false);
+  });
+
+  it('reopens after the window expires (window does not slide on rejection)', async () => {
+    const b = budget({ addressHourly: 1 });
+    const email = addr();
+    expect((await b.consume({ kind: 'reset', email })).allowed).toBe(true);
+    expect((await b.consume({ kind: 'reset', email })).allowed).toBe(false);
+    // Age the hour bucket past its window; the day bucket stays fresh.
+    await pool.query(
+      'UPDATE auth_send_limits SET window_start = window_start - $1 WHERE key = $2',
+      [61 * 60 * 1000, `h:reset:${email}`],
+    );
+    expect((await b.consume({ kind: 'reset', email })).allowed).toBe(true);
+  });
+});
+
+describe('send-budget per-address daily cap', () => {
+  it('denies with scope address-day once the day budget is spent', async () => {
+    const b = budget({ addressHourly: 100, addressDaily: 2 });
+    const email = addr();
+    expect((await b.consume({ kind: 'verify', email })).allowed).toBe(true);
+    expect((await b.consume({ kind: 'verify', email })).allowed).toBe(true);
+    expect(await b.consume({ kind: 'verify', email }))
+      .toEqual({ allowed: false, scope: 'address-day' });
+  });
+});
+
+describe('send-budget global breaker', () => {
+  it('denies with scope global-hour across distinct addresses', async () => {
+    // The global counter is a single shared key, so start from its live value.
+    const probe = budget({});
+    await probe.consume({ kind: 'reset', email: addr() });
+    const { rows } = await pool.query(
+      "SELECT count FROM auth_send_limits WHERE key = 'g:sends'",
+    );
+    const b = budget({ globalHourly: rows[0].count + 1 });
+    expect((await b.consume({ kind: 'reset', email: addr() })).allowed).toBe(true);
+    expect(await b.consume({ kind: 'reset', email: addr() }))
+      .toEqual({ allowed: false, scope: 'global-hour' });
+  });
+
+  it('address-scope denials do not spend the global budget', async () => {
+    const before = await pool.query(
+      "SELECT count FROM auth_send_limits WHERE key = 'g:sends'",
+    );
+    const b = budget({ addressHourly: 1 });
+    const email = addr();
+    await b.consume({ kind: 'reset', email });
+    await b.consume({ kind: 'reset', email }); // denied at address-hour
+    const after = await pool.query(
+      "SELECT count FROM auth_send_limits WHERE key = 'g:sends'",
+    );
+    expect(after.rows[0].count).toBe(before.rows[0].count + 1);
+  });
+});
+
+describe('send-budget failure mode', () => {
+  it('fails OPEN when storage errors', async () => {
+    const errors = [];
+    const b = createSendBudget({
+      pool: { query: async () => { throw new Error('pg down'); } },
+      logger: { ...quietLogger, error: (...args) => errors.push(args) },
+      caps: { addressHourly: 1, addressDaily: 1, globalHourly: 1 },
+    });
+    expect(await b.consume({ kind: 'reset', email: addr() }))
+      .toEqual({ allowed: true, degraded: true });
+    expect(errors.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes #198. 

## What was wrong

Two defects on `/request-password-reset` and `/send-verification-email`.

1. **The 5/hour cap was platform-wide.** the auth owner proxies these endpoints server-to-server, so better-auth's `getIp` collapsed every end-user into one rate bucket. The 6th password reset in any rolling hour — usually an unrelated user — was refused.
2. **A mail outage became an account-enumeration oracle.** `sendVerificationEmail` rethrew send failures; better-auth awaits that hook bare and reaches it *only* for a registered-and-unverified address (unknown / verified addresses mint a decoy token and 200). A bare 500 therefore meant exactly "this address is registered and unverified" — on the same handler better-auth gives a 500ms constant-time floor to hide that distinction on the timing channel. (The reset path already swallowed hook errors via `runInBackgroundOrAwait`.)

## What this PR does

**Per-client IP keying** — `lib/auth/client-ip-gate.js`, mounted ahead of the better-auth handler in `index.mjs`: `x-client-ip` survives only when the request carries the matching `AUTH_PROXY_SECRET` in `x-auth-proxy-secret` (constant-time digest compare, single valid IP only, secret header always removed). better-auth reads it first via `advanced.ipAddress.ipAddressHeaders`, so the BFF can forward the real end-user IP and the existing per-IP `customRules` become genuinely per-person (raised 5 → 10/hour). Secret unset ⇒ header always stripped ⇒ exactly today's behaviour.

**Per-address budgets + global breaker** — `lib/auth/send-budget.js`, enforced in `hooks.before` for the three email paths (`/request-password-reset`, `/forget-password`, `/send-verification-email`), HTTP and server-side `auth.api` dispatches alike:

- per submitted address: 3/hour, 10/day (`AUTH_EMAIL_PER_ADDRESS_*`) — the inbox-bombing guard, immune to IP rotation;
- global: 250/hour (`AUTH_EMAIL_GLOBAL_HOURLY`) — the smtp2go quota / sender-reputation circuit-breaker; tripping it logs at ERROR (that log is the pager signal).

Enforced **before any user lookup**, keyed only on the submitted address, identical work for known and unknown addresses — so the 429 is uniform and not an enumeration oracle. Counters are fixed-window (anchored at first request, no slide on rejection), stored in an auto-created table on the auth pool (deliberately **no migration step** — see the satellite-tables incident), and the check **fails open** on storage errors: sending mail never depends on the limiter's availability.

**Send hooks log-and-swallow** — `lib/auth/email-hooks.js` (factored out of `index.js`, contract now testable): both hooks catch, log `… email send FAILED` at ERROR, and return. No response status can depend on whether an address is registered. Mail outages are an operator signal — **alert on those logs**; they are the only signal left, by design. Side benefit: a send failure during self-signup no longer 500s the signup.

**Signup resend tolerance** — `api/paths/users/signup.js` treats a budget 429 from the double-opt-in resend as the neutral `pending` answer (earlier emails already consumed that address's budget, so "check your inbox" stays truthful).

## Rate-limit layers after this PR

| Layer | Key | Store | Purpose |
|---|---|---|---|
| better-auth per-IP (10/hr) | end-user IP (BFF-forwarded, secret-gated) | memory, per process | per-person UX shaping |
| address budget (3/hr, 10/day) | submitted address | Postgres, cluster-wide | inbox-bombing guard |
| global breaker (250/hr) | — | Postgres, cluster-wide | smtp2go quota / reputation |

## Deploy

Generate one secret (`openssl rand -base64 32`), set `AUTH_PROXY_SECRET` here and in any client app that uses our auth. Either side without it degrades to current behaviour. Deploy llm-agent before client.

## Verify

- New: `tests/auth-send-budget.test.mjs` (windows, scopes, normalisation, global accounting, fail-open), `tests/auth-client-ip-gate.test.mjs` (stripping matrix incl. arrays/lists/invalid IPs), `tests/auth-email-hooks.test.mjs` (resolve-never-reject contract, invite suppression).
- Full suite: **65 suites / 686 tests passing** (was 664 before this PR).


