### PR TITLE
fix: surface the organisation name on GET /api/me

### DIFF
--- a/lib/auth/permissions.js
+++ b/lib/auth/permissions.js
@@ -212,6 +212,16 @@ function resolveStatements(entity) {
 }
 
 /**
+ * The Organisation columns an RBAC principal load needs (middleware/auth.js →
+ * attachRbac). Kept deliberately narrow so the per-request load stays cheap:
+ * the RBAC inputs (`status`/`role`/`permissions`/`allowedModels`) plus `name`,
+ * which is the one presentational field principals read back (GET /api/me
+ * labels a dashboard shell with it — omitting it silently rendered
+ * `organisationName: null` for every lazily-loaded principal, issue #203).
+ */
+export const ORGANISATION_RBAC_ATTRIBUTES = ['id', 'name', 'status', 'role', 'permissions', 'allowedModels'];
+
+/**
  * Effective action permissions for a user, with their organisation as the
  * baseline floor (R2). `org` is normally the eager-loaded `user.Organisation`.
  */
@@ -340,4 +350,4 @@ export function validateRbacFields(body = {}) {
   return null;
 }
 
-export default { statements, roles, mergeStatements, statementsFor, modelsFor, effectivePermissions, can, requirePermission, containsCrossTenant, isSubsetOf, actorCanGrant, intersectStatements, keyRestrictionStatements, validateRbacFields };
+export default { statements, roles, ORGANISATION_RBAC_ATTRIBUTES, mergeStatements, statementsFor, modelsFor, effectivePermissions, can, requirePermission, containsCrossTenant, isSubsetOf, actorCanGrant, intersectStatements, keyRestrictionStatements, validateRbacFields };

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -4,7 +4,7 @@ import { scopeWhereForUser } from '../lib/scope.js';
 import * as firebase from 'firebase-admin/auth';
 import { auth as betterAuth } from '../lib/auth/index.js';
 import { fromNodeHeaders } from 'better-auth/node';
-import { effectivePermissions, statementsFor, intersectStatements, keyRestrictionStatements, can } from '../lib/auth/permissions.js';
+import { effectivePermissions, statementsFor, intersectStatements, keyRestrictionStatements, can, ORGANISATION_RBAC_ATTRIBUTES } from '../lib/auth/permissions.js';
 import { effectiveAllowedModels } from '../lib/auth/model-access.js';
 import { isBootstrapSuperAdmin } from '../lib/admin-gate.js';
 
@@ -80,7 +80,7 @@ async function attachRbac(user) {
   if (user.organisationId && !user.Organisation) {
     try {
       user.Organisation = await Organisation.findByPk(user.organisationId, {
-        attributes: ['id', 'status', 'role', 'permissions', 'allowedModels'],
+        attributes: ORGANISATION_RBAC_ATTRIBUTES,
       });
     } catch (e) {
       // FAIL CLOSED: never proceed with user-only perms (which would silently drop

--- a/tests/me-organisation-name.test.mjs
+++ b/tests/me-organisation-name.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * Regression: GET /api/me must report the caller's organisation NAME (issue #203).
+ *
+ * The bug was upstream of the handler: attachRbac lazy-loaded the Organisation
+ * with an attribute allow-list that omitted `name`, so `u.Organisation.name`
+ * was undefined and `?? null` made it look like a legitimate "unnamed org".
+ * Both halves are asserted here: the load selects `name`, and the handler
+ * surfaces it.
+ */
+import { ORGANISATION_RBAC_ATTRIBUTES } from '../lib/auth/permissions.js';
+import meRoute from '../api/paths/me.js';
+
+const logger = { info() { }, error() { }, debug() { }, warn() { } };
+
+function mockRes(user) {
+  const res = { locals: { user }, statusCode: 200, body: null };
+  res.status = (c) => { res.statusCode = c; return res; };
+  res.send = (b) => { res.body = b; return res; };
+  res.json = (b) => { res.body = b; return res; };
+  return res;
+}
+
+async function getMe(user) {
+  const res = mockRes(user);
+  await meRoute(logger).GET({}, res);
+  return res;
+}
+
+describe('/api/me organisation name (#203)', () => {
+  test('the RBAC organisation load selects name alongside the RBAC inputs', () => {
+    expect(ORGANISATION_RBAC_ATTRIBUTES).toContain('name');
+    // still narrow — the RBAC inputs are all that may join it
+    expect([...ORGANISATION_RBAC_ATTRIBUTES].sort())
+      .toEqual(['allowedModels', 'id', 'name', 'permissions', 'role', 'status']);
+  });
+
+  test('returns the organisation name for a user attached to a named org', async () => {
+    const org = { id: 'org-1', name: 'Pennine Flow Controls', status: 'active', role: 'owner' };
+    const res = await getMe({ id: 'u1', role: 'owner', status: 'active', organisationId: org.id, Organisation: org });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.organisationId).toBe('org-1');
+    expect(res.body.organisationName).toBe('Pennine Flow Controls');
+  });
+
+  test('stays null when there is genuinely no organisation', async () => {
+    const res = await getMe({ id: 'u2', role: 'owner', status: 'active' });
+    expect(res.body.organisationId).toBeNull();
+    expect(res.body.organisationName).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #203

## What / why

`GET /api/me` reported `organisationName: null` for every principal whose Organisation was lazy-loaded by `attachRbac`, because the load used an attribute allow-list that omitted `name`. `api/paths/me.js` then read `undefined` and `?? null` made it look like a legitimate "unnamed org". This is the whole of polite-ai's dashboard shell-labelling bug.

## Change (lanes: `middleware/auth.js`, `lib/auth/permissions.js`, `tests/`)

- `lib/auth/permissions.js`: new exported `ORGANISATION_RBAC_ATTRIBUTES = ['id','name','status','role','permissions','allowedModels']`, documented as "the RBAC inputs plus the one presentational field principals read back". Keeps the load deliberately narrow rather than dropping the allow-list.
- `middleware/auth.js`: `attachRbac` uses that constant instead of the inline list (adds `name`).
- `tests/me-organisation-name.test.mjs`: regression test — the list selects `name` **and** stays narrow; `/me` returns the org name for a user attached to a named org; still `null` when there is genuinely no org (i.e. a test that would have failed before, not one that only checks the field is present).

No API-doc change: `/me`'s response schema is a free-form object and `organisationName` was already documented/emitted; only its value was wrong.

## Verify

- `cd agents/livekit && yarn build` → **Build success** (the configured gate).
- New test: 3/3 pass. RBAC suites re-run against the touched module: `rbac-permissions`, `rbac-model-access`, `rbac-admin-scope` → 71/71 pass.
  (Note: jest in a ship worktree needs `--testPathIgnorePatterns "/node_modules/" "/agents/"` because the worktree path contains `.claude`, which the repo config ignores. Unrelated to this change.)

## Self-review

- (a) Acceptance criterion read literally: `/api/me` now returns the organisation's actual name for a user attached to a named org — asserted end-to-end through the real handler, not just "something changed".
- (b) Runtime path traced: `attachRbac` → `Organisation.findByPk(..., { attributes })` → `res.locals.user.Organisation` → `me.js:25`. The only reason `name` was `undefined` was the missing column; it is now selected. The `!user.Organisation` guard is untouched, so paths that already attach a full org are unchanged.
- (c) Hunk walk: adding one column widens no permission and leaks nothing across tenants (a principal only ever loads its own org). `effectivePermissions` / `effectiveAllowedModels` read named fields, so an extra attribute cannot perturb RBAC. Fail-closed catch around the load is untouched. Null/empty paths kept: no `organisationId` still yields `organisationName: null` (covered by a test).
- (d) Conventions: ESM imports, no API-doc drift, no hot-file edits, no secrets, no injection surface.
- Known and deliberately out of scope: bootstrap super-admins (`ADMIN_USER_IDS` / `x-shared-token`) return from `attachRbac` before any org load, so they still see `organisationName: null`; likewise the two `organisation:read` questions raised at the end of the issue (onboardingService key, owner reading their own org) are separate policy decisions, not this fix.

Closes #203
