### PR TITLE
fix(auth): dispatch better-auth verification/reset mail in the background

### DIFF
--- a/lib/auth/email-hooks.js
+++ b/lib/auth/email-hooks.js
@@ -3,10 +3,12 @@
  * factored out of index.js so their contract is testable in isolation.
  *
  * CONTRACT: a send failure is logged and SWALLOWED — never rethrown. better-auth
- * runs `sendResetPassword` through `runInBackgroundOrAwait` (which swallows),
- * but AWAITS `sendVerificationEmail` bare on `/send-verification-email`, where
- * it reaches the hook ONLY for a registered-and-unverified address. A rethrow
- * there becomes better-call's bare 500 — so during any smtp2go outage the
+ * runs both hooks through `runInBackgroundOrAwait`, which only really runs them
+ * in the background when `advanced.backgroundTasks.handler` is configured (it is
+ * — see index.js); without it the send is AWAITED inline, and on
+ * `/send-verification-email` the hook is reached ONLY for a
+ * registered-and-unverified address. A rethrow there would become better-call's
+ * bare 500 — so during any smtp2go outage the
  * status code says exactly "this address is registered and unverified": an
  * account-enumeration oracle on the very handler better-auth gives a 500ms
  * constant-time floor to hide the same distinction on the timing channel

--- a/lib/auth/email-hooks.js
+++ b/lib/auth/email-hooks.js
@@ -2,76 +2,101 @@
  * The outbound-email hooks for better-auth (password reset + verification),
  * factored out of index.js so their contract is testable in isolation.
  *
- * CONTRACT: a send failure is logged and SWALLOWED — never rethrown. better-auth
- * runs both hooks through `runInBackgroundOrAwait`, which only really runs them
- * in the background when `advanced.backgroundTasks.handler` is configured (it is
- * — see index.js); without it the send is AWAITED inline, and on
- * `/send-verification-email` the hook is reached ONLY for a
- * registered-and-unverified address. A rethrow there would become better-call's
- * bare 500 — so during any smtp2go outage the
- * status code says exactly "this address is registered and unverified": an
- * account-enumeration oracle on the very handler better-auth gives a 500ms
- * constant-time floor to hide the same distinction on the timing channel
- * (polite-ai-website PR #197 findings). Swallowing on BOTH paths keeps every
- * response account-blind; a mail outage is an OPERATOR signal, carried by the
- * `… email send FAILED` error logs below — alert on those, they are the only
- * signal left by design.
+ * CONTRACT 1 — a send failure is logged and SWALLOWED, never rethrown.
+ * better-auth runs `sendResetPassword` through `runInBackgroundOrAwait` (which
+ * swallows), but AWAITS `sendVerificationEmail` bare on
+ * `/send-verification-email` (better-auth dist/api/routes/email-verification.mjs
+ * line 31) — no `advanced.backgroundTasks.handler` can change that — and there
+ * the hook is reached ONLY for a registered-and-unverified address. A rethrow
+ * there becomes better-call's bare 500 — so during any smtp2go outage the status
+ * code says exactly "this address is registered and unverified": an account-
+ * enumeration oracle on the very handler better-auth gives a 500ms constant-time
+ * floor to hide the same distinction on the timing channel (polite-ai-website PR
+ * #197 findings). Swallowing on BOTH paths keeps every response account-blind; a
+ * mail outage is an OPERATOR signal, carried by the `… email send FAILED` error
+ * logs below — alert on those, they are the only signal left by design.
+ *
+ * CONTRACT 2 — a hook NEVER blocks the request for longer than
+ * SEND_DEADLINE_MS. Because of that bare await, swallowing errors is not
+ * enough: an smtp2go that HANGS rather than errors stalls the sending branch
+ * until the ingress gives up (504) while the no-op branch still returns 200 in
+ * ~500ms — the same enumeration oracle, on the latency/status channel
+ * (issue #208). So the send is raced against a deadline set BELOW better-auth's
+ * constant-time floor: whatever the provider does, both branches return inside
+ * that floor and are indistinguishable. On timeout the send simply continues
+ * detached, still logging its own outcome through the same swallow. Do NOT
+ * convert these into a bare unawaited dispatch — awaiting the *bounded* race is
+ * what keeps success/failure logging (and the tests) deterministic.
  */
 
+// Below better-auth's MINIMUM_MS = 500 constant-time floor on
+// /send-verification-email, so a slow or hanging send can never push the
+// sending branch past the floor that exists to hide it.
+const SEND_DEADLINE_MS = 250;
+
+// Resolve on whichever comes first: the (already-swallowing) send, or the
+// deadline; the loser continues in the background either way. The timer is
+// deliberately NOT unref'd — an unref'd one lets an otherwise-idle event loop
+// exit while a hung send leaves the race unsettled forever; 250ms of extra
+// liveness is a cheaper price than a request that never resolves.
+function bounded(sendPromise) {
+  return Promise.race([
+    sendPromise,
+    new Promise((resolve) => { setTimeout(resolve, SEND_DEADLINE_MS); }),
+  ]);
+}
+
 export function createSendHooks({ emailClient, logger }) {
+  const send = async (message, kind) => {
+    try {
+      const info = await emailClient.send(message);
+      logger.info({ to: message.to, transport: emailClient.provider, id: info?.id }, `${kind} email sent`);
+    } catch (err) {
+      logger.error({ err: err?.message, to: message.to, transport: emailClient.provider }, `${kind} email send FAILED`);
+    }
+  };
+
   return {
     // Enabling sendResetPassword also turns on the Firebase->Better-Auth bridge
     // for PASSWORD users: a migrating Firebase row has no Better-Auth credential,
     // and resetPassword *creates* a `credential` account on that existing row
     // when none exists — so setting a password lands on the existing user
     // (id + data preserved), never a dup.
-    sendResetPassword: async ({ user, url }) => {
-      try {
-        const info = await emailClient.send({
-          to: user.email,
-          subject: 'Set your polite.ai password',
-          text: [
-            'Open this link to set your polite.ai password:',
-            '',
-            url,
-            '',
-            "If you didn't request this, you can safely ignore this email.",
-          ].join('\n'),
-        });
-        logger.info({ to: user.email, transport: emailClient.provider, id: info?.id }, 'reset-password email sent');
-      } catch (err) {
-        logger.error({ err: err?.message, to: user.email, transport: emailClient.provider }, 'reset-password email send FAILED');
-      }
-    },
+    sendResetPassword: ({ user, url }) => bounded(send({
+      to: user.email,
+      subject: 'Set your polite.ai password',
+      text: [
+        'Open this link to set your polite.ai password:',
+        '',
+        url,
+        '',
+        "If you didn't request this, you can safely ignore this email.",
+      ].join('\n'),
+    }, 'reset-password')),
 
-    sendVerificationEmail: async ({ user, url }, request) => {
+    sendVerificationEmail: ({ user, url }, request) => {
       // Invite-completion signups (polite-ai onboarding) already proved address
       // ownership via the emailed invite link — skip the redundant double opt-in
       // mail. Spoofing the header only suppresses the sender's own email; the
       // account is provisional-gated regardless.
       if (request?.headers?.get('x-onboarding-invite') === 'complete') {
         logger.info({ to: user.email }, 'verification email suppressed (invite-completion signup)');
-        return;
+        return Promise.resolve();
       }
-      try {
-        const info = await emailClient.send({
-          to: user.email,
-          subject: 'Confirm your polite.ai subscription',
-          text: [
-            'Thanks for registering your interest in polite.ai.',
-            '',
-            'Please confirm your subscription by opening this link:',
-            url,
-            '',
-            "If you didn't request this, you can safely ignore this email.",
-            '',
-            '— polite.ai · Communication, reimagined.',
-          ].join('\n'),
-        });
-        logger.info({ to: user.email, transport: emailClient.provider, id: info?.id }, 'verification email sent');
-      } catch (err) {
-        logger.error({ err: err?.message, to: user.email, transport: emailClient.provider }, 'verification email send FAILED');
-      }
+      return bounded(send({
+        to: user.email,
+        subject: 'Confirm your polite.ai subscription',
+        text: [
+          'Thanks for registering your interest in polite.ai.',
+          '',
+          'Please confirm your subscription by opening this link:',
+          url,
+          '',
+          "If you didn't request this, you can safely ignore this email.",
+          '',
+          '— polite.ai · Communication, reimagined.',
+        ].join('\n'),
+      }, 'verification'));
     },
   };
 }

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -174,18 +174,21 @@ if (enabled) {
     // outranks x-forwarded-for. Browsers can never supply it (CORS never
     // allows the header and the gate drops it regardless).
     //
-    // backgroundTasks.handler: better-auth wraps every outbound-mail dispatch in
-    // `runInBackgroundOrAwait`, which AWAITS the send inline unless this handler
-    // is supplied. Awaiting it means only the branch that actually sends (i.e. a
-    // REGISTERED address on /request-password-reset, a registered-and-unverified
-    // one on /send-verification-email) pays the SMTP latency: when the provider
-    // degrades to hanging rather than erroring, that branch stalls to a 504 while
-    // the no-op branch still returns 200 in ~500ms — an account-existence oracle
-    // on the status/latency channel that better-auth's 500ms constant-time floor
-    // cannot hide. Dispatching in the background makes both branches return in
-    // the same bounded time regardless of SMTP health. The send hooks already
-    // log-and-swallow their own failures (email-hooks.js); the extra catch here
-    // is belt-and-braces so a rejected task can never surface as an
+    // backgroundTasks.handler: the mail dispatches better-auth DOES route
+    // through `runInBackgroundOrAwait` (/request-password-reset among them) are
+    // otherwise AWAITED inline. Awaiting means only the branch that actually
+    // sends — i.e. a REGISTERED address — pays the SMTP latency: when the
+    // provider degrades to hanging rather than erroring, that branch stalls to a
+    // 504 while the no-op branch still returns 200 in ~500ms, an account-
+    // existence oracle on the status/latency channel that better-auth's 500ms
+    // constant-time floor cannot hide (issue #208). This handler takes those
+    // dispatches off the request path. It is NOT the whole fix: better-auth
+    // awaits sendVerificationEmail BARE on /send-verification-email
+    // (dist/api/routes/email-verification.mjs line 31), where this option has no
+    // effect — that path is bounded inside the hook itself (email-hooks.js
+    // SEND_DEADLINE_MS), which is what makes both endpoints uniform. The send
+    // hooks already log-and-swallow their own failures; the catch here is
+    // belt-and-braces so a rejected task can never surface as an
     // unhandledRejection and kill the process.
     advanced: {
       ipAddress: { ipAddressHeaders: ['x-client-ip', 'x-forwarded-for'] },
@@ -282,9 +285,11 @@ if (enabled) {
       expiresIn: 60 * 60 * 24 * 7, // 7 days
       // Log-and-swallow, same contract as sendResetPassword above: a rethrow
       // here used to become a bare 500 that fired ONLY for registered-and-
-      // unverified addresses — an enumeration oracle during any mail outage.
-      // (Both hooks now also run OFF the request path, via
-      // advanced.backgroundTasks above.) See email-hooks.js.
+      // unverified addresses (better-auth awaits this hook BARE, unlike the
+      // reset one, so advanced.backgroundTasks above does NOT cover it) — an
+      // enumeration oracle during any mail outage. The hook additionally bounds
+      // its own await, so a hanging provider cannot turn that same asymmetry
+      // into a latency/504 oracle either. See email-hooks.js.
       sendVerificationEmail: sendHooks.sendVerificationEmail,
     },
 

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -173,8 +173,29 @@ if (enabled) {
     // verified the BFF's shared secret (index.mjs strips it otherwise), so it
     // outranks x-forwarded-for. Browsers can never supply it (CORS never
     // allows the header and the gate drops it regardless).
+    //
+    // backgroundTasks.handler: better-auth wraps every outbound-mail dispatch in
+    // `runInBackgroundOrAwait`, which AWAITS the send inline unless this handler
+    // is supplied. Awaiting it means only the branch that actually sends (i.e. a
+    // REGISTERED address on /request-password-reset, a registered-and-unverified
+    // one on /send-verification-email) pays the SMTP latency: when the provider
+    // degrades to hanging rather than erroring, that branch stalls to a 504 while
+    // the no-op branch still returns 200 in ~500ms — an account-existence oracle
+    // on the status/latency channel that better-auth's 500ms constant-time floor
+    // cannot hide. Dispatching in the background makes both branches return in
+    // the same bounded time regardless of SMTP health. The send hooks already
+    // log-and-swallow their own failures (email-hooks.js); the extra catch here
+    // is belt-and-braces so a rejected task can never surface as an
+    // unhandledRejection and kill the process.
     advanced: {
       ipAddress: { ipAddressHeaders: ['x-client-ip', 'x-forwarded-for'] },
+      backgroundTasks: {
+        handler: (promise) => {
+          promise.catch((err) => {
+            logger.error({ err: err?.message }, 'better-auth background task failed');
+          });
+        },
+      },
     },
 
     // Pre-lookup send budgets (layers 2-3 above). Runs for every dispatch of
@@ -261,8 +282,9 @@ if (enabled) {
       expiresIn: 60 * 60 * 24 * 7, // 7 days
       // Log-and-swallow, same contract as sendResetPassword above: a rethrow
       // here used to become a bare 500 that fired ONLY for registered-and-
-      // unverified addresses (better-auth awaits this hook, unlike the reset
-      // one) — an enumeration oracle during any mail outage. See email-hooks.js.
+      // unverified addresses — an enumeration oracle during any mail outage.
+      // (Both hooks now also run OFF the request path, via
+      // advanced.backgroundTasks above.) See email-hooks.js.
       sendVerificationEmail: sendHooks.sendVerificationEmail,
     },
 


### PR DESCRIPTION
Closes #208

## What / why

`lib/auth/index.js` had no `advanced.backgroundTasks.handler`, so better-auth's
`runInBackgroundOrAwait` (`dist/context/create-context.mjs:214-223`) took its
`else await promise` branch and the smtp2go send was **awaited inline** in the
request handler.

On `/request-password-reset` and `/send-verification-email` only one branch
actually sends (registered / registered-and-unverified); the other is a local
no-op. So a hanging SMTP provider stalled the sending branch to a 504 while the
no-op branch returned 200 in ~500 ms — an account-existence oracle on the
status/latency channel, which better-auth's 500 ms constant-time floor exists
precisely to close on the timing channel.

The fix is in two parts, because one option does not cover both endpoints:

1. **`advanced.backgroundTasks.handler`** (`lib/auth/index.js`) — takes every
   dispatch better-auth *does* route through `runInBackgroundOrAwait` off the
   request path. That covers `/request-password-reset`. The handler adds its own
   `.catch` so a rejected task can never become an `unhandledRejection`.
2. **A bounded await inside the hook** (`lib/auth/email-hooks.js`) — the
   `POST /send-verification-email` unauthenticated branch calls
   `sendVerificationEmailFn`, which awaits
   `options.emailVerification.sendVerificationEmail(...)` **bare**
   (`dist/api/routes/email-verification.mjs:31`), never touching
   `runInBackgroundOrAwait`; the option above has no effect there. So each hook
   now races its send against a `SEND_DEADLINE_MS = 250` deadline — deliberately
   *below* better-auth's `MINIMUM_MS = 500` floor — and returns. On timeout the
   send continues detached, still logging its own outcome through the existing
   log-and-swallow.

Net effect: both branches of both endpoints return in the same bounded time
whatever the provider does.

Lane: `lib/auth/index.js` (config + corrected comments),
`lib/auth/email-hooks.js` (bounded dispatch; the log-and-swallow contract is
unchanged and still load-bearing — the bare await is exactly why).

## Verify

- `cd agents/livekit && yarn build` → **Build success** (green).
- `tests/auth-email-hooks.test.mjs` → 5 passed, unchanged (the bounded race
  keeps the fast path fully synchronous with the send, so success/failure
  logging stays deterministic — that is why this is a race and not a bare
  unawaited dispatch).
- End-to-end against a real `betterAuth` instance (memoryAdapter, send stubbed
  to hang forever), this exact config:
  `reset registered 1ms` / `reset unknown 1ms` /
  `sendverif registered 502ms` / `sendverif unknown 502ms` — i.e. the
  constant-time floor, not the provider, decides the response time.

## Self-review

- (a) Re-checked the issue's acceptance criterion end to end rather than the
  literal wording "configure better-auth": the config-only change leaves
  `/send-verification-email` at 5000 ms vs 503 ms under a hanging provider, so
  the option alone does **not** meet it. Both endpoints are now measured.
- (b) Placed `backgroundTasks` under the existing `advanced` key so `ipAddress`
  (rate-limit IP resolution) is preserved — replacing `advanced` would have
  silently broken the `x-client-ip` ordering.
- (c) The deadline timer is intentionally **not** `unref`'d: an unref'd timer
  lets an otherwise-idle event loop exit with the race unsettled. The
  `x-onboarding-invite` suppression path returns before any dispatch and is
  unaffected. Trade-off accepted and noted: an in-flight send can be lost if the
  process is killed mid-dispatch — the same class of loss as an SMTP failure,
  and the existing `… email send FAILED` error-log alerting is unchanged.
- (d) No secrets, no new user-controlled input, no HTML/injection surface; the
  error log records `err.message` only. ES-module style and `lib/logger.js`
  logging conventions followed per docs/CONTEXT.md; no `lib → agents/*/dist`
  layering touched; no API-contract (`api/api-doc.yaml`) drift.
