### PR TITLE
fix: gate cross-tenant organisation status changes behind organisation:delete

### DIFF
--- a/api/paths/organisations/{organisationId}.js
+++ b/api/paths/organisations/{organisationId}.js
@@ -55,6 +55,15 @@ export default function (logger) {
     if ('chargeableNumberLimit' in req.body && !can(res.locals.user, 'organisation', 'setRate')) {
       return res.status(403).json({ message: 'forbidden', detail: 'Requires organisation:setRate (super admin)' });
     }
+    // `status` is a soft-delete lever (DELETE sets status='deactivated'), so a
+    // cross-tenant principal changing someone ELSE's status must hold the same
+    // capability as DELETE. orgAdmin editing their OWN org is unaffected, and
+    // superAdmin holds organisation:delete.
+    if ('status' in req.body
+      && org.id !== res.locals.user?.organisationId
+      && !can(res.locals.user, 'organisation', 'delete')) {
+      return res.status(403).json({ message: 'forbidden', detail: 'Requires organisation:delete to change status cross-tenant' });
+    }
     const baselineKeys = ['role', 'permissions', 'allowedModels'];
     if (baselineKeys.some((k) => k in req.body)) {
       if (!can(res.locals.user, 'organisation', 'setPermissions')) {

--- a/tests/organisation-status-gate.test.mjs
+++ b/tests/organisation-status-gate.test.mjs
@@ -1,0 +1,97 @@
+import { jest } from '@jest/globals';
+
+/**
+ * PATCH /api/organisations/{organisationId} — cross-tenant `status` gate.
+ *
+ * `organisation:update` is held cross-tenant by the onboardingService principal
+ * (issue #207), but `status` is the soft-delete lever (DELETE sets
+ * status='deactivated'). Changing another tenant's status therefore requires
+ * `organisation:delete`; an org's own admin editing their OWN status is
+ * unaffected.
+ */
+const rows = new Map();
+
+jest.unstable_mockModule('../lib/database.js', () => ({
+  Organisation: {
+    findByPk: async (id) => rows.get(id) || null,
+  },
+}));
+
+const { default: orgItem } = await import('../api/paths/organisations/{organisationId}.js');
+
+const mockLogger = { info() { }, error() { }, warn() { }, debug() { } };
+const patch = orgItem(mockLogger).PATCH;
+
+const makeOrg = (id, extra = {}) => {
+  const org = { id, name: 'Acme', status: 'active', saved: false, ...extra };
+  org.save = async () => { org.saved = true; };
+  rows.set(id, org);
+  return org;
+};
+
+const makeRes = () => ({
+  locals: { user: null },
+  _status: null,
+  _body: null,
+  status(code) { this._status = code; return this; },
+  send(body) { this._body = body; this._status = this._status || 200; return this; },
+  json(body) { this._body = body; this._status = this._status || 200; return this; },
+});
+
+const call = async ({ user, orgId, body }) => {
+  const req = { params: { organisationId: orgId }, body, log: mockLogger };
+  const res = makeRes();
+  res.locals.user = user;
+  await patch(req, res);
+  return res;
+};
+
+describe('organisation PATCH — cross-tenant status gate', () => {
+  beforeEach(() => rows.clear());
+
+  test('onboardingService may NOT change another org status (403)', async () => {
+    const org = makeOrg('org-target');
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: 'org-service' },
+      orgId: 'org-target',
+      body: { status: 'deactivated' },
+    });
+    expect(res._status).toBe(403);
+    expect(res._body.detail).toMatch(/organisation:delete/);
+    expect(org.status).toBe('active');
+    expect(org.saved).toBe(false);
+  });
+
+  test('onboardingService may still update a name cross-tenant', async () => {
+    const org = makeOrg('org-target');
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: 'org-service' },
+      orgId: 'org-target',
+      body: { name: 'Renamed' },
+    });
+    expect(res._status).toBe(200);
+    expect(org.name).toBe('Renamed');
+  });
+
+  test('orgAdmin may set status on their OWN org', async () => {
+    const org = makeOrg('org-1');
+    const res = await call({
+      user: { role: 'orgAdmin', organisationId: 'org-1' },
+      orgId: 'org-1',
+      body: { status: 'suspended' },
+    });
+    expect(res._status).toBe(200);
+    expect(org.status).toBe('suspended');
+  });
+
+  test('superAdmin (holds organisation:delete) may set status cross-tenant', async () => {
+    const org = makeOrg('org-target');
+    const res = await call({
+      user: { role: 'superAdmin', organisationId: 'org-other' },
+      orgId: 'org-target',
+      body: { status: 'deactivated' },
+    });
+    expect(res._status).toBe(200);
+    expect(org.status).toBe('deactivated');
+  });
+});


### PR DESCRIPTION
Closes #212

## What / why

The widened `onboardingService` grant from #207 (`organisation: read/readAll/update`) let a cross-tenant principal soft-delete another organisation by PATCHing `status` to `deactivated` — the exact effect of `DELETE`, which requires `organisation:delete`.

PATCH `/api/organisations/{organisationId}` now rejects a `status` change when the target org is not the principal's own **and** the principal lacks `organisation:delete`:

```
403 { message: 'forbidden', detail: 'Requires organisation:delete to change status cross-tenant' }
```

The `read`/`readAll`/`update` grant mandated by #207 is untouched; orgAdmin setting status on their OWN org still works; superAdmin holds `organisation:delete` and is unaffected.

## Lane / files

- `api/paths/organisations/{organisationId}.js` — the new gate, alongside the existing `agentLimit` / `chargeableNumberLimit` / baseline gates.
- `tests/organisation-status-gate.test.mjs` — new no-DB test (mocks `lib/database.js`).

## Verify

- `cd agents/livekit && yarn build` → **Build success**.
- New tests: 4 passed (`onboardingService` cross-tenant status → 403 and row unsaved; cross-tenant `name` update still 200; orgAdmin own-org status → 200; superAdmin cross-tenant status → 200). Run with the repo's no-db jest config (the config's `.claude` ignore pattern excludes everything when run from a worktree under `.claude/`, so `--testPathIgnorePatterns` was overridden locally; unchanged in CI).

## Self-review

- (a) Acceptance criteria checked literally against the issue: gate lives in the PATCH handler beside the existing gates; condition is `'status' in req.body && org.id !== res.locals.user?.organisationId && !can(user,'organisation','delete')`; 403 with the specified detail; own-org orgAdmin and superAdmin preserved; test added in the org-item route lane.
- (b) Runtime path traced: `requirePermission(update)` → `findByPk` → `targetInScope` → gates → `EDITABLE` copy → `org.save()`. The new check precedes the field copy, so a rejected request never mutates or saves the row (asserted in the test).
- (c) Hunk walk: only adds an early return. `'status' in req.body` is presence-based, so setting status to its current value cross-tenant is also refused (deliberate — matches the other gates' shape). `org.id !== user?.organisationId` is fail-closed for a null/undefined `organisationId`; org-less admins are already 404'd earlier by `targetInScope`. `DELETE` and `GET` untouched; no OpenAPI/contract change (same operation, additional 403 for an already-documented `default` error shape).
- (d) Conventions: ES-module imports, existing `can()` helper, `res.status(403).json({ message:'forbidden', detail })` shape identical to the sibling gates. No secrets, no injected HTML, no new input reflected into output.

Note (out of scope, flagged in the issue): the sibling user PATCH route may need the same shape for its `status`/ban-like field.

Closes #212
