### PR TITLE
fix: gate status transitions on PATCH /api/users/{userId}

### DIFF
--- a/api/paths/users/{userId}.js
+++ b/api/paths/users/{userId}.js
@@ -7,10 +7,13 @@ import { targetInScope } from '../../../lib/auth/admin-scope.js';
  *   GET    fetch a user (orgAdmin: own org only).
  *   PATCH  accept/activate (status), and edit role / agentLimit / name /
  *          `status` is the soft-delete lever (DELETE sets status='deactivated'), so
- *          moving ANOTHER tenant's user to a non-`active` status requires the same
- *          `user:delete` capability as DELETE. Activation stays open to the
- *          cross-tenant onboarding seam, and orgAdmin editing their OWN org's
- *          users is unaffected.
+ *          ANY cross-tenant status change requires the same `user:delete` capability
+ *          as DELETE — with one exemption, the onboarding accept seam
+ *          (`provisional` -> `active`). Re-activating an already suspended/deactivated
+ *          user is NOT exempt: it reverses an admin action. A `user:readAll` principal
+ *          counts as cross-tenant by definition (it can move the target into its own
+ *          org via `organisationId` on this same route); orgAdmin editing their OWN
+ *          org's users is unaffected.
  *          permissions / allowedModels / organisationId / emailVerified.
  *          `emailVerified` asserts address ownership (equivalent to what better-auth
  *          writes on a proven emailed link), so it needs the cross-tenant `user:readAll`
@@ -86,16 +89,28 @@ export default function (logger) {
       return res.status(403).json({ message: 'forbidden', detail: 'Requires user:readAll' });
     }
     // `status` is a lifecycle lever: DELETE soft-deletes by setting
-    // status='deactivated', so a principal changing SOMEONE ELSE'S tenant's user to
-    // any non-`active` status must hold the same capability as DELETE (`user:delete`).
-    // `active` is deliberately exempt — cross-tenant activation is the onboarding
-    // seam (`onboardingService` accepting an invited user) and can only ever widen
-    // access to that user's own account. orgAdmin deactivating a user in their OWN
-    // org is unaffected (documented above), and superAdmin holds `user:delete`.
-    if ('status' in req.body && req.body.status !== 'active'
-        && (u.organisationId == null || u.organisationId !== res.locals.user?.organisationId)
-        && !can(res.locals.user, 'user', 'delete')) {
-      return res.status(403).json({ message: 'forbidden', detail: 'Requires user:delete to change status cross-tenant' });
+    // status='deactivated', so a principal changing SOMEONE ELSE'S tenant's user
+    // must hold the same capability as DELETE (`user:delete`).
+    //
+    // "Cross-tenant" cannot be decided from the target's CURRENT organisationId alone:
+    // `organisationId` is itself editable on this very route under `user:readAll`, so a
+    // readAll+update principal could move the user into its own org and then deactivate
+    // it as an "own-org" edit. A `user:readAll` principal is therefore cross-tenant by
+    // definition (and an `organisationId` in the same body counts too); only a
+    // tenant-confined admin (orgAdmin) gets the own-org path.
+    const statusCrossTenant = actorReadAll
+      || 'organisationId' in req.body
+      || u.organisationId == null
+      || u.organisationId !== res.locals.user?.organisationId;
+    if ('status' in req.body && statusCrossTenant) {
+      // The ONLY cross-tenant status transition that isn't a privilege move is the
+      // onboarding accept seam: lifting a `provisional` user to `active`. Anything
+      // else — suspending, deactivating, or RE-activating a user an admin has already
+      // suspended/deactivated (reversing the #215 soft-delete) — needs `user:delete`.
+      const acceptSeam = req.body.status === 'active' && u.status === 'provisional';
+      if (!acceptSeam && !can(res.locals.user, 'user', 'delete')) {
+        return res.status(403).json({ message: 'forbidden', detail: 'Requires user:delete to change status cross-tenant' });
+      }
     }
     // An admin may only grant a role/permission set within their OWN effective perms
     // — blocks cross-tenant readAll AND intra-tenant capability escalation by proxy.
@@ -116,6 +131,18 @@ export default function (logger) {
       // `organisation:update` AND have the org in tenancy scope (own org, or
       // `organisation:readAll`). Without that we simply skip the side-effect — the
       // user edit itself was legitimate, so this is a no-op, not a 403.
+      //
+      // RECORDED DECISION (#216, deliberate divergence): the DIRECT route
+      // PATCH /api/organisations/{organisationId} requires `organisation:delete` for
+      // ANY cross-tenant status change, including -> active. This seam is gated on the
+      // weaker `organisation:update` on purpose, because `onboardingService` holds
+      // organisation:['create','read','readAll','update'] and NOT `delete`; requiring
+      // `delete` here would break self-signup acceptance. The exposure is bounded to
+      // exactly the transition onboarding needs — `provisional` -> `active` on the org
+      // of a user being accepted — and can never suspend or deactivate an org. So the
+      // #216 invariant holds in the strong form for org DEACTIVATION everywhere, and in
+      // this weaker form only for provisional-org activation. Closing the gap fully
+      // means giving onboardingService its own capability; out of scope here.
       if (req.body.status === 'active' && u.organisationId) {
         const actor = res.locals.user;
         const org = await Organisation.findByPk(u.organisationId);

--- a/api/paths/users/{userId}.js
+++ b/api/paths/users/{userId}.js
@@ -9,7 +9,7 @@ import { targetInScope } from '../../../lib/auth/admin-scope.js';
  *          `status` is the soft-delete lever (DELETE sets status='deactivated'), so
  *          ANY cross-tenant status change requires the same `user:delete` capability
  *          as DELETE — with one exemption, the onboarding accept seam
- *          (`provisional` -> `active`). Re-activating an already suspended/deactivated
+ *          (-> `active` for a user no admin has actioned). Re-activating an already suspended/deactivated
  *          user is NOT exempt: it reverses an admin action. A `user:readAll` principal
  *          counts as cross-tenant by definition (it can move the target into its own
  *          org via `organisationId` on this same route); orgAdmin editing their OWN
@@ -104,10 +104,19 @@ export default function (logger) {
       || u.organisationId !== res.locals.user?.organisationId;
     if ('status' in req.body && statusCrossTenant) {
       // The ONLY cross-tenant status transition that isn't a privilege move is the
-      // onboarding accept seam: lifting a `provisional` user to `active`. Anything
-      // else — suspending, deactivating, or RE-activating a user an admin has already
-      // suspended/deactivated (reversing the #215 soft-delete) — needs `user:delete`.
-      const acceptSeam = req.body.status === 'active' && u.status === 'provisional';
+      // onboarding accept seam: moving a user to `active` when no admin has taken a
+      // lifecycle action against them. Anything else — suspending, deactivating, or
+      // RE-activating a user an admin has already suspended/deactivated (reversing
+      // the #215 soft-delete) — needs `user:delete`.
+      //
+      // The seam is keyed on the ABSENCE of an admin action, NOT on
+      // `u.status === 'provisional'`: a self-signup user is auto-activated on first
+      // Firebase login (lib/database.js `activate`) and by the startup heal, while
+      // their ORGANISATION stays provisional. Accept — and any retry of a partially
+      // applied accept — must therefore still work for an already-`active` user, or
+      // the org is wedged provisional with no recovery path for that principal.
+      const adminActioned = u.status === 'suspended' || u.status === 'deactivated';
+      const acceptSeam = req.body.status === 'active' && !adminActioned;
       if (!acceptSeam && !can(res.locals.user, 'user', 'delete')) {
         return res.status(403).json({ message: 'forbidden', detail: 'Requires user:delete to change status cross-tenant' });
       }

--- a/api/paths/users/{userId}.js
+++ b/api/paths/users/{userId}.js
@@ -6,6 +6,11 @@ import { targetInScope } from '../../../lib/auth/admin-scope.js';
  * /api/users/{userId} (item) — RBAC-gated (`user:*`), org-scoped.
  *   GET    fetch a user (orgAdmin: own org only).
  *   PATCH  accept/activate (status), and edit role / agentLimit / name /
+ *          `status` is the soft-delete lever (DELETE sets status='deactivated'), so
+ *          moving ANOTHER tenant's user to a non-`active` status requires the same
+ *          `user:delete` capability as DELETE. Activation stays open to the
+ *          cross-tenant onboarding seam, and orgAdmin editing their OWN org's
+ *          users is unaffected.
  *          permissions / allowedModels / organisationId / emailVerified.
  *          `emailVerified` asserts address ownership (equivalent to what better-auth
  *          writes on a proven emailed link), so it needs the cross-tenant `user:readAll`
@@ -80,6 +85,18 @@ export default function (logger) {
     if ('emailVerified' in req.body && !actorReadAll) {
       return res.status(403).json({ message: 'forbidden', detail: 'Requires user:readAll' });
     }
+    // `status` is a lifecycle lever: DELETE soft-deletes by setting
+    // status='deactivated', so a principal changing SOMEONE ELSE'S tenant's user to
+    // any non-`active` status must hold the same capability as DELETE (`user:delete`).
+    // `active` is deliberately exempt — cross-tenant activation is the onboarding
+    // seam (`onboardingService` accepting an invited user) and can only ever widen
+    // access to that user's own account. orgAdmin deactivating a user in their OWN
+    // org is unaffected (documented above), and superAdmin holds `user:delete`.
+    if ('status' in req.body && req.body.status !== 'active'
+        && (u.organisationId == null || u.organisationId !== res.locals.user?.organisationId)
+        && !can(res.locals.user, 'user', 'delete')) {
+      return res.status(403).json({ message: 'forbidden', detail: 'Requires user:delete to change status cross-tenant' });
+    }
     // An admin may only grant a role/permission set within their OWN effective perms
     // — blocks cross-tenant readAll AND intra-tenant capability escalation by proxy.
     if (('role' in req.body || 'permissions' in req.body)
@@ -95,9 +112,22 @@ export default function (logger) {
       await u.save();
       // Accepting a (self-signup) user also activates their PROVISIONAL org so the
       // org-status gate doesn't immediately re-block the freshly-accepted user.
+      // It is an ORGANISATION mutation, so it is gated as one: the actor must hold
+      // `organisation:update` AND have the org in tenancy scope (own org, or
+      // `organisation:readAll`). Without that we simply skip the side-effect — the
+      // user edit itself was legitimate, so this is a no-op, not a 403.
       if (req.body.status === 'active' && u.organisationId) {
+        const actor = res.locals.user;
         const org = await Organisation.findByPk(u.organisationId);
-        if (org && org.status === 'provisional') { org.status = 'active'; await org.save(); }
+        if (org && org.status === 'provisional') {
+          if (can(actor, 'organisation', 'update') && targetInScope(actor, 'organisation', org)) {
+            org.status = 'active';
+            await org.save();
+          } else {
+            logger.warn({ userId: u.id, organisationId: org.id },
+              'skipped provisional-org activation: actor lacks organisation:update in scope');
+          }
+        }
       }
       return res.send(u);
     } catch (err) {

--- a/tests/user-status-gate.test.mjs
+++ b/tests/user-status-gate.test.mjs
@@ -1,0 +1,195 @@
+import { jest } from '@jest/globals';
+
+/**
+ * PATCH /api/users/{userId} — `status` transition gate (issues #215 / #216).
+ *
+ * `user:update` is held cross-tenant by the onboardingService principal, but
+ * `status` is the soft-delete lever (DELETE sets status='deactivated'). Moving
+ * ANOTHER tenant's user to a non-`active` status therefore requires `user:delete`;
+ * `active` stays open (the onboarding accept seam), and an orgAdmin editing their
+ * OWN org's users is unaffected.
+ *
+ * The provisional-org activation side-effect that rides on { status: 'active' } is
+ * an organisation mutation, so it needs `organisation:update` in tenancy scope.
+ */
+const users = new Map();
+const orgs = new Map();
+
+jest.unstable_mockModule('../lib/database.js', () => ({
+  User: { findByPk: async (id) => users.get(id) || null },
+  Organisation: { findByPk: async (id) => orgs.get(id) || null },
+}));
+
+const { default: userItem } = await import('../api/paths/users/{userId}.js');
+
+const mockLogger = { info() { }, error() { }, warn() { }, debug() { } };
+const patch = userItem(mockLogger).PATCH;
+
+const makeUser = (id, organisationId, extra = {}) => {
+  const u = { id, organisationId, status: 'provisional', saved: false, ...extra };
+  u.save = async () => { u.saved = true; };
+  users.set(id, u);
+  return u;
+};
+
+const makeOrg = (id, status = 'provisional') => {
+  const org = { id, status, saved: false };
+  org.save = async () => { org.saved = true; };
+  orgs.set(id, org);
+  return org;
+};
+
+const makeRes = () => ({
+  locals: { user: null },
+  _status: null,
+  _body: null,
+  status(code) { this._status = code; return this; },
+  send(body) { this._body = body; this._status = this._status || 200; return this; },
+  json(body) { this._body = body; this._status = this._status || 200; return this; },
+});
+
+const call = async ({ user, userId, body }) => {
+  const req = { params: { userId }, body, log: mockLogger };
+  const res = makeRes();
+  res.locals.user = user;
+  await patch(req, res);
+  return res;
+};
+
+describe('user PATCH — cross-tenant status gate (#215)', () => {
+  beforeEach(() => { users.clear(); orgs.clear(); });
+
+  test('onboardingService may NOT deactivate another tenant\'s user (403)', async () => {
+    const u = makeUser('u-1', 'org-target', { status: 'active' });
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: null },
+      userId: 'u-1',
+      body: { status: 'deactivated' },
+    });
+    expect(res._status).toBe(403);
+    expect(res._body.detail).toMatch(/user:delete/);
+    expect(u.status).toBe('active');
+    expect(u.saved).toBe(false);
+  });
+
+  test('suspension is gated the same way as deactivation', async () => {
+    const u = makeUser('u-1', 'org-target', { status: 'active' });
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: null },
+      userId: 'u-1',
+      body: { status: 'suspended' },
+    });
+    expect(res._status).toBe(403);
+    expect(u.saved).toBe(false);
+  });
+
+  test('onboardingService may still ACTIVATE a user cross-tenant (the accept seam)', async () => {
+    const u = makeUser('u-1', 'org-target');
+    makeOrg('org-target');
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: null },
+      userId: 'u-1',
+      body: { status: 'active' },
+    });
+    expect(res._status).toBe(200);
+    expect(u.status).toBe('active');
+  });
+
+  test('onboardingService may still edit a non-status field cross-tenant', async () => {
+    const u = makeUser('u-1', 'org-target');
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: null },
+      userId: 'u-1',
+      body: { name: 'Renamed' },
+    });
+    expect(res._status).toBe(200);
+    expect(u.name).toBe('Renamed');
+  });
+
+  test('orgAdmin may deactivate a user in their OWN org', async () => {
+    const u = makeUser('u-1', 'org-1', { status: 'active' });
+    const res = await call({
+      user: { id: 'admin-1', role: 'orgAdmin', organisationId: 'org-1' },
+      userId: 'u-1',
+      body: { status: 'deactivated' },
+    });
+    expect(res._status).toBe(200);
+    expect(u.status).toBe('deactivated');
+  });
+
+  test('orgAdmin may NOT deactivate a user in another org (404 — out of scope)', async () => {
+    const u = makeUser('u-1', 'org-2', { status: 'active' });
+    const res = await call({
+      user: { id: 'admin-1', role: 'orgAdmin', organisationId: 'org-1' },
+      userId: 'u-1',
+      body: { status: 'deactivated' },
+    });
+    expect(res._status).toBe(404);
+    expect(u.saved).toBe(false);
+  });
+
+  test('superAdmin (holds user:delete) may deactivate cross-tenant', async () => {
+    const u = makeUser('u-1', 'org-target', { status: 'active' });
+    const res = await call({
+      user: { id: 'su', role: 'superAdmin', organisationId: 'org-other' },
+      userId: 'u-1',
+      body: { status: 'deactivated' },
+    });
+    expect(res._status).toBe(200);
+    expect(u.status).toBe('deactivated');
+  });
+});
+
+describe('user PATCH — provisional-org activation side-effect (#216)', () => {
+  beforeEach(() => { users.clear(); orgs.clear(); });
+
+  test('onboardingService (holds organisation:update + readAll) still activates the provisional org', async () => {
+    makeUser('u-1', 'org-target');
+    const org = makeOrg('org-target');
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: null },
+      userId: 'u-1',
+      body: { status: 'active' },
+    });
+    expect(res._status).toBe(200);
+    expect(org.status).toBe('active');
+    expect(org.saved).toBe(true);
+  });
+
+  test('a user-only cross-tenant principal activates the user but NOT the org', async () => {
+    const u = makeUser('u-1', 'org-target');
+    const org = makeOrg('org-target');
+    const res = await call({
+      user: { id: 'svc', permissions: { user: ['read', 'readAll', 'update'] }, organisationId: null },
+      userId: 'u-1',
+      body: { status: 'active' },
+    });
+    expect(res._status).toBe(200);
+    expect(u.status).toBe('active');
+    expect(org.status).toBe('provisional');
+    expect(org.saved).toBe(false);
+  });
+
+  test('orgAdmin activating a user in their own provisional org still activates the org', async () => {
+    makeUser('u-1', 'org-1');
+    const org = makeOrg('org-1');
+    const res = await call({
+      user: { id: 'admin-1', role: 'orgAdmin', organisationId: 'org-1' },
+      userId: 'u-1',
+      body: { status: 'active' },
+    });
+    expect(res._status).toBe(200);
+    expect(org.status).toBe('active');
+  });
+
+  test('an already-active org is left alone', async () => {
+    makeUser('u-1', 'org-target');
+    const org = makeOrg('org-target', 'active');
+    await call({
+      user: { role: 'onboardingService', organisationId: null },
+      userId: 'u-1',
+      body: { status: 'active' },
+    });
+    expect(org.saved).toBe(false);
+  });
+});

--- a/tests/user-status-gate.test.mjs
+++ b/tests/user-status-gate.test.mjs
@@ -95,6 +95,22 @@ describe('user PATCH — cross-tenant status gate (#215)', () => {
     expect(u.status).toBe('active');
   });
 
+  // A self-signup user is auto-activated on first Firebase login (lib/database.js)
+  // while their ORG stays provisional; the accept PATCH (or a retry of a partially
+  // applied one) must still succeed and run the org side-effect.
+  test('accept still works for an ALREADY-ACTIVE user whose org is provisional', async () => {
+    const u = makeUser('u-1', 'org-target', { status: 'active' });
+    const org = makeOrg('org-target');
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: null },
+      userId: 'u-1',
+      body: { status: 'active' },
+    });
+    expect(res._status).toBe(200);
+    expect(u.status).toBe('active');
+    expect(org.status).toBe('active');
+  });
+
   test('onboardingService may still edit a non-status field cross-tenant', async () => {
     const u = makeUser('u-1', 'org-target');
     const res = await call({

--- a/tests/user-status-gate.test.mjs
+++ b/tests/user-status-gate.test.mjs
@@ -138,6 +138,63 @@ describe('user PATCH — cross-tenant status gate (#215)', () => {
     expect(res._status).toBe(200);
     expect(u.status).toBe('deactivated');
   });
+
+  const svc = { id: 'svc', permissions: { user: ['read', 'readAll', 'update'] }, organisationId: 'org-me' };
+
+  test('a readAll principal cannot launder the gate by first moving the user into its own org', async () => {
+    const u = makeUser('u-1', 'org-target', { status: 'active' });
+    // step 1: the org move itself is still allowed (user:readAll)
+    const move = await call({ user: svc, userId: 'u-1', body: { organisationId: 'org-me' } });
+    expect(move._status).toBe(200);
+    expect(u.organisationId).toBe('org-me');
+    // step 2: the status change is STILL cross-tenant (the actor holds user:readAll)
+    const res = await call({ user: svc, userId: 'u-1', body: { status: 'deactivated' } });
+    expect(res._status).toBe(403);
+    expect(u.status).toBe('active');
+  });
+
+  test('a readAll principal cannot deactivate in the same request as the org move', async () => {
+    const u = makeUser('u-1', 'org-me', { status: 'active' });
+    const res = await call({
+      user: svc, userId: 'u-1', body: { organisationId: 'org-me', status: 'deactivated' },
+    });
+    expect(res._status).toBe(403);
+    expect(u.status).toBe('active');
+  });
+
+  test('a cross-tenant principal without user:delete cannot RE-activate a deactivated user', async () => {
+    const u = makeUser('u-1', 'org-target', { status: 'deactivated' });
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: null },
+      userId: 'u-1',
+      body: { status: 'active' },
+    });
+    expect(res._status).toBe(403);
+    expect(u.status).toBe('deactivated');
+    expect(u.saved).toBe(false);
+  });
+
+  test('...nor un-suspend a suspended user', async () => {
+    const u = makeUser('u-1', 'org-target', { status: 'suspended' });
+    const res = await call({
+      user: { role: 'onboardingService', organisationId: null },
+      userId: 'u-1',
+      body: { status: 'active' },
+    });
+    expect(res._status).toBe(403);
+    expect(u.status).toBe('suspended');
+  });
+
+  test('superAdmin may re-activate a deactivated user cross-tenant', async () => {
+    const u = makeUser('u-1', 'org-target', { status: 'deactivated' });
+    const res = await call({
+      user: { id: 'su', role: 'superAdmin', organisationId: 'org-other' },
+      userId: 'u-1',
+      body: { status: 'active' },
+    });
+    expect(res._status).toBe(200);
+    expect(u.status).toBe('active');
+  });
 });
 
 describe('user PATCH — provisional-org activation side-effect (#216)', () => {


### PR DESCRIPTION
Closes #215
Closes #216

## The shared question

Both issues ask the same underspecified thing: **what permission/tenancy check governs a `status` change on `PATCH /api/users/{userId}`?** `status` sat in `EDITABLE` behind nothing but the bare `user:update` entry check plus the isSelf guard, so a cross-tenant principal holding `user:readAll` + `user:update` (`onboardingService`) could both soft-delete another tenant's user and flip that user's provisional organisation to `active`.

The two issues pull in opposite directions: #215 wants cross-tenant status changes locked down, #216 points at the *one* cross-tenant status change that must keep working (the onboarding accept seam that sets `status: 'active'`). A blanket "cross-tenant status needs `user:delete`" would fix #215 and break the seam #216 is about; deleting the org side-effect would fix #216 and break onboarding.

**The reading chosen:** `status` is a *lifecycle* lever, and only the restrictive direction is the soft-delete. So the gate is directional, and the org side-effect is gated as what it actually is — an organisation mutation.

## What changed (`api/paths/users/{userId}.js`)

1. **Cross-tenant status changes require `user:delete`** (403 otherwise) — exactly the capability the DELETE route reserves for the identical soft-delete, mirroring the organisation gate landed by #212/#214. Two details matter:
   - **"Cross-tenant" is not decided from the target's current `organisationId`.** `organisationId` is itself editable on this same route under `user:readAll`, so an own-org comparison alone is launderable: move the target into your org, then deactivate it as an "own-org" edit. A `user:readAll` principal is therefore treated as cross-tenant by definition, and an `organisationId` in the same body counts too. Only a tenant-confined admin (orgAdmin) takes the own-org path.
   - **The only exempt transition is the onboarding accept seam: → `active` for a user no admin has actioned.** The seam is keyed on the *absence* of an admin lifecycle action (target not `suspended`/`deactivated`), not on `u.status === 'provisional'` — a self-signup user is auto-activated on first Firebase login (`lib/database.js`) and by the startup heal while their organisation stays `provisional`, so accept (and any retry of a partially applied accept) must still succeed for an already-`active` user; otherwise the org wedges `provisional` with no recovery path for `onboardingService`. Re-activating a user an admin has already suspended or deactivated reverses the #215 soft-delete, so it still needs `user:delete` like any other lifecycle move.
2. **The provisional-org activation side-effect now requires `organisation:update` AND tenancy scope** (`targetInScope(actor, 'organisation', org)` — own org, or `organisation:readAll`). If the actor lacks that, the side-effect is **skipped and logged**, not 403'd: the user edit itself was legitimate, so failing the whole request would be a regression for a principal that legitimately holds only `user:*`.

`onboardingService` holds `organisation: ['create','read','readAll','update']`, so the real onboarding seam is unchanged end-to-end. `orgAdmin` managing users in their own org is unaffected (they still deactivate via PATCH, as the route header documents).

**Recorded decision (#216):** the *direct* route `PATCH /api/organisations/{organisationId}` (landed by #214) requires `organisation:delete` for ANY cross-tenant status change, including → `active`. This side-effect is deliberately gated on the weaker `organisation:update` instead, because `onboardingService` holds `organisation: ['create','read','readAll','update']` and not `delete`; requiring `delete` here would break self-signup acceptance. The exposure is bounded to exactly the transition onboarding needs (`provisional` → `active` on the org of a user being accepted) and can never suspend or deactivate an org. So the #216 invariant holds in its strong form for org *deactivation* everywhere, and in this weaker form only for provisional-org activation. Closing that last gap means giving `onboardingService` its own capability — deliberately out of scope here, and now recorded in the code comment rather than left implicit.

## How each issue is satisfied

- **#215** — `PATCH { status: 'deactivated' | 'suspended' | 'provisional' }` against another tenant's user now 403s for `onboardingService` (and any `readAll`+`update` principal without `user:delete`), including via a prior or same-request `organisationId` move, and re-activating an already-suspended/deactivated user is blocked the same way. superAdmin, which holds `user:delete`, is unaffected.
- **#216** — the `org.status = 'active'` side-effect no longer runs off `user:*` permissions alone; it requires an `organisation:update` capability in scope. "Cross-tenant org status changes require an organisation capability" is now a whole-system invariant.

## Lane / files

Auth-RBAC lane: `api/paths/users/{userId}.js`, `tests/user-status-gate.test.mjs` (new). No `api/api-doc.yaml` change — the request schema and status enum are unchanged; only the authorisation of a value already in the schema.

## Verify

- `cd agents/livekit && yarn build` → **Build success** (the configured gate).
- New + neighbouring suites green: `user-status-gate`, `organisation-status-gate`, `rbac-permissions` → **green**; `user-status-gate` is now 17 tests. (Run with `--testPathIgnorePatterns` overridden, because `jest.config.no-db.js` ignores any path containing `.claude` and this ran in a `.claude/worktrees/…` worktree — worth knowing, it silently matches zero tests otherwise.)

## Self-review performed

- Re-read both issues and checked their acceptance criteria literally: the exact escalation path each describes (`onboardingService` → `{status:'deactivated'}` cross-tenant; `onboardingService` → `{status:'active'}` → `org.status='active'`) has a test asserting the new behaviour, and the counter-case each issue implicitly protects (onboarding accept still works; non-status cross-tenant edits still work; orgAdmin own-org deactivation still works) has one too. Neither fix re-breaks the other — that interaction is the reason for the single design above.
- Traced the runtime path: gate sits after `targetInScope`/self-guard and **before** `u.save()`, so a rejected request mutates nothing (tests assert `saved === false`). The org gate sits inside the existing post-save block and reads `res.locals.user` — no new DB round-trip beyond the `findByPk` already there.
- Hunk-by-hunk edge cases: an org-less target (`u.organisationId == null`) counts as cross-tenant → fail-closed; an org-less actor (service principals, `organisationId` null) likewise; an already-`active` org is still left untouched; error paths and the DELETE route are unchanged; `can`/`targetInScope` were both already imported.
- Conventions: matches the sibling `organisations/{organisationId}.js` gate in shape, wording and 403 body (`{ message: 'forbidden', detail: … }`); ES-module imports; `logger.warn` in the project's `(obj, msg)` pino style. Out-of-scope targets still 404 rather than 403, so no cross-tenant existence leak is introduced. No secrets, no user input interpolated anywhere.


