### PR TITLE
Enforce outbound destination policy on every worker; operator policy wins on chargeable trunks

### DIFF
--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -564,6 +564,54 @@ async function makeApiRequest<T>(endpoint: string, options: RequestInit = {}): P
   }
 }
 
+/** Decision returned by the platform's outbound destination authorisation. */
+export interface OutboundAuthorisation {
+  allowed: boolean;
+  code:
+    | "ok"
+    | "agent_filter"
+    | "default_filter"
+    | "trunk_filter"
+    | "not_rateable"
+    | "invalid_destination";
+  reason: string | null;
+  /** True when the leg egresses one of the platform's own (carrier-cost) trunks. */
+  chargeable: boolean;
+  trunkId: string | null;
+  /** Canonical +E.164 form of the destination, when it is a dialable number. */
+  destination: string | null;
+  tariff?: string;
+  prefix?: string;
+}
+
+/**
+ * Ask the platform whether this destination may be dialled on this leg.
+ *
+ * The policy is SERVER-side (lib/outbound-authorisation.js) because only the API
+ * server can see the trunk's operator filter and the organisation's rating deck:
+ * on a chargeable (our-carrier) trunk the agent's own `options.outboundCallFilter`
+ * may only narrow the operator policy, never widen it. The worker must therefore
+ * never re-implement this check, and must fail CLOSED if the call throws — the
+ * caller treats a transport failure as a refusal.
+ */
+export async function authoriseOutboundDestination(params: {
+  calledId: string;
+  /** Caller-ID for the leg; lets the platform resolve the egress trunk when aplisayId isn't known. */
+  callerId?: string | null;
+  agentId?: string;
+  agentOptions?: Record<string, any> | null;
+  organisationId?: string | null;
+  userId?: string | null;
+  aplisayId?: string | null;
+  outboundTrunkId?: string | null;
+  registrationOriginated?: boolean;
+}): Promise<OutboundAuthorisation> {
+  return makeApiRequest<OutboundAuthorisation>(`/api/agent-db/outbound-authorisation`, {
+    method: "POST",
+    body: JSON.stringify(params),
+  });
+}
+
 // Get instance by ID from the API
 export async function getInstanceById(instanceId: string): Promise<any> {
   return makeApiRequest(`/api/agent-db/instance?instanceId=${instanceId}`);

--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -14,6 +14,8 @@ import {
   createCall,
   createTransactionLog,
   saveUsage,
+  authoriseOutboundDestination,
+  type OutboundAuthorisation,
   type PhoneNumberInfo,
   type PhoneRegistrationInfo,
   type TrunkInfo,
@@ -293,30 +295,14 @@ async function validateTransferArgs(
   args: TransferArgs,
   agent: Agent,
   calledId: string,
-  aplisayId: string
+  aplisayId: string,
+  registrationOriginated?: boolean
 ): Promise<{
   effectiveCallerId: string;
   effectiveAplisayId: string;
   /** Set when the caller-ID is a phone_registration: the B-leg must egress via its B2BUA gateway. */
   registrationEgress?: RegistrationEgress;
 }> {
-  // Validate that transfer number matches the agent's outboundCallFilter if specified
-  if (agent.options?.outboundCallFilter) {
-    const filterRegexp = new RegExp(agent.options.outboundCallFilter);
-    if (!filterRegexp.test(args.number)) {
-      throw new Error(
-        `Invalid number: transfer target ${args.number} does not match the agent's outbound call filter pattern`
-      );
-    }
-  } else {
-    // Fallback to default UK validation if no filter is specified
-    if (!args.number.match(/^(\+44|44|0)[1237]\d{6,15}$/)) {
-      throw new Error(
-        "Invalid number: only UK geographic and mobile numbers are supported currently as transfer targets"
-      );
-    }
-  }
-
   let effectiveCallerId = args.callerId || calledId;
   let effectiveAplisayId = aplisayId;
   let registrationEgress: RegistrationEgress | undefined;
@@ -417,6 +403,44 @@ async function validateTransferArgs(
       };
       effectiveCallerId = regCallerNumber;
     }
+  }
+
+  // Destination authorisation — deliberately AFTER the caller-ID resolution above,
+  // because whether this leg egresses one of OUR chargeable carrier trunks (and so
+  // whether the operator's per-trunk filter + the org's rating deck are the
+  // authority, rather than the agent's own outboundCallFilter) depends on the
+  // resolved egress. A registration caller-ID leaves via the customer's own B2BUA,
+  // which is never our carrier. The policy lives server-side; see
+  // lib/outbound-authorisation.js and api/paths/agent-db/outbound-authorisation.js.
+  //
+  // Fail CLOSED: an unreachable/erroring platform means "not authorised", never
+  // "allowed by default".
+  let decision: OutboundAuthorisation;
+  try {
+    decision = await authoriseOutboundDestination({
+      calledId: args.number,
+      callerId: registrationEgress ? null : effectiveCallerId,
+      agentOptions: agent.options ?? null,
+      organisationId: agent.organisationId,
+      userId: agent.userId,
+      aplisayId: effectiveAplisayId || aplisayId || null,
+      registrationOriginated: !!registrationEgress || registrationOriginated === true,
+    });
+  } catch (err) {
+    logger.error(
+      { number: args.number, err },
+      "outbound destination authorisation failed; refusing transfer"
+    );
+    throw new Error(
+      `Invalid number: transfer target ${args.number} could not be authorised`
+    );
+  }
+  if (!decision.allowed) {
+    logger.warn(
+      { number: args.number, code: decision.code, trunkId: decision.trunkId, chargeable: decision.chargeable },
+      "transfer refused: destination not authorised"
+    );
+    throw new Error(`Invalid number: ${decision.reason}`);
   }
 
   return {
@@ -2111,7 +2135,7 @@ export async function handleTransfer(
 
   // Validate and resolve transfer arguments
   const { effectiveCallerId, effectiveAplisayId, registrationEgress } =
-    await validateTransferArgs(args, agent, calledId, aplisayId);
+    await validateTransferArgs(args, agent, calledId, aplisayId, registrationOriginated);
 
   // A registration caller-ID must egress via the registration's B2BUA gateway
   // (X-Aplisay-PhoneRegistration header + the registration username as the

--- a/agents/pipecat/pipecat_aplisay/api_client.py
+++ b/agents/pipecat/pipecat_aplisay/api_client.py
@@ -169,6 +169,41 @@ async def invoke_subagent(
     return (data or {}).get("result") if isinstance(data, dict) else data
 
 
+async def authorise_outbound_destination(
+    *,
+    called_id: str,
+    caller_id: Optional[str] = None,
+    agent_options: Optional[dict] = None,
+    organisation_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    aplisay_id: Optional[str] = None,
+    outbound_trunk_id: Optional[str] = None,
+    registration_originated: bool = False,
+) -> dict:
+    """Authorise one outbound destination against the platform's policy.
+
+    Returns the decision dict (``allowed``, ``code``, ``reason``, ``chargeable``,
+    ``trunkId``, ``destination``). Raises on transport/server failure — the caller
+    (``outbound_filter.authorise_destination``) treats that as a REFUSAL, since the
+    policy it enforces (per-trunk operator filter + destination rating on our own
+    carrier trunks) cannot be evaluated here.
+    """
+    return await _request(
+        "POST",
+        "/api/agent-db/outbound-authorisation",
+        body={
+            "calledId": called_id,
+            "callerId": caller_id,
+            "agentOptions": agent_options or {},
+            "organisationId": organisation_id,
+            "userId": user_id,
+            "aplisayId": aplisay_id,
+            "outboundTrunkId": outbound_trunk_id,
+            "registrationOriginated": bool(registration_originated),
+        },
+    )
+
+
 async def get_phone_number(number: str) -> Optional[dict]:
     """Look up a provisioned PhoneNumber (DDI/trunk number) by E.164 number.
 

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -328,8 +328,26 @@ class CallSession:
                     active_model = fallback_cfg["model"]
                     continue
 
-                # 3. Number-level fallback (blind transfer)
+                # 3. Number-level fallback (blind transfer). Configured on the agent
+                #    rather than chosen by the model, but it still puts a leg out on
+                #    (possibly) our carrier, so it clears the same gate as a tool-call
+                #    transfer — see _on_transfer / outbound_filter.py.
                 if fallback_cfg.get("number"):
+                    from .outbound_filter import authorise_destination
+
+                    fallback_decision = await authorise_destination(
+                        number=str(fallback_cfg["number"]),
+                        agent=active_agent,
+                        aplisay_id=self.aplisay_id,
+                        registration_endpoint_id=self.registration_endpoint_id,
+                        registration_originated=self.registration_originated,
+                    )
+                    if not fallback_decision.allowed:
+                        logger.error(
+                            "fallback transfer refused: "
+                            f"{fallback_decision.failure_message}"
+                        )
+                        raise
                     try:
                         await self.gateway_session.transfer(
                             TransferRequest(
@@ -1510,7 +1528,38 @@ class CallSession:
         tools on the consult bot drive subsequent state changes
         (talking / rejected / none).
         """
+        from .outbound_filter import authorise_destination
         from .transfer_prompts import resolve_transfer_prompt
+
+        # Destination authorisation — the FIRST thing every transfer path does, so
+        # blind, consultative and both WebRTC (media-relay) flows are gated by the
+        # one check. The policy is server-side (lib/outbound-authorisation.js): the
+        # agent's own options.outboundCallFilter on a customer-owned egress, and the
+        # operator's per-trunk filter + a rateable destination on one of OUR
+        # chargeable carrier trunks, where the agent's filter may only narrow it.
+        # Fails CLOSED — an unreachable platform is a refusal.
+        #
+        # A callerId that is a registration-endpoint UUID means the leg egresses
+        # THAT registration's B2BUA (the customer's own PBX, never our carrier) —
+        # the discriminator _resolve_webrtc_egress uses. Ownership of the
+        # registration is validated there; here it only decides whose minutes are
+        # at risk, so a bogus UUID buys nothing: egress resolution still fails.
+        caller_id_arg = str(args.get("callerId") or "")
+        egress_is_registration = (
+            bool(self.registration_endpoint_id)
+            or self.registration_originated
+            or bool(_UUID_RE.match(caller_id_arg))
+        )
+        decision = await authorise_destination(
+            number=str(args.get("number") or ""),
+            agent=self.agent,
+            caller_id=(None if egress_is_registration else caller_id_arg or None),
+            aplisay_id=self.aplisay_id,
+            registration_endpoint_id=self.registration_endpoint_id,
+            registration_originated=egress_is_registration,
+        )
+        if not decision.allowed:
+            return self._transfer_failed(decision.failure_message)
 
         op = args.get("operation", "blind")
         # Legacy callers may pass "consult" or "bridged"; normalize for
@@ -1711,7 +1760,7 @@ class CallSession:
 
     def _transfer_failed(self, reason: str) -> dict:
         """Record a failed transfer_state and return the tool-result dict."""
-        logger.bind(session_id=self.session_id).warning(f"webrtc transfer failed: {reason}")
+        logger.bind(session_id=self.session_id).warning(f"transfer failed: {reason}")
         self.transfer_state = TransferState("failed", reason)
         return {"error": reason, "status": "FAILED", "reason": reason}
 

--- a/agents/pipecat/pipecat_aplisay/outbound_filter.py
+++ b/agents/pipecat/pipecat_aplisay/outbound_filter.py
@@ -1,0 +1,107 @@
+"""Outbound destination authorisation for the Pipecat worker.
+
+Every path that puts a leg out of the platform — blind and consultative
+transfers, the WebRTC bridge/consult legs, and the last-resort ``fallback.number``
+transfer — must clear this gate before a number is dialled.
+
+The policy itself is NOT here. It lives server-side in llm-agent
+(``lib/outbound-authorisation.js``), because only the API server can see the
+egress ``Trunk``'s operator filter and the organisation's rating deck:
+
+* on a non-chargeable egress (a registration B2BUA to the customer's own PBX, a
+  BYO trunk) the agent's ``options.outboundCallFilter`` is authoritative, as it
+  has always been, defaulting to UK geographic/mobile;
+* on one of OUR chargeable carrier trunks the operator's per-trunk filter plus a
+  rateable destination decide, and the agent's own filter may only narrow that —
+  the tenant does not get to choose which destinations we pay a carrier for.
+
+This module is a thin, FAIL-CLOSED client of that decision: any transport or
+server error is a refusal, never an allow. Mirrors
+``agents/livekit/lib/transfer-handler.ts``.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from loguru import logger
+
+from . import api_client
+
+
+@dataclass
+class OutboundDecision:
+    """One authorisation decision, as returned by the platform."""
+
+    allowed: bool
+    code: str = "unavailable"
+    reason: Optional[str] = None
+    chargeable: bool = False
+    trunk_id: Optional[str] = None
+    destination: Optional[str] = None
+
+    @property
+    def failure_message(self) -> str:
+        """Message to surface to the model as the transfer failure reason."""
+        return self.reason or f"destination not authorised ({self.code})"
+
+
+async def authorise_destination(
+    *,
+    number: str,
+    agent: dict,
+    caller_id: Optional[str] = None,
+    aplisay_id: Optional[str] = None,
+    registration_endpoint_id: Optional[str] = None,
+    registration_originated: bool = False,
+) -> OutboundDecision:
+    """Ask llm-agent whether ``number`` may be dialled on this leg.
+
+    A leg carrying a ``registration_endpoint_id`` egresses the customer's own
+    B2BUA (never our carrier), so it is reported as registration-originated
+    regardless of how the call itself arrived — matching the billing gate in
+    ``_chargeable_outbound_trunk_id``.
+
+    ``caller_id`` lets the platform resolve the egress trunk for a WebRTC-origin
+    transfer, whose routing comes from the tool-supplied caller-ID rather than
+    from any inbound trunk on the session.
+    """
+    dialled = (number or "").strip()
+    if not dialled:
+        return OutboundDecision(
+            allowed=False, code="invalid_destination",
+            reason="transfer requires a destination number",
+        )
+
+    try:
+        raw = await api_client.authorise_outbound_destination(
+            called_id=dialled,
+            caller_id=caller_id,
+            agent_options=agent.get("options") or {},
+            organisation_id=agent.get("organisationId"),
+            user_id=agent.get("userId"),
+            aplisay_id=aplisay_id,
+            registration_originated=bool(registration_endpoint_id) or registration_originated,
+        )
+    except Exception as e:  # noqa: BLE001 — fail closed on ANY failure
+        logger.bind(destination=dialled, error=str(e)).error(
+            "outbound destination authorisation failed; refusing transfer"
+        )
+        return OutboundDecision(
+            allowed=False, code="unavailable",
+            reason=f"destination {dialled} could not be authorised",
+        )
+
+    decision = OutboundDecision(
+        allowed=bool(raw.get("allowed")),
+        code=str(raw.get("code") or "unknown"),
+        reason=raw.get("reason"),
+        chargeable=bool(raw.get("chargeable")),
+        trunk_id=raw.get("trunkId"),
+        destination=raw.get("destination"),
+    )
+    if not decision.allowed:
+        logger.bind(
+            destination=dialled, code=decision.code,
+            trunk_id=decision.trunk_id, chargeable=decision.chargeable,
+        ).warning("transfer refused: destination not authorised")
+    return decision

--- a/agents/pipecat/tests/test_outbound_filter.py
+++ b/agents/pipecat/tests/test_outbound_filter.py
@@ -1,0 +1,192 @@
+"""Tests for outbound destination authorisation on the Pipecat worker.
+
+Before this gate the worker dialled whatever the model asked for: unlike the
+LiveKit worker and the originate API it consulted neither
+``options.outboundCallFilter`` nor any default, so a prompt-injected or simply
+over-eager agent could transfer a call to any number on earth.
+
+The worker deliberately does NOT hold the policy — it asks llm-agent
+(``/api/agent-db/outbound-authorisation``), because only the server can see the
+egress trunk's operator filter and the organisation's rating deck. What is pinned
+here is that every transfer path consults it, that it FAILS CLOSED, and that the
+registration-egress discriminator is reported correctly (a leg leaving via the
+customer's own B2BUA is never on our carrier).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pipecat_aplisay import api_client, outbound_filter
+from pipecat_aplisay.call_session import CallSession
+
+REG_UUID = "11111111-1111-4111-8111-111111111111"
+
+AGENT = {
+    "id": "agent-1",
+    "modelName": "pipecat:openai/gpt-4o",
+    "organisationId": "org-1",
+    "userId": "user-1",
+    "options": {"outboundCallFilter": "^\\+44\\d+$"},
+}
+
+
+def _session(**kwargs) -> CallSession:
+    call = api_client.CallRecord(
+        id="call-1", userId="user-1", organisationId="org-1",
+        instanceId="inst-1", agentId="agent-1", persisted=False,
+    )
+
+    class _StubGatewaySession:
+        transport = None
+
+        async def shutdown(self) -> None:  # pragma: no cover
+            return None
+
+    return CallSession(
+        session_id="s1",
+        agent=dict(AGENT),
+        instance={"streamLog": False},
+        sip_gateway=None,  # type: ignore[arg-type]
+        gateway_session=_StubGatewaySession(),  # type: ignore[arg-type]
+        call=call,
+        **kwargs,
+    )
+
+
+def _patch_authorisation(monkeypatch, *, response=None, raises=None):
+    """Capture the request the worker makes, and script the platform's answer."""
+    seen: dict = {}
+
+    async def fake(**kwargs):
+        seen.update(kwargs)
+        if raises is not None:
+            raise raises
+        return response
+
+    monkeypatch.setattr(api_client, "authorise_outbound_destination", fake)
+    return seen
+
+
+class TestAuthoriseDestination:
+    """The thin client in outbound_filter.py."""
+
+    def test_allows_when_platform_allows(self, monkeypatch) -> None:
+        seen = _patch_authorisation(monkeypatch, response={
+            "allowed": True, "code": "ok", "reason": None,
+            "chargeable": True, "trunkId": "public", "destination": "+447700900123",
+        })
+        decision = asyncio.run(outbound_filter.authorise_destination(
+            number="+447700900123", agent=AGENT, aplisay_id="trunk-a",
+        ))
+        assert decision.allowed is True
+        assert decision.chargeable is True
+        assert seen["called_id"] == "+447700900123"
+        assert seen["organisation_id"] == "org-1"
+        assert seen["agent_options"] == AGENT["options"]
+        assert seen["registration_originated"] is False
+
+    def test_refusal_carries_the_platform_reason(self, monkeypatch) -> None:
+        _patch_authorisation(monkeypatch, response={
+            "allowed": False, "code": "not_rateable",
+            "reason": "destination +8801700000000 is not rated for this organisation",
+            "chargeable": True, "trunkId": "public", "destination": "+8801700000000",
+        })
+        decision = asyncio.run(outbound_filter.authorise_destination(
+            number="+8801700000000", agent=AGENT,
+        ))
+        assert decision.allowed is False
+        assert decision.code == "not_rateable"
+        assert "not rated" in decision.failure_message
+
+    def test_fails_closed_when_the_platform_is_unreachable(self, monkeypatch) -> None:
+        _patch_authorisation(monkeypatch, raises=RuntimeError("connection refused"))
+        decision = asyncio.run(outbound_filter.authorise_destination(
+            number="+447700900123", agent=AGENT,
+        ))
+        assert decision.allowed is False
+        assert decision.code == "unavailable"
+
+    def test_empty_destination_never_reaches_the_platform(self, monkeypatch) -> None:
+        seen = _patch_authorisation(monkeypatch, response={"allowed": True, "code": "ok"})
+        decision = asyncio.run(outbound_filter.authorise_destination(number="  ", agent=AGENT))
+        assert decision.allowed is False
+        assert decision.code == "invalid_destination"
+        assert seen == {}
+
+    def test_registration_egress_is_reported_as_not_our_carrier(self, monkeypatch) -> None:
+        seen = _patch_authorisation(monkeypatch, response={"allowed": True, "code": "ok"})
+        asyncio.run(outbound_filter.authorise_destination(
+            number="8092", agent=AGENT, registration_endpoint_id=REG_UUID,
+        ))
+        assert seen["registration_originated"] is True
+
+
+class TestTransferGate:
+    """_on_transfer refuses before any dialling happens."""
+
+    def test_refused_transfer_never_reaches_the_gateway(self, monkeypatch) -> None:
+        _patch_authorisation(monkeypatch, response={
+            "allowed": False, "code": "trunk_filter",
+            "reason": "destination +9098790123 is not permitted on this outbound trunk",
+            "chargeable": True, "trunkId": "public", "destination": "+449098790123",
+        })
+        session = _session()
+        dialled: list = []
+
+        async def _explode(*args, **kwargs):  # pragma: no cover - must not run
+            dialled.append(args)
+            raise AssertionError("gateway must not be asked to dial a refused destination")
+
+        session.gateway_session.transfer = _explode  # type: ignore[attr-defined]
+
+        result = asyncio.run(session._on_transfer({"number": "09098790123", "operation": "blind"}))
+        assert result["status"] == "FAILED"
+        assert "not permitted" in result["reason"]
+        assert session.transfer_state.state == "failed"
+        assert dialled == []
+
+    def test_webrtc_transfer_is_gated_too(self, monkeypatch) -> None:
+        """The WebRTC (media-relay) paths branch off inside _on_transfer, so the
+        gate has to sit ahead of that branch — pin it."""
+        _patch_authorisation(monkeypatch, response={
+            "allowed": False, "code": "agent_filter",
+            "reason": "destination +18005550199 does not match the agent's outbound call filter",
+            "chargeable": False, "trunkId": None, "destination": "+18005550199",
+        })
+        session = _session()
+        session.is_webrtc_origin = True
+
+        result = asyncio.run(session._on_transfer({"number": "+18005550199"}))
+        assert result["status"] == "FAILED"
+        assert "outbound call filter" in result["reason"]
+
+    def test_a_registration_uuid_caller_id_marks_the_leg_off_carrier(self, monkeypatch) -> None:
+        """A callerId that is a registration UUID means the leg egresses the
+        customer's own B2BUA, so the chargeable-trunk policy must not be applied
+        to it. Ownership of that registration is enforced separately by
+        _resolve_webrtc_egress, so a bogus UUID buys nothing."""
+        seen = _patch_authorisation(monkeypatch, response={
+            "allowed": False, "code": "agent_filter", "reason": "nope",
+            "chargeable": False, "trunkId": None, "destination": None,
+        })
+        session = _session()
+        asyncio.run(session._on_transfer({"number": "8092", "callerId": REG_UUID}))
+        assert seen["registration_originated"] is True
+        # No point asking the platform to resolve an egress trunk for a leg that
+        # does not use one.
+        assert seen["caller_id"] is None
+
+    def test_an_e164_caller_id_is_forwarded_for_trunk_resolution(self, monkeypatch) -> None:
+        """A WebRTC-origin transfer routes on its tool-supplied callerId, so the
+        platform needs it to find the egress trunk (and hence whether the
+        chargeable-trunk policy applies)."""
+        seen = _patch_authorisation(monkeypatch, response={
+            "allowed": False, "code": "trunk_filter", "reason": "nope",
+            "chargeable": True, "trunkId": "public", "destination": None,
+        })
+        session = _session()
+        session.is_webrtc_origin = True
+        asyncio.run(session._on_transfer({"number": "+18005550199", "callerId": "+442080996945"}))
+        assert seen["caller_id"] == "+442080996945"
+        assert seen["registration_originated"] is False

--- a/api/paths/agent-db/outbound-authorisation.js
+++ b/api/paths/agent-db/outbound-authorisation.js
@@ -1,0 +1,175 @@
+import { Agent, PhoneNumber } from '../../../lib/database.js';
+import { authoriseOutboundDestination } from '../../../lib/outbound-authorisation.js';
+import { normalizeE164 } from '../../../lib/validation.js';
+
+let appParameters, log;
+
+export default function (logger, voices, wsServer) {
+  (appParameters = {
+    logger,
+    voices,
+    wsServer
+  });
+  log = logger;
+  return {
+    POST: authoriseOutbound
+  };
+};
+
+/**
+ * Internal (x-shared-token) authorisation of one outbound destination, for the
+ * workers. The policy itself lives in lib/outbound-authorisation.js because only
+ * the API server can see `Trunk`, `RateCard` and `Tariff`; a worker must never
+ * re-implement it, and must fail CLOSED when this endpoint is unreachable.
+ *
+ * `agentId` is preferred over an inline `agentOptions`: the agent's filter is then
+ * read from the database rather than trusted from the caller. `agentOptions` is
+ * accepted for the in-call case where the worker already holds a resolved (possibly
+ * listener-overridden) agent definition.
+ *
+ * Always 200 with `{ allowed }` for a decided request — a refusal is a decision,
+ * not a transport error — so callers distinguish "denied" from "could not decide".
+ */
+const authoriseOutbound = (async (req, res) => {
+  const {
+    calledId,
+    callerId,
+    agentId,
+    agentOptions,
+    organisationId,
+    userId,
+    aplisayId,
+    outboundTrunkId,
+    registrationOriginated,
+  } = req.body || {};
+
+  try {
+    if (!calledId || typeof calledId !== 'string') {
+      return res.status(400).send({ error: 'calledId is required' });
+    }
+
+    let options = agentOptions && typeof agentOptions === 'object' ? agentOptions : null;
+    let owner = { organisationId, userId };
+    if (agentId) {
+      const agent = await Agent.findByPk(agentId, {
+        attributes: ['id', 'options', 'userId', 'organisationId'],
+      });
+      if (!agent) {
+        return res.status(404).send({ error: `Agent ${agentId} not found` });
+      }
+      // The stored options win over anything the caller asserted: the filter is
+      // part of the tenant's configuration, not a per-request parameter.
+      options = agent.options || null;
+      owner = {
+        organisationId: organisationId || agent.organisationId,
+        userId: userId || agent.userId,
+      };
+    }
+
+    // A worker that knows only the caller-ID (a WebRTC-origin transfer resolves its
+    // egress from it) gets the trunk resolved here, so the chargeable-trunk policy
+    // does not silently fall back to the platform default trunk.
+    let egressAplisayId = aplisayId || null;
+    if (!egressAplisayId && callerId && registrationOriginated !== true) {
+      const caller = await PhoneNumber.findByPk(normalizeE164(callerId), { attributes: ['aplisayId'] });
+      egressAplisayId = caller?.aplisayId || null;
+    }
+
+    const decision = await authoriseOutboundDestination({
+      calledId,
+      agentOptions: options,
+      organisationId: owner.organisationId,
+      userId: owner.userId,
+      aplisayId: egressAplisayId,
+      outboundTrunkId,
+      registrationOriginated: registrationOriginated === true,
+    });
+
+    if (!decision.allowed) {
+      log.info(
+        { calledId, agentId, organisationId: owner.organisationId, code: decision.code, trunkId: decision.trunkId },
+        'outbound destination refused',
+      );
+    }
+    res.send(decision);
+  } catch (err) {
+    log.error(err, 'error authorising outbound destination');
+    res.status(500).send({ error: 'Internal server error' });
+  }
+});
+
+authoriseOutbound.apiDoc = {
+  summary: 'Authorise an outbound destination against the agent, trunk and rating policy (internal).',
+  operationId: 'authoriseOutboundDestination',
+  tags: ['agent-db'],
+  requestBody: {
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object',
+          properties: {
+            calledId: { type: 'string', description: 'The destination as dialled' },
+            callerId: {
+              type: 'string',
+              description: "Caller-ID for the leg. Used to resolve the egress trunk when aplisayId isn't known (e.g. a WebRTC-origin transfer). Ignored when registrationOriginated is true.",
+            },
+            agentId: {
+              type: 'string',
+              description: 'Agent whose stored options.outboundCallFilter applies. Preferred over agentOptions.',
+            },
+            agentOptions: {
+              type: 'object',
+              description: 'Resolved agent options when the caller already holds them (reads outboundCallFilter). Ignored when agentId is supplied.',
+            },
+            organisationId: { type: 'string', description: 'Owning organisation, for the rating check' },
+            userId: { type: 'string', description: 'Owning user, for a per-user rate override' },
+            aplisayId: { type: 'string', description: "The caller number's trunk id" },
+            outboundTrunkId: { type: 'string', description: 'Explicit egress trunk id when the caller knows it' },
+            registrationOriginated: {
+              type: 'boolean',
+              description: 'True when the leg egresses a customer B2BUA (never our carrier, so never chargeable)',
+            },
+          },
+          required: ['calledId'],
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'Authorisation decision.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              allowed: { type: 'boolean' },
+              code: {
+                type: 'string',
+                enum: ['ok', 'agent_filter', 'default_filter', 'trunk_filter', 'not_rateable', 'invalid_destination'],
+              },
+              reason: { type: 'string', nullable: true },
+              chargeable: { type: 'boolean', description: 'Whether the leg egresses one of our carrier trunks' },
+              trunkId: { type: 'string', nullable: true },
+              destination: { type: 'string', nullable: true, description: 'Canonical +E.164 form' },
+              tariff: { type: 'string' },
+              prefix: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+    400: {
+      description: 'Bad request',
+      content: { 'application/json': { schema: { type: 'object', properties: { error: { type: 'string' } } } } },
+    },
+    404: {
+      description: 'Agent not found',
+      content: { 'application/json': { schema: { type: 'object', properties: { error: { type: 'string' } } } } },
+    },
+    500: {
+      description: 'Internal server error',
+      content: { 'application/json': { schema: { type: 'object', properties: { error: { type: 'string' } } } } },
+    },
+  },
+};

--- a/api/paths/listener/{listenerId}/originate.js
+++ b/api/paths/listener/{listenerId}/originate.js
@@ -4,6 +4,7 @@ import { getHandler } from '../../../../lib/handlers/index.js';
 import { userOwnsRow, userOwnsPhoneNumber } from '../../../../lib/scope.js';
 import { normalizeE164 } from '../../../../lib/validation.js';
 import { requirePermission } from '../../../../lib/auth/permissions.js';
+import { authoriseOutboundDestination } from '../../../../lib/outbound-authorisation.js';
 
 let appParameters, log;
 
@@ -87,21 +88,26 @@ const originateCall = (async (req, res) => {
       }
     }
 
-    // Validate that calledId matches the agent's outboundCallFilter if specified
-    if (agent.options?.outboundCallFilter) {
-      const filterRegexp = new RegExp(agent.options.outboundCallFilter);
-      if (!filterRegexp.test(calledId)) {
-        return res.status(400).send({
-          error: `Called number ${calledId} does not match the agent's outbound call filter pattern`
-        });
-      }
-    } else {
-      // Fallback to default UK validation if no filter is specified
-      if (!calledId.match(/^(\+44|44|0)[1237]\d{6,15}$/)) {
-        return res.status(400).send({
-          error: `Called number ${calledId} is not a valid UK geographic or mobile number`
-        });
-      }
+    // Authorise the destination. On a non-chargeable egress (a registration B2BUA to
+    // the customer's own PBX, a BYO trunk) this is the historical agent-filter check.
+    // On one of OUR chargeable carrier trunks the operator's per-trunk filter plus the
+    // organisation's rating deck decide, and the agent's own filter may only narrow
+    // them — the tenant does not choose which destinations we pay a carrier for.
+    // See lib/outbound-authorisation.js.
+    const decision = await authoriseOutboundDestination({
+      calledId,
+      agentOptions: agent.options,
+      organisationId: instance.organisationId || agent.organisationId,
+      userId: instance.userId || agent.userId,
+      aplisayId,
+      registrationOriginated: !!callerPhoneRegistration,
+    });
+    if (!decision.allowed) {
+      req.log.info(
+        { listenerId, calledId, code: decision.code, trunkId: decision.trunkId, chargeable: decision.chargeable },
+        'originate refused: destination not authorised',
+      );
+      return res.status(400).send({ error: decision.reason, code: decision.code });
     }
 
     // Check if the handler for this model has a outbound handler
@@ -164,7 +170,10 @@ originateCall.apiDoc = {
           properties: {
             calledId: {
               type: "string",
-              description: "The phone number to call (must be a valid UK geographic or mobile number)",
+              description: "The phone number to call. Must be permitted by the agent's options.outboundCallFilter "
+                + "(default: a UK geographic or mobile number). When the call egresses one of the platform's "
+                + "chargeable carrier trunks it must ALSO be permitted by that trunk's outboundCallFilter and be "
+                + "priced by the organisation's destination tariff; the agent's own filter can only narrow that.",
               example: "+447911123456"
             },
             callerId: {

--- a/api/paths/trunks.js
+++ b/api/paths/trunks.js
@@ -1,8 +1,9 @@
 import { Trunk, Organisation, Op } from '../../lib/database.js';
 import { requirePermission } from '../../lib/auth/permissions.js';
 import { TELEPHONY_HANDLER_NAMES } from '../../lib/handlers/index.js';
+import { validateOutboundCallFilter, DEFAULT_TRUNK_OUTBOUND_FILTER } from '../../lib/outbound-filter.js';
 
-const TRUNK_ATTRS = ['id', 'name', 'handler', 'outbound', 'chargeable', 'flags'];
+const TRUNK_ATTRS = ['id', 'name', 'handler', 'outbound', 'chargeable', 'outboundCallFilter', 'flags'];
 const withOrgs = { include: [{ model: Organisation, attributes: ['id'], through: { attributes: [] } }] };
 const projectWithOrgs = (t) => ({
   id: t.id,
@@ -10,6 +11,7 @@ const projectWithOrgs = (t) => ({
   handler: t.handler ?? null,
   outbound: !!t.outbound,
   chargeable: !!t.chargeable,
+  outboundCallFilter: t.outboundCallFilter ?? null,
   flags: t.flags ?? null,
   organisationIds: (t.Organisations || []).map((o) => o.id),
 });
@@ -93,7 +95,7 @@ const TRUNK_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
  */
 const createTrunk = async (req, res) => {
   if (!requirePermission(res, 'trunk', 'create')) return;
-  const { id, name, handler, outbound, chargeable, provider, organisationIds } = req.body || {};
+  const { id, name, handler, outbound, chargeable, outboundCallFilter, provider, organisationIds } = req.body || {};
 
   const trunkId = typeof id === 'string' ? id.trim() : '';
   if (!TRUNK_ID_RE.test(trunkId)) {
@@ -110,6 +112,10 @@ const createTrunk = async (req, res) => {
   }
   if (chargeable !== undefined && typeof chargeable !== 'boolean') {
     return res.status(400).send({ message: 'chargeable must be a boolean' });
+  }
+  if (outboundCallFilter !== undefined && outboundCallFilter !== null) {
+    const filterError = validateOutboundCallFilter(outboundCallFilter);
+    if (filterError) return res.status(400).send({ message: filterError });
   }
 
   // Validate the org-assignment set up-front so a bad id fails cleanly.
@@ -141,6 +147,9 @@ const createTrunk = async (req, res) => {
         handler: handler ?? null,
         outbound: !!outbound,
         chargeable: !!chargeable,
+        outboundCallFilter: (typeof outboundCallFilter === 'string' && outboundCallFilter.trim())
+          ? outboundCallFilter.trim()
+          : null,
         flags: Object.keys(flags).length ? flags : null,
       }, { transaction });
       if (orgs && orgs.length) await trunk.setOrganisations(orgs, { transaction });
@@ -214,6 +223,7 @@ listTrunks.apiDoc = {
                     handler: { type: 'string', nullable: true, description: 'Telephony handler for this trunk (e.g. livekit, jambonz)' },
                     outbound: { type: 'boolean', description: 'Whether this trunk can be used for outbound calls' },
                     chargeable: { type: 'boolean', description: 'Whether outbound minutes on this trunk are destination-billed to the org (our carrier trunks); false for BYO/inbound/registration trunks' },
+                    outboundCallFilter: { type: 'string', nullable: true, description: `Operator allow-pattern (regex) for outbound destinations carried on this trunk, applied to the canonical +E.164 form. Authoritative on a chargeable trunk: an agent's own options.outboundCallFilter may only narrow it. Null = the UK geographic/mobile default (${DEFAULT_TRUNK_OUTBOUND_FILTER})` },
                     flags: { type: 'object', nullable: true, description: 'JSON object containing trunk flags (e.g., canRefer, provider)' },
                     organisationIds: { type: 'array', items: { type: 'string' }, description: 'Organisations this trunk is assigned to (only present for scope=all)' }
                   }
@@ -257,6 +267,7 @@ createTrunk.apiDoc = {
             handler: { type: 'string', enum: TELEPHONY_HANDLER_NAMES, nullable: true, description: 'Telephony handler this trunk routes via' },
             outbound: { type: 'boolean', default: false, description: 'Whether the trunk supports outbound calls' },
             chargeable: { type: 'boolean', default: false, description: 'Shared carrier trunk whose outbound minutes are destination-billed' },
+            outboundCallFilter: { type: 'string', nullable: true, description: `Operator allow-pattern (regex) for outbound destinations on this trunk, matched against the canonical +E.164 destination. Only meaningful on a chargeable trunk, where it overrides any wider agent-supplied filter. Null/omitted = the UK geographic/mobile default (${DEFAULT_TRUNK_OUTBOUND_FILTER})` },
             provider: { type: 'string', nullable: true, description: 'Numbering provider a chargeable trunk fronts (stored under flags.provider)' },
             organisationIds: { type: 'array', items: { type: 'string' }, description: 'Organisations to assign this trunk to' }
           }

--- a/api/paths/trunks/{trunkId}.js
+++ b/api/paths/trunks/{trunkId}.js
@@ -1,5 +1,6 @@
 import { Trunk, Organisation } from '../../../lib/database.js';
 import { requirePermission } from '../../../lib/auth/permissions.js';
+import { validateOutboundCallFilter, DEFAULT_TRUNK_OUTBOUND_FILTER } from '../../../lib/outbound-filter.js';
 
 /**
  * /api/trunks/{trunkId} (item) — superAdmin-only trunk administration.
@@ -12,7 +13,8 @@ import { requirePermission } from '../../../lib/auth/permissions.js';
  * assignment-gated so trunk sharing isn't leaked cross-tenant.
  *
  *   GET   full trunk incl. its organisation assignments (organisationIds).
- *   PATCH edit name / chargeable ("billable") / organisation assignments.
+ *   PATCH edit name / chargeable ("billable") / outboundCallFilter / organisation
+ *         assignments.
  */
 export default function (logger) {
   // Project a Trunk row (with an eager Organisations include) to the wire shape.
@@ -22,6 +24,7 @@ export default function (logger) {
     handler: trunk.handler ?? null,
     outbound: !!trunk.outbound,
     chargeable: !!trunk.chargeable,
+    outboundCallFilter: trunk.outboundCallFilter ?? null,
     flags: trunk.flags ?? null,
     organisationIds: (trunk.Organisations || []).map((o) => o.id),
   });
@@ -51,10 +54,14 @@ export default function (logger) {
     const trunk = await Trunk.findByPk(req.params.trunkId, withOrgs);
     if (!trunk) return res.status(404).send({ message: `Trunk ${req.params.trunkId} not found` });
 
-    const { name, chargeable, organisationIds, provider } = req.body || {};
+    const { name, chargeable, outboundCallFilter, organisationIds, provider } = req.body || {};
 
     if (provider !== undefined && provider !== null && typeof provider !== 'string') {
       return res.status(400).send({ message: 'provider must be a string, or null to clear it' });
+    }
+    if (outboundCallFilter !== undefined && outboundCallFilter !== null) {
+      const filterError = validateOutboundCallFilter(outboundCallFilter);
+      if (filterError) return res.status(400).send({ message: filterError });
     }
 
     // Validate the assignment set up-front (before any write) so a bad org id
@@ -76,6 +83,13 @@ export default function (logger) {
         // name is nullable in the model; treat an empty string as "clear it".
         if (name !== undefined) trunk.name = typeof name === 'string' && name.trim() ? name.trim() : null;
         if (chargeable !== undefined) trunk.chargeable = !!chargeable;
+        // Operator allow-pattern for destinations carried on this trunk; empty/null
+        // clears it back to the UK geographic/mobile default.
+        if (outboundCallFilter !== undefined) {
+          trunk.outboundCallFilter = (typeof outboundCallFilter === 'string' && outboundCallFilter.trim())
+            ? outboundCallFilter.trim()
+            : null;
+        }
         // provider is stored under flags.provider (the numbering provider this
         // chargeable trunk fronts, e.g. "magrathea"); reassign flags so the
         // JSONB column is marked dirty. Empty/null clears it.
@@ -98,7 +112,7 @@ export default function (logger) {
     }
   };
   update.apiDoc = {
-    summary: 'Update a trunk: name, chargeable (billable), organisation assignments (super admin).',
+    summary: 'Update a trunk: name, chargeable (billable), outbound call filter, organisation assignments (super admin).',
     operationId: 'updateTrunk',
     tags: ['Phone Endpoints'],
     parameters: [{ in: 'path', name: 'trunkId', required: true, schema: { type: 'string' } }],
@@ -110,6 +124,7 @@ export default function (logger) {
             properties: {
               name: { type: 'string', nullable: true, description: 'Free-form human name; empty clears it' },
               chargeable: { type: 'boolean', description: 'Whether outbound minutes are destination-billed to the org' },
+              outboundCallFilter: { type: 'string', nullable: true, description: `Operator allow-pattern (regex) for outbound destinations carried on this trunk, matched against the canonical +E.164 destination. On a chargeable trunk this is authoritative — an agent's options.outboundCallFilter may only narrow it. Empty/null clears it back to the UK geographic/mobile default (${DEFAULT_TRUNK_OUTBOUND_FILTER}).` },
               provider: { type: 'string', nullable: true, description: 'Numbering provider this chargeable trunk fronts (stored under flags.provider, e.g. "magrathea"); the Buy-number flow lands a bought number on the chargeable trunk whose provider matches the carrier it was bought from. Empty/null clears it.' },
               organisationIds: {
                 type: 'array',

--- a/docs/call-transfers.md
+++ b/docs/call-transfers.md
@@ -763,6 +763,23 @@ Add the `outboundCallFilter` option to your agent definition:
 - The regexp is anchored with `^` and `$` to match the complete phone number
 - Only outbound calls (via `transfer` or `originate`) where the destination number matches this pattern will be allowed
 - If a transfer is attempted to a number that doesn't match the filter, the transfer will fail with an error
+- It is enforced identically on the originate API and on both voice workers (LiveKit and Pipecat), across blind, consultative and WebRTC-origin transfers, and on an agent's `fallback.number`
+
+### On a chargeable (platform carrier) trunk, the filter can only narrow
+
+This filter is **your** control over **your** agent, and on a leg that leaves via
+your own PBX registration or your own BYO trunk it is the whole of the policy.
+
+When a call goes out on one of Aplisay's own carrier trunks — where Aplisay pays
+the carrier for the minutes — the platform applies its own policy *first*: the
+trunk's operator allow-pattern (UK geographic/mobile by default) and a destination
+the organisation actually has a rate for. Your `outboundCallFilter` is then applied
+on top and can only remove destinations, never add them. A wide filter therefore
+does not open up international or premium-rate dialling on a platform trunk;
+refusals come back to the agent as a `transfer` failure with a reason.
+
+See [outbound call authorisation](outbound-call-authorisation.md) for the full
+policy, refusal codes and trunk configuration.
 
 ### Example Patterns
 

--- a/docs/livekit-agent-architecture.md
+++ b/docs/livekit-agent-architecture.md
@@ -425,7 +425,8 @@ All outbound destination numbers are normalized to E.164 form. The platform has 
 Destination validation is applied before any outbound is dispatched:
 
 - `agent.options.outboundCallFilter` — anchored regex applied to the destination. Calls whose destination doesn't match are rejected.
-- `transfer.callerId` override — when a caller ID is overridden on a transfer call, the agent validates that the user owns that number before honoring the override.
+- **Egress-aware authorisation** — the destination check is delegated to the platform (`POST /api/agent-db/outbound-authorisation`), not evaluated in the worker, because it depends on the egress trunk and the organisation's rating deck. On a chargeable (our-carrier) trunk the trunk's operator filter and a rateable destination are the authority, and the agent's own filter can only narrow them; on a customer-owned egress the agent's filter remains authoritative. The worker fails **closed** if the platform cannot be reached. See [outbound-call-authorisation.md](outbound-call-authorisation.md).
+- `transfer.callerId` override — when a caller ID is overridden on a transfer call, the agent validates that the user owns that number before honoring the override. The authorisation call is made *after* this resolution, since a registration caller-ID changes the egress.
 
 ### 6.7 Transfer — REFER vs blind-bridge decision
 
@@ -512,7 +513,7 @@ A re-implementer must honor:
 **Number handling**
 
 - E.164 normalization with default-country setting.
-- `agent.options.outboundCallFilter` regex gates outbound destinations.
+- `agent.options.outboundCallFilter` regex gates outbound destinations, narrowing (never widening) the platform's own per-trunk + rating policy on a chargeable trunk — see [outbound-call-authorisation.md](outbound-call-authorisation.md).
 - Caller-ID override on `transfer` requires user ownership.
 
 ## 7. Call lifecycle and disconnect taxonomy

--- a/docs/livekit-pipecat-transfer-parity.md
+++ b/docs/livekit-pipecat-transfer-parity.md
@@ -17,7 +17,8 @@ repo, REST + VSI) — with a focus on call transfers.
 | Consultative finalise, bridged | ✅ `moveParticipant` into caller room | ✅ `mode: "bridged"` relay | ✅ room bridge |
 | Consultative finalise, attended REFER-with-Replaces | ✅ | ✅ `mode: "attended"` | ❌ — falls back to media bridge (voiceblender's transfer API takes `replaces_leg_id`, but the worker integration for the consult finalise is not wired; the bridged fallback is used) |
 | Transfer mode selection (origin defaults + `forceBridged`/`forceRefer` + endpoint options) | ✅ | ✅ | ✅ |
-| `transfer_status`, `transferPrompt`, `consultFeedback`, `callerId` override, outboundCallFilter | ✅ | ✅ | ✅ |
+| `transfer_status`, `transferPrompt`, `consultFeedback`, `callerId` override | ✅ | ✅ | ✅ |
+| Outbound destination authorisation (`outboundCallFilter` + per-trunk/rating policy — [doc](outbound-call-authorisation.md)) | ✅ platform call in `validateTransferArgs` | ✅ platform call in `_on_transfer` (gateway-independent) | ✅ same |
 | Confidence tone (`options.transferTone`) | ✅ | ✅ | ✅ |
 | WebRTC (browser) origin transfers | n/a (LiveKit rooms native) | ✅ worker-side media relay | ✅ worker-side media relay |
 | Bridged call record for the post-transfer segment | ✅ child call, `modelName: "telephony:bridged-call"` | ✅ when the bridge is monitored/transcribed; plain bridges still have no record (no event path) | ✅ same condition |

--- a/docs/originate-api.md
+++ b/docs/originate-api.md
@@ -10,7 +10,7 @@ The originate endpoint validates and starts an outbound call from an **agent lis
 
 - **`listenerId`**: Listener / instance ID (from `POST …/listen`).
 - **Body**
-  - **`calledId`**: Destination number. If the agent has no custom `outboundCallFilter`, default validation is UK geographic/mobile (same rules as historically).
+  - **`calledId`**: Destination number, subject to [outbound call authorisation](outbound-call-authorisation.md). If the agent has no custom `outboundCallFilter`, default validation is UK geographic/mobile (same rules as historically). If the call egresses one of the platform's **chargeable** carrier trunks, the trunk's own `outboundCallFilter` and the organisation's destination tariff decide instead, and the agent's filter can only narrow that — a refusal comes back as `400` with a `code` (`trunk_filter`, `not_rateable`, …).
   - **`callerId`**: Either **E.164** for an allocated number in `phone_numbers`, or a **UUID** primary key of a row in `phone_registrations`.
   - **`metadata`**: Optional; forwarded to the LiveKit outbound dispatch.
 

--- a/docs/outbound-call-authorisation.md
+++ b/docs/outbound-call-authorisation.md
@@ -1,0 +1,119 @@
+# Outbound call authorisation
+
+Every path that puts a call *out* of the platform — the originate API, a blind or
+consultative `transfer`, a WebRTC bridge leg, an agent's last-resort
+`fallback.number` — passes through one policy: **`lib/outbound-authorisation.js`**.
+
+There is exactly one implementation. The workers do not carry their own copy: the
+LiveKit and Pipecat workers call `POST /api/agent-db/outbound-authorisation` (an
+internal, `x-shared-token` route) and treat any failure to reach it as a refusal.
+
+## Why the agent's own filter cannot be the whole story
+
+`agents.options.outboundCallFilter` is a **tenant-controlled** value. It is a good
+tool for an agent author who wants to pin their agent to a handful of numbers, and
+that is exactly how it is documented in [call-transfers.md](call-transfers.md).
+
+It is not a control the *operator* can rely on, because the person who writes the
+filter is the person we would be protecting ourselves from. An agent whose filter
+is `^\+?\d+$` — or an agent with a narrow filter whose destination arrives from a
+CRM field an attacker can write — can dial international premium-rate and
+revenue-share ranges. When that call leaves on one of **our** carrier trunks, we
+pay the carrier. That is the classic toll-fraud monetisation path, and it can run
+up five figures in a day.
+
+So the policy splits on one question: **whose minutes are at risk?**
+
+## The two cases
+
+### 1. Not our carrier — the agent's filter is authoritative
+
+A leg that egresses a **registration B2BUA** (the customer's own PBX), a BYO
+trunk, or any trunk not flagged `chargeable` costs us nothing. Behaviour here is
+unchanged from before this policy existed:
+
+* `options.outboundCallFilter` if the agent sets one;
+* otherwise the historical default — a UK geographic, non-geographic or mobile
+  number in any of the accepted dialled forms (`^(\+44|44|0)[1237]\d{6,15}$`).
+
+### 2. Our chargeable carrier trunk — the operator's policy is authoritative
+
+A leg that egresses a trunk with `Trunk.chargeable = true` is carried at our cost
+(this is the same flag that drives destination billing — see
+[implementation/rate-cards-STATUS.md](implementation/rate-cards-STATUS.md)). The
+destination must satisfy **all three** of:
+
+| # | Gate | Source |
+|---|------|--------|
+| a | `Trunk.outboundCallFilter` — the operator's allow-pattern, applied to the canonical `+E.164` destination. Unset ⇒ UK geographic/mobile: `^\+44[1237]\d{8,9}$` | operator (superAdmin) |
+| b | **Rateable** — the destination longest-prefix-matches a prefix in the tariff named by the `destination` line of the rate card in force for this org/user | operator (rate cards + tariffs) |
+| c | `options.outboundCallFilter`, when the agent sets one | tenant — **narrows only** |
+
+(c) can only ever remove destinations that (a) and (b) already permit. A wide-open
+agent filter buys nothing on a chargeable trunk.
+
+Gate (b) is deliberately the same resolution the costing engine performs at call
+end (`costUsageRow` → per-user rate override, then the organisation's, then the
+covering rate card, its `destination` line, the effective tariff, longest-prefix
+match). **If we cannot price the call, we do not carry it** — which also means a
+destination cannot be dialled before it has been added to the tariff deck.
+
+## Refusal codes
+
+The decision returns `{ allowed, code, reason, chargeable, trunkId, destination }`.
+
+| `code` | Meaning |
+|--------|---------|
+| `ok` | Permitted |
+| `default_filter` | No agent filter; failed the historical UK default |
+| `agent_filter` | Failed the agent's own `options.outboundCallFilter` |
+| `trunk_filter` | Failed the egress trunk's operator allow-pattern |
+| `not_rateable` | We hold no rate/tariff that prices this destination for this organisation |
+| `invalid_destination` | Not a dialable number at all |
+
+The originate API returns these as a `400` with `error` and `code`. In a worker
+the refusal surfaces to the model as the `transfer` tool's failure reason, so the
+agent can tell the caller rather than silently stalling.
+
+## Configuring a trunk filter
+
+`Trunk.outboundCallFilter` is superAdmin-only, on the existing trunk endpoints:
+
+```bash
+curl -X PATCH "$API/api/trunks/$TRUNK_ID" \
+  -H 'content-type: application/json' \
+  -d '{"outboundCallFilter": "^\\+44[1237]\\d{8,9}$"}'
+```
+
+Notes:
+
+* it is matched against the **canonical `+E.164`** form, so there is one way to
+  write it regardless of how the number was dialled (`07700…`, `447700…`,
+  `+447700…` all normalise first);
+* `null` (or an empty string) restores the UK geographic/mobile default — it never
+  means "allow everything";
+* patterns are capped at 512 characters and must compile; an unusable pattern is
+  rejected at write time, and if one ever reaches the gate it is treated as *no
+  match* (fail closed);
+* it is ignored on a non-chargeable trunk, where case 1 applies.
+
+## Failure modes
+
+* **Platform unreachable from a worker** — the transfer is refused. The gate
+  protects a cost we cannot undo, so "cannot decide" resolves to "no".
+* **A chargeable trunk with no tariff coverage yet** — everything is refused with
+  `not_rateable`. Load the tariff deck before enabling the trunk.
+* **`APLISAY_OUTBOUND_TRUNK_ID` unset** — the platform's public trunk is not
+  identified, so a carried leg resolves to whatever trunk the caller number's
+  `aplisayId` names. This is the same env the workers stamp destination billing
+  from; set it consistently on the API server and both workers.
+
+## Where it is enforced
+
+| Path | Enforcement |
+|------|-------------|
+| `POST /api/listener/{id}/originate` | in-process, all handlers |
+| LiveKit worker `transfer` (blind, consultative, bridge) | `validateTransferArgs` → internal endpoint |
+| Pipecat worker `transfer` (blind, consultative, WebRTC relay) | `_on_transfer` → `outbound_filter.py` → internal endpoint |
+| Pipecat worker `fallback.number` | same gate as a tool-call transfer |
+| jambonz / native Ultravox | no outbound or transfer capability; nothing to gate |

--- a/environment-example
+++ b/environment-example
@@ -132,7 +132,9 @@ LIVEKIT_API_SECRET=<LIVEKIT API SECRET>
 # PIPECAT_DISPATCH_TOKEN=      # bearer token for dispatch calls
 # PIPECAT_JOIN_SECRET=         # shared secret for join callbacks
 # PIPECAT_PUBLIC_URL=          # public URL handed to the worker for callbacks
-# Real Trunk.id pipecat outbound/carried legs egress on (billing attribution):
+# Real Trunk.id pipecat outbound/carried legs egress on (billing attribution AND
+# outbound destination authorisation — docs/outbound-call-authorisation.md). Set the
+# same value here and on both voice workers.
 # APLISAY_OUTBOUND_TRUNK_ID=
 
 # ── Call recordings ──────────────────────────────────────────────────────────

--- a/lib/database.js
+++ b/lib/database.js
@@ -10,8 +10,16 @@ import { validatePromptMetadata } from './prompt-metadata-validate.js';
 import { initPhoneRegistration } from './database-models/phone-registration.js';
 import { encryptSecret, decryptSecret } from './utils/credentials.js';
 import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-limits.js';
+// Import-cycle note: lib/outbound-filter.js is deliberately dependency-free so the
+// Trunk model can validate an operator filter pattern without pulling in the
+// policy module (which imports this file).
+import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 57;  // 57: listener-level transfer overrides — `instances.bridged_transfer_to_agent`,
+const schemaVersion = 58;  // 58: `trunks.outbound_call_filter` — the operator's per-trunk allow pattern for
+                           //     outbound destinations on a chargeable (our-carrier) trunk. Authoritative over
+                           //     the tenant-supplied `agents.options.outboundCallFilter`, which may only narrow
+                           //     it. Null = the UK geographic/mobile default (lib/outbound-authorisation.js).
+                           // 57: listener-level transfer overrides — `instances.bridged_transfer_to_agent`,
                            //     `instances.bridged_transfer_transcribe`, `instances.dtmf_timeout`: per-listener
                            //     wholesale overrides of the same-named agent options (docs/transfer-back-plan.md).
                            // 56: `agents.prompt_metadata` — declared call metadata stated to the model in its
@@ -429,6 +437,16 @@ Agent.init({
             if (tone.enabled !== undefined && typeof tone.enabled !== 'boolean') {
               throw new Error('options.transferTone.enabled must be a boolean');
             }
+          }
+        }
+        if (this.options?.outboundCallFilter !== undefined && this.options?.outboundCallFilter !== null) {
+          // Agent-level allow pattern for outbound destinations (originate + transfer
+          //  targets). Reject an unusable pattern at write time rather than failing
+          //  closed mid-call. NB on a chargeable (our-carrier) trunk this filter can
+          //  only NARROW the trunk's own filter — see lib/outbound-authorisation.js.
+          const filterError = validateOutboundCallFilter(this.options.outboundCallFilter);
+          if (filterError) {
+            throw new Error(`options.${filterError}`);
           }
         }
         if (this.options?.bridgedTransferToAgent !== undefined && this.options?.bridgedTransferToAgent !== null) {
@@ -2303,6 +2321,24 @@ Trunk.init({
     type: DataTypes.BOOLEAN,
     allowNull: false,
     defaultValue: false
+  },
+  // Operator allow-pattern for outbound destinations carried on this trunk, applied
+  // to the canonical `+E.164` form of the dialled number. On a `chargeable` trunk this
+  // is AUTHORITATIVE: an agent's own `options.outboundCallFilter` can only narrow it,
+  // never widen it, because the tenant does not get to choose which destinations we
+  // pay a carrier for (see lib/outbound-authorisation.js). Null = the UK geographic /
+  // mobile default. Ignored on non-chargeable trunks (customer PBX / BYO carrier),
+  // where the agent's own filter remains authoritative as it always has been.
+  outboundCallFilter: {
+    type: DataTypes.STRING(512),
+    allowNull: true,
+    defaultValue: null,
+    validate: {
+      isUsableRegExp(value) {
+        const error = validateOutboundCallFilter(value);
+        if (error) throw new Error(error);
+      }
+    }
   },
   flags: {
     type: DataTypes.JSONB,

--- a/lib/outbound-authorisation.js
+++ b/lib/outbound-authorisation.js
@@ -1,0 +1,277 @@
+/**
+ * Outbound destination authorisation — the single policy that decides whether a
+ * dialled number may be carried, for EVERY worker technology and every path that
+ * puts a call out of the platform (the originate API, blind/consultative
+ * transfers, WebRTC bridge legs, fallback numbers).
+ *
+ * Two different trust models, keyed on WHOSE minutes are at risk:
+ *
+ *  - **Not our carrier** (a registration B2BUA to the customer's own PBX, a BYO
+ *    trunk, no outbound trunk at all): the agent author's `options.outboundCallFilter`
+ *    is authoritative, defaulting to UK geographic/mobile. This is the historical
+ *    behaviour and is preserved exactly — the fraud risk is the customer's own.
+ *
+ *  - **Our chargeable public trunk** (`Trunk.chargeable`, the carrier minutes WE
+ *    pay for): the agent-supplied filter is a tenant-controlled input and therefore
+ *    CANNOT be the authority — an agent author (or a prompt-injected LLM working
+ *    within a wide filter) could otherwise dial premium-rate or international
+ *    revenue-share destinations at our cost. On these trunks a destination must
+ *    satisfy ALL of:
+ *      a. `Trunk.outboundCallFilter` — the operator's per-trunk allow pattern,
+ *         applied to the CANONICAL `+E.164` form, defaulting to UK geographic/
+ *         mobile ({@link DEFAULT_TRUNK_OUTBOUND_FILTER}) when unset;
+ *      b. **rateable** — the destination longest-prefix-matches a prefix in the
+ *         tariff named by the destination line of the rate card in force for this
+ *         org/user (lib/rates.js + lib/tariffs.js). If we cannot price the call we
+ *         will not carry it;
+ *      c. the agent's own `options.outboundCallFilter` when set — which can only
+ *         ever NARROW (a) and (b), never widen them.
+ *
+ * The policy lives server-side because only the API server can see `Trunk`,
+ * `RateCard` and `Tariff`. Workers do not re-implement it: they call
+ * `POST /api/agent-db/outbound-authorisation` (see that path) and fail CLOSED.
+ *
+ * @module lib/outbound-authorisation
+ */
+import {
+  Trunk as DefaultTrunk,
+  Organisation as DefaultOrganisation,
+  User as DefaultUser,
+  RateCard as DefaultRateCard,
+  Tariff as DefaultTariff,
+  TariffPrefix as DefaultTariffPrefix,
+} from './database.js';
+import { resolveOrgRateName, resolveRateCard } from './rates.js';
+import { normaliseDestination, resolveTariff, matchTariffPrefix } from './tariffs.js';
+import {
+  DEFAULT_AGENT_OUTBOUND_FILTER,
+  DEFAULT_TRUNK_OUTBOUND_FILTER,
+  filterAllows,
+} from './outbound-filter.js';
+
+export {
+  DEFAULT_AGENT_OUTBOUND_FILTER,
+  DEFAULT_TRUNK_OUTBOUND_FILTER,
+  MAX_FILTER_LENGTH,
+  filterAllows,
+  validateOutboundCallFilter,
+} from './outbound-filter.js';
+
+/**
+ * Canonical `+E.164` form of a dialled destination, or null when it is not a
+ * plausible number (the `WebRTC` sentinel, an internal test id, junk). Wraps
+ * {@link normaliseDestination} — the SAME normalisation the billing path freezes
+ * onto the usage row, so "what we authorise" and "what we rate" cannot diverge.
+ *
+ * @param {string} raw
+ * @param {object} [opts]
+ * @param {string} [opts.defaultCountry='GB'] home country for national `0…` forms
+ * @returns {string|null}
+ */
+export function canonicaliseDestination(raw, { defaultCountry = 'GB' } = {}) {
+  const intl = normaliseDestination(raw, { defaultCountry });
+  return intl ? `+${intl}` : null;
+}
+
+/**
+ * Resolve the trunk an outbound leg will egress on, and hence whether WE carry
+ * its cost.
+ *
+ * A registration-originated leg goes out over the customer's own B2BUA (their
+ * PBX, never our carrier) and is therefore never chargeable — mirroring the
+ * billing gate in `telephony.ts` / `call_session.py` that declines to stamp
+ * `Call.outboundTrunkId` in that case.
+ *
+ * Otherwise we consider, in order, the trunk id the caller states for the leg,
+ * the platform's configured public outbound trunk (`APLISAY_OUTBOUND_TRUNK_ID` —
+ * the same env the workers stamp billing from), and the caller number's own
+ * `aplisayId` trunk. The FIRST chargeable trunk found wins; if none is chargeable
+ * the first resolvable trunk is returned for context.
+ *
+ * @returns {Promise<{trunk: object|null, chargeable: boolean}>}
+ */
+export async function resolveEgressTrunk({
+  outboundTrunkId,
+  aplisayId,
+  registrationOriginated,
+} = {}, { Trunk = DefaultTrunk, env = process.env } = {}) {
+  if (registrationOriginated) return { trunk: null, chargeable: false };
+
+  const candidates = [outboundTrunkId, env.APLISAY_OUTBOUND_TRUNK_ID, aplisayId]
+    .filter((id) => typeof id === 'string' && id.trim())
+    .map((id) => id.trim());
+  const seen = new Set();
+  let first = null;
+  for (const id of candidates) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    // eslint-disable-next-line no-await-in-loop
+    const trunk = await Trunk.findByPk(id);
+    if (!trunk) continue;
+    if (trunk.chargeable) return { trunk, chargeable: true };
+    if (!first) first = trunk;
+  }
+  return { trunk: first, chargeable: false };
+}
+
+/**
+ * Can we price a call to this destination for this org/user? Mirrors the costing
+ * resolution in `costUsageRow` exactly — per-user rate override first, then the
+ * organisation's, then the covering rate card, its `destination` line, the named
+ * tariff effective now, and finally a longest-prefix match on the destination —
+ * so a number that authorises here is a number that will actually be charged.
+ *
+ * @returns {Promise<{rateable: boolean, reason?: string, rateName?: string,
+ *                    tariff?: string, prefix?: string, destination?: string}>}
+ */
+export async function isDestinationRateable({ organisationId, userId, calledId, at = new Date() }, {
+  Organisation = DefaultOrganisation, User = DefaultUser, RateCard = DefaultRateCard,
+  Tariff = DefaultTariff, TariffPrefix = DefaultTariffPrefix,
+} = {}) {
+  const org = organisationId ? await Organisation.findByPk(organisationId) : null;
+  const user = userId
+    ? await User.findByPk(userId, { attributes: ['rateHistory'] }).catch(() => null)
+    : null;
+  const rateName = (user && resolveOrgRateName(user, at)) || resolveOrgRateName(org, at);
+  if (!rateName) return { rateable: false, reason: 'no rate assigned to this organisation' };
+
+  const card = await resolveRateCard(rateName, at, { RateCard });
+  if (!card) return { rateable: false, reason: `no rate card "${rateName}" in force`, rateName };
+
+  const lines = Array.isArray(card?.detail?.lines) ? card.detail.lines : [];
+  const destLine = lines.find((l) => l && l.dim === 'destination' && l.tariff);
+  if (!destLine) {
+    return { rateable: false, reason: `rate "${rateName}" prices no destinations`, rateName };
+  }
+
+  const tariff = await resolveTariff(destLine.tariff, at, { Tariff });
+  if (!tariff) {
+    return { rateable: false, reason: `no tariff "${destLine.tariff}" in force`, rateName };
+  }
+
+  // Normalise with the TARIFF's own home country, as the costing path does.
+  const number = normaliseDestination(calledId, { defaultCountry: tariff.defaultCountry });
+  if (!number) return { rateable: false, reason: 'destination is not a dialable number', rateName };
+
+  const prefixRow = await matchTariffPrefix(tariff.id, number, { TariffPrefix });
+  if (!prefixRow) {
+    return {
+      rateable: false,
+      reason: `destination is not in tariff "${tariff.name}"`,
+      rateName,
+      tariff: tariff.name,
+      destination: `+${number}`,
+    };
+  }
+  return {
+    rateable: true, rateName, tariff: tariff.name, prefix: prefixRow.prefix, destination: `+${number}`,
+  };
+}
+
+/**
+ * THE authorisation decision for one outbound destination. Every technology
+ * routes through this (directly on the API server, or over
+ * `/api/agent-db/outbound-authorisation` from a worker).
+ *
+ * @param {object}  params
+ * @param {string}  params.calledId               the dialled destination, as dialled
+ * @param {object}  [params.agentOptions]         the agent's `options` (reads `outboundCallFilter`)
+ * @param {string}  [params.organisationId]       owning organisation (for rating)
+ * @param {string}  [params.userId]               owning user (per-user rate override)
+ * @param {string}  [params.aplisayId]            the caller number's trunk id
+ * @param {string}  [params.outboundTrunkId]      explicit egress trunk id, when the caller knows it
+ * @param {boolean} [params.registrationOriginated] leg egresses a customer B2BUA
+ * @param {Date}    [params.at]                   decision instant (tests)
+ * @returns {Promise<{allowed: boolean, code: string, reason: string|null,
+ *                    chargeable: boolean, trunkId: string|null, destination: string|null,
+ *                    tariff?: string, prefix?: string}>}
+ */
+export async function authoriseOutboundDestination({
+  calledId,
+  agentOptions,
+  organisationId,
+  userId,
+  aplisayId,
+  outboundTrunkId,
+  registrationOriginated = false,
+  at = new Date(),
+} = {}, models = {}) {
+  const agentFilter = agentOptions?.outboundCallFilter || null;
+  const dialled = typeof calledId === 'string' ? calledId.trim() : '';
+
+  if (!dialled) {
+    return {
+      allowed: false, code: 'invalid_destination', chargeable: false, trunkId: null, destination: null,
+      reason: 'no destination number supplied',
+    };
+  }
+
+  const { trunk, chargeable } = await resolveEgressTrunk(
+    { outboundTrunkId, aplisayId, registrationOriginated }, models,
+  );
+  const trunkId = trunk?.id || null;
+
+  // ---- Not our carrier: historical, tenant-authoritative behaviour ----
+  if (!chargeable) {
+    const pattern = agentFilter || DEFAULT_AGENT_OUTBOUND_FILTER;
+    if (!filterAllows(pattern, dialled)) {
+      return {
+        allowed: false,
+        code: agentFilter ? 'agent_filter' : 'default_filter',
+        chargeable: false,
+        trunkId,
+        destination: canonicaliseDestination(dialled),
+        reason: agentFilter
+          ? `destination ${dialled} does not match the agent's outbound call filter`
+          : `destination ${dialled} is not a valid UK geographic or mobile number`,
+      };
+    }
+    return {
+      allowed: true, code: 'ok', chargeable: false, trunkId,
+      destination: canonicaliseDestination(dialled), reason: null,
+    };
+  }
+
+  // ---- Our chargeable public trunk: operator policy is authoritative ----
+  const destination = canonicaliseDestination(dialled);
+  if (!destination) {
+    return {
+      allowed: false, code: 'invalid_destination', chargeable: true, trunkId, destination: null,
+      reason: `destination ${dialled} is not a dialable international number`,
+    };
+  }
+
+  // (a) per-trunk operator allow pattern, on the canonical form.
+  const trunkFilter = trunk?.outboundCallFilter || DEFAULT_TRUNK_OUTBOUND_FILTER;
+  if (!filterAllows(trunkFilter, destination)) {
+    return {
+      allowed: false, code: 'trunk_filter', chargeable: true, trunkId, destination,
+      reason: `destination ${destination} is not permitted on this outbound trunk`,
+    };
+  }
+
+  // (b) must be rateable for this org — if we cannot charge it we do not carry it.
+  const rating = await isDestinationRateable({ organisationId, userId, calledId: dialled, at }, models);
+  if (!rating.rateable) {
+    return {
+      allowed: false, code: 'not_rateable', chargeable: true, trunkId, destination,
+      reason: `destination ${destination} is not rated for this organisation (${rating.reason})`,
+    };
+  }
+
+  // (c) the agent's own filter may narrow, never widen. Applied to the RAW dialled
+  // string so existing agent patterns keep their existing meaning.
+  if (agentFilter && !filterAllows(agentFilter, dialled)) {
+    return {
+      allowed: false, code: 'agent_filter', chargeable: true, trunkId, destination,
+      reason: `destination ${dialled} does not match the agent's outbound call filter`,
+    };
+  }
+
+  return {
+    allowed: true, code: 'ok', chargeable: true, trunkId, destination, reason: null,
+    tariff: rating.tariff, prefix: rating.prefix,
+  };
+}
+
+export default authoriseOutboundDestination;

--- a/lib/outbound-filter.js
+++ b/lib/outbound-filter.js
@@ -1,0 +1,74 @@
+/**
+ * Outbound call filter primitives — pure pattern handling with NO imports at all,
+ * so the model layer (`Trunk.outboundCallFilter` validation in lib/database.js)
+ * can use them without an import cycle. The policy that decides WHICH filters
+ * apply to a given leg lives in lib/outbound-authorisation.js.
+ *
+ * @module lib/outbound-filter
+ */
+
+/**
+ * Historical platform default when an agent sets no `outboundCallFilter`: UK
+ * geographic (01/02), non-geographic (03) and mobile (07), in any of the dialled
+ * forms the platform has always accepted (`+44…`, `44…`, `0…`). Applied to the
+ * RAW dialled string, exactly as the previous inline checks in the originate
+ * endpoint and the LiveKit transfer handler did.
+ */
+export const DEFAULT_AGENT_OUTBOUND_FILTER = '^(\\+44|44|0)[1237]\\d{6,15}$';
+
+/**
+ * Default `Trunk.outboundCallFilter` for a chargeable trunk that has none
+ * configured: UK geographic/non-geographic/mobile in CANONICAL `+E.164` form
+ * (the form this filter is always applied to, so there is exactly one way to
+ * write an operator pattern). `[1237]` + 8–9 further digits covers both the
+ * 9- and 10-digit national formats.
+ */
+export const DEFAULT_TRUNK_OUTBOUND_FILTER = '^\\+44[1237]\\d{8,9}$';
+
+/**
+ * Upper bound on an accepted filter pattern. Both agent- and operator-supplied
+ * patterns are compiled into a RegExp, so cap the source length to keep the
+ * catastrophic-backtracking surface small (destinations are themselves capped at
+ * E.164's 15 digits, which bounds the input side).
+ */
+export const MAX_FILTER_LENGTH = 512;
+
+/** Longest string we will ever run a filter against (E.164 + punctuation slack). */
+export const MAX_DESTINATION_LENGTH = 32;
+
+/**
+ * Validate a user/operator-supplied outbound call filter pattern.
+ * @param {*} pattern
+ * @returns {string|null} an error message, or null when the pattern is usable
+ */
+export function validateOutboundCallFilter(pattern) {
+  if (pattern == null || pattern === '') return null;
+  if (typeof pattern !== 'string') return 'outboundCallFilter must be a string';
+  if (pattern.length > MAX_FILTER_LENGTH) {
+    return `outboundCallFilter must be at most ${MAX_FILTER_LENGTH} characters`;
+  }
+  try {
+    // eslint-disable-next-line no-new
+    new RegExp(pattern);
+  } catch (e) {
+    return `outboundCallFilter is not a valid regular expression: ${e.message}`;
+  }
+  return null;
+}
+
+/**
+ * Test `value` against a filter `pattern`. Never throws: an unusable pattern
+ * (invalid regex, over-long, non-string) is treated as NOT matching, so a
+ * malformed filter fails closed rather than opening the gate.
+ *
+ * @returns {boolean}
+ */
+export function filterAllows(pattern, value) {
+  if (typeof value !== 'string' || !value || value.length > MAX_DESTINATION_LENGTH) return false;
+  if (validateOutboundCallFilter(pattern) !== null) return false;
+  try {
+    return new RegExp(pattern).test(value);
+  } catch {
+    return false;
+  }
+}

--- a/tests/outbound-authorisation.test.mjs
+++ b/tests/outbound-authorisation.test.mjs
@@ -1,0 +1,270 @@
+import {
+  setupRealDatabase, teardownRealDatabase,
+  Organisation, User, Trunk, RateCard, Tariff, TariffPrefix, databaseStarted,
+} from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+import {
+  authoriseOutboundDestination, resolveEgressTrunk, isDestinationRateable,
+  filterAllows, validateOutboundCallFilter,
+  DEFAULT_TRUNK_OUTBOUND_FILTER,
+} from '../lib/outbound-authorisation.js';
+
+// The outbound destination authorisation policy (lib/outbound-authorisation.js).
+//
+// The security property under test: on one of OUR chargeable carrier trunks the
+// tenant's agents.options.outboundCallFilter is NOT the authority — the operator's
+// Trunk.outboundCallFilter and the organisation's destination tariff are, and the
+// agent's filter may only narrow them. On a non-chargeable egress (customer PBX /
+// BYO trunk) the historical agent-filter behaviour is preserved exactly.
+
+const PREFIX = `oa-test-${randomUUID()}-`;
+const START = new Date('2020-01-01T00:00:00Z');
+
+// A wide-open agent filter of the kind an agent author could set today: every
+// destination on earth, including international premium-rate revenue share.
+const WIDE_OPEN_FILTER = '^\\+?\\d{6,15}$';
+
+describe('outbound call filter primitives', () => {
+  test('validates a pattern and rejects an unusable one', () => {
+    expect(validateOutboundCallFilter(null)).toBeNull();
+    expect(validateOutboundCallFilter('^\\+44\\d+$')).toBeNull();
+    expect(validateOutboundCallFilter('^(')).toMatch(/not a valid regular expression/);
+    expect(validateOutboundCallFilter('x'.repeat(513))).toMatch(/at most/);
+    expect(validateOutboundCallFilter(42)).toMatch(/must be a string/);
+  });
+
+  test('a malformed or over-long filter fails CLOSED rather than opening the gate', () => {
+    expect(filterAllows('^\\+44\\d+$', '+447700900123')).toBe(true);
+    expect(filterAllows('^(', '+447700900123')).toBe(false);
+    expect(filterAllows('^\\+44\\d+$', '+'.padEnd(40, '4'))).toBe(false);
+    expect(filterAllows(null, '+447700900123')).toBe(false);
+  });
+
+  test('the default trunk filter admits UK geographic/mobile only', () => {
+    for (const ok of ['+442079460958', '+447700900123', '+441632960123', '+443069990000']) {
+      expect(filterAllows(DEFAULT_TRUNK_OUTBOUND_FILTER, ok)).toBe(true);
+    }
+    for (const bad of ['+449098790123', '+18005550199', '+8801700000000', '+447700900123456']) {
+      expect(filterAllows(DEFAULT_TRUNK_OUTBOUND_FILTER, bad)).toBe(false);
+    }
+  });
+});
+
+describe('outbound destination authorisation', () => {
+  let orgId; let userId;
+  const unratedOrgIds = [];
+  const cardName = `${PREFIX}card`;
+  const tariffName = `${PREFIX}tariff`;
+  const chargeableTrunkId = `${PREFIX}public`;
+  const byoTrunkId = `${PREFIX}byo`;
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    await databaseStarted;
+    orgId = randomUUID(); userId = randomUUID();
+    await Organisation.create({
+      id: orgId, name: 'Filter Org', rateHistory: [{ name: cardName, startDate: START }],
+    });
+    await User.create({
+      id: userId, name: 'Filter User', email: `f-${userId}@example.com`,
+      emailVerified: true, phone: '', phoneVerified: false, picture: '', role: 'owner',
+      organisationId: orgId,
+    });
+
+    // A deck that prices UK landline + mobile only — nothing international, and
+    // NOT the UK 09 premium-rate range.
+    const tariff = await Tariff.create({ name: tariffName, startDate: START });
+    await TariffPrefix.bulkCreate([
+      { tariffId: tariff.id, prefix: '4420', connectMicros: 0, peakPerMinuteMicros: 100_000, offPeakPerMinuteMicros: 100_000 },
+      { tariffId: tariff.id, prefix: '4477', connectMicros: 0, peakPerMinuteMicros: 300_000, offPeakPerMinuteMicros: 300_000 },
+    ]);
+    await RateCard.create({
+      name: cardName, startDate: START, currency: 'gbp',
+      detail: { lines: [{ dim: 'destination', tariff: tariffName }] },
+    });
+
+    await Trunk.create({ id: chargeableTrunkId, name: 'Our carrier', outbound: true, chargeable: true });
+    await Trunk.create({ id: byoTrunkId, name: 'Customer BYO', outbound: true, chargeable: false });
+  });
+
+  afterAll(async () => {
+    // Suites share one database, and a leftover chargeable trunk is exactly the
+    // sort of row a global-trunk listing test would trip over. Clean up ours.
+    await Trunk.destroy({ where: { id: [chargeableTrunkId, byoTrunkId] } });
+    await RateCard.destroy({ where: { name: cardName } });
+    await Tariff.destroy({ where: { name: tariffName } });
+    await User.destroy({ where: { id: userId } });
+    await Organisation.destroy({ where: { id: [orgId, ...unratedOrgIds] } });
+    await teardownRealDatabase();
+  }, 30000);
+
+  // `{ env: {} }` pins the egress-trunk resolution to what each case passes
+  // explicitly, so a set APLISAY_OUTBOUND_TRUNK_ID in the ambient environment
+  // cannot introduce a third candidate trunk and make these cases flaky.
+  const NO_ENV = { env: {} };
+  const authorise = (calledId, extra = {}) => authoriseOutboundDestination({
+    calledId, organisationId: orgId, userId, at: new Date(), ...extra,
+  }, NO_ENV);
+
+  describe('non-chargeable egress keeps the historical agent-authoritative behaviour', () => {
+    test('defaults to UK geographic/mobile when the agent sets no filter', async () => {
+      await expect(authorise('+447700900123', { aplisayId: byoTrunkId }))
+        .resolves.toMatchObject({ allowed: true, chargeable: false });
+      await expect(authorise('+18005550199', { aplisayId: byoTrunkId }))
+        .resolves.toMatchObject({ allowed: false, code: 'default_filter' });
+    });
+
+    test("honours the agent's own filter, wide or narrow", async () => {
+      await expect(authorise('+18005550199', {
+        aplisayId: byoTrunkId, agentOptions: { outboundCallFilter: WIDE_OPEN_FILTER },
+      })).resolves.toMatchObject({ allowed: true, chargeable: false });
+      await expect(authorise('+447700900123', {
+        aplisayId: byoTrunkId, agentOptions: { outboundCallFilter: '^\\+441632\\d+$' },
+      })).resolves.toMatchObject({ allowed: false, code: 'agent_filter' });
+    });
+
+    test('a registration-originated leg is never chargeable, whatever trunk is around', async () => {
+      const decision = await authorise('8092', {
+        registrationOriginated: true,
+        agentOptions: { outboundCallFilter: '^\\d{4}$' },
+        outboundTrunkId: chargeableTrunkId,
+      });
+      expect(decision).toMatchObject({ allowed: true, chargeable: false, trunkId: null });
+    });
+  });
+
+  describe('chargeable carrier trunk: operator policy wins', () => {
+    test('a wide-open agent filter can no longer reach an unrated destination', async () => {
+      const decision = await authorise('+18005550199', {
+        outboundTrunkId: chargeableTrunkId,
+        agentOptions: { outboundCallFilter: WIDE_OPEN_FILTER },
+      });
+      expect(decision.allowed).toBe(false);
+      expect(decision.chargeable).toBe(true);
+      // Blocked by the trunk's default UK-only filter, before rating is consulted.
+      expect(decision.code).toBe('trunk_filter');
+    });
+
+    test('a UK premium-rate number passes a wide agent filter but is not rated', async () => {
+      // Widen the trunk filter to all of +44 so the rating gate is what bites.
+      await Trunk.update({ outboundCallFilter: '^\\+44\\d{9,10}$' }, { where: { id: chargeableTrunkId } });
+      const decision = await authorise('+449098790123', {
+        outboundTrunkId: chargeableTrunkId,
+        agentOptions: { outboundCallFilter: WIDE_OPEN_FILTER },
+      });
+      expect(decision).toMatchObject({ allowed: false, code: 'not_rateable', chargeable: true });
+      expect(decision.reason).toMatch(/not rated/);
+      await Trunk.update({ outboundCallFilter: null }, { where: { id: chargeableTrunkId } });
+    });
+
+    test('a rated destination inside the trunk filter is allowed and reports its tariff', async () => {
+      const decision = await authorise('+447700900123', { outboundTrunkId: chargeableTrunkId });
+      expect(decision).toMatchObject({
+        allowed: true, code: 'ok', chargeable: true, destination: '+447700900123',
+        tariff: tariffName, prefix: '4477',
+      });
+    });
+
+    test('the operator filter narrows a rateable destination', async () => {
+      await Trunk.update({ outboundCallFilter: '^\\+4420\\d{8}$' }, { where: { id: chargeableTrunkId } });
+      await expect(authorise('+447700900123', { outboundTrunkId: chargeableTrunkId }))
+        .resolves.toMatchObject({ allowed: false, code: 'trunk_filter' });
+      await expect(authorise('+442079460958', { outboundTrunkId: chargeableTrunkId }))
+        .resolves.toMatchObject({ allowed: true });
+      await Trunk.update({ outboundCallFilter: null }, { where: { id: chargeableTrunkId } });
+    });
+
+    test("the agent's filter may still narrow, never widen", async () => {
+      await expect(authorise('+447700900123', {
+        outboundTrunkId: chargeableTrunkId,
+        agentOptions: { outboundCallFilter: '^\\+4420\\d+$' },
+      })).resolves.toMatchObject({ allowed: false, code: 'agent_filter', chargeable: true });
+    });
+
+    test('a national-format destination is canonicalised before every check', async () => {
+      await expect(authorise('07700900123', { outboundTrunkId: chargeableTrunkId }))
+        .resolves.toMatchObject({ allowed: true, destination: '+447700900123' });
+    });
+
+    test('an undialable destination is refused outright', async () => {
+      await expect(authorise('WebRTC', { outboundTrunkId: chargeableTrunkId }))
+        .resolves.toMatchObject({ allowed: false, code: 'invalid_destination' });
+      await expect(authoriseOutboundDestination({ calledId: '', organisationId: orgId }, NO_ENV))
+        .resolves.toMatchObject({ allowed: false, code: 'invalid_destination' });
+    });
+
+    test('an org with no rate card cannot dial on our carrier at all', async () => {
+      const unratedOrgId = randomUUID();
+      unratedOrgIds.push(unratedOrgId);
+      await Organisation.create({ id: unratedOrgId, name: 'Unrated Org', rateHistory: [] });
+      const decision = await authoriseOutboundDestination({
+        calledId: '+447700900123', organisationId: unratedOrgId,
+        outboundTrunkId: chargeableTrunkId,
+        agentOptions: { outboundCallFilter: WIDE_OPEN_FILTER },
+      }, NO_ENV);
+      expect(decision).toMatchObject({ allowed: false, code: 'not_rateable' });
+      expect(decision.reason).toMatch(/no rate assigned/);
+    });
+  });
+
+  describe('POST /api/agent-db/outbound-authorisation (the workers\' entry point)', () => {
+    const mockLogger = {
+      info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, child: () => mockLogger,
+    };
+    const req = (body = {}) => ({ body, params: {}, query: {}, headers: {}, log: mockLogger });
+    const res = () => ({
+      locals: { user: null }, _status: null, _body: null,
+      status(c) { this._status = c; return this; },
+      send(b) { this._body = b; this._status = this._status || 200; return this; },
+    });
+    let authorise;
+
+    beforeAll(async () => {
+      const mod = await import('../api/paths/agent-db/outbound-authorisation.js');
+      authorise = mod.default(mockLogger, {}, {}).POST;
+    });
+
+    test('a refusal is a 200 decision, not an error — callers must distinguish it from "could not decide"', async () => {
+      const s = res();
+      await authorise(req({
+        calledId: '+18005550199', organisationId: orgId, userId,
+        outboundTrunkId: chargeableTrunkId,
+        agentOptions: { outboundCallFilter: WIDE_OPEN_FILTER },
+      }), s);
+      expect(s._status).toBe(200);
+      expect(s._body).toMatchObject({ allowed: false, code: 'trunk_filter' });
+    });
+
+    test('a missing destination is a 400', async () => {
+      const s = res();
+      await authorise(req({ organisationId: orgId }), s);
+      expect(s._status).toBe(400);
+    });
+
+    test('an allowed destination reports the resolved tariff', async () => {
+      const s = res();
+      await authorise(req({
+        calledId: '07700900123', organisationId: orgId, userId, outboundTrunkId: chargeableTrunkId,
+      }), s);
+      expect(s._body).toMatchObject({ allowed: true, destination: '+447700900123', tariff: tariffName });
+    });
+  });
+
+  describe('helpers', () => {
+    test('resolveEgressTrunk prefers a chargeable trunk among the candidates', async () => {
+      await expect(resolveEgressTrunk({ outboundTrunkId: byoTrunkId, aplisayId: chargeableTrunkId }, NO_ENV))
+        .resolves.toMatchObject({ chargeable: true, trunk: expect.objectContaining({ id: chargeableTrunkId }) });
+      await expect(resolveEgressTrunk({ aplisayId: byoTrunkId }, NO_ENV))
+        .resolves.toMatchObject({ chargeable: false });
+      await expect(resolveEgressTrunk({ aplisayId: 'no-such-trunk' }, NO_ENV))
+        .resolves.toMatchObject({ chargeable: false, trunk: null });
+    });
+
+    test('isDestinationRateable mirrors the costing resolution', async () => {
+      await expect(isDestinationRateable({ organisationId: orgId, userId, calledId: '+442079460958' }))
+        .resolves.toMatchObject({ rateable: true, tariff: tariffName, prefix: '4420' });
+      await expect(isDestinationRateable({ organisationId: orgId, userId, calledId: '+8801700000000' }))
+        .resolves.toMatchObject({ rateable: false });
+    });
+  });
+});


### PR DESCRIPTION
Closes two issues with `options.outboundCallFilter` found in testing.

## 1. The Pipecat worker ignored the filter entirely

Unlike the LiveKit worker (`validateTransferArgs`) and the originate API, the Pipecat
worker checked *nothing* before dialling — no agent filter, no default. Every transfer
path (blind, consultative, both WebRTC media-relay flows) and the agent's last-resort
`fallback.number` would dial whatever it was handed.

## 2. On our own carrier trunks, the tenant cannot be the authority

`options.outboundCallFilter` is written by the agent author — the same party we would be
protecting ourselves from. A filter of `^\+?\d+$`, or a narrow filter whose destination
arrives from an injectable CRM field, reaches international premium-rate and revenue-share
ranges. When the leg leaves on a `Trunk.chargeable` trunk, **we** pay the carrier.

## The policy

One implementation — `lib/outbound-authorisation.js` — used by every path, split on whose
minutes are at risk:

**Not our carrier** (registration B2BUA to the customer's PBX, BYO trunk, no outbound
trunk): unchanged. The agent's filter, defaulting to the historical
`^(\+44|44|0)[1237]\d{6,15}$`.

**Our chargeable trunk**: all three of

| | Gate | Owner |
|---|---|---|
| a | `Trunk.outboundCallFilter` — new column, matched on the canonical `+E.164` form. Null ⇒ UK geographic/mobile `^\+44[1237]\d{8,9}$` | operator |
| b | **Rateable** — longest-prefix match in the tariff named by the `destination` line of the rate card in force for this org/user (the *same* resolution `costUsageRow` performs). If we cannot price it, we do not carry it | operator |
| c | `options.outboundCallFilter` when set | tenant — **narrows only** |

Workers never re-implement this: they call `POST /api/agent-db/outbound-authorisation`
(internal, `x-shared-token`) and **fail closed** — "cannot decide" resolves to "no",
because the cost this gate protects cannot be undone.

## Enforcement points

| Path | How |
|---|---|
| `POST /api/listener/{id}/originate` | in-process — covers every handler |
| LiveKit `transfer` (blind / consultative / bridge) | `validateTransferArgs` → internal endpoint |
| Pipecat `transfer` (incl. both WebRTC relay flows) | `_on_transfer` → `outbound_filter.py` → internal endpoint |
| Pipecat `fallback.number` | same gate |
| jambonz / native Ultravox | no outbound or transfer capability — nothing to gate |

The LiveKit authorisation deliberately runs **after** caller-ID resolution: a registration
caller-ID changes the egress, and therefore the answer. Pipecat applies the same
discriminator (a registration-UUID `callerId` ⇒ customer's own B2BUA); a bogus UUID buys
nothing, since `_resolve_webrtc_egress` still enforces ownership.

## Also in here

- **schema v58** — `trunks.outbound_call_filter`, with superAdmin CRUD on
  `POST /api/trunks` and `PATCH /api/trunks/{id}`.
- Agent `options.outboundCallFilter` is now **validated at write time** (compiles, ≤512
  chars) instead of failing closed mid-call; an unusable pattern at the gate is treated as
  no-match.
- `docs/outbound-call-authorisation.md` (policy, refusal codes, trunk configuration,
  failure modes); `call-transfers.md`, `originate-api.md`, `livekit-agent-architecture.md`
  and the transfer parity matrix updated — the matrix previously claimed Pipecat parity on
  this that did not exist.

## ⚠️ Behaviour changes to review before merge

1. **Pipecat agents that transfer to non-UK or short/extension numbers will now be
   refused** unless the agent sets `options.outboundCallFilter` (e.g. `^\d{3,6}$` for PBX
   extensions). This is the point of the fix and matches LiveKit's long-standing
   behaviour, but it is a live behaviour change for any Pipecat agent relying on the gap.
2. **A chargeable trunk with no tariff coverage refuses everything** (`not_rateable`).
   Load the tariff deck before flagging a trunk chargeable.
3. `APLISAY_OUTBOUND_TRUNK_ID` is now read by the API server as well as the workers — set
   it consistently, or a carried leg falls back to the caller number's `aplisayId` trunk.

## Deploy

- Needs `DB_FORCE_SYNC` (or the usual upgrade path) for schema v58.
- Both workers must point at an API server carrying this change, or every transfer fails
  closed. Deploy the API server first.

## Testing

- `tests/outbound-authorisation.test.mjs` — 19 cases: filter primitives (incl. fail-closed
  on a malformed pattern), both egress classes, operator-narrows, agent-narrows,
  wide-agent-filter-cannot-widen, unrated premium rate, unrated org, canonicalisation, and
  the internal endpoint. All green.
- `agents/pipecat/tests/test_outbound_filter.py` — 9 cases: gate consulted on every path,
  refusal never reaches the gateway, fail-closed on transport error, registration
  discriminator, caller-ID forwarding. Full Pipecat suite 305 passed.
- Related JS suites (`rates`, `tariffs`, `chargeable-trunk-global`, `outbound-authorisation`):
  91 passed.
- **Not done locally:** the LiveKit worker is not built or type-checked here (its
  `node_modules` isn't installed in this worktree — `tsc` reports only pre-existing
  missing-module errors), and nothing has been live-call verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
