### PR TITLE
Restore the 'outbound call filter pattern' refusal wording (fixes CI on next)

### DIFF
--- a/lib/outbound-authorisation.js
+++ b/lib/outbound-authorisation.js
@@ -222,7 +222,7 @@ export async function authoriseOutboundDestination({
         trunkId,
         destination: canonicaliseDestination(dialled),
         reason: agentFilter
-          ? `destination ${dialled} does not match the agent's outbound call filter`
+          ? `destination ${dialled} does not match the agent's outbound call filter pattern`
           : `destination ${dialled} is not a valid UK geographic or mobile number`,
       };
     }
@@ -264,7 +264,7 @@ export async function authoriseOutboundDestination({
   if (agentFilter && !filterAllows(agentFilter, dialled)) {
     return {
       allowed: false, code: 'agent_filter', chargeable: true, trunkId, destination,
-      reason: `destination ${dialled} does not match the agent's outbound call filter`,
+      reason: `destination ${dialled} does not match the agent's outbound call filter pattern`,
     };
   }
 

--- a/tests/outbound-authorisation.test.mjs
+++ b/tests/outbound-authorisation.test.mjs
@@ -114,6 +114,19 @@ describe('outbound destination authorisation', () => {
         .resolves.toMatchObject({ allowed: false, code: 'default_filter' });
     });
 
+    test('keeps the historical refusal wording', async () => {
+      // listener-join-originate.test.mjs asserts these substrings, and they are
+      // the strings the originate API has always returned to API clients.
+      await expect(authorise('+1234567890', {
+        aplisayId: byoTrunkId, agentOptions: { outboundCallFilter: '^\\+44\\d+$' },
+      })).resolves.toMatchObject({
+        reason: expect.stringContaining("does not match the agent's outbound call filter pattern"),
+      });
+      await expect(authorise('+1234567890', { aplisayId: byoTrunkId })).resolves.toMatchObject({
+        reason: expect.stringContaining('is not a valid UK geographic or mobile number'),
+      });
+    });
+
     test("honours the agent's own filter, wide or narrow", async () => {
       await expect(authorise('+18005550199', {
         aplisayId: byoTrunkId, agentOptions: { outboundCallFilter: WIDE_OPEN_FILTER },


### PR DESCRIPTION
Follow-up to #218, which was squash-merged before this fix reached the branch — so
`next` is currently red.

`lib/outbound-authorisation.js` rephrased the agent-filter refusal and dropped the
trailing **`pattern`**:

```
was:  Called number +1234567890 does not match the agent's outbound call filter pattern
became: destination +1234567890 does not match the agent's outbound call filter
```

Five assertions in `tests/listener-join-originate.test.mjs` (lines 802, 817, 862, 912,
972) match on that substring, failing 4 tests. It is also a string API clients may match
on, so restoring it is right regardless of the tests.

Restored in both branches of the policy (non-chargeable and chargeable egress), and both
historical refusal strings are now pinned directly in `tests/outbound-authorisation.test.mjs`
against the same function the originate endpoint calls, so they cannot drift again.

No behaviour change — only the message text. Everything else in the failing suite already
passed under #218, including the UK-default cases whose wording was unaffected.
