### PR TITLE
fix(sipbridge): advertise a TLS Contact on outbound legs

### DIFF
--- a/agents/pipecat/sipbridge/internal/sip/contact_test.go
+++ b/agents/pipecat/sipbridge/internal/sip/contact_test.go
@@ -1,0 +1,97 @@
+package sip
+
+import (
+	"testing"
+
+	"github.com/emiago/sipgo/sip"
+)
+
+// testServer is the minimal Server needed to exercise Contact building —
+// contactURI reads only the advertised address and the two ports.
+func testServer() *Server {
+	return &Server{
+		signalIP:      "198.51.100.7",
+		signalPort:    5060,
+		tlsSignalPort: 5061,
+	}
+}
+
+// A TLS dialog must advertise sips: on the TLS port with ;transport=tls.
+// Anything else and the peer aims in-dialog requests (ACK, BYE) at UDP
+// 5060, where a TLS-only deployment isn't listening — the failure that
+// left outbound legs hanging until the RTP watchdog reaped them.
+func TestContactURITLS(t *testing.T) {
+	s := testServer()
+	for _, transport := range []string{"tls", "TLS", "wss"} {
+		uri := s.contactURI(transport)
+		if uri.Scheme != "sips" {
+			t.Errorf("%s: scheme = %q, want sips", transport, uri.Scheme)
+		}
+		if uri.Port != 5061 {
+			t.Errorf("%s: port = %d, want the TLS port 5061", transport, uri.Port)
+		}
+		if got := uri.UriParams.GetOr("transport", ""); got != "tls" {
+			t.Errorf("%s: transport param = %q, want tls", transport, got)
+		}
+		if uri.Host != "198.51.100.7" {
+			t.Errorf("%s: host = %q, want the advertised signal IP", transport, uri.Host)
+		}
+	}
+}
+
+// Plaintext transports keep the sip:/UDP-port form.
+func TestContactURIPlaintext(t *testing.T) {
+	s := testServer()
+	for _, transport := range []string{"", "udp", "UDP", "tcp"} {
+		uri := s.contactURI(transport)
+		if uri.Scheme == "sips" {
+			t.Errorf("%q: got sips scheme on a plaintext transport", transport)
+		}
+		if uri.Port != 5060 {
+			t.Errorf("%q: port = %d, want the UDP port 5060", transport, uri.Port)
+		}
+		if got := uri.UriParams.GetOr("transport", ""); got == "tls" {
+			t.Errorf("%q: advertised transport=tls on a plaintext transport", transport)
+		}
+	}
+}
+
+// When no TLS port is configured we must not invent one — fall back to
+// the signalling port rather than advertising 0.
+func TestContactURITLSWithoutTLSPort(t *testing.T) {
+	s := testServer()
+	s.tlsSignalPort = 0
+	if got := s.contactURI("tls").Port; got != 5060 {
+		t.Errorf("port = %d, want fallback to 5060 when no TLS port is set", got)
+	}
+}
+
+// isTLSURI drives the outbound Contact choice, so it has to recognise
+// both spellings a carrier / SBC target can arrive in.
+func TestIsTLSURI(t *testing.T) {
+	tlsParams := sip.NewParams()
+	tlsParams.Add("transport", "tls")
+	udpParams := sip.NewParams()
+	udpParams.Add("transport", "udp")
+	mixedParams := sip.NewParams()
+	mixedParams.Add("transport", "TLS")
+
+	cases := []struct {
+		name string
+		uri  sip.Uri
+		want bool
+	}{
+		{"sips scheme", sip.Uri{Scheme: "sips", Host: "sbc.example.net", Port: 5061}, true},
+		{"sips uppercase", sip.Uri{Scheme: "SIPS", Host: "sbc.example.net"}, true},
+		{"transport param", sip.Uri{Host: "sbc.example.net", Port: 5061, UriParams: tlsParams}, true},
+		{"transport param mixed case", sip.Uri{Host: "sbc.example.net", UriParams: mixedParams}, true},
+		{"plain sip", sip.Uri{Scheme: "sip", Host: "sbc.example.net", Port: 5060}, false},
+		{"explicit udp", sip.Uri{Scheme: "sip", Host: "sbc.example.net", UriParams: udpParams}, false},
+		{"bare uri, no params", sip.Uri{Host: "sbc.example.net"}, false},
+	}
+	for _, c := range cases {
+		if got := isTLSURI(c.uri); got != c.want {
+			t.Errorf("%s: isTLSURI = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/agents/pipecat/sipbridge/internal/sip/server.go
+++ b/agents/pipecat/sipbridge/internal/sip/server.go
@@ -546,14 +546,23 @@ func (s *Server) onInvite(req *sip.Request, tx sip.ServerTransaction) {
 func (s *Server) contactForDialog(dlg *sipgo.DialogServerSession) *sip.ContactHeader {
 	transport := ""
 	if dlg.Dialog.InviteRequest != nil {
-		transport = strings.ToLower(dlg.Dialog.InviteRequest.Transport())
+		transport = dlg.Dialog.InviteRequest.Transport()
 	}
+	return &sip.ContactHeader{Address: s.contactURI(transport)}
+}
+
+// contactURI builds the Contact address for a dialog running over the
+// named transport. Shared by the UAS path (contactForDialog, answering
+// an inbound INVITE) and the UAC path (Originate, dialling out) so both
+// directions advertise a reachable target — see contactForDialog for
+// why a transport-mismatched Contact breaks in-dialog routing.
+func (s *Server) contactURI(transport string) sip.Uri {
 	uri := sip.Uri{
 		User: "sipbridge",
 		Host: s.signalIP,
 		Port: s.signalPort,
 	}
-	switch transport {
+	switch strings.ToLower(transport) {
 	case "tls", "wss":
 		uri.Scheme = "sips"
 		if s.tlsSignalPort > 0 {
@@ -562,7 +571,16 @@ func (s *Server) contactForDialog(dlg *sipgo.DialogServerSession) *sip.ContactHe
 		uri.UriParams = sip.NewParams()
 		uri.UriParams.Add("transport", "tls")
 	}
-	return &sip.ContactHeader{Address: uri}
+	return uri
+}
+
+// isTLSURI reports whether a request URI names a TLS destination —
+// either a ``sips:`` scheme or an explicit ``;transport=tls``.
+func isTLSURI(u sip.Uri) bool {
+	if strings.EqualFold(u.Scheme, "sips") {
+		return true
+	}
+	return strings.EqualFold(u.UriParams.GetOr("transport", ""), "tls")
 }
 
 func (s *Server) onAck(req *sip.Request, tx sip.ServerTransaction) {
@@ -732,7 +750,27 @@ func (s *Server) Originate(
 		extra = append(extra, sip.NewHeader(k, v))
 	}
 
-	dlg, err := s.ub.Invite(ctx, targetURI, sdpOffer, extra...)
+	// Advertise a Contact that matches the transport we're dialling out
+	// over. The DialogUA carries a single static ContactHDR, built in
+	// NewServer for the plaintext UDP case; for a TLS target we Invite on
+	// a shallow copy carrying the ``sips:``/TLS-port/``;transport=tls``
+	// form instead. (Copy rather than mutate: Originate runs concurrently
+	// for every outbound call on this Server.)
+	//
+	// This is the UAC twin of the contactForDialog bug, and it fails the
+	// same silent way — the peer takes our Contact as the remote target
+	// for the whole dialog, so a ``sip:...:5060`` Contact on a TLS dialog
+	// sends their BYE to UDP 5060. Kamailio logs "protocol/port mismatch
+	// (forced tls:...:5061, to udp:...:5060)", the BYE times out at 408,
+	// and the leg lingers until the RTP watchdog reaps it seconds later.
+	ua := s.ub
+	if isTLSURI(targetURI) {
+		tlsUA := *s.ub
+		tlsUA.ContactHDR = sip.ContactHeader{Address: s.contactURI("tls")}
+		ua = &tlsUA
+	}
+
+	dlg, err := ua.Invite(ctx, targetURI, sdpOffer, extra...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("sip: Invite: %w", err)
 	}


### PR DESCRIPTION
## What

An outbound INVITE dialled over TLS still advertised the static **plaintext** Contact built in `NewServer` — `sip:sipbridge@<signal-ip>:5060`, no scheme, no transport param. `DialogUA` carries a single `ContactHDR`, and only the UAS path (`contactForDialog`) was ever made transport-aware.

## Why it matters

The peer takes our Contact as the remote target for the life of the dialog, so every in-dialog request for an outbound call was aimed at UDP 5060 while the dialog ran over TLS on 5061. Kamailio names the fault and then gives up:

```
WITHINDLG enter BYE ... ru=sip:sipbridge@<node>:5060
WARNING: get_send_socket2(): protocol/port mismatch
         (forced tls:0.0.0.0:5061, to udp:<node>:5060)
-> code=408 Request Timeout dst_user=sipbridge
```

The carrier's BYE never arrived. The leg stayed up until the RTP watchdog reaped it ~12s later — billing the difference, and making a perfectly clean teardown look like a media fault.

Observed end to end on staging: the inbound leg ended at 22:29:15 having sent its BYE and received a 200 OK; the outbound leg only died at 22:29:27 on `media timeout`, and its own BYE then came back `481 Call Does Not Exist`.

## The fix

`Originate` picks the Contact from the target transport, inviting on a shallow copy of the `DialogUA` when the target is TLS — copy rather than mutate, since `Originate` runs concurrently across calls. URI construction is shared with `contactForDialog` via the new `contactURI`, so both directions stay in step.

## Tests

First tests for `internal/sip`: both Contact forms, the no-TLS-port fallback, and the `sips:` / `;transport=tls` spellings `isTLSURI` must recognise.

`go vet ./...` and `go test ./...` clean; container builds via `docker compose --profile sipbridge build`.

## Not included

This is the second of two faults behind the missing BYE. The first was infrastructure: staging had no SIP-signalling firewall rule at all (prod has `pipecat-sip-signal-prod`), so in-dialog requests to the node were dropped outright. `pipecat-sip-signal-staging` (tcp/5061 from the SBC) has been created separately and is already verified — that fix is what got the inbound ACK flowing.
