### PR TITLE
BYOK: organisation provider keys used in preference to platform keys

### DIFF
--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -39,11 +39,27 @@ export class AgentConcurrencyLimitExceededBusyError extends Error {
 }
 
 // API-related type definitions
+
+/**
+ * Decrypted org-level BYOK provider keys by canonical provider slug
+ * (docs/byok.md: openai, google, ultravox, deepgram, elevenlabs, cartesia, …).
+ * A `null` value is a stored key the server could not decrypt: the affected
+ * provider must fail the session rather than fall back to platform keys.
+ */
+export type OrganisationKeys = Record<string, string | null>;
+
 export interface Instance {
   id: string;
   metadata?: Record<string, any>;
   Agent?: Agent;
   streamLog?: boolean;
+  /**
+   * Org BYOK keys for this call (internal agent-db responses only; omitted
+   * when the org has none). Re-attached non-enumerably on fetch (see
+   * concealOrganisationKeys) so dumps of the doc never emit key values — read
+   * the property explicitly, and note object spreads of the doc drop it.
+   */
+  organisationKeys?: OrganisationKeys;
   recording?: {
     enabled: boolean;
     key?: string;
@@ -300,6 +316,34 @@ export interface Agent {
   };
   functions?: AgentFunction[];
   keys?: string[];
+  /**
+   * Org BYOK keys, present on `GET /api/agent-db/agent` responses only (the
+   * public /api/agents API never carries them). Same non-enumerable handling
+   * and caveats as {@link Instance.organisationKeys}.
+   */
+  organisationKeys?: OrganisationKeys;
+}
+
+/**
+ * Re-attach `organisationKeys` (BYOK secrets) as a non-enumerable property of
+ * the fetched document, so logging or serialising the doc — pino, invocation
+ * log capture, JSON.stringify — can never emit key values (all of those walk
+ * enumerable own properties only). Consumers still read `doc.organisationKeys`
+ * directly; anything that spreads/clones the doc drops the bag, so pass it
+ * explicitly wherever it must travel.
+ */
+function concealOrganisationKeys<T>(doc: T): T {
+  if (doc && typeof doc === 'object' && 'organisationKeys' in doc) {
+    const keys = (doc as { organisationKeys?: OrganisationKeys }).organisationKeys;
+    delete (doc as { organisationKeys?: OrganisationKeys }).organisationKeys;
+    Object.defineProperty(doc, 'organisationKeys', {
+      value: keys,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
+  }
+  return doc;
 }
 
 /**
@@ -323,7 +367,9 @@ export async function getInternalAgentById(
     agentId,
     ...(expectedOrganisationId ? { expectedOrganisationId } : {}),
   });
-  return makeApiRequest<Agent>(`/api/agent-db/agent?${query.toString()}`);
+  return concealOrganisationKeys(
+    await makeApiRequest<Agent>(`/api/agent-db/agent?${query.toString()}`),
+  );
 }
 
 /**
@@ -614,12 +660,16 @@ export async function authoriseOutboundDestination(params: {
 
 // Get instance by ID from the API
 export async function getInstanceById(instanceId: string): Promise<any> {
-  return makeApiRequest(`/api/agent-db/instance?instanceId=${instanceId}`);
+  return concealOrganisationKeys(
+    await makeApiRequest(`/api/agent-db/instance?instanceId=${instanceId}`),
+  );
 }
 
 // Get instance by phone number from the API
 export async function getInstanceByNumber(number: string): Promise<any> {
-  return makeApiRequest(`/api/agent-db/instance?number=${encodeURIComponent(number)}`);
+  return concealOrganisationKeys(
+    await makeApiRequest(`/api/agent-db/instance?number=${encodeURIComponent(number)}`),
+  );
 }
 
 // Get phone numbers from the API

--- a/agents/livekit/lib/bridge-transcription.ts
+++ b/agents/livekit/lib/bridge-transcription.ts
@@ -50,12 +50,13 @@ import type {
 import type { ReadableStream } from "node:stream/web";
 import logger from "./logger.js";
 import { createTransactionLog } from "./api-client.js";
-import type { Agent, Call } from "./api-client.js";
+import type { Agent, Call, OrganisationKeys } from "./api-client.js";
 import { resolvePipelineStt } from "./pipeline-inference-options.js";
 import {
   buildProviderPipelineStt,
   pipelineUsesProviderApiKeys,
 } from "./pipeline-provider-keys.js";
+import { resolveOrganisationKey } from "./voice-session-factory.js";
 
 /** Speaker labels — the exact strings pipecat's collector renders. */
 export const CALLER = "caller";
@@ -176,8 +177,17 @@ export class BridgeTranscriptCollector {
  * nova-3 when `options.stt` is absent (realtime models) — or the direct
  * Deepgram plugin under LIVEKIT_PIPELINE_USE_PROVIDER_KEYS. A `language`
  * from the transcribe option overrides the agent's STT language.
+ *
+ * BYOK (docs/byok.md): an org deepgram key forces the direct plugin with
+ * that key, mirroring the pipeline's own STT resolution in
+ * voice-session-factory. A null/unreadable entry throws (fail-closed) —
+ * the bridge segment must never silently run on the platform key.
  */
-export function buildBridgeStt(agent: Agent, language?: string | null): stt.STT {
+export function buildBridgeStt(
+  agent: Agent,
+  language?: string | null,
+  organisationKeys?: OrganisationKeys,
+): stt.STT {
   const effectiveAgent: Agent = language
     ? ({
         ...agent,
@@ -187,6 +197,15 @@ export function buildBridgeStt(agent: Agent, language?: string | null): stt.STT 
         },
       } as Agent)
     : agent;
+  const sttOrgKey = resolveOrganisationKey(
+    organisationKeys,
+    resolvePipelineStt(effectiveAgent).startsWith("deepgram/")
+      ? "deepgram"
+      : undefined,
+  );
+  if (sttOrgKey !== undefined) {
+    return buildProviderPipelineStt(effectiveAgent, sttOrgKey);
+  }
   if (pipelineUsesProviderApiKeys()) {
     return buildProviderPipelineStt(effectiveAgent);
   }
@@ -329,6 +348,12 @@ export interface ArmBridgedTranscriptionParams {
   transcribe: BridgedTranscribeConfig;
   /** instance.streamLog: live transaction-log POST per utterance vs batch. */
   streamLog: boolean;
+  /**
+   * Org BYOK provider keys for this call (docs/byok.md), read from the
+   * fetched instance doc. Consumed only as the STT plugin's constructor
+   * apiKey; never logged.
+   */
+  organisationKeys?: OrganisationKeys;
 }
 
 /**
@@ -349,6 +374,7 @@ export function armBridgedTranscription(
     agent,
     transcribe,
     streamLog,
+    organisationKeys,
   } = params;
 
   const collector = new BridgeTranscriptCollector(bridgedCall, streamLog);
@@ -395,7 +421,11 @@ export function armBridgedTranscription(
       const track = await waitForAudioTrack(room, participant);
       if (disposed) return;
 
-      const sttInstance = buildBridgeStt(agent, transcribe.language);
+      const sttInstance = buildBridgeStt(
+        agent,
+        transcribe.language,
+        organisationKeys,
+      );
       const sttStream = sttInstance.stream();
       const audioStream = new AudioStream(track, {
         sampleRate: BRIDGE_STT_SAMPLE_RATE,

--- a/agents/livekit/lib/pipeline-provider-keys.ts
+++ b/agents/livekit/lib/pipeline-provider-keys.ts
@@ -47,8 +47,12 @@ function parseDeepgramStt(agent: Agent): { model: string; language: string } {
   return { model: m[1]!, language: deepgramSttLanguage(agent) };
 }
 
-export function buildProviderPipelineStt(agent: Agent): stt.STT {
-  const apiKey = process.env.DEEPGRAM_API_KEY?.trim();
+export function buildProviderPipelineStt(
+  agent: Agent,
+  // BYOK org key, already resolved fail-closed by the caller; env otherwise.
+  apiKeyOverride?: string,
+): stt.STT {
+  const apiKey = apiKeyOverride ?? process.env.DEEPGRAM_API_KEY?.trim();
   if (!apiKey) {
     throw new Error(
       "LIVEKIT_PIPELINE_USE_PROVIDER_KEYS: DEEPGRAM_API_KEY is missing or empty (set it in the environment or .env loaded before the agent runs).",
@@ -77,6 +81,8 @@ function parseLivekitModelName(modelName: string): { plugin: string; modelId: st
 export function buildProviderPipelineLlm(
   agent: Agent,
   modelName: string,
+  // BYOK org key, already resolved fail-closed by the caller; env otherwise.
+  apiKeyOverride?: string,
 ): llm.LLM {
   const { plugin, modelId } = parseLivekitModelName(modelName);
   const temperature =
@@ -85,6 +91,16 @@ export function buildProviderPipelineLlm(
       : undefined;
 
   if (plugin === "google") {
+    // A BYOK google key is a Gemini API key (docs/byok.md): force API-key
+    // auth so the org key is never routed via Vertex service-account config.
+    if (apiKeyOverride) {
+      return new google.LLM({
+        model: modelId,
+        temperature,
+        apiKey: apiKeyOverride,
+        vertexai: false,
+      });
+    }
     return new google.LLM({
       model: modelId,
       temperature,
@@ -98,6 +114,7 @@ export function buildProviderPipelineLlm(
       model: modelId,
       temperature,
       strictToolSchema: false,
+      ...(apiKeyOverride ? { apiKey: apiKeyOverride } : {}),
     });
   }
   throw new Error(
@@ -118,8 +135,11 @@ function deepgramAuraModelFromSuffix(suffix: string): string {
   return `aura-${s}-en`;
 }
 
-function buildDeepgramPluginTtsFromAuraDescriptor(descriptor: string): tts.TTS {
-  const apiKey = process.env.DEEPGRAM_API_KEY?.trim();
+function buildDeepgramPluginTtsFromAuraDescriptor(
+  descriptor: string,
+  apiKeyOverride?: string,
+): tts.TTS {
+  const apiKey = apiKeyOverride ?? process.env.DEEPGRAM_API_KEY?.trim();
   if (!apiKey) {
     throw new Error(
       "LIVEKIT_PIPELINE_USE_PROVIDER_KEYS: DEEPGRAM_API_KEY is required for Deepgram TTS (aura).",
@@ -150,11 +170,22 @@ function cartesiaLanguage(agent: Agent): string {
 /**
  * Direct-provider TTS (ElevenLabs, Cartesia, Deepgram Aura). Google Gemini TTS is handled separately in `voice-session-factory`.
  */
-export function buildProviderPipelineTts(agent: Agent): tts.TTS {
+export function buildProviderPipelineTts(
+  agent: Agent,
+  // BYOK org key, already resolved fail-closed by the caller; env otherwise.
+  apiKeyOverride?: string,
+): tts.TTS {
   const t = agent.options?.tts;
   const vendor = (t?.vendor || (t?.voice ? inferTtsVendor(t.voice) : "")).toLowerCase();
+  // BYOK path only (the caller resolved an org key for the vendor prefix):
+  // `vendor` may be model-scoped (`deepgram/aura-2`, `cartesia/sonic-3`), so
+  // the plugin is chosen by that prefix, model resolution below unchanged.
+  // The platform path (no override) keeps exact vendor matching — a
+  // model-scoped vendor remains an unsupported-vendor error, byte-identical
+  // to pre-BYOK behaviour.
+  const vendorKey = apiKeyOverride !== undefined ? vendor.split("/")[0]! : vendor;
 
-  if (vendor === "elevenlabs") {
+  if (vendorKey === "elevenlabs") {
     const voiceRaw = String(t?.voice || "").trim();
     const id = voiceRaw.includes(":")
       ? voiceRaw.split(":").pop()!.trim()
@@ -165,9 +196,10 @@ export function buildProviderPipelineTts(agent: Agent): tts.TTS {
       voiceId: id,
       model: model as never,
       language: ttsPrimaryLanguage(agent),
+      ...(apiKeyOverride ? { apiKey: apiKeyOverride } : {}),
     });
   }
-  if (vendor === "cartesia") {
+  if (vendorKey === "cartesia") {
     const voiceRaw = String(t?.voice || "").trim();
     const id = voiceRaw.includes(":")
       ? voiceRaw.split(":").pop()!.trim()
@@ -178,12 +210,13 @@ export function buildProviderPipelineTts(agent: Agent): tts.TTS {
       voice: id,
       model,
       language: cartesiaLanguage(agent),
+      ...(apiKeyOverride ? { apiKey: apiKeyOverride } : {}),
     });
   }
-  if (vendor === "deepgram") {
+  if (vendorKey === "deepgram") {
     const ttsStr = resolvePipelineTts(agent);
     if (ttsStr.startsWith("deepgram/aura-2:")) {
-      return buildDeepgramPluginTtsFromAuraDescriptor(ttsStr);
+      return buildDeepgramPluginTtsFromAuraDescriptor(ttsStr, apiKeyOverride);
     }
     throw new Error(
       `LIVEKIT_PIPELINE_USE_PROVIDER_KEYS: Deepgram TTS expects options.tts.vendor to be "deepgram/aura-2" (or voice config to infer deepgram) so it resolves to deepgram/aura-2:... (got "${ttsStr}")`,

--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -559,6 +559,10 @@ function armBridgedTransferToAgentWatch(
         agent: context.agent,
         transcribe,
         streamLog: context.instance?.streamLog === true,
+        // BYOK bag from the fetched instance doc (docs/byok.md): the bag is a
+        // non-enumerable property, so it must be read explicitly here — it
+        // does not survive spreads/serialisation of the doc.
+        organisationKeys: context.instance?.organisationKeys,
       });
     } catch (e) {
       logger.warn(

--- a/agents/livekit/lib/types.ts
+++ b/agents/livekit/lib/types.ts
@@ -6,6 +6,7 @@ import type {
   AgentFunction,
   Call,
   CallMetadata,
+  OrganisationKeys,
   OutboundInfo,
 } from './api-client.js';
 import { type ParticipantInfo } from "livekit-server-sdk";
@@ -149,6 +150,15 @@ export interface RunAgentWorkerParams<TContext = any, TRoom = any> {
   calledId: string;
   modelName: string;
   metadata: any;
+  /**
+   * Org BYOK provider keys from the fetched instance document — or, after an
+   * agent-level fallback, from that agent's own agent-db document
+   * (docs/byok.md). Consumed only as provider-plugin constructor arguments in
+   * voice-session-factory — never logged and never placed in room/participant
+   * metadata. A slug present with a null value must fail that provider's
+   * session rather than fall back to platform keys.
+   */
+  organisationKeys?: OrganisationKeys;
   sendMessage: (message: any, createdAt?: Date) => Promise<void>;
   call: Call;
   onHangup: () => Promise<HangupResult>;

--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -39,6 +39,7 @@ export async function runAgentWorker({
   calledId,
   modelName,
   metadata,
+  organisationKeys,
   sendMessage,
   call,
   onHangup,
@@ -1181,6 +1182,11 @@ export async function runAgentWorker({
           call: newCall,
           tools,
           vad,
+          // The incoming agent's own BYOK bag: getInternalAgentById fetched it
+          // fresh with this handover, filtered to the NEW agent's providers.
+          // Read from newAgentDef (the spread above drops the non-enumerable
+          // property, deliberately, so agentForSession stays dump-safe).
+          organisationKeys: newAgentDef.organisationKeys,
         });
       wireHandoverSession(newSession, newAgentDef);
 
@@ -1490,6 +1496,7 @@ export async function runAgentWorker({
           call,
           tools,
           vad,
+          organisationKeys,
         });
         /** Skip echo of opening user line (Ultravox) and empty STT placeholders. */
         const initialUserTranscriptToSkip =

--- a/agents/livekit/lib/voice-session-factory.ts
+++ b/agents/livekit/lib/voice-session-factory.ts
@@ -7,7 +7,7 @@ import type { VAD } from "@livekit/agents";
 import * as openai from "@livekit/agents-plugin-openai";
 import * as google from "@livekit/agents-plugin-google";
 import * as ultravox from "../plugins/ultravox/src/index.js";
-import type { Agent, Call } from "./api-client.js";
+import type { Agent, Call, OrganisationKeys } from "./api-client.js";
 import { promptWithMetadata } from "../agent-lib/prompt-metadata.js";
 import type { VoiceMode } from "./voice-mode.js";
 import {
@@ -115,7 +115,7 @@ function inferenceTtsForDeepgramAura2(ttsStr: string, agent: Agent) {
 }
 
 /** LiveKit Inference TTS model string, Deepgram `inference.TTS`, or Google Gemini TTS plugin. */
-function buildPipelineTts(agent: Agent) {
+function buildPipelineTts(agent: Agent, organisationKeys?: OrganisationKeys) {
   const useKeys = pipelineUsesProviderApiKeys();
 
   const t = agent.options?.tts;
@@ -129,6 +129,8 @@ function buildPipelineTts(agent: Agent) {
     }
     const model =
       process.env.LIVEKIT_PIPELINE_GEMINI_TTS_MODEL?.trim() || "gemini-2.5-flash-preview-tts";
+    // Google TTS stays on platform credentials even under BYOK: it uses
+    // service-account / Vertex auth, which docs/byok.md scopes out of v1.
     return new google.beta.TTS({
       model,
       voiceName: geminiVoiceNameForGoogleTtsOption(agent),
@@ -136,6 +138,21 @@ function buildPipelineTts(agent: Agent) {
       project: process.env.GOOGLE_CLOUD_PROJECT,
       location: process.env.GOOGLE_CLOUD_LOCATION,
     });
+  }
+
+  // BYOK: an org key for the TTS vendor forces the direct provider plugin with
+  // that key, even when LIVEKIT_PIPELINE_USE_PROVIDER_KEYS is unset. The
+  // vendor string may be model-scoped (`deepgram/aura-2`, `cartesia/sonic-3`);
+  // the provider slug is the vendor prefix. Google is excluded above.
+  const vendorPrefix = vendor.split("/")[0]!;
+  const ttsOrgKey = resolveOrganisationKey(
+    organisationKeys,
+    ["elevenlabs", "cartesia", "deepgram"].includes(vendorPrefix)
+      ? vendorPrefix
+      : undefined,
+  );
+  if (ttsOrgKey !== undefined) {
+    return buildProviderPipelineTts(agent, ttsOrgKey);
   }
 
   if (useKeys) {
@@ -173,6 +190,42 @@ export function getRealtimePlugin(modelName: string): {
 export function parseProviderModelName(modelName: string): string | undefined {
   const m = modelName.match(/^livekit:[^/]+\/(.+)$/);
   return m ? m[1] : undefined;
+}
+
+/**
+ * Canonical BYOK provider slug for the provider segment of a
+ * `livekit:<provider>/…` model name (docs/byok.md registry):
+ * openai→openai, google|gemini→google, ultravox|fixie-ai→ultravox.
+ * Undefined for anything else — no BYOK injection for that component.
+ */
+export function providerSlugForModelSegment(
+  segment: string | undefined,
+): string | undefined {
+  const s = (segment || "").trim().toLowerCase();
+  if (s === "openai") return "openai";
+  if (s === "google" || s === "gemini") return "google";
+  if (s === "ultravox" || s === "fixie-ai") return "ultravox";
+  return undefined;
+}
+
+/**
+ * Fail-closed BYOK key lookup. A slug absent from the bag returns undefined
+ * (platform behaviour unchanged); a slug present with a null/empty value is a
+ * stored key the server could not read, and MUST fail the session rather than
+ * silently substitute the platform key (docs/byok.md: org key wins, no silent
+ * fallback — the org would otherwise burn platform credit believing its own
+ * key was in use).
+ */
+export function resolveOrganisationKey(
+  organisationKeys: OrganisationKeys | undefined,
+  slug: string | undefined,
+): string | undefined {
+  if (!slug || !organisationKeys || !(slug in organisationKeys)) return undefined;
+  const value = organisationKeys[slug];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`organisation BYOK key for ${slug} could not be read`);
+  }
+  return value;
 }
 
 const PIPELINE_ON_ENTER_REPLY_INSTRUCTIONS =
@@ -334,12 +387,27 @@ export interface CreateVoiceModelAndSessionParams {
   tools: llm.ToolContext;
   /** Required for pipeline mode (Silero VAD from prewarm). */
   vad?: VAD;
+  /**
+   * Org BYOK provider keys for this call (docs/byok.md). Used solely as
+   * provider-plugin constructor `apiKey` arguments here; never logged. Pass
+   * the bag from whichever agent-db document this session was fetched for —
+   * the initial instance doc, or the fresh agent doc on a handover.
+   */
+  organisationKeys?: OrganisationKeys;
 }
 
 export function createVoiceModelAndSession(
   params: CreateVoiceModelAndSessionParams,
 ): { session: voice.AgentSession; model: voice.Agent } {
-  const { voiceMode, modelName, agent: agentDef, call, tools, vad } = params;
+  const {
+    voiceMode,
+    modelName,
+    agent: agentDef,
+    call,
+    tools,
+    vad,
+    organisationKeys,
+  } = params;
 
   // Resolve the agent's `promptMetadata` declaration ONCE, here: every session
   // passes through this factory — the initial run and each transfer_agent
@@ -375,15 +443,35 @@ export function createVoiceModelAndSession(
   if (voiceMode === "pipeline") {
     const providerSeg = parseProviderModelName(modelName);
     const useProviderKeys = pipelineUsesProviderApiKeys();
-    const sttModel = useProviderKeys
-      ? buildProviderPipelineStt(agent)
-      : resolvePipelineStt(agent);
-    const pipelineLlm = useProviderKeys
-      ? buildProviderPipelineLlm(agent, modelName)
-      : new inference.LLM({
-          model: providerSeg || process.env.LIVEKIT_PIPELINE_LLM || "openai/gpt-4o-mini",
-        });
-    const ttsModel = buildPipelineTts(agent);
+    // BYOK per-component forcing (docs/byok.md): a component whose provider
+    // has an org key is built as a direct provider plugin with that key even
+    // when LIVEKIT_PIPELINE_USE_PROVIDER_KEYS is unset — LiveKit Inference
+    // cannot carry provider keys. Components without an org key keep today's
+    // behaviour exactly.
+    const sttDescriptor = resolvePipelineStt(agent);
+    const sttOrgKey = resolveOrganisationKey(
+      organisationKeys,
+      sttDescriptor.startsWith("deepgram/") ? "deepgram" : undefined,
+    );
+    const sttModel =
+      sttOrgKey !== undefined
+        ? buildProviderPipelineStt(agent, sttOrgKey)
+        : useProviderKeys
+          ? buildProviderPipelineStt(agent)
+          : sttDescriptor;
+    const llmOrgKey = resolveOrganisationKey(
+      organisationKeys,
+      providerSlugForModelSegment(modelName.match(/^livekit:([^/]+)\//)?.[1]),
+    );
+    const pipelineLlm =
+      llmOrgKey !== undefined
+        ? buildProviderPipelineLlm(agent, modelName, llmOrgKey)
+        : useProviderKeys
+          ? buildProviderPipelineLlm(agent, modelName)
+          : new inference.LLM({
+              model: providerSeg || process.env.LIVEKIT_PIPELINE_LLM || "openai/gpt-4o-mini",
+            });
+    const ttsModel = buildPipelineTts(agent, organisationKeys);
 
     // Prefer Silero VAD + vad turn detection when `proc.userData.vad` is set (optional prewarm);
     // otherwise use STT-based turn detection (no extra native deps).
@@ -406,7 +494,7 @@ export function createVoiceModelAndSession(
     return { session, model };
   }
 
-  const { realtime } = getRealtimePlugin(modelName);
+  const { plugin, realtime } = getRealtimePlugin(modelName);
   if (!realtime) {
     throw new Error(
       `Unsupported realtime model: ${modelName} (expected livekit:<openai|ultravox|google>/...)`,
@@ -414,6 +502,17 @@ export function createVoiceModelAndSession(
   }
 
   const llmOptions = buildRealtimeLlmOptions(modelName, agent, call.id);
+  // BYOK: the org's key for this realtime provider wins over the plugin's env
+  // fallback (openai/google/ultravox all accept an `apiKey` constructor
+  // option). Applied here, not in buildRealtimeLlmOptions, so the exported
+  // option-mapping stays a pure, key-free translation.
+  const realtimeOrgKey = resolveOrganisationKey(
+    organisationKeys,
+    providerSlugForModelSegment(plugin),
+  );
+  if (realtimeOrgKey !== undefined) {
+    llmOptions.apiKey = realtimeOrgKey;
+  }
 
   // Ultravox does idle natively (mapped to provider inactivityMessages in
   // buildRealtimeLlmOptions); only NON-ultravox realtime uses the SDK

--- a/agents/livekit/lib/worker.ts
+++ b/agents/livekit/lib/worker.ts
@@ -32,7 +32,7 @@ import {
   type PhoneRegistrationInfo,
   type TrunkInfo,
   endCallById,
-  getAgentById,
+  getInternalAgentById,
 } from "./api-client.js";
 import {
   handleTransfer,
@@ -410,6 +410,11 @@ export default defineAgent({
        */
       let activeAgent = agent;
       let activeModelName = modelName;
+      // BYOK bag for the ACTIVE agent (docs/byok.md): starts as the instance
+      // doc's bag and is replaced by the fallback agent's own bag on an agent
+      // switch below. Carried separately from activeAgent because the bag is
+      // non-enumerable and would be dropped by the options-normalising spread.
+      let activeOrganisationKeys = instance.organisationKeys;
       let usedFallbackModel = false;
       let usedFallbackAgent = false;
 
@@ -431,6 +436,12 @@ export default defineAgent({
             calledId,
             modelName: activeModelName,
             metadata,
+            // BYOK bag for the active agent. The instance doc's bag covers
+            // the primary agent's providers (including options.fallback.model,
+            // so model fallback retries reuse it); a fallback AGENT switch
+            // swaps in that agent's own bag, fetched with it via the internal
+            // agent-db API — see docs/byok.md need-to-know filtering.
+            organisationKeys: activeOrganisationKeys,
             sendMessage,
             call,
             onHangup,
@@ -484,7 +495,14 @@ export default defineAgent({
                 },
                 "Retrying with fallback agent after failure",
               );
-              const nextAgent = await getAgentById(fallbackConfig.agent);
+              // Internal agent-db fetch (not the public /api/agents API) so
+              // the fallback agent arrives with its own organisationKeys bag,
+              // exactly like the transfer_agent restart path; the server
+              // refuses a cross-organisation fetch.
+              const nextAgent = await getInternalAgentById(
+                fallbackConfig.agent,
+                call.organisationId,
+              );
               if (!nextAgent) {
                 throw new Error(
                   `Fallback agent ${fallbackConfig.agent} not found`,
@@ -507,6 +525,10 @@ export default defineAgent({
               let nextAgentOptions = nextAgent.options || {};
               // Switch active agent and model; subsequent fallback decisions will
               // be driven by the new agent's options.fallback.
+              // Read the BYOK bag off the fetched doc first: the spread below
+              // deliberately drops the non-enumerable property (dump-safety),
+              // as restartWithAgent's handover path does.
+              activeOrganisationKeys = nextAgent.organisationKeys;
               activeAgent = { ...nextAgent, options: nextAgentOptions };
               activeModelName = nextAgent.modelName;
               usedFallbackAgent = true;
@@ -1367,6 +1389,11 @@ async function setupCallAndUtilities({
     logger.debug({ state, description }, "Transfer state updated");
   };
 
+  // BYOK (docs/byok.md): stamp WHICH providers have org keys on this call —
+  // provider slugs only, never values — so billing can distinguish BYOK
+  // traffic later. Informational / best-effort.
+  const byokProviders = Object.keys(instance.organisationKeys || {});
+
   const call = await createCall({
     id: callId,
     userId,
@@ -1393,6 +1420,7 @@ async function setupCallAndUtilities({
         // Inbound SIP INVITE X- headers (empty for outbound / WebRTC). Referenced
         // in prompts/tools via metadata paths like `aplisay.sipHeaders.x-my-header`.
         ...(Object.keys(sipHeaders).length ? { sipHeaders } : {}),
+        ...(byokProviders.length ? { byokProviders } : {}),
       },
     },
   });

--- a/agents/pipecat/pipecat_aplisay/api_client.py
+++ b/agents/pipecat/pipecat_aplisay/api_client.py
@@ -112,7 +112,26 @@ async def _request(
 # ---- Lookup ----
 
 
+def pop_organisation_keys(doc: Any) -> dict:
+    """Remove and return the BYOK provider-key bag from a fetched document.
+
+    The agent-db API delivers the organisation's decrypted provider keys
+    per call as a top-level ``organisationKeys`` object — a sibling of
+    ``Agent`` on the instance document, and a property of the agent json
+    from ``/api/agent-db/agent`` (see docs/byok.md). Callers pop it off
+    immediately after the fetch so the instance / agent dicts they store,
+    serialise, or log never carry key material. Returns ``{}`` when the
+    document has no bag (the server omits it when empty).
+    """
+    if not isinstance(doc, dict):
+        return {}
+    bag = doc.pop("organisationKeys", None)
+    return bag if isinstance(bag, dict) else {}
+
+
 async def get_instance_by_id(instance_id: str) -> dict:
+    # The returned document may carry a top-level ``organisationKeys`` bag
+    # (BYOK); callers that build sessions pop it via pop_organisation_keys.
     return await _request("GET", "/api/agent-db/instance", params={"instanceId": instance_id})
 
 
@@ -132,6 +151,10 @@ async def get_internal_agent_by_id(
     Used for in-call ``transfer_agent`` handover. Always pass the calling
     call's organisation id so the server can refuse cross-tenant fetches —
     mirrors ``getInternalAgentById`` in the LiveKit worker's api-client.ts.
+
+    The returned agent json may carry an ``organisationKeys`` property (the
+    incoming agent's own BYOK bag) — callers must pop it off with
+    :func:`pop_organisation_keys` before storing or embedding the dict.
     """
     params: dict = {"agentId": agent_id}
     if expected_organisation_id:

--- a/agents/pipecat/pipecat_aplisay/bridged_transfer.py
+++ b/agents/pipecat/pipecat_aplisay/bridged_transfer.py
@@ -227,6 +227,11 @@ class BtaContext:
     # bridged call record, encrypted with the same client key.
     recording_enabled: bool = False
     recording_key: Optional[str] = None
+    # The parent session's BYOK provider-key bag — carried so the sipbridge
+    # transcription tap's STT streams resolve the same (organisation) key the
+    # parent pipeline used. SECRET: never logged or embedded in metadata
+    # (``repr=False`` keeps it out of any repr of the context).
+    organisation_keys: dict = field(default_factory=dict, repr=False)
 
 
 @dataclass
@@ -246,6 +251,11 @@ class TakeoverPayload:
     # threaded onto the takeover CallSession so its ``transfer_summary``
     # builtin can await it. None when the map entry has no summaryAgent.
     summary_future: Optional[Any] = None
+    # The takeover agent's own BYOK provider-key bag, popped off the internal
+    # agent fetch in ``prepare_takeover`` — carried here (never inside the
+    # ``agent`` dict) to ``setup_takeover_call``. SECRET: never logged
+    # (``repr=False`` keeps it out of any repr of the payload).
+    organisation_keys: dict = field(default_factory=dict, repr=False)
 
 
 def bta_context_from_session(
@@ -288,6 +298,7 @@ def bta_context_from_session(
         consult_transcript=consult_transcript,
         recording_enabled=bool(getattr(recording, "enabled", False)),
         recording_key=getattr(recording, "key", None),
+        organisation_keys=dict(getattr(session, "organisation_keys", None) or {}),
     )
 
 
@@ -522,6 +533,9 @@ async def prepare_takeover(
     new_agent = await api_client.get_internal_agent_by_id(
         target.agent_id, expected_organisation_id=ctx.organisation_id
     )
+    # BYOK: strip the incoming agent's key bag before the dict is copied /
+    # embedded anywhere; it rides the TakeoverPayload separately.
+    org_keys = api_client.pop_organisation_keys(new_agent)
     if (new_agent.get("type") or "interactive-audio") != "interactive-audio":
         raise RuntimeError(
             f"bridgedTransferToAgent target {target.agent_id} is type "
@@ -586,6 +600,7 @@ async def prepare_takeover(
         instance=ctx.instance,
         call=call,
         summary_future=summary_future,
+        organisation_keys=org_keys,
     )
 
 
@@ -759,8 +774,14 @@ async def run_sipbridge_bta_watch(
             async def _target_text(text: str) -> None:
                 await collector.add(bt.TARGET, text)
 
-            caller_stt = bt.SttStream(build_stt_service(ctx.agent), _caller_text)
-            target_stt = bt.SttStream(build_stt_service(ctx.agent), _target_text)
+            caller_stt = bt.SttStream(
+                build_stt_service(ctx.agent, org_keys=ctx.organisation_keys),
+                _caller_text,
+            )
+            target_stt = bt.SttStream(
+                build_stt_service(ctx.agent, org_keys=ctx.organisation_keys),
+                _target_text,
+            )
             await caller_stt.start()
             await target_stt.start()
         except Exception as e:  # noqa: BLE001

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -158,6 +158,16 @@ class CallSession:
     # CallSession — used so the accept/reject tools can drive the parent's
     # transfer_state and trigger the bridge.
     parent_session: Optional["CallSession"] = None
+    # Per-call organisation (BYOK) provider-key bag — ``{slug: value}`` from
+    # the fetched agent-db document, need-to-know filtered server-side.
+    # SECRET: consumed only by ``build_voice_session`` at service
+    # construction; never logged, never embedded in agent/transfer dicts,
+    # metadata, or transaction/invocation logs (docs/byok.md). Constructors
+    # either pass it explicitly (after popping it off the fetched doc) or
+    # leave it for ``__post_init__`` to pop from ``instance`` / ``agent``.
+    # ``repr=False`` keeps the plaintext keys out of any repr of the session
+    # (debug prints, loguru diagnose frames, ...).
+    organisation_keys: dict = field(default_factory=dict, repr=False)
 
     # Origin / transfer-mode context, threaded from the inbound lookup
     # (worker.py) so ``_on_transfer`` can resolve REFER-vs-bridge at transfer
@@ -273,6 +283,17 @@ class CallSession:
     _pending_summary: Optional[Any] = None
 
     def __post_init__(self):
+        # BYOK: strip the provider-key bag off the fetched documents at this
+        # one choke point (every constructor path passes through) so the
+        # stored instance / agent dicts never carry key material into
+        # metadata dumps or the invocation-log capture. When a constructor
+        # already popped the bag (to stamp byokProviders / inherit from a
+        # parent) it arrives via ``organisation_keys`` and these pops are
+        # empty no-ops.
+        instance_bag = api_client.pop_organisation_keys(self.instance)
+        agent_bag = api_client.pop_organisation_keys(self.agent)
+        if not self.organisation_keys:
+            self.organisation_keys = instance_bag or agent_bag
         # Listener-level transfer overrides (instance columns) wholesale-replace
         # the same-named agent options for every session under this listener —
         # including takeover and consult sessions. Idempotent; also applied to
@@ -317,7 +338,23 @@ class CallSession:
                     and fallback_cfg["agent"] != active_agent.get("id")
                 ):
                     try:
-                        next_agent = await api_client.get_agent_by_id(fallback_cfg["agent"])
+                        # Internal fetch (same-organisation guarded, like the
+                        # transfer_agent handover) so the fallback agent's own
+                        # organisationKeys bag rides along — the public agent
+                        # route omits it, which would silently run a fallback
+                        # model on the platform key (docs/byok.md: org key
+                        # wins, no silent fallback).
+                        next_agent = await api_client.get_internal_agent_by_id(
+                            fallback_cfg["agent"],
+                            expected_organisation_id=self.call.organisationId,
+                        )
+                        # Pop + adopt immediately, mirroring _on_agent_transfer:
+                        # the rebuilt session resolves provider keys from the
+                        # incoming agent's own bag, and the stored dict never
+                        # carries key material.
+                        self.organisation_keys = api_client.pop_organisation_keys(
+                            next_agent
+                        )
                         active_agent = next_agent
                         active_model = next_agent["modelName"]
                         used_fallback_agent = True
@@ -470,6 +507,10 @@ class CallSession:
             relay_endpoint=self.relay_endpoint,
             tone_injector=self._tone_injector,
             on_inactivity_hangup=self._on_inactivity_hangup,
+            # BYOK: the active agent's provider keys, applied at every
+            # construction path through here — initial run, transfer_agent
+            # handover continuations and the consult-side bot alike.
+            org_keys=self.organisation_keys,
         )
         # Stash the context handle so ``get_parent_transcript`` (used by
         # the consultative-transfer flow) can walk the chat history.
@@ -1124,6 +1165,11 @@ class CallSession:
             )
         except api_client.ApiRequestError as e:
             return self._transfer_failed(f"could not load target agent: {e}")
+        # BYOK: strip the incoming agent's key bag off the dict immediately —
+        # it must never ride into prompts, transfer dicts or logs. Adopted
+        # onto the session only once the handover commits (below), so a
+        # refused handover leaves the current agent's bag untouched.
+        new_org_keys = api_client.pop_organisation_keys(new_agent)
 
         if (new_agent.get("type") or "interactive-audio") != "interactive-audio":
             return self._transfer_failed(
@@ -1149,6 +1195,9 @@ class CallSession:
         if self._needs_full_handover(new_agent):
             result = await self._begin_agent_handover(new_agent, prompt)
             if result.get("status") == "OK":
+                # The continuation's prepare_run (run_prepared loop) resolves
+                # provider keys from the incoming agent's own bag.
+                self.organisation_keys = new_org_keys
                 await self._send_message(
                     {"inject": f"Call transferred to agent {new_agent.get('name') or target}"}
                 )
@@ -1163,6 +1212,10 @@ class CallSession:
             include_history=include_history,
         ).info("transfer_agent: handing session to new agent (in place)")
 
+        # In-place swap keeps the running services (and their keys); adopt the
+        # incoming agent's bag so any LATER rebuild (full handover, fallback)
+        # resolves against it. Same organisation is enforced by the fetch.
+        self.organisation_keys = new_org_keys
         # Apply the swap from a detached task so the tool call's own result
         # (delivered with run_llm=False) lands before the context is replaced,
         # and so the swap survives the LLM cancelling this coroutine on a
@@ -2485,6 +2538,10 @@ async def setup_inbound_call(
 ) -> CallSession:
     session_params = GatewaySessionParams(session_id=inbound.session_id)
     gw_session = await sip_gateway.setup_inbound(inbound, session_params)
+    # BYOK: pop the provider-key bag off the fetched instance document BEFORE
+    # its metadata is embedded anywhere; the values ride only on the session
+    # (below) while the metadata carries just the provider NAMES for billing.
+    org_keys = api_client.pop_organisation_keys(instance)
     call = await api_client.create_call(
         {
             "userId": agent["userId"],
@@ -2512,6 +2569,9 @@ async def setup_inbound_call(
                     # prompts/tools via metadata paths like
                     # `aplisay.sipHeaders.x-my-header`.
                     **({"sipHeaders": inbound.sip_headers} if inbound.sip_headers else {}),
+                    # Providers this call runs on organisation (BYOK) keys —
+                    # names only, informational for billing (docs/byok.md).
+                    **({"byokProviders": sorted(org_keys)} if org_keys else {}),
                 },
             },
         }
@@ -2524,6 +2584,7 @@ async def setup_inbound_call(
         sip_gateway=sip_gateway,
         gateway_session=gw_session,
         call=call,
+        organisation_keys=org_keys,
         registration_originated=inbound.registration_originated,
         force_refer_transfer=inbound.force_refer_transfer,
         force_bridged_transfer=inbound.force_bridged_transfer,
@@ -2633,7 +2694,10 @@ def build_transfer_agent_dict(
         ],
         # Drop platform keys — the TransferAgent's tools call the
         # bridge / esl-poller / voiceblender REST via the parent's
-        # gateway, not via the agent's own credentials.
+        # gateway, not via the agent's own credentials. The BYOK
+        # ``organisationKeys`` bag is likewise never embedded in this (or
+        # any) agent dict — consult sessions inherit it out-of-band via
+        # ``CallSession.organisation_keys`` (docs/byok.md).
         "keys": [],
     }
 
@@ -2700,6 +2764,10 @@ async def setup_consult_call(
         gateway_session=gw_session,
         call=call,
         parent_session=parent,
+        # The TransferAgent runs the parent's model in the parent's org —
+        # inherit the parent's BYOK bag (its instance dict is already
+        # stripped, so __post_init__ would otherwise find nothing).
+        organisation_keys=dict(getattr(parent, "organisation_keys", None) or {}),
     )
 
 
@@ -2730,6 +2798,10 @@ async def setup_takeover_call(
         gateway_session=gw_session,
         call=payload.call,
         _pending_summary=payload.summary_future,
+        # The incoming agent's own BYOK bag, popped off the internal fetch in
+        # ``prepare_takeover`` and carried on the payload — never in the
+        # agent dict itself.
+        organisation_keys=dict(getattr(payload, "organisation_keys", None) or {}),
     )
 
 
@@ -2779,6 +2851,9 @@ async def setup_consult_outbound_call(
         gateway_session=gw_session,
         call=call,
         parent_session=parent,
+        # Inherit the parent's BYOK bag — same model, same organisation (see
+        # setup_consult_call).
+        organisation_keys=dict(getattr(parent, "organisation_keys", None) or {}),
     )
 
 
@@ -2819,7 +2894,9 @@ async def setup_outbound_call(
 
     # The Call record was created in lib/handlers/pipecat.js. The Python worker
     # needs a representation to drive end(); reconstruct it from the agent /
-    # instance the dispatcher passed.
+    # instance the dispatcher passed. The BYOK bag is popped off the instance
+    # document first so only the provider NAMES land in metadata (billing).
+    org_keys = api_client.pop_organisation_keys(instance)
     call = api_client.CallRecord(
         id=call_id,
         userId=agent["userId"],
@@ -2827,7 +2904,13 @@ async def setup_outbound_call(
         instanceId=instance["id"],
         agentId=agent["id"],
         metadata={
-            "aplisay": {"callerId": caller_id, "calledId": called_id, "callId": call_id, "model": agent["modelName"]},
+            "aplisay": {
+                "callerId": caller_id,
+                "calledId": called_id,
+                "callId": call_id,
+                "model": agent["modelName"],
+                **({"byokProviders": sorted(org_keys)} if org_keys else {}),
+            },
             "aplisayId": aplisay_id,
             "outbound": True,
         },
@@ -2840,6 +2923,7 @@ async def setup_outbound_call(
         sip_gateway=sip_gateway,
         gateway_session=gw_session,
         call=call,
+        organisation_keys=org_keys,
         origin_caller_id=caller_id,
         aplisay_id=aplisay_id,
         # Carry the originate's trunk contract onto the session so a transfer

--- a/agents/pipecat/pipecat_aplisay/invocation_log.py
+++ b/agents/pipecat/pipecat_aplisay/invocation_log.py
@@ -16,6 +16,7 @@ rather than accumulated forever.
 from __future__ import annotations
 
 import os
+import sys
 import threading
 from typing import Any
 
@@ -99,12 +100,24 @@ def install_capture(level: str | None = None) -> None:
     """Register the buffering sink on the shared loguru logger (idempotent).
 
     Call once at worker startup, after all imports, so nothing later resets the
-    handler set out from under us. Adds a handler; the existing stderr sink is
-    left untouched, so console output is unchanged.
+    handler set out from under us.
+
+    Also replaces loguru's DEFAULT stderr handler, which ships
+    ``diagnose=True``: its exception tracebacks render each frame's local
+    variables, so a failure inside service construction would print the
+    decrypted BYOK ``org_keys`` bag in plaintext to the worker logs
+    (docs/byok.md — keys must never be logged). The replacement is otherwise
+    equivalent (same default level/format, ``backtrace`` kept) so console
+    output is unchanged apart from the variable rendering.
     """
     global _installed
     if _installed:
         return
+    try:
+        logger.remove(0)  # loguru's default stderr handler (diagnose=True)
+    except ValueError:
+        pass  # already removed/replaced (e.g. by a test harness)
+    logger.add(sys.stderr, backtrace=True, diagnose=False)
     logger.add(
         _capture_sink,
         level=(level or os.environ.get("LOGLEVEL", "INFO")).upper(),

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -351,13 +351,17 @@ def _dtmf_aggregator_for(agent: dict) -> DTMFAggregator:
     )
 
 
-def build_stt_service(agent: dict) -> Any:
+def build_stt_service(agent: dict, org_keys: Optional[dict] = None) -> Any:
     """Construct a fresh STT service from ``agent.options.stt`` (defaulting
     to Deepgram). Used by the pipeline build below and by the bridged-
     transfer transcription tap (``bridged_transfer.py``), which runs extra
     STT streams over the human↔human segment of a monitored bridge —
     each call returns a NEW service instance, safe to run alongside the
-    pipeline's own."""
+    pipeline's own.
+
+    ``org_keys`` is the per-call BYOK bag (see ``_resolve_provider_key``);
+    only Deepgram is BYOK-injectable here — Google STT authenticates with a
+    service account, which stays on platform credentials (docs/byok.md)."""
     stt_opts = (agent.get("options") or {}).get("stt") or {}
     stt_vendor = (stt_opts.get("vendor") or "deepgram").split("/")[0].lower()
     # ``options.stt.language`` (falling back to ``options.tts.language``). Each
@@ -371,7 +375,7 @@ def build_stt_service(agent: dict) -> Any:
         # Deepgram takes the full regional tag — nova-3 accepts en-GB/en-AU/…
         # alongside the bare primary tags, so there is nothing to truncate.
         return DeepgramSTTService(
-            api_key=_require_env("DEEPGRAM_API_KEY"),
+            api_key=_resolve_provider_key(org_keys, stt_vendor, "DEEPGRAM_API_KEY"),
             **(
                 {"settings": DeepgramSTTSettings(language=language)}
                 if language is not None
@@ -408,9 +412,11 @@ def build_stt_service(agent: dict) -> Any:
     raise RuntimeError(f"Unsupported STT vendor {stt_vendor!r} for pipeline mode")
 
 
-def build_tts_service(agent: dict) -> Any:
+def build_tts_service(agent: dict, org_keys: Optional[dict] = None) -> Any:
     """Construct the pipeline's TTS service from ``agent.options.tts``
-    (defaulting to Cartesia).
+    (defaulting to Cartesia). ``org_keys`` is the per-call BYOK bag — the
+    cartesia / elevenlabs / deepgram vendors resolve their API key through
+    ``_resolve_provider_key`` (org key wins, fail-closed).
 
     Peer of :func:`build_stt_service`, split out of ``_build_pipeline`` for the
     same reason: each call returns a NEW instance, and having it addressable
@@ -436,7 +442,7 @@ def build_tts_service(agent: dict) -> Any:
         from pipecat.services.cartesia.tts import CartesiaTTSService
 
         return CartesiaTTSService(
-            api_key=_require_env("CARTESIA_API_KEY"),
+            api_key=_resolve_provider_key(org_keys, tts_vendor, "CARTESIA_API_KEY"),
             settings=CartesiaTTSService.Settings(
                 voice=voice or "71a7ad14-091c-4e8e-a314-022ece01c121",
                 **({"language": language} if language is not None else {}),
@@ -455,7 +461,9 @@ def build_tts_service(agent: dict) -> Any:
         # for the language anyway, using both would mean relying on the
         # settings-wins precedence rule between them.
         return ElevenLabsTTSService(
-            api_key=_require_env("ELEVENLABS_API_KEY", "ELEVEN_API_KEY"),
+            api_key=_resolve_provider_key(
+                org_keys, tts_vendor, "ELEVENLABS_API_KEY", "ELEVEN_API_KEY"
+            ),
             settings=ElevenLabsTTSSettings(
                 voice=voice or "Rachel",
                 **({"language": language} if language is not None else {}),
@@ -474,7 +482,7 @@ def build_tts_service(agent: dict) -> Any:
         from pipecat.services.deepgram.tts import DeepgramTTSService
 
         return DeepgramTTSService(
-            api_key=_require_env("DEEPGRAM_API_KEY"),
+            api_key=_resolve_provider_key(org_keys, tts_vendor, "DEEPGRAM_API_KEY"),
             voice=voice or "aura-asteria-en",
         )
     raise RuntimeError(f"Unsupported TTS vendor {tts_vendor!r} for pipeline mode")
@@ -500,6 +508,66 @@ def _require_env(name: str, *aliases: str) -> str:
         f"(remember to fully restart the worker after setting env vars; "
         f"uvicorn --reload only watches code, not the shell's exports)."
     )
+
+
+class ByokKeyError(RuntimeError):
+    """An organisation-supplied (BYOK) provider key is configured but unusable.
+
+    Raised when the per-call ``organisationKeys`` bag carries an entry for the
+    provider whose value is null/empty (e.g. the stored key failed to decrypt
+    server-side). Fail-closed by design: the platform's own key is never
+    silently substituted for a call the organisation believes runs on its key
+    (docs/byok.md). The message is surfaced to tenants (``/webrtc/offer``
+    returns it as the HTTP error detail), so it must name neither key material
+    nor platform env vars.
+    """
+
+
+#: Model-id provider segment → canonical BYOK provider slug. Must stay in
+#: step with the registry in lib/utils/provider-keys.js (docs/byok.md).
+_MODEL_PROVIDER_SLUGS = {
+    "openai": "openai",
+    "anthropic": "anthropic",
+    "google": "google",
+    "gemini": "google",
+    "ultravox": "ultravox",
+    "fixie-ai": "ultravox",
+}
+
+
+def _model_provider_slug(model_id: str) -> Optional[str]:
+    """Canonical provider slug for a model id's provider segment
+    (``google/gemini-2.0-flash`` → ``google``), or ``None`` when the segment
+    is not a BYOK-registered provider."""
+    return _MODEL_PROVIDER_SLUGS.get(model_id.split("/", 1)[0].strip().lower())
+
+
+def _resolve_provider_key(
+    org_keys: Optional[dict], slug: str, *env_names: str
+) -> str:
+    """Resolve a provider API key: organisation (BYOK) key first, worker env
+    otherwise.
+
+    The ``org_keys`` bag is the need-to-know-filtered ``organisationKeys``
+    object from the per-call agent-db document. Precedence per docs/byok.md:
+
+    - slug present with a usable value → that value (org key wins);
+    - slug present but null/empty → :class:`ByokKeyError` — fail closed,
+      NEVER fall through to the platform env key;
+    - slug absent (or no bag at all) → the existing ``_require_env`` path,
+      platform behaviour unchanged.
+    """
+    if org_keys and slug in org_keys:
+        value = org_keys.get(slug)
+        if isinstance(value, str) and value.strip():
+            return value
+        raise ByokKeyError(
+            f"The organisation's stored {slug} API key could not be used "
+            "(missing or unreadable). Re-save or delete the key in the "
+            "organisation's provider-key settings; the platform's own "
+            f"{slug} credentials are never substituted for it."
+        )
+    return _require_env(*env_names)
 from pipecat.transports.base_transport import BaseTransport
 
 from .voice_mode import VoiceMode, model_id_from_name, resolve_voice_mode
@@ -891,8 +959,13 @@ async def build_voice_session(
     relay_endpoint: "Optional[Any]" = None,
     tone_injector: "Optional[Any]" = None,
     on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
+    org_keys: Optional[dict] = None,
 ) -> tuple[PipelineTask, Optional[AudioBufferProcessor], LLMContext, Any]:
     """Construct a configured ``PipelineTask`` for the call.
+
+    ``org_keys`` is the per-call organisation (BYOK) provider-key bag —
+    consumed only at service construction via ``_resolve_provider_key``,
+    never stored on the agent dict or logged (docs/byok.md).
 
     When ``enable_recording`` is true the returned ``AudioBufferProcessor``
     is appended to the pipeline (stereo, user-left/bot-right per
@@ -923,12 +996,12 @@ async def build_voice_session(
     if mode == "realtime":
         task, context, llm = await _build_realtime(
             transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector,
-            on_inactivity_hangup,
+            on_inactivity_hangup, org_keys=org_keys,
         )
     else:
         task, context, llm = await _build_pipeline(
             transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector,
-            on_inactivity_hangup,
+            on_inactivity_hangup, org_keys=org_keys,
         )
     return task, audio_buffer, context, llm
 
@@ -944,9 +1017,13 @@ async def _build_realtime(
     relay_endpoint: "Optional[Any]" = None,
     tone_injector: "Optional[Any]" = None,
     on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
+    org_keys: Optional[dict] = None,
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
+    # BYOK slug for the realtime provider, derived from the model id's
+    # provider segment (matches the branch prefixes below).
+    provider_slug = _model_provider_slug(model_id)
 
     if model_id.startswith("openai/"):
         # OpenAI Realtime: `voice` lives inside SessionProperties → audio →
@@ -969,7 +1046,7 @@ async def _build_realtime(
         _, openai_model = model_id.split("/", 1)
         voice = (options.get("tts") or {}).get("voice") or "alloy"
         llm = OpenAIRealtimeLLMService(
-            api_key=_require_env("OPENAI_API_KEY"),
+            api_key=_resolve_provider_key(org_keys, provider_slug, "OPENAI_API_KEY"),
             settings=OpenAIRealtimeLLMService.Settings(
                 model=openai_model,
                 system_instruction=system_prompt,
@@ -985,7 +1062,9 @@ async def _build_realtime(
         from pipecat.services.google.gemini_live.llm import GeminiLiveLLMService
 
         llm = GeminiLiveLLMService(
-            api_key=_require_env("GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"),
+            api_key=_resolve_provider_key(
+                org_keys, provider_slug, "GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"
+            ),
             system_instruction=system_prompt,
         )
     elif model_id.startswith("ultravox/"):
@@ -1096,7 +1175,7 @@ async def _build_realtime(
         # field storage and Pipecat's downstream code only stringifies the
         # value.
         params = OneShotInputParams(
-            api_key=_require_env("ULTRAVOX_API_KEY"),
+            api_key=_resolve_provider_key(org_keys, provider_slug, "ULTRAVOX_API_KEY"),
             system_prompt=system_prompt,
             # ``model`` on the request body maps to the Ultravox catalogue
             # id (``ultravox-v0.6`` etc.). The default in the library is
@@ -1254,12 +1333,16 @@ async def _build_pipeline(
     relay_endpoint: "Optional[Any]" = None,
     tone_injector: "Optional[Any]" = None,
     on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
+    org_keys: Optional[dict] = None,
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
+    # BYOK slug for the pipeline LLM, derived from the model id's provider
+    # segment (matches the branch prefixes below).
+    provider_slug = _model_provider_slug(model_id)
 
     # STT
-    stt = build_stt_service(agent)
+    stt = build_stt_service(agent, org_keys=org_keys)
 
     # LLM
     if model_id.startswith("openai/"):
@@ -1267,7 +1350,7 @@ async def _build_pipeline(
 
         _, openai_model = model_id.split("/", 1)
         llm = OpenAILLMService(
-            api_key=_require_env("OPENAI_API_KEY"),
+            api_key=_resolve_provider_key(org_keys, provider_slug, "OPENAI_API_KEY"),
             model=openai_model,
             settings=OpenAILLMService.Settings(system_instruction=system_prompt),
         )
@@ -1276,7 +1359,9 @@ async def _build_pipeline(
 
         _, gemini_model = model_id.split("/", 1)
         llm = GoogleLLMService(
-            api_key=_require_env("GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"),
+            api_key=_resolve_provider_key(
+                org_keys, provider_slug, "GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"
+            ),
             model=gemini_model,
             settings=GoogleLLMService.Settings(system_instruction=system_prompt),
         )
@@ -1285,14 +1370,14 @@ async def _build_pipeline(
 
         _, anthropic_model = model_id.split("/", 1)
         llm = AnthropicLLMService(
-            api_key=_require_env("ANTHROPIC_API_KEY"),
+            api_key=_resolve_provider_key(org_keys, provider_slug, "ANTHROPIC_API_KEY"),
             model=anthropic_model,
             settings=AnthropicLLMService.Settings(system_instruction=system_prompt),
         )
     else:
         raise RuntimeError(f"Unsupported LLM in pipeline mode: {model_id}")
 
-    tts = build_tts_service(agent)
+    tts = build_tts_service(agent, org_keys=org_keys)
 
     schemas = _register_tools_on_llm(llm, tools)
 

--- a/agents/pipecat/tests/test_byok_keys.py
+++ b/agents/pipecat/tests/test_byok_keys.py
@@ -1,0 +1,342 @@
+"""BYOK (Bring Your Own Key) — the per-call ``organisationKeys`` bag
+(docs/byok.md).
+
+Covers the worker-side contract:
+
+- ``_resolve_provider_key`` precedence: an organisation key wins over the
+  worker env; a present-but-null/empty entry fails CLOSED (``ByokKeyError``,
+  never the platform env key); an absent slug falls through to the existing
+  ``_require_env`` behaviour; and neither anywhere raises the usual missing
+  key error.
+- Model-id provider-segment → canonical slug mapping.
+- The pipeline STT/TTS construction sites consume the bag (and only the
+  BYOK-registered vendors do — Google STT is service-account auth).
+- The bag never rides inside agent dicts: ``build_transfer_agent_dict``
+  and ``prepare_takeover`` carry it out-of-band, and ``CallSession``
+  strips it off fetched instance/agent documents at construction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pipecat_aplisay import api_client
+from pipecat_aplisay.voice_session import (
+    ByokKeyError,
+    _model_provider_slug,
+    _resolve_provider_key,
+    build_stt_service,
+    build_tts_service,
+)
+
+ORG_KEY = "org-supplied-key"
+ENV_KEY = "platform-env-key"
+
+
+@pytest.fixture
+def no_provider_env(monkeypatch):
+    """Guarantee the platform env keys are ABSENT, so a successful service
+    construction proves the org key was used."""
+    for name in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_GENAI_API_KEY",
+        "ULTRAVOX_API_KEY",
+        "DEEPGRAM_API_KEY",
+        "CARTESIA_API_KEY",
+        "ELEVENLABS_API_KEY",
+        "ELEVEN_API_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+class TestResolveProviderKey:
+    def test_org_key_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", ENV_KEY)
+        assert (
+            _resolve_provider_key({"openai": ORG_KEY}, "openai", "OPENAI_API_KEY")
+            == ORG_KEY
+        )
+
+    def test_null_org_entry_fails_closed_even_with_env(self, monkeypatch):
+        # A stored key that failed to decrypt arrives as null. The platform
+        # env key must NOT be silently substituted (docs/byok.md principle 3).
+        monkeypatch.setenv("OPENAI_API_KEY", ENV_KEY)
+        with pytest.raises(ByokKeyError):
+            _resolve_provider_key({"openai": None}, "openai", "OPENAI_API_KEY")
+
+    def test_empty_org_entry_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", ENV_KEY)
+        with pytest.raises(ByokKeyError):
+            _resolve_provider_key({"deepgram": "  "}, "deepgram", "DEEPGRAM_API_KEY")
+
+    def test_absent_slug_falls_through_to_env(self, monkeypatch):
+        monkeypatch.setenv("CARTESIA_API_KEY", ENV_KEY)
+        # A bag for OTHER providers leaves this one on platform behaviour.
+        assert (
+            _resolve_provider_key({"openai": ORG_KEY}, "cartesia", "CARTESIA_API_KEY")
+            == ENV_KEY
+        )
+        assert _resolve_provider_key(None, "cartesia", "CARTESIA_API_KEY") == ENV_KEY
+        assert _resolve_provider_key({}, "cartesia", "CARTESIA_API_KEY") == ENV_KEY
+
+    def test_env_aliases_still_honoured(self, monkeypatch, no_provider_env):
+        monkeypatch.setenv("ELEVEN_API_KEY", ENV_KEY)
+        assert (
+            _resolve_provider_key(
+                {}, "elevenlabs", "ELEVENLABS_API_KEY", "ELEVEN_API_KEY"
+            )
+            == ENV_KEY
+        )
+
+    def test_missing_both_raises_the_env_error(self, no_provider_env):
+        with pytest.raises(KeyError):
+            _resolve_provider_key({}, "openai", "OPENAI_API_KEY")
+
+    def test_byok_error_message_is_tenant_safe(self, monkeypatch):
+        # The message reaches tenants via /webrtc/offer error details: it must
+        # name neither key material nor the platform env var names.
+        monkeypatch.setenv("OPENAI_API_KEY", ENV_KEY)
+        with pytest.raises(ByokKeyError) as exc:
+            _resolve_provider_key({"openai": ""}, "openai", "OPENAI_API_KEY")
+        message = str(exc.value)
+        assert "OPENAI_API_KEY" not in message
+        assert ENV_KEY not in message
+        assert "openai" in message
+
+
+class TestModelProviderSlug:
+    @pytest.mark.parametrize(
+        "model_id,slug",
+        [
+            ("openai/gpt-4o", "openai"),
+            ("anthropic/claude-sonnet-4-5", "anthropic"),
+            ("google/gemini-2.0-flash-live-001", "google"),
+            ("gemini/gemini-2.0-flash", "google"),
+            ("ultravox/ultravox-v0.7", "ultravox"),
+            ("fixie-ai/ultravox-v0.6", "ultravox"),
+            ("OpenAI/gpt-4o", "openai"),
+        ],
+    )
+    def test_known_segments(self, model_id, slug):
+        assert _model_provider_slug(model_id) == slug
+
+    def test_unknown_segment_is_none(self):
+        assert _model_provider_slug("acme/whatever") is None
+
+
+class TestServiceConstructionSites:
+    def test_deepgram_stt_uses_org_key(self, no_provider_env):
+        # No DEEPGRAM_API_KEY in the environment: construction can only
+        # succeed if the org key was used.
+        service = build_stt_service(
+            {"options": {"stt": {"vendor": "deepgram"}}},
+            org_keys={"deepgram": ORG_KEY},
+        )
+        assert service is not None
+
+    def test_deepgram_stt_fails_closed_on_null_org_key(self, monkeypatch):
+        monkeypatch.setenv("DEEPGRAM_API_KEY", ENV_KEY)
+        with pytest.raises(ByokKeyError):
+            build_stt_service(
+                {"options": {"stt": {"vendor": "deepgram"}}},
+                org_keys={"deepgram": None},
+            )
+
+    @pytest.mark.parametrize(
+        "vendor,slug",
+        [
+            ("cartesia", "cartesia"),
+            ("elevenlabs", "elevenlabs"),
+            ("deepgram", "deepgram"),
+        ],
+    )
+    def test_tts_vendors_use_org_key(self, no_provider_env, vendor, slug):
+        service = build_tts_service(
+            {"options": {"tts": {"vendor": vendor}}},
+            org_keys={slug: ORG_KEY},
+        )
+        assert service is not None
+
+    @pytest.mark.parametrize(
+        "vendor,slug",
+        [
+            ("cartesia", "cartesia"),
+            ("elevenlabs", "elevenlabs"),
+            ("deepgram", "deepgram"),
+        ],
+    )
+    def test_tts_vendors_fail_closed_on_null_org_key(
+        self, monkeypatch, vendor, slug
+    ):
+        monkeypatch.setenv("CARTESIA_API_KEY", ENV_KEY)
+        monkeypatch.setenv("ELEVENLABS_API_KEY", ENV_KEY)
+        monkeypatch.setenv("DEEPGRAM_API_KEY", ENV_KEY)
+        with pytest.raises(ByokKeyError):
+            build_tts_service(
+                {"options": {"tts": {"vendor": vendor}}},
+                org_keys={slug: None},
+            )
+
+    def test_backward_compatible_signatures(self, monkeypatch):
+        # bridged_transfer.py historically calls these with the agent alone;
+        # org_keys must stay optional.
+        monkeypatch.setenv("DEEPGRAM_API_KEY", ENV_KEY)
+        assert build_stt_service({"options": {"stt": {"vendor": "deepgram"}}}) is not None
+
+
+class TestPopOrganisationKeys:
+    def test_pops_and_returns_bag(self):
+        doc = {"id": "i1", "Agent": {"id": "a1"}, "organisationKeys": {"openai": ORG_KEY}}
+        assert api_client.pop_organisation_keys(doc) == {"openai": ORG_KEY}
+        assert "organisationKeys" not in doc
+
+    def test_absent_or_malformed_is_empty(self):
+        assert api_client.pop_organisation_keys({"id": "i1"}) == {}
+        assert api_client.pop_organisation_keys(None) == {}
+        assert api_client.pop_organisation_keys({"organisationKeys": "junk"}) == {}
+
+
+def _call_record() -> api_client.CallRecord:
+    return api_client.CallRecord(
+        id="call-1",
+        userId="user-1",
+        organisationId="org-1",
+        instanceId="inst-1",
+        agentId="agent-1",
+        persisted=False,
+    )
+
+
+class _StubGatewaySession:
+    transport = None
+
+    async def shutdown(self) -> None:  # pragma: no cover
+        return None
+
+
+def _session(agent: dict, instance: dict, **kwargs):
+    from pipecat_aplisay.call_session import CallSession
+
+    return CallSession(
+        session_id="s1",
+        agent=agent,
+        instance=instance,
+        sip_gateway=None,  # type: ignore[arg-type]
+        gateway_session=_StubGatewaySession(),  # type: ignore[arg-type]
+        call=_call_record(),
+        **kwargs,
+    )
+
+
+class TestCallSessionStripsBag:
+    def test_bag_popped_off_instance_document(self):
+        instance = {
+            "id": "inst-1",
+            "streamLog": False,
+            "Agent": {"id": "agent-1"},
+            "organisationKeys": {"openai": ORG_KEY},
+        }
+        session = _session(
+            {"id": "agent-1", "modelName": "pipecat:openai/gpt-4o"}, instance
+        )
+        assert session.organisation_keys == {"openai": ORG_KEY}
+        assert "organisationKeys" not in instance
+        assert "organisationKeys" not in session.instance
+
+    def test_bag_popped_off_agent_dict(self):
+        agent = {
+            "id": "agent-1",
+            "modelName": "pipecat:openai/gpt-4o",
+            "organisationKeys": {"deepgram": ORG_KEY},
+        }
+        session = _session(agent, {"streamLog": False})
+        assert session.organisation_keys == {"deepgram": ORG_KEY}
+        assert "organisationKeys" not in session.agent
+
+    def test_explicitly_passed_bag_wins_and_docs_still_stripped(self):
+        # Consult/takeover constructors pop the bag themselves and pass it in;
+        # a (stale) bag on the docs is stripped but not adopted.
+        instance = {"streamLog": False, "organisationKeys": {"openai": "stale"}}
+        session = _session(
+            {"id": "agent-1", "modelName": "pipecat:openai/gpt-4o"},
+            instance,
+            organisation_keys={"openai": ORG_KEY},
+        )
+        assert session.organisation_keys == {"openai": ORG_KEY}
+        assert "organisationKeys" not in instance
+
+
+class TestTransferAgentDictNeverCarriesBag:
+    def test_build_transfer_agent_dict_excludes_organisation_keys(self):
+        from pipecat_aplisay.call_session import build_transfer_agent_dict
+
+        parent_agent = {
+            "id": "agent-1",
+            "userId": "user-1",
+            "organisationId": "org-1",
+            "modelName": "pipecat:openai/gpt-4o",
+            "options": {"tts": {"voice": "x"}},
+            # Should never be here in practice (CallSession strips it), but
+            # even a poisoned parent dict must not leak into the consult leg.
+            "organisationKeys": {"openai": ORG_KEY},
+        }
+        transfer_agent = build_transfer_agent_dict(
+            parent_agent=parent_agent,
+            transfer_agent_prompt="You are consulting.",
+        )
+        assert "organisationKeys" not in transfer_agent
+        assert ORG_KEY not in str(transfer_agent)
+
+    def test_prepare_takeover_carries_bag_outside_agent_dict(self, monkeypatch):
+        from pipecat_aplisay.bridged_transfer import (
+            BtaContext,
+            BtaTarget,
+            prepare_takeover,
+        )
+
+        async def fake_fetch(agent_id: str, expected_organisation_id=None) -> dict:
+            return {
+                "id": agent_id,
+                "type": "interactive-audio",
+                "modelName": "pipecat:openai/gpt-4o",
+                "prompt": "You take over.",
+                "options": {},
+                "organisationKeys": {"openai": ORG_KEY},
+            }
+
+        async def fake_create_call(call_data: dict) -> api_client.CallRecord:
+            # The reserved continuation call must not embed key material.
+            assert ORG_KEY not in str(call_data)
+            return _call_record()
+
+        async def fake_start_call(call) -> None:
+            return None
+
+        monkeypatch.setattr(api_client, "get_internal_agent_by_id", fake_fetch)
+        monkeypatch.setattr(api_client, "create_call", fake_create_call)
+        monkeypatch.setattr(api_client, "start_call", fake_start_call)
+
+        ctx = BtaContext(
+            targets={"1": BtaTarget(key="1", agent_id="target-agent")},
+            agent={"id": "agent-1", "options": {}},
+            instance={"id": "inst-1"},
+            parent_call_id="call-0",
+            organisation_id="org-1",
+            user_id="user-1",
+            instance_id="inst-1",
+            caller_id="+441234",
+            called_id="+445678",
+            transcript="",
+        )
+        payload = asyncio.run(
+            prepare_takeover(
+                ctx, ctx.targets["1"], platform="pipecat", session_id="sb-bta-1"
+            )
+        )
+        assert payload.organisation_keys == {"openai": ORG_KEY}
+        assert "organisationKeys" not in payload.agent

--- a/api/paths/agent-db/agent.js
+++ b/api/paths/agent-db/agent.js
@@ -1,4 +1,5 @@
 import { Agent } from '../../../lib/database.js';
+import { providersForAgent, resolveOrganisationKeys } from '../../../lib/org-keys.js';
 
 let log;
 
@@ -34,7 +35,15 @@ const agentGet = async (req, res) => {
       log.warn({ agentId, expectedOrganisationId, actual: agent.organisationId }, 'cross-organisation agent fetch refused');
       return res.status(404).send({ error: 'Agent not found' });
     }
-    res.send(agent.toJSON());
+    const result = agent.toJSON();
+    // BYOK (docs/byok.md): decrypted org keys for the providers this agent can
+    // actually use, delivered ONLY over this internal shared-token API. Never
+    // logged; omitted entirely when the org has no relevant keys.
+    const organisationKeys = await resolveOrganisationKeys(agent.organisationId, providersForAgent(agent));
+    if (Object.keys(organisationKeys).length) {
+      result.organisationKeys = organisationKeys;
+    }
+    res.send(result);
   }
   catch (err) {
     log.error(err, 'error fetching agent');
@@ -43,7 +52,7 @@ const agentGet = async (req, res) => {
 };
 
 agentGet.apiDoc = {
-  summary: 'Internal: returns a full agent definition by ID.',
+  summary: 'Internal: returns a full agent definition by ID. When the organisation holds BYOK keys for providers the agent references, they are included decrypted as an `organisationKeys` property of the agent JSON (omitted when empty).',
   operationId: 'agentDbGetAgent',
   tags: ["Agent"],
   parameters: [

--- a/api/paths/agent-db/instance.js
+++ b/api/paths/agent-db/instance.js
@@ -1,4 +1,5 @@
 import { Instance, Agent, PhoneNumber } from '../../../lib/database.js';
+import { providersForAgent, resolveOrganisationKeys } from '../../../lib/org-keys.js';
 
 let appParameters, log;
 
@@ -64,6 +65,14 @@ const instanceGet = (async (req, res) => {
       Agent: agent
     };
 
+    // BYOK (docs/byok.md): decrypted org keys for the providers this agent can
+    // actually use, delivered ONLY over this internal shared-token API. Never
+    // logged; omitted entirely when the org has no relevant keys.
+    const organisationKeys = await resolveOrganisationKeys(agent.organisationId, providersForAgent(agent));
+    if (Object.keys(organisationKeys).length) {
+      result.organisationKeys = organisationKeys;
+    }
+
     res.send(result);
   }
   catch (err) {
@@ -73,7 +82,7 @@ const instanceGet = (async (req, res) => {
 });
 
 instanceGet.apiDoc = {
-  summary: 'Returns an instance by ID or phone number with its associated agent.',
+  summary: 'Returns an instance by ID or phone number with its associated agent. Internal: when the organisation holds BYOK keys for providers the agent references, they are included decrypted as a top-level `organisationKeys` object (omitted when empty).',
   operationId: 'getInstance',
   tags: ["Agent"],
   parameters: [

--- a/api/paths/organisations/{organisationId}/provider-keys.js
+++ b/api/paths/organisations/{organisationId}/provider-keys.js
@@ -1,0 +1,81 @@
+import { Organisation, OrganisationKey } from '../../../../lib/database.js';
+import { requirePermission } from '../../../../lib/auth/permissions.js';
+import { targetInScope } from '../../../../lib/auth/admin-scope.js';
+import { listProviders } from '../../../../lib/utils/provider-keys.js';
+
+/**
+ * /api/organisations/{organisationId}/provider-keys — the org's BYOK provider
+ * API keys (docs/byok.md).
+ *   GET  list stored keys as { provider, hint, updatedAt } plus the provider
+ *        registry catalogue for UIs. Values are WRITE-ONLY and never returned;
+ *        the listing reads only the separately-stored hint, never `value`.
+ *
+ * Gated on `organisation:providerKeys` (owner/orgAdmin: own org; superAdmin:
+ * any org) then targetInScope — out-of-scope targets 404 so existence isn't
+ * leaked across tenants.
+ */
+export default function (logger) {
+  const get = async (req, res) => {
+    if (!requirePermission(res, 'organisation', 'providerKeys')) return;
+    const org = await Organisation.findByPk(req.params.organisationId);
+    if (!org || !targetInScope(res.locals.user, 'organisation', org)) {
+      return res.status(404).send({ message: `Organisation ${req.params.organisationId} not found` });
+    }
+    const rows = await OrganisationKey.findAll({
+      where: { organisationId: org.id },
+      attributes: ['provider', 'hint', 'updatedAt'],
+      order: [['provider', 'ASC']],
+    });
+    return res.send({
+      items: rows.map((row) => ({ provider: row.provider, hint: row.hint ?? null, updatedAt: row.updatedAt })),
+      providers: listProviders(),
+    });
+  };
+  get.apiDoc = {
+    summary: 'List an organisation’s BYOK provider keys (hints only — values are never returned).',
+    operationId: 'listOrganisationProviderKeys',
+    tags: ['Organisations'],
+    parameters: [{ in: 'path', name: 'organisationId', required: true, schema: { type: 'string' } }],
+    responses: {
+      200: {
+        description: 'Stored keys (masked) plus the provider registry catalogue',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                items: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      provider: { type: 'string', description: 'Canonical provider slug' },
+                      hint: { type: 'string', nullable: true, description: 'Last 4 characters of the stored key' },
+                      updatedAt: { type: 'string', format: 'date-time' },
+                    },
+                  },
+                },
+                providers: {
+                  type: 'array',
+                  description: 'The provider registry (for key-management UIs)',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      id: { type: 'string' },
+                      label: { type: 'string' },
+                      dimensions: { type: 'array', items: { type: 'string' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
+      default: { description: 'An error occurred', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    },
+  };
+
+  return { GET: get };
+}

--- a/api/paths/organisations/{organisationId}/provider-keys/{provider}.js
+++ b/api/paths/organisations/{organisationId}/provider-keys/{provider}.js
@@ -1,0 +1,132 @@
+import { Organisation, OrganisationKey } from '../../../../../lib/database.js';
+import { requirePermission } from '../../../../../lib/auth/permissions.js';
+import { targetInScope } from '../../../../../lib/auth/admin-scope.js';
+import { isKnownProvider } from '../../../../../lib/utils/provider-keys.js';
+
+/**
+ * /api/organisations/{organisationId}/provider-keys/{provider} — one BYOK key
+ * (docs/byok.md).
+ *   PUT    upsert the key for a provider slug. Fail-closed: when
+ *          CREDENTIALS_KEY is unavailable the write is refused (500) and
+ *          NOTHING is stored — never plaintext. Responds with the masking
+ *          hint only, never the value.
+ *   DELETE remove the stored key (platform keys apply again from the next
+ *          call); 404 when none is stored.
+ *
+ * Same `organisation:providerKeys` + targetInScope gates as the listing.
+ */
+export default function (logger) {
+  // The org row, or null after sending the 404/403 — shared by both verbs.
+  const gate = async (req, res) => {
+    if (!requirePermission(res, 'organisation', 'providerKeys')) return null;
+    const org = await Organisation.findByPk(req.params.organisationId);
+    if (!org || !targetInScope(res.locals.user, 'organisation', org)) {
+      res.status(404).send({ message: `Organisation ${req.params.organisationId} not found` });
+      return null;
+    }
+    return org;
+  };
+
+  const put = async (req, res) => {
+    const org = await gate(req, res);
+    if (!org) return;
+    const { provider } = req.params;
+    // Validated in-handler (not left to express-openapi): unknown slugs and
+    // malformed bodies must 400 on every entry path.
+    if (!isKnownProvider(provider)) {
+      return res.status(400).send({ message: `Unknown provider ${provider}` });
+    }
+    const { value } = req.body || {};
+    if (typeof value !== 'string' || !value.length) {
+      return res.status(400).send({ message: 'value must be a non-empty string' });
+    }
+    const hint = value.slice(-4);
+    try {
+      const existing = await OrganisationKey.findOne({ where: { organisationId: org.id, provider } });
+      if (existing) {
+        // The value setter encrypts strictly — it throws (before any save)
+        // when CREDENTIALS_KEY is unavailable.
+        existing.value = value;
+        existing.hint = hint;
+        await existing.save();
+      } else {
+        await OrganisationKey.create({ organisationId: org.id, provider, value, hint });
+      }
+    } catch (err) {
+      // Never log or echo the submitted value.
+      logger.error({ err: err?.message, provider, organisationId: org.id }, 'storing organisation provider key');
+      return res.status(500).send({ message: err?.message || 'Failed to store provider key' });
+    }
+    return res.send({ provider, hint });
+  };
+  put.apiDoc = {
+    summary: 'Store (upsert) an organisation’s BYOK key for a provider. Write-only: the value is never returned.',
+    operationId: 'upsertOrganisationProviderKey',
+    tags: ['Organisations'],
+    parameters: [
+      { in: 'path', name: 'organisationId', required: true, schema: { type: 'string' } },
+      { in: 'path', name: 'provider', required: true, schema: { type: 'string' }, description: 'Canonical provider slug (see the listing’s `providers` catalogue)' },
+    ],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['value'],
+            properties: {
+              value: { type: 'string', minLength: 1, description: 'The provider API key (stored encrypted; write-only)' },
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: 'Stored',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                provider: { type: 'string' },
+                hint: { type: 'string', description: 'Last 4 characters of the stored key' },
+              },
+            },
+          },
+        },
+      },
+      400: { description: 'Unknown provider or invalid body', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+      404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
+      500: { description: 'Encryption unavailable (CREDENTIALS_KEY unset) — nothing stored', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+      default: { description: 'An error occurred', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    },
+  };
+
+  const del = async (req, res) => {
+    const org = await gate(req, res);
+    if (!org) return;
+    const { provider } = req.params;
+    const deleted = await OrganisationKey.destroy({ where: { organisationId: org.id, provider } });
+    if (!deleted) {
+      return res.status(404).send({ message: `No ${provider} key stored for organisation ${org.id}` });
+    }
+    return res.status(204).send();
+  };
+  del.apiDoc = {
+    summary: 'Delete an organisation’s BYOK key for a provider (platform keys apply again from the next call).',
+    operationId: 'deleteOrganisationProviderKey',
+    tags: ['Organisations'],
+    parameters: [
+      { in: 'path', name: 'organisationId', required: true, schema: { type: 'string' } },
+      { in: 'path', name: 'provider', required: true, schema: { type: 'string' } },
+    ],
+    responses: {
+      204: { description: 'Deleted' },
+      404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
+      default: { description: 'An error occurred', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    },
+  };
+
+  return { PUT: put, DELETE: del };
+}

--- a/docs/byok.md
+++ b/docs/byok.md
@@ -1,0 +1,230 @@
+# Bring Your Own Key (BYOK)
+
+Organisation-level provider API keys that are used **in preference to** the
+platform's own keys wherever the platform would otherwise spend its own
+credential on that organisation's traffic: ultravox, livekit and pipecat
+realtime and pipeline voice agents, and text-based agents (interactive chat,
+one-shot invoke, and in-call subagents/summarisers, which all execute in the
+main server process).
+
+## Principles
+
+1. **Encrypted at rest, fail-closed.** Key values are AES-256-GCM encrypted
+   with the existing `CREDENTIALS_KEY` secret (`lib/utils/credentials.js`).
+   Unlike the legacy warn-and-store-plaintext behaviour used for SIP
+   passwords, BYOK writes are *refused* (500) when `CREDENTIALS_KEY` is not
+   configured, and a stored value that fails to decrypt fails the call rather
+   than silently falling back.
+2. **Need-to-know distribution, per call.** Decryption happens only in the
+   main server process. Workers receive decrypted keys only inside the
+   per-call config document they already fetch over the internal
+   `x-shared-token` agent-db API, filtered down to the providers that call
+   can actually use. Nothing is cached worker-side, so rotation/revocation
+   takes effect on the next call. Keys never enter LiveKit dispatch/room/
+   participant metadata, pipecat dispatch payloads, join tokens, transaction
+   logs, or invocation logs.
+3. **Org key wins, no silent fallback.** If the organisation has a key for
+   the provider in use, that key is used. If it is invalid or unreadable the
+   session fails with a clear error; the platform key is *not* silently
+   substituted (that would burn platform credit while the org believes its
+   key is in use). If the organisation has no key for a provider, platform
+   behaviour is unchanged.
+4. **v1 does not extend the model roster.** BYOK overrides credentials for
+   models the platform already offers (`GET /api/models` is unchanged).
+   BYOK-only model availability needs the static `canLoad` roster reworked
+   and is deferred.
+
+## Out of scope for v1
+
+- **jambonz family** (`jambonz:` models): untouched entirely, LLM included.
+  Note the *ultravox* family remains fully in scope even on telephony: the
+  Ultravox handler resolves its own org key inside `join()`/`destroy()`/
+  `callEnded()` (a direct `OrganisationKey` DB lookup), so it behaves
+  identically whether it executes in the main server (WebRTC) or inside the
+  jambonz bridge process (telephony) without touching jambonz-family code.
+- **Service-account-JSON credentials**: Google BYOK covers Gemini
+  API-key auth (LLM + realtime). Google pipeline STT/TTS (service-account /
+  ADC / Vertex auth) stays on platform credentials.
+- **LiveKit Inference components**: pipeline components with no org key keep
+  today's behaviour (LiveKit Inference or worker env). A component whose
+  provider *has* an org key is built as a direct provider plugin instead.
+- **Voice-catalogue browsing** (`GET /voices`) stays on platform keys.
+- **Automatic billing zero-rating.** Pricing remains the per-org rate-card
+  mechanism. The workers stamp `metadata.aplisay.byokProviders` on calls that
+  used org keys (informational, best-effort) so billing can distinguish BYOK
+  traffic later.
+- Built-in platform agents (`builtin:set-builder`) keep platform keys.
+
+## Provider registry
+
+`lib/utils/provider-keys.js` is the single source of truth. Keys are stored
+by **canonical provider slug**, never by env-var name (the same provider has
+different env names across runtimes).
+
+| slug | label | dimensions | used by |
+|---|---|---|---|
+| `openai` | OpenAI | llm, realtime | text/pipecat/livekit LLM + realtime |
+| `anthropic` | Anthropic | llm | text + pipecat pipeline LLM |
+| `google` | Google (Gemini API key) | llm, realtime | text/pipecat/livekit Gemini |
+| `ultravox` | Ultravox | realtime | ultravox: family, livekit:/pipecat: ultravox models |
+| `deepgram` | Deepgram | stt, tts | pipeline STT/TTS (livekit + pipecat) |
+| `elevenlabs` | ElevenLabs | tts | pipeline TTS (livekit + pipecat) |
+| `cartesia` | Cartesia | tts | pipeline TTS (livekit + pipecat) |
+| `kimi` | Kimi (Moonshot) | llm | text: |
+| `openrouter` | OpenRouter | llm | text: |
+| `deepseek` | DeepSeek | llm | text: |
+
+Model-string provider segments map to slugs case-insensitively:
+`openai→openai`, `anthropic→anthropic`, `google|gemini→google`,
+`ultravox|fixie-ai→ultravox`, `kimi|moonshot→kimi`, `openrouter→openrouter`,
+`deepseek→deepseek`. `options.stt.vendor` maps `deepgram→deepgram` (other
+STT vendors are not BYOK-injectable in v1); `options.tts.vendor` maps
+`elevenlabs`, `cartesia`, `deepgram` to themselves (`google` TTS excluded —
+SA auth).
+
+## Storage
+
+New table `organisation_keys`, model `OrganisationKey` in
+`lib/database-models/organisation-key.js` (PhoneRegistration pattern),
+registered from `lib/database.js`; schemaVersion 58 → 59.
+
+| column | type | notes |
+|---|---|---|
+| `id` | UUID PK | `DataTypes.UUID`, default UUIDV4 |
+| `organisationId` | STRING FK → organisations.id | CASCADE on delete |
+| `provider` | STRING | canonical slug; **unique per organisation** (composite unique index with organisationId) |
+| `value` | TEXT | encrypted via strict (fail-closed) `encryptSecret`; transparent decrypt getter; `enc:` idempotency guard on set |
+| `hint` | STRING(8) | last 4 chars of the plaintext, stored separately at write time so listings never touch `value` |
+
+`lib/utils/credentials.js` gains `encryptSecretStrict(plainText)` which
+throws when `CREDENTIALS_KEY` is unset or the cipher fails (never returns
+plaintext). `decryptSecret` is unchanged.
+
+The sync chain adds `OrganisationKey.sync({ alter: true })` immediately
+after `Organisation.sync` in the versioned upgrade, **plus** an
+unconditional plain `OrganisationKey.sync()` beside the `ChatSession.sync()`
+hardening call (gated new-table creation has silently missed environments
+twice before).
+
+## API
+
+Admin-style org subresource, tagged `Organisations`. All routes gate on the
+new `organisation:providerKeys` RBAC action then `targetInScope(user,
+'organisation', org)` (own org for owner/orgAdmin; any org for superAdmin;
+out-of-scope is 404, not 403). `providerKeys` is granted to
+owner/textOnly/audioOnly (via `OWNER_STATEMENTS`), orgAdmin and superAdmin —
+not member.
+
+```
+GET    /api/organisations/{organisationId}/provider-keys
+  200 { items:     [{ provider, hint, updatedAt }],
+        providers: [{ id, label, dimensions }] }   # registry catalogue for UIs
+  # values are write-only and never returned
+
+PUT    /api/organisations/{organisationId}/provider-keys/{provider}
+  body { value: "sk-..." }        # non-empty string
+  200 { provider, hint }          # upsert (insert or replace)
+  400 unknown provider slug / invalid body
+  500 { message } when CREDENTIALS_KEY is unavailable (fail-closed, nothing stored)
+
+DELETE /api/organisations/{organisationId}/provider-keys/{provider}
+  204                             # platform keys apply again from the next call
+  404 no such stored key
+```
+
+## Distribution
+
+### Server-side resolution — `lib/org-keys.js`
+
+- `providersForAgent(agent)` → `Set<slug>` — the need-to-know filter:
+  providers referenced by `agent.modelName`, `agent.options.stt.vendor`,
+  `agent.options.tts.vendor` and `agent.options.fallback.model`. Because the
+  workers resolve vendor defaults the agent row does not record (STT defaults
+  to deepgram on both workers; TTS is defaulted or inferred from the voice per
+  worker; bridged-transfer transcription taps build STT even for realtime
+  models), an UNSET vendor on a livekit/pipecat agent ships every key the
+  worker's own defaulting could consume (deepgram for STT;
+  cartesia/elevenlabs/deepgram for TTS) — only an explicit vendor narrows the
+  set. Model-scoped vendor strings (`deepgram/nova-3`) resolve by their
+  prefix. jambonz-family agents ship nothing (out of scope).
+- `resolveOrganisationKeys(organisationId, providers)` →
+  `{ [slug]: value|null }` — decrypted values for the stored subset of
+  `providers`. Providers with no stored key are **omitted**; a stored key
+  that fails to decrypt is present with value `null` (consumers must treat
+  `null` as fatal for that provider — fail-closed, no env fallback).
+
+### Wire shape (internal agent-db API only)
+
+`GET /api/agent-db/instance` and `GET /api/agent-db/agent` responses gain a
+top-level `organisationKeys` object (omitted when empty):
+
+```json
+{ "...": "...", "Agent": { "...": "..." }, "organisationKeys": { "openai": "sk-..." } }
+```
+
+(for `/agent-db/agent` the object is a property of the returned agent JSON).
+These endpoints are already `x-shared-token`-only and hidden from public
+Swagger. The public API never carries `organisationKeys` anywhere.
+
+### Workers
+
+- **pipecat** (`voice_session.py`): a `_resolve_provider_key(org_keys,
+  slug, *env_names)` helper — org key wins; `null`/empty org entry raises a
+  clear `ByokKeyError`; absent slug falls through to `_require_env`.
+  Applied at every service construction site: `_build_realtime`
+  (openai/google/ultravox), `_build_pipeline` LLM
+  (openai/google/anthropic), `build_stt_service` (deepgram),
+  `build_tts_service` (cartesia/elevenlabs/deepgram). Handover
+  (`transfer_agent`) and fallback paths re-fetch and re-resolve naturally.
+- **livekit** (`voice-session-factory.ts` + `pipeline-provider-keys.ts`):
+  the fetched doc's `organisationKeys` is threaded into
+  `createVoiceModelAndSession`. Realtime: `llmOptions.apiKey` set from the
+  org key when present (openai / google / vendored ultravox plugins all
+  accept it). Pipeline: a component whose provider has an org key is built
+  as a direct provider plugin with an explicit `apiKey`
+  (deepgram/elevenlabs/cartesia/openai/google); components without org keys
+  keep existing behaviour. Both the initial session and the transfer/
+  fallback re-construction sites are covered.
+- **Fallback agents**: both workers fetch `options.fallback.agent` through
+  the internal agent-db route (with `expectedOrganisationId`) rather than the
+  public agent GET, so the fallback agent's own `organisationKeys` bag
+  applies to the rebuilt session.
+- **text agents (Node)**: `lib/text-chat.js buildLlm()` and
+  `lib/subagent.js runSubagent()` resolve the model's provider key via
+  `lib/org-keys.js` and pass an `apiKey` constructor override. Drivers:
+  `openai.js`, `gemini.js`, `openai-compatible.js` accept `apiKey`
+  (per-instance clients already); `anthropic.js` constructs a per-instance
+  SDK client only when an override is present (platform traffic keeps the
+  module singleton and its prompt-cache behaviour); the fail-closed
+  missing-key throw in `openai-compatible.js` is preserved (an org key for
+  the *wrong* provider must never fall through to `OPENAI_API_KEY`).
+- **ultravox voice** (`lib/handlers/ultravox.js` + `lib/models/ultravox.js`):
+  `join()` resolves the org's `ultravox` key (direct `OrganisationKey`
+  lookup by `agent.organisationId`) and, when present, uses a per-call
+  axios client for `POST calls` / `DELETE calls/{id}` /
+  `GET calls/{id}/messages` instead of the module-frozen client. Works
+  identically in the main server and the jambonz bridge process (both have
+  DB access and `CREDENTIALS_KEY`).
+
+### Redaction
+
+`organisationKeys` must never be logged: both workers and the server strip
+it from any debug/invocation-log dump of the agent/instance document, and it
+is excluded from transfer-agent dicts except where service construction
+needs it. BYOK keys are delivered only as constructor arguments, never
+through anything that reaches `messageHandler`/transaction logs.
+Mechanisms: the LiveKit worker re-attaches the bag NON-ENUMERABLY to fetched
+docs (spreads/`JSON.stringify` drop it); the pipecat worker pops it off the
+agent dict into separate (`repr=False`) fields at every entry point and runs
+loguru with `diagnose=False` so traceback frames cannot render local
+variables; the Ultravox handler logs Axios failures under pino's `err`
+serializer only (a raw AxiosError key would emit the `X-API-Key` request
+header via `toJSON()`).
+
+## Deployment
+
+- Schema bump ⇒ one boot with `DB_FORCE_SYNC=true` per environment.
+- `CREDENTIALS_KEY` must be set (already on the production checklist) or all
+  BYOK writes are refused.
+- Worker images (livekit, pipecat) must be rolled to pick up the injection
+  code; no new worker env vars are required.

--- a/environment-example
+++ b/environment-example
@@ -115,6 +115,8 @@ POSTGRES_PASSWORD=<DB PASSWORD>
 # Encryption key for stored credentials (SIP registration passwords, agent key
 # material). If UNSET those secrets are stored in PLAINTEXT (a warning is
 # logged) — set it in every real deployment: `openssl rand -base64 32`
+# Also protects organisation BYOK provider keys (docs/byok.md) — those writes
+# are fail-closed: BYOK key storage is REFUSED (500) when this is unset.
 CREDENTIALS_KEY=<RANDOM SECRET>
 
 # ── Model / voice providers (enable the ones this deployment uses) ──────────

--- a/lib/auth/permissions.js
+++ b/lib/auth/permissions.js
@@ -58,7 +58,9 @@ export const statements = {
   // least-privilege `billingService` role, NOT bundled into setRate).
   // `billing` = operate the org's billing controls (billingBlocked flag +
   // billingConfig balance callbacks) — same service-seam posture as `credit`.
-  organisation: ['create', 'read', 'readAll', 'update', 'delete', 'verify', 'setLimits', 'setRate', 'credit', 'billing', 'setPermissions'],
+  // `providerKeys` = manage the org's BYOK provider API keys (docs/byok.md) —
+  // own-org for owner/orgAdmin, cross-tenant for superAdmin; values write-only.
+  organisation: ['create', 'read', 'readAll', 'update', 'delete', 'verify', 'setLimits', 'setRate', 'credit', 'billing', 'setPermissions', 'providerKeys'],
   user: ['create', 'read', 'readAll', 'update', 'delete', 'ban', 'setRole', 'setLimits', 'setPermissions', 'impersonate'],
 
   // Platform / staff
@@ -76,6 +78,9 @@ const OWNER_STATEMENTS = {
   usage: ['read'],
   profile: ['read', 'update', 'verifyEmail', 'verifyPhone'],
   apiKey: ['create', 'read', 'revoke'],
+  // BYOK: an owner manages their own org's provider keys (tenancy still
+  // confines them to their own org via targetInScope).
+  organisation: ['providerKeys'],
 };
 
 /**
@@ -133,7 +138,7 @@ export const roles = {
       // NB: no organisation:setPermissions — the org's own RBAC/model baseline is
       // a platform policy editable only by superAdmin (and the org-edit modal is
       // super-only). orgAdmin may rename / set status / set the agent limit.
-      organisation: ['read', 'update', 'setLimits'],
+      organisation: ['read', 'update', 'setLimits', 'providerKeys'],
     },
   },
 
@@ -151,7 +156,7 @@ export const roles = {
       trunk: ['read', 'assign', 'create'],
       system: ['readConfig', 'manage'],
       user: ['create', 'read', 'readAll', 'update', 'delete', 'ban', 'setRole', 'setLimits', 'setPermissions', 'impersonate'],
-      organisation: ['create', 'read', 'readAll', 'update', 'delete', 'verify', 'setLimits', 'setRate', 'credit', 'billing', 'setPermissions'],
+      organisation: ['create', 'read', 'readAll', 'update', 'delete', 'verify', 'setLimits', 'setRate', 'credit', 'billing', 'setPermissions', 'providerKeys'],
     },
   },
 

--- a/lib/database-models/organisation-key.js
+++ b/lib/database-models/organisation-key.js
@@ -1,0 +1,65 @@
+import { Model, DataTypes } from 'sequelize';
+import { encryptSecretStrict, decryptSecret } from '../utils/credentials.js';
+
+class OrganisationKey extends Model {}
+
+export function initOrganisationKey(sequelize, types = DataTypes) {
+  OrganisationKey.init({
+    id: {
+      type: types.UUID,
+      primaryKey: true,
+      defaultValue: types.UUIDV4
+    },
+    organisationId: {
+      type: types.STRING,
+      allowNull: false,
+      references: {
+        model: 'organisations',
+        key: 'id'
+      }
+    },
+    // Canonical provider slug (lib/utils/provider-keys.js); unique per
+    // organisation via the composite index below.
+    provider: {
+      type: types.STRING,
+      allowNull: false
+    },
+    value: {
+      type: types.TEXT,
+      allowNull: false,
+      set(value) {
+        // Strict (fail-closed): unlike SIP passwords, a BYOK write throws when
+        // CREDENTIALS_KEY is unavailable rather than storing plaintext. No
+        // 'enc:' idempotency guard here: values only ever enter as user
+        // plaintext, and skipping encryption for an 'enc:'-prefixed submission
+        // would store it raw yet unreadable.
+        this.setDataValue('value', encryptSecretStrict(value));
+      },
+      get() {
+        const raw = this.getDataValue('value');
+        return decryptSecret(raw);
+      }
+    },
+    // Last 4 chars of the plaintext, stored separately at write time so
+    // listings never touch (or decrypt) `value`.
+    hint: {
+      type: types.STRING(8),
+      allowNull: true
+    }
+  }, {
+    sequelize,
+    timestamps: true,
+    underscored: true,
+    charset: 'utf8',
+    collate: 'utf8_general_ci',
+    modelName: 'OrganisationKey',
+    tableName: 'organisation_keys',
+    indexes: [
+      { unique: true, fields: ['organisation_id', 'provider'] }
+    ]
+  });
+
+  return OrganisationKey;
+}
+
+export { OrganisationKey };

--- a/lib/database.js
+++ b/lib/database.js
@@ -8,6 +8,7 @@ import { getVoiceNamesForAgentValidation, getTtsVendorsForAgentValidation } from
 import { validateToolsCallsMetadataUsage } from './handlers/toolsCalls-metadata-capability.js';
 import { validatePromptMetadata } from './prompt-metadata-validate.js';
 import { initPhoneRegistration } from './database-models/phone-registration.js';
+import { initOrganisationKey } from './database-models/organisation-key.js';
 import { encryptSecret, decryptSecret } from './utils/credentials.js';
 import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-limits.js';
 // Import-cycle note: lib/outbound-filter.js is deliberately dependency-free so the
@@ -15,7 +16,10 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 58;  // 58: `trunks.outbound_call_filter` — the operator's per-trunk allow pattern for
+const schemaVersion = 59;  // 59: `organisation_keys` — BYOK org-level provider API keys (docs/byok.md):
+                           //     value encrypted fail-closed with CREDENTIALS_KEY, unique per
+                           //     (organisation, provider), distributed need-to-know via the agent-db API.
+                           // 58: `trunks.outbound_call_filter` — the operator's per-trunk allow pattern for
                            //     outbound destinations on a chargeable (our-carrier) trunk. Authoritative over
                            //     the tenant-supplied `agents.options.outboundCallFilter`, which may only narrow
                            //     it. Null = the UK geographic/mobile default (lib/outbound-authorisation.js).
@@ -2228,8 +2232,14 @@ AuthKey.init({
     collate: 'utf8_general_ci',
   });
 
+// Organisation-level BYOK provider API keys (docs/byok.md)
+const OrganisationKey = initOrganisationKey(sequelize, DataTypes);
+
 User.belongsTo(Organisation, { onDelete: 'CASCADE', foreignKey: 'organisationId' });
 Organisation.hasMany(User, { onDelete: 'CASCADE', foreignKey: 'organisationId' });
+
+OrganisationKey.belongsTo(Organisation, { onDelete: 'CASCADE', foreignKey: 'organisationId' });
+Organisation.hasMany(OrganisationKey, { onDelete: 'CASCADE', foreignKey: 'organisationId' });
 
 PhoneNumber.belongsTo(Organisation, { foreignKey: 'organisationId', onDelete: 'SET NULL' });
 PhoneRegistration.belongsTo(Organisation, { foreignKey: 'organisationId', onDelete: 'SET NULL' });
@@ -2540,6 +2550,7 @@ const databaseStarted = sequelize.authenticate()
   .then(() => migrateUsersRoleToString())
   .then(() => (doUpgrade && Metadata.sync({ alter: true })
     .then(() => Organisation.sync({ alter: true }))
+    .then(() => OrganisationKey.sync({ alter: true }))
     .then(() => User.sync({ alter: true }))
     .then(() => AgentSet.sync({ alter: true }))
     .then(() => Agent.sync({ alter: true }))
@@ -2575,6 +2586,10 @@ const databaseStarted = sequelize.authenticate()
     // feature's failure mode is the quietest yet: chats keep working, history
     // just never records, and the UI shows an innocuous empty state.
     await ChatSession.sync();
+    // organisation_keys gets the same unconditional treatment for the same
+    // reason: a BYOK table missing on an environment would 500 every key write
+    // while everything else looks healthy.
+    await OrganisationKey.sync();
     // Boot sweep: sessions live only in THIS process's memory, so any row
     // still open (ended_at IS NULL) at boot belongs to a previous process and
     // is by definition dead — close it at its last write, or the history UI
@@ -2753,6 +2768,7 @@ export {
   TariffPrefix,
   User,
   Organisation,
+  OrganisationKey,
   AuthKey,
   Trunk,
   CallConcurrency,

--- a/lib/handlers/ultravox.js
+++ b/lib/handlers/ultravox.js
@@ -3,6 +3,7 @@ import Handler from './handler.js';
 import JambonzHandler from './jambonz.js';
 import UltravoxModel from '../models/ultravox.js';
 import { Call } from '../database.js';
+import { resolveOrganisationKeys } from '../org-keys.js';
 import { maybeSendCallHook } from '../call-hook.js';
 import { AgentConcurrencyLimitExceededError } from '../concurrency/agent-concurrency-limits.js';
 import { promptWithMetadata } from '../prompt-metadata.js';
@@ -63,6 +64,32 @@ class Ultravox extends Handler {
   static needKey = { ULTRAVOX_API_KEY };
   static voices = getVoices;
 
+  // BYOK (docs/byok.md): an organisation ultravox key moves the call's API
+  // traffic onto a per-call client. Resolved by direct DB lookup so this works
+  // identically in the main server and the jambonz bridge process, and re-run
+  // by destroy()/callEnded() because the end-of-call webhook constructs a
+  // FRESH handler on which join() never ran. A stored key that fails to
+  // decrypt fails the call: never silently fall back to the platform key.
+  async ensureOrgApi() {
+    if (this.api !== undefined) return this.api;
+    const { agent: { organisationId } = {} } = this;
+    const orgKeys = await resolveOrganisationKeys(organisationId, ['ultravox']);
+    if ('ultravox' in orgKeys) {
+      if (orgKeys.ultravox === null) {
+        throw new Error('The organisation\'s Ultravox API key could not be read — check or replace it');
+      }
+      this.api = axios.create({
+        baseURL: 'https://api.ultravox.ai/api/',
+        headers: {
+          'X-API-Key': orgKeys.ultravox
+        }
+      });
+    }
+    else {
+      this.api = null; // resolved: no org key — the platform client applies
+    }
+    return this.api;
+  }
 
   async join({ websocket, telephony = false, options = {}, callerId = 'WebRTC', calledId = 'WebRTC', callId = this.callId }) {
     let { agent: { id: agentId, userId, organisationId, modelName, promptMetadata, options: agentOptions = {} }, logger, instance: { id: instanceId, metadata: instanceMetadata } } = this;
@@ -71,6 +98,7 @@ class Ultravox extends Handler {
       callId = uuidv4();
       logger.info({ callId, thisCallId: this.callId }, 'no callId provided, generating one');
     }
+    await this.ensureOrgApi();
     const metadata = {
       ...instanceMetadata,
       ...options.metadata,
@@ -124,7 +152,7 @@ class Ultravox extends Handler {
       });
       let {
         data: { callId: platformCallId, ended, joinUrl }
-      } = await api.post('calls', modelData);
+      } = await (this.api || api).post('calls', modelData);
       if (ended || !platformCallId?.length || !joinUrl?.length) {
         throw new Error('API call failed');
       }
@@ -188,9 +216,12 @@ class Ultravox extends Handler {
       const response = error?.response;
       const responseBody = response?.data;
 
-      // Log as much detail as we can about the far-end error
+      // Log as much detail as we can about the far-end error. The error goes
+      // under `err` (pino's Error serializer: type/message/stack) — a raw
+      // AxiosError key would serialise via toJSON() and emit the request
+      // config including the X-API-Key header.
       logger.error({
-        error,
+        err: error,
         status: response?.status,
         statusText: response?.statusText,
         responseBody
@@ -255,11 +286,13 @@ class Ultravox extends Handler {
 
     try {
       if (!callId) {
-        await api.delete(`calls/${callId}`);
+        await this.ensureOrgApi();
+        await (this.api || api).delete(`calls/${callId}`);
       }
     }
     catch (error) {
-      logger.error({ error }, error.message);
+      // `err`, not a raw AxiosError key — toJSON() would leak the X-API-Key header.
+      logger.error({ err: error }, error.message);
       throw new Error(`Inband call teardown: ${error.message}`);
     }
 
@@ -327,9 +360,12 @@ class Ultravox extends Handler {
       await call.end('ultravox call ended', { endedAt: endedAt ? new Date(endedAt) : undefined });
       if (callId) {
         this.callId = call.id;
+        // BYOK calls were created in the ORG's Ultravox account: the platform
+        // client cannot see them, so resolve the org client before fetching.
+        await this.ensureOrgApi();
         let apiCall = `calls/${callId}/messages`;
         do {
-          let { data: { next, results } } = await api.get(apiCall);
+          let { data: { next, results } } = await (this.api || api).get(apiCall);
           logger.debug({ next, results, callId }, 'got messages');
           apiCall = next;
           for (var message of results){
@@ -348,7 +384,8 @@ class Ultravox extends Handler {
       }
     }
     catch (error) {
-      logger.error({ error }, `callEnded error ${error.message}`);
+      // `err`, not a raw AxiosError key — toJSON() would leak the X-API-Key header.
+      logger.error({ err: error }, `callEnded error ${error.message}`);
     }
   }
 }

--- a/lib/models/anthropic.js
+++ b/lib/models/anthropic.js
@@ -116,11 +116,16 @@ class Anthropic extends Llm {
     return requested;
   }
 
-  constructor({ logger, prompt, options, model, modelName, mcpServers, interactive }) {
+  constructor({ logger, prompt, options, model, modelName, mcpServers, interactive, apiKey }) {
     super(...arguments);
     // The module-level SDK instance, referenced per-instance so tests can
     // inject a fake client (parity with the openai driver's this.client).
-    this.client = anthropic;
+    // A BYOK organisation key (docs/byok.md) gets its own per-instance client
+    // instead; platform traffic keeps the shared singleton and its
+    // prompt-cache behaviour.
+    this.client = apiKey
+      ? new AnthropicSdk({ apiKey, timeout: REQUEST_TIMEOUT_MS, maxRetries: MAX_RETRIES })
+      : anthropic;
     this.mcpServers = Array.isArray(mcpServers) ? mcpServers : [];
     // Handler-constructed (voice) sessions spread agent.dataValues, which has
     // only modelName — without this fallback they'd silently run the catalogue

--- a/lib/models/gemini.js
+++ b/lib/models/gemini.js
@@ -48,9 +48,11 @@ class Gemini extends Llm {
   static supportsMcp = () => true;
   static provider = 'google';
 
-  constructor({ logger, prompt, options, model, modelName, mcpServers, keys }) {
+  constructor({ logger, prompt, options, model, modelName, mcpServers, keys, apiKey }) {
     super(...arguments);
-    this.ai = new GoogleGenAI({ apiKey: GOOGLE_API_KEY });
+    // BYOK (docs/byok.md): an organisation key passed by the caller wins over
+    // the platform env key.
+    this.ai = new GoogleGenAI({ apiKey: apiKey || GOOGLE_API_KEY });
     // Handler-constructed (voice) sessions spread agent.dataValues, which has
     // only modelName — without this fallback they'd silently run the catalogue
     // default instead of the agent's configured model.

--- a/lib/models/openai-compatible.js
+++ b/lib/models/openai-compatible.js
@@ -47,9 +47,11 @@ class OpenAiCompatible extends Llm {
 
   static provider = 'openai';
 
-  constructor({ logger, prompt, options, model, modelName, mcpServers, keys }) {
+  constructor({ logger, prompt, options, model, modelName, mcpServers, keys, apiKey: apiKeyOverride }) {
     super(...arguments);
-    const apiKey = process.env[this.constructor.apiKeyEnv];
+    // BYOK (docs/byok.md): an organisation key passed by the caller wins over
+    // the provider's own env var.
+    const apiKey = apiKeyOverride || process.env[this.constructor.apiKeyEnv];
     // Fail CLOSED on a missing key: with apiKey undefined the openai SDK's
     // own default kicks in and reads OPENAI_API_KEY from the env — which
     // would send OpenAI's secret to this provider's host as a Bearer.

--- a/lib/models/openai.js
+++ b/lib/models/openai.js
@@ -54,10 +54,12 @@ class OpenAi extends Llm {
   static supportsMcp = () => true;
   static provider = 'openai';
 
-  constructor({ logger, prompt, options, model, modelName, mcpServers, keys }) {
+  constructor({ logger, prompt, options, model, modelName, mcpServers, keys, apiKey }) {
     super(...arguments);
+    // BYOK (docs/byok.md): an organisation key passed by the caller wins over
+    // the platform env key.
     this.client = new OpenAI({
-      apiKey: OPENAI_API_KEY,
+      apiKey: apiKey || OPENAI_API_KEY,
       maxRetries: 1,
       timeout: Number(process.env.OPENAI_TIMEOUT_MS || 900000),
     });

--- a/lib/org-keys.js
+++ b/lib/org-keys.js
@@ -1,0 +1,74 @@
+/**
+ * BYOK organisation-key resolution (docs/byok.md): the need-to-know filter for
+ * an agent, and decryption of the stored keys for that filtered provider set.
+ * Decryption happens ONLY here, in the main server process — workers receive
+ * the resolved values inside the per-call agent-db document and never touch
+ * the table or CREDENTIALS_KEY themselves.
+ */
+import { OrganisationKey } from './database.js';
+import { providerForModel, providerForSttVendor, providerForTtsVendor } from './utils/provider-keys.js';
+
+/**
+ * The provider slugs a call running this agent could actually use: its model,
+ * pipeline STT/TTS vendors, and any fallback model. This is the filter applied
+ * before distributing keys — a worker never sees org keys for providers the
+ * agent doesn't reference.
+ *
+ * STT/TTS vendors are resolved worker-side with defaults the agent row does
+ * not record (STT defaults to deepgram on both workers; TTS is defaulted or
+ * inferred from the voice per worker; bridged-transfer transcription taps
+ * build STT even for realtime models), so for the livekit/pipecat families an
+ * UNSET vendor ships every key the worker's own defaulting could consume —
+ * only an explicit vendor narrows to that vendor's provider.
+ *
+ * @param {object} agent the Agent row (or plain agent JSON)
+ * @returns {Set<string>} canonical provider slugs
+ */
+export function providersForAgent(agent) {
+  const providers = new Set();
+  const add = (slug) => slug && providers.add(slug);
+  const modelName = agent?.modelName;
+  const family = typeof modelName === 'string' && modelName.includes(':') ? modelName.split(':')[0] : null;
+  // jambonz-family agents are out of BYOK scope in v1 (docs/byok.md); their
+  // worker never fetches the agent-db document, so ship nothing for them.
+  if (family === 'jambonz') return providers;
+  add(providerForModel(modelName));
+  const fallbackModel = agent?.options?.fallback?.model;
+  if (typeof fallbackModel !== 'string' || !fallbackModel.startsWith('jambonz:')) {
+    add(providerForModel(fallbackModel));
+  }
+  if (family === 'livekit' || family === 'pipecat') {
+    const sttVendor = agent?.options?.stt?.vendor;
+    add(sttVendor ? providerForSttVendor(sttVendor) : 'deepgram');
+    const ttsVendor = agent?.options?.tts?.vendor;
+    if (ttsVendor) {
+      add(providerForTtsVendor(ttsVendor));
+    } else {
+      ['cartesia', 'elevenlabs', 'deepgram'].forEach(add);
+    }
+  }
+  return providers;
+}
+
+/**
+ * Decrypted org keys for the stored subset of `providers`. Providers with no
+ * stored row are OMITTED (platform behaviour unchanged); a stored value that
+ * fails to decrypt is present with value null — consumers MUST treat null as
+ * fatal for that provider (fail-closed, no silent platform-key fallback).
+ *
+ * @param {string} organisationId
+ * @param {Set<string>|string[]} providers canonical slugs (from providersForAgent)
+ * @returns {Promise<object>} { [slug]: decryptedValue | null }
+ */
+export async function resolveOrganisationKeys(organisationId, providers) {
+  const wanted = [...(providers || [])];
+  if (!organisationId || !wanted.length) return {};
+  const rows = await OrganisationKey.findAll({ where: { organisationId, provider: wanted } });
+  const keys = {};
+  for (const row of rows) {
+    keys[row.provider] = row.value; // getter decrypts; null = undecryptable
+  }
+  return keys;
+}
+
+export default { providersForAgent, resolveOrganisationKeys };

--- a/lib/subagent.js
+++ b/lib/subagent.js
@@ -1,6 +1,8 @@
 import defaultLogger from './logger.js';
 import handlers from './handlers/index.js';
 import { functionHandler } from './function-handler.js';
+import { providerForModel } from './utils/provider-keys.js';
+import { isBuiltinAgentId } from './builtin-agents.js';
 
 // Hard ceiling on text-agent → text-agent delegation to stop runaway recursion
 const MAX_SUBAGENT_DEPTH = 3;
@@ -117,6 +119,27 @@ export async function runSubagent({
     }
   }
 
+  // BYOK (docs/byok.md): an organisation key for this model's provider
+  // overrides the platform key — fail-closed on an unreadable stored key,
+  // never a silent platform-key fallback. Skipped for test-injected
+  // implementations (no real provider to key) and for builtin platform agents
+  // (they stay on platform keys, docs/byok.md out-of-scope); lazy import keeps
+  // this module loadable in contexts without a database.
+  let apiKey;
+  const provider = (implementationOverride || isBuiltinAgentId(agent.id))
+    ? null
+    : providerForModel(agent.modelName);
+  if (provider) {
+    const { resolveOrganisationKeys } = await import('./org-keys.js');
+    const orgKeys = await resolveOrganisationKeys(agent.organisationId, [provider]);
+    if (provider in orgKeys) {
+      if (orgKeys[provider] === null) {
+        throw new SubagentError(`The organisation's ${provider} API key could not be read — check or replace it`, 500);
+      }
+      apiKey = orgKeys[provider];
+    }
+  }
+
   // Agent functions are stored either as an array or as an object keyed by name
   const functions = Array.isArray(agent.functions)
     ? agent.functions
@@ -138,6 +161,7 @@ export async function runSubagent({
     // knowledge subagent's whole purpose. Without this the subagent runs blind
     // to its MCP. (text-chat.js passes this too; this path used to drop it.)
     mcpServers: agent.mcpServers,
+    ...(apiKey ? { apiKey } : {}),
   });
 
   const transcript = [];

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -20,6 +20,9 @@ import { functionHandler } from './function-handler.js';
 import { llmFunctions, runSubagentById } from './subagent.js';
 import { createAgentSetForAgent, updateAgentSetForAgent, patchAgentSetForAgent } from './agent-set-service.js';
 import { recordLlmTokens, recordSubagentUsage, finaliseSession } from './usage.js';
+import { providerForModel } from './utils/provider-keys.js';
+import { resolveOrganisationKeys } from './org-keys.js';
+import { isBuiltinAgentId } from './builtin-agents.js';
 import { ChatSession } from './database.js';
 
 // Persisted transcripts are capped: keep the newest entries (with an elision
@@ -416,6 +419,21 @@ class TextChatSession {
     if (!Handler) throw new Error(`Unknown model name: ${this.agent.modelName}`);
     const { implementation: Implementation } = Handler.parseName(this.agent.modelName);
     if (!Implementation) throw new Error(`No LLM implementation for ${this.agent.modelName}`);
+    // BYOK (docs/byok.md): an organisation key for this model's provider
+    // overrides the platform key. A stored key that fails to decrypt fails the
+    // session — never silently fall back to the platform key. Builders and
+    // other builtin agents are the PLATFORM's product surface: they stay on
+    // platform keys (docs/byok.md out-of-scope), which also keeps the builder
+    // usable when an org's stored key is broken.
+    const isPlatformAgent = isBuiltinAgentId(this.agent.id)
+      || String(this.agent.description || '').includes('[polite:agent-builder]');
+    const provider = isPlatformAgent ? null : providerForModel(this.agent.modelName);
+    const orgKeys = provider
+      ? await resolveOrganisationKeys(this.agent.organisationId, [provider])
+      : {};
+    if (provider && provider in orgKeys && orgKeys[provider] === null) {
+      throw new Error(`The organisation's ${provider} API key could not be read — check or replace it`);
+    }
     this.llm = new Implementation({
       logger: this.logger,
       user: `chat-${this.agent.id}`,
@@ -429,6 +447,7 @@ class TextChatSession {
       // Human-paced session: drivers that cache the prompt prefix may use a
       // long TTL (a think-pause or test call outlives the 5m default).
       interactive: true,
+      ...(orgKeys[provider] ? { apiKey: orgKeys[provider] } : {}),
     });
   }
 

--- a/lib/utils/credentials.js
+++ b/lib/utils/credentials.js
@@ -24,6 +24,20 @@ export function encryptSecret(plainText) {
   }
 }
 
+// Strict (fail-closed) variant for BYOK organisation provider keys: unlike the
+// legacy encryptSecret above it NEVER returns plaintext — a missing
+// CREDENTIALS_KEY or a cipher failure throws so the caller refuses the write.
+export function encryptSecretStrict(plainText) {
+  if (!encryptionKey) {
+    throw new Error('CREDENTIALS_KEY is not configured; refusing to store secret');
+  }
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', encryptionKey, iv);
+  const ciphertext = Buffer.concat([cipher.update(String(plainText), 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return 'enc:' + Buffer.from(iv).toString('base64') + ':' + Buffer.from(tag).toString('base64') + ':' + Buffer.from(ciphertext).toString('base64');
+}
+
 export function decryptSecret(stored) {
   if (stored == null) return null;
   try {

--- a/lib/utils/provider-keys.js
+++ b/lib/utils/provider-keys.js
@@ -1,0 +1,98 @@
+/**
+ * BYOK provider registry (docs/byok.md) — the single source of truth for the
+ * canonical provider slugs organisation keys are stored under, and the mapping
+ * from the places an agent references a provider (model-string provider
+ * segment, `options.stt.vendor`, `options.tts.vendor`) to those slugs.
+ *
+ * Pure module: no DB imports — shared by the API layer, lib/org-keys.js and
+ * anything that needs to reason about provider slugs without a DB connection.
+ */
+
+// slug -> { label, dimensions }. `dimensions` describes where the key applies
+// (llm / realtime / stt / tts) — informational, surfaced to key-management UIs.
+export const PROVIDERS = {
+  openai: { label: 'OpenAI', dimensions: ['llm', 'realtime'] },
+  anthropic: { label: 'Anthropic', dimensions: ['llm'] },
+  google: { label: 'Google (Gemini API key)', dimensions: ['llm', 'realtime'] },
+  ultravox: { label: 'Ultravox', dimensions: ['realtime'] },
+  deepgram: { label: 'Deepgram', dimensions: ['stt', 'tts'] },
+  elevenlabs: { label: 'ElevenLabs', dimensions: ['tts'] },
+  cartesia: { label: 'Cartesia', dimensions: ['tts'] },
+  kimi: { label: 'Kimi (Moonshot)', dimensions: ['llm'] },
+  openrouter: { label: 'OpenRouter', dimensions: ['llm'] },
+  deepseek: { label: 'DeepSeek', dimensions: ['llm'] },
+};
+
+// Model-string provider segment -> canonical slug (segments not listed here
+// are not BYOK-injectable in v1).
+const MODEL_PROVIDER_SLUGS = {
+  openai: 'openai',
+  anthropic: 'anthropic',
+  google: 'google',
+  gemini: 'google',
+  ultravox: 'ultravox',
+  'fixie-ai': 'ultravox',
+  kimi: 'kimi',
+  moonshot: 'kimi',
+  openrouter: 'openrouter',
+  deepseek: 'deepseek',
+};
+
+// options.stt.vendor -> slug. Deepgram only in v1 (other STT vendors are not
+// BYOK-injectable).
+const STT_VENDOR_SLUGS = {
+  deepgram: 'deepgram',
+};
+
+// options.tts.vendor -> slug. `google` TTS is deliberately absent
+// (service-account auth, out of BYOK scope).
+const TTS_VENDOR_SLUGS = {
+  elevenlabs: 'elevenlabs',
+  cartesia: 'cartesia',
+  deepgram: 'deepgram',
+};
+
+/** Is `slug` a canonical provider slug organisation keys may be stored under? */
+export function isKnownProvider(slug) {
+  return typeof slug === 'string' && Object.hasOwn(PROVIDERS, slug);
+}
+
+/** The registry as a catalogue array for UIs: [{ id, label, dimensions }]. */
+export function listProviders() {
+  return Object.entries(PROVIDERS).map(([id, { label, dimensions }]) => ({ id, label, dimensions: [...dimensions] }));
+}
+
+const lookup = (map, key) => {
+  if (typeof key !== 'string') return null;
+  const normalised = key.trim().toLowerCase();
+  return Object.hasOwn(map, normalised) ? map[normalised] : null;
+};
+
+/**
+ * The canonical slug for the provider segment of a `handler:provider/model`
+ * string (e.g. `livekit:openai/gpt-realtime` -> 'openai'), or null when the
+ * provider is not BYOK-injectable.
+ */
+export function providerForModel(modelName) {
+  if (typeof modelName !== 'string' || !modelName) return null;
+  const segment = modelName.split(':').pop().split('/')[0];
+  return lookup(MODEL_PROVIDER_SLUGS, segment);
+}
+
+/**
+ * The canonical slug for an `options.stt.vendor` value, or null. Vendor values
+ * may be model-scoped ("deepgram/nova-3") — both workers split on '/' before
+ * resolving, so the mapping must too.
+ */
+export function providerForSttVendor(vendor) {
+  if (typeof vendor !== 'string') return null;
+  return lookup(STT_VENDOR_SLUGS, vendor.split('/')[0]);
+}
+
+/** The canonical slug for an `options.tts.vendor` value, or null. Splits model-scoped values like the STT mapper. */
+export function providerForTtsVendor(vendor) {
+  if (typeof vendor !== 'string') return null;
+  return lookup(TTS_VENDOR_SLUGS, vendor.split('/')[0]);
+}
+
+export default { PROVIDERS, isKnownProvider, listProviders, providerForModel, providerForSttVendor, providerForTtsVendor };

--- a/tests/byok-driver-injection.test.mjs
+++ b/tests/byok-driver-injection.test.mjs
@@ -1,0 +1,124 @@
+// BYOK driver-injection unit tests (docs/byok.md): each text/ultravox driver
+// accepts an optional `apiKey` constructor override — the org key — which must
+// win over the platform env key, while its absence leaves platform behaviour
+// (including the Anthropic prompt-cache singleton) unchanged. No network:
+// nothing here calls a provider — assertions read what each SDK client exposes.
+process.env.OPENAI_API_KEY ||= 'platform-openai-key';
+process.env.ANTHROPIC_API_KEY ||= 'platform-anthropic-key';
+process.env.GOOGLE_API_KEY ||= 'platform-google-key';
+process.env.KIMI_KEY ||= 'platform-kimi-key';
+process.env.ULTRAVOX_API_KEY ||= 'platform-ultravox-key';
+
+const { default: OpenAi } = await import('../lib/models/openai.js');
+const { default: Anthropic } = await import('../lib/models/anthropic.js');
+const { default: Gemini } = await import('../lib/models/gemini.js');
+const { default: Kimi } = await import('../lib/models/kimi.js');
+
+const logger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const baseArgs = (model) => ({
+  logger,
+  user: 'test',
+  prompt: 'You are a test agent.',
+  options: {},
+  model,
+  modelName: model,
+  mcpServers: [],
+  keys: [],
+});
+
+describe('OpenAi (Responses) apiKey override', () => {
+  test('org key wins over the platform env key', () => {
+    const byok = new OpenAi({ ...baseArgs('text:openai/gpt-5.6-terra'), apiKey: 'org-openai-key' });
+    expect(byok.client.apiKey).toBe('org-openai-key');
+  });
+
+  test('no override keeps the platform key and client options', () => {
+    const platform = new OpenAi(baseArgs('text:openai/gpt-5.6-terra'));
+    expect(platform.client.apiKey).toBe(process.env.OPENAI_API_KEY);
+    expect(platform.client.maxRetries).toBe(1);
+  });
+
+  test('override preserves timeout/maxRetries options', () => {
+    const platform = new OpenAi(baseArgs('text:openai/gpt-5.6-terra'));
+    const byok = new OpenAi({ ...baseArgs('text:openai/gpt-5.6-terra'), apiKey: 'org-openai-key' });
+    expect(byok.client.maxRetries).toBe(platform.client.maxRetries);
+    expect(byok.client.timeout).toBe(platform.client.timeout);
+  });
+});
+
+describe('Anthropic per-instance vs singleton client selection', () => {
+  test('platform instances share the module singleton (prompt-cache behaviour)', () => {
+    const a = new Anthropic(baseArgs('text:anthropic/claude-sonnet-5'));
+    const b = new Anthropic(baseArgs('text:anthropic/claude-sonnet-5'));
+    expect(a.client).toBe(b.client);
+    expect(a.client.apiKey).toBe(process.env.ANTHROPIC_API_KEY);
+  });
+
+  test('an org key gets its own per-instance client with the same timeout/retry opts', () => {
+    const platform = new Anthropic(baseArgs('text:anthropic/claude-sonnet-5'));
+    const byok = new Anthropic({ ...baseArgs('text:anthropic/claude-sonnet-5'), apiKey: 'org-anthropic-key' });
+    expect(byok.client).not.toBe(platform.client);
+    expect(byok.client.apiKey).toBe('org-anthropic-key');
+    expect(byok.client.timeout).toBe(platform.client.timeout);
+    expect(byok.client.maxRetries).toBe(platform.client.maxRetries);
+    // The singleton must not have been touched by the BYOK construction.
+    expect(platform.client.apiKey).toBe(process.env.ANTHROPIC_API_KEY);
+  });
+});
+
+describe('Gemini apiKey override', () => {
+  test('org key wins over the platform env key', () => {
+    const byok = new Gemini({ ...baseArgs('text:google/gemini-2.5-flash'), apiKey: 'org-google-key' });
+    expect(byok.ai.apiKey).toBe('org-google-key');
+  });
+
+  test('no override keeps the platform key', () => {
+    const platform = new Gemini(baseArgs('text:google/gemini-2.5-flash'));
+    expect(platform.ai.apiKey).toBe(process.env.GOOGLE_API_KEY);
+  });
+});
+
+describe('openai-compatible apiKey override and fail-closed throw', () => {
+  test('org key wins over the provider env var', () => {
+    const byok = new Kimi({ ...baseArgs('text:kimi/kimi-k2.6'), apiKey: 'org-kimi-key' });
+    expect(byok.client.apiKey).toBe('org-kimi-key');
+    expect(byok.client.baseURL).toBe(Kimi.baseURL);
+  });
+
+  test('no override keeps the provider env key', () => {
+    const platform = new Kimi(baseArgs('text:kimi/kimi-k2.6'));
+    expect(platform.client.apiKey).toBe(process.env.KIMI_KEY);
+  });
+
+  test('still throws with neither key (never falls back to OPENAI_API_KEY)', () => {
+    const saved = process.env.KIMI_KEY;
+    delete process.env.KIMI_KEY;
+    try {
+      expect(() => new Kimi(baseArgs('text:kimi/kimi-k2.6'))).toThrow('KIMI_KEY is not set');
+    } finally {
+      process.env.KIMI_KEY = saved;
+    }
+  });
+
+  test('an org key alone is sufficient when the env var is unset', () => {
+    const saved = process.env.KIMI_KEY;
+    delete process.env.KIMI_KEY;
+    try {
+      const byok = new Kimi({ ...baseArgs('text:kimi/kimi-k2.6'), apiKey: 'org-kimi-key' });
+      expect(byok.client.apiKey).toBe('org-kimi-key');
+    } finally {
+      process.env.KIMI_KEY = saved;
+    }
+  });
+});
+
+// Ultravox BYOK is handler-side (lib/handlers/ultravox.js ensureOrgApi — a
+// per-call client resolved from the org's stored key for join/destroy/
+// callEnded), not a model-constructor concern: the Handler base spreads
+// agent.dataValues only, so a model-level apiKey would be dead code. The
+// handler path needs the database and is exercised by the DB-backed suite
+// (tests/organisation-provider-keys.test.mjs covers the resolver it uses).

--- a/tests/organisation-provider-keys.test.mjs
+++ b/tests/organisation-provider-keys.test.mjs
@@ -1,0 +1,279 @@
+import { setupRealDatabase, teardownRealDatabase, Organisation, User, Agent, Instance } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+/**
+ * Organisation BYOK provider keys (docs/byok.md):
+ *  - PUT /api/organisations/{id}/provider-keys/{provider} → upsert, encrypted at
+ *    rest, hint = last 4 chars, fail-closed writes.
+ *  - GET /api/organisations/{id}/provider-keys → masked listing + registry
+ *    catalogue; values NEVER returned.
+ *  - DELETE → 204 / 404.
+ *  - RBAC organisation:providerKeys + targetInScope (own org for owner, any org
+ *    for superAdmin, out-of-scope is 404).
+ *  - agent-db distribution: instance/agent responses carry decrypted
+ *    organisationKeys filtered to providersForAgent(agent).
+ */
+describe('Organisation BYOK provider keys', () => {
+  let listKeys;
+  let putKey;
+  let deleteKey;
+  let instanceGet;
+  let agentGet;
+  let OrganisationKey;
+  let providersForAgent;
+  let resolveOrganisationKeys;
+
+  let orgId;
+
+  const mockLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, child: () => mockLogger };
+  const req = (data = {}) => ({ body: data.body || {}, params: data.params || {}, query: data.query || {}, headers: {}, log: mockLogger, ...data });
+  const res = () => ({
+    locals: { user: null },
+    _status: null,
+    _body: null,
+    status(c) { this._status = c; return this; },
+    send(b) { this._body = b; this._status = this._status || 200; return this; },
+    json(b) { this._body = b; this._status = this._status || 200; return this; },
+  });
+
+  const superUser = () => ({ role: 'superAdmin' });
+  const ownerUser = (org = orgId) => ({ role: 'owner', organisationId: org });
+  const memberUser = () => ({ role: 'member', organisationId: orgId });
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    // Same already-initialised module instance the wrapper imported; the
+    // wrapper does not (yet) re-export OrganisationKey.
+    ({ OrganisationKey } = await import('../lib/database.js'));
+    ({ providersForAgent, resolveOrganisationKeys } = await import('../lib/org-keys.js'));
+    listKeys = (await import('../api/paths/organisations/{organisationId}/provider-keys.js')).default(mockLogger).GET;
+    const itemModule = (await import('../api/paths/organisations/{organisationId}/provider-keys/{provider}.js')).default(mockLogger);
+    putKey = itemModule.PUT;
+    deleteKey = itemModule.DELETE;
+    instanceGet = (await import('../api/paths/agent-db/instance.js')).default(mockLogger).GET;
+    agentGet = (await import('../api/paths/agent-db/agent.js')).default(mockLogger).GET;
+  }, 30000);
+
+  afterAll(async () => { await teardownRealDatabase(); }, 60000);
+
+  beforeEach(async () => {
+    orgId = randomUUID();
+    await Organisation.create({ id: orgId, name: 'Provider Keys Test Org' });
+  });
+
+  afterEach(async () => {
+    await OrganisationKey.destroy({ where: { organisationId: orgId } }).catch(() => {});
+    await Organisation.destroy({ where: { id: orgId } });
+  });
+
+  const put = async (provider, body, user = ownerUser(), org = orgId) => {
+    const r = req({ params: { organisationId: org, provider }, body }); const s = res(); s.locals.user = user;
+    await putKey(r, s); return s;
+  };
+  const del = async (provider, user = ownerUser(), org = orgId) => {
+    const r = req({ params: { organisationId: org, provider } }); const s = res(); s.locals.user = user;
+    await deleteKey(r, s); return s;
+  };
+  const list = async (user = ownerUser(), org = orgId) => {
+    const r = req({ params: { organisationId: org } }); const s = res(); s.locals.user = user;
+    await listKeys(r, s); return s;
+  };
+
+  test('PUT stores the value encrypted at rest and responds with the masking hint only', async () => {
+    const s = await put('openai', { value: 'sk-test-secret-abcd1234' });
+    expect(s._status).toBe(200);
+    expect(s._body).toEqual({ provider: 'openai', hint: '1234' });
+
+    const [rows] = await OrganisationKey.sequelize.query(
+      'SELECT value, hint FROM organisation_keys WHERE organisation_id = :orgId AND provider = :provider',
+      { replacements: { orgId, provider: 'openai' } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].value.startsWith('enc:')).toBe(true);
+    expect(rows[0].value).not.toContain('sk-test-secret-abcd1234');
+    expect(rows[0].hint).toBe('1234');
+
+    // The model getter round-trips the plaintext (main-server decryption).
+    const row = await OrganisationKey.findOne({ where: { organisationId: orgId, provider: 'openai' } });
+    expect(row.value).toBe('sk-test-secret-abcd1234');
+  });
+
+  test('GET lists masked items plus the registry catalogue, and never returns values', async () => {
+    await put('openai', { value: 'sk-test-secret-abcd1234' });
+    await put('elevenlabs', { value: 'el-test-secret-wxyz9876' });
+
+    const s = await list();
+    expect(s._status).toBe(200);
+    expect(s._body.items).toEqual([
+      { provider: 'elevenlabs', hint: '9876', updatedAt: expect.anything() },
+      { provider: 'openai', hint: '1234', updatedAt: expect.anything() },
+    ]);
+    const catalogue = s._body.providers;
+    expect(catalogue).toEqual(expect.arrayContaining([
+      { id: 'openai', label: 'OpenAI', dimensions: ['llm', 'realtime'] },
+      { id: 'deepgram', label: 'Deepgram', dimensions: ['stt', 'tts'] },
+    ]));
+    const serialised = JSON.stringify(s._body);
+    expect(serialised).not.toContain('sk-test-secret-abcd1234');
+    expect(serialised).not.toContain('el-test-secret-wxyz9876');
+    expect(serialised).not.toContain('enc:');
+  });
+
+  test('an unknown provider slug is a 400', async () => {
+    const s = await put('nonesuch', { value: 'whatever' });
+    expect(s._status).toBe(400);
+    expect(await OrganisationKey.count({ where: { organisationId: orgId } })).toBe(0);
+  });
+
+  test('an invalid body is a 400', async () => {
+    for (const body of [{}, { value: '' }, { value: 42 }, null]) {
+      const s = await put('openai', body);
+      expect(s._status).toBe(400);
+    }
+    expect(await OrganisationKey.count({ where: { organisationId: orgId } })).toBe(0);
+  });
+
+  test('DELETE removes a stored key (204) and 404s when none is stored', async () => {
+    expect((await del('openai'))._status).toBe(404);
+    await put('openai', { value: 'sk-test-secret-abcd1234' });
+    expect((await del('openai'))._status).toBe(204);
+    expect(await OrganisationKey.count({ where: { organisationId: orgId, provider: 'openai' } })).toBe(0);
+    expect((await del('openai'))._status).toBe(404);
+  });
+
+  test('PUT upserts: a second write replaces the same provider row', async () => {
+    await put('openai', { value: 'sk-first-value-1111' });
+    const s = await put('openai', { value: 'sk-second-value-2222' });
+    expect(s._status).toBe(200);
+    expect(s._body).toEqual({ provider: 'openai', hint: '2222' });
+
+    expect(await OrganisationKey.count({ where: { organisationId: orgId, provider: 'openai' } })).toBe(1);
+    const row = await OrganisationKey.findOne({ where: { organisationId: orgId, provider: 'openai' } });
+    expect(row.value).toBe('sk-second-value-2222');
+    expect(row.hint).toBe('2222');
+  });
+
+  test('RBAC: a member lacks organisation:providerKeys (403)', async () => {
+    expect((await put('openai', { value: 'sk-x' }, memberUser()))._status).toBe(403);
+    expect((await list(memberUser()))._status).toBe(403);
+    expect((await del('openai', memberUser()))._status).toBe(403);
+  });
+
+  test('RBAC: an owner manages their own org but gets 404 for another org', async () => {
+    expect((await put('openai', { value: 'sk-own-org-1234' }, ownerUser()))._status).toBe(200);
+
+    const otherOrgId = randomUUID();
+    await Organisation.create({ id: otherOrgId, name: 'Other Org' });
+    try {
+      expect((await put('openai', { value: 'sk-x' }, ownerUser(), otherOrgId))._status).toBe(404);
+      expect((await list(ownerUser(), otherOrgId))._status).toBe(404);
+      expect((await del('openai', ownerUser(), otherOrgId))._status).toBe(404);
+      expect(await OrganisationKey.count({ where: { organisationId: otherOrgId } })).toBe(0);
+    } finally {
+      await Organisation.destroy({ where: { id: otherOrgId } });
+    }
+  });
+
+  test('RBAC: superAdmin manages any org cross-tenant', async () => {
+    expect((await put('openai', { value: 'sk-super-cross-5678' }, superUser()))._status).toBe(200);
+    const s = await list(superUser());
+    expect(s._status).toBe(200);
+    expect(s._body.items).toEqual([{ provider: 'openai', hint: '5678', updatedAt: expect.anything() }]);
+    expect((await del('openai', superUser()))._status).toBe(204);
+  });
+
+  test('agent-db instance and agent responses carry organisationKeys filtered to the agent providers', async () => {
+    const userId = randomUUID();
+    await User.create({
+      id: userId,
+      organisationId: orgId,
+      name: 'Keys User',
+      email: `${userId}@test.example.com`,
+      emailVerified: true,
+      phone: '+10000000001',
+      phoneVerified: true,
+      picture: 'https://example.com/p.png',
+      role: 'owner',
+    });
+    const agent = await Agent.create({
+      name: 'BYOK agent',
+      modelName: 'livekit:openai/gpt-realtime',
+      prompt: 'You are a test agent.',
+      options: { stt: { vendor: 'deepgram' }, fallback: { model: 'livekit:google/gemini-live' } },
+      userId,
+      organisationId: orgId,
+    });
+    const instance = await Instance.create({ agentId: agent.id, type: 'livekit', key: 'k', userId, organisationId: orgId });
+
+    try {
+      await put('openai', { value: 'sk-openai-value-1111' });
+      await put('deepgram', { value: 'dg-value-2222' });
+      await put('anthropic', { value: 'sk-ant-value-3333' }); // NOT referenced by the agent
+
+      const ri = req({ query: { instanceId: instance.id } }); const si = res();
+      await instanceGet(ri, si);
+      expect(si._status).toBe(200);
+      // openai (model) + deepgram (stt vendor) delivered decrypted; anthropic is
+      // outside the need-to-know set; google (fallback) has no stored key.
+      expect(si._body.organisationKeys).toEqual({ openai: 'sk-openai-value-1111', deepgram: 'dg-value-2222' });
+
+      const ra = req({ query: { agentId: agent.id } }); const sa = res();
+      await agentGet(ra, sa);
+      expect(sa._status).toBe(200);
+      expect(sa._body.organisationKeys).toEqual({ openai: 'sk-openai-value-1111', deepgram: 'dg-value-2222' });
+
+      // With no stored keys the property is omitted entirely.
+      await OrganisationKey.destroy({ where: { organisationId: orgId } });
+      const rEmpty = req({ query: { agentId: agent.id } }); const sEmpty = res();
+      await agentGet(rEmpty, sEmpty);
+      expect(sEmpty._status).toBe(200);
+      expect(sEmpty._body.organisationKeys).toBeUndefined();
+    } finally {
+      await Instance.destroy({ where: { id: instance.id } });
+      await Agent.destroy({ where: { id: agent.id } });
+      await User.destroy({ where: { id: userId } });
+    }
+  });
+
+  test('providersForAgent maps model / stt / tts / fallback references to canonical slugs', () => {
+    // Voice families ship the worker-side vendor DEFAULTS when options don't
+    // pin a vendor (STT defaults to deepgram; TTS is defaulted/inferred per
+    // worker; bridged-transfer transcription taps use STT even on realtime
+    // models), so an unset vendor ships every key the worker could consume.
+    expect(providersForAgent({ modelName: 'livekit:openai/gpt-realtime' }))
+      .toEqual(new Set(['openai', 'deepgram', 'cartesia', 'elevenlabs']));
+    expect(providersForAgent({ modelName: 'pipecat:gemini/gemini-2.0-flash' }).has('google')).toBe(true);
+    expect(providersForAgent({ modelName: 'livekit:fixie-ai/ultravox-70B' }).has('ultravox')).toBe(true);
+    expect(providersForAgent({ modelName: 'text:moonshot/kimi-k2.6' }).has('kimi')).toBe(true);
+    expect(providersForAgent({ modelName: 'Text:OpenRouter/some-model' }).has('openrouter')).toBe(true); // case-insensitive
+    expect(providersForAgent({ modelName: 'ultravox' }).has('ultravox')).toBe(true); // bare family name
+    // text: families have no STT/TTS dimension — only the model (and any fallback) ships.
+    expect(providersForAgent({ modelName: 'text:moonshot/kimi-k2.6' }).size).toBe(1);
+
+    // Explicit vendors narrow the voice-family set to those vendors' providers
+    // (model-scoped vendor strings split on '/').
+    const full = providersForAgent({
+      modelName: 'pipecat:anthropic/claude-sonnet-5',
+      options: { stt: { vendor: 'deepgram/nova-3' }, tts: { vendor: 'cartesia' }, fallback: { model: 'text:deepseek/deepseek-chat' } },
+    });
+    expect(full).toEqual(new Set(['anthropic', 'deepgram', 'cartesia', 'deepseek']));
+
+    // Not BYOK-injectable: an explicit unknown stt vendor and google TTS
+    // (service-account auth) contribute nothing beyond the model's provider...
+    expect(providersForAgent({
+      modelName: 'pipecat:openai/gpt-4o',
+      options: { stt: { vendor: 'azure' }, tts: { vendor: 'google' } },
+    })).toEqual(new Set(['openai']));
+    // ...and the jambonz family is out of BYOK scope entirely: nothing ships.
+    expect(providersForAgent({
+      modelName: 'jambonz:openai/gpt-4o',
+      options: { stt: { vendor: 'deepgram' } },
+    }).size).toBe(0);
+    expect(providersForAgent({}).size).toBe(0);
+  });
+
+  test('resolveOrganisationKeys returns {} for an empty org or provider set', async () => {
+    expect(await resolveOrganisationKeys(null, new Set(['openai']))).toEqual({});
+    expect(await resolveOrganisationKeys(orgId, new Set())).toEqual({});
+    expect(await resolveOrganisationKeys(orgId, new Set(['openai']))).toEqual({});
+  });
+});


### PR DESCRIPTION
## What

Bring Your Own Key: an organisation can store its own LLM / realtime / TTS / STT provider API keys, which are then used **in preference to** the platform's keys across ultravox, livekit and pipecat (realtime + pipeline) voice agents and all text agent paths (chat, invoke, in-call subagents/summarisers). Full design contract: [docs/byok.md](docs/byok.md).

## API

New admin-style org subresource, gated by the new `organisation:providerKeys` RBAC action (owner / orgAdmin / superAdmin; `targetInScope` tenancy, 404 out of scope):

- `GET /api/organisations/{organisationId}/provider-keys` → stored keys as `{provider, hint, updatedAt}` (values are write-only, never returned) plus the provider catalogue for UIs
- `PUT /api/organisations/{organisationId}/provider-keys/{provider}` `{value}` → upsert; 400 unknown slug; **500 + nothing stored** when `CREDENTIALS_KEY` is unavailable (fail-closed, unlike the legacy warn-and-store-plaintext behaviour)
- `DELETE /api/organisations/{organisationId}/provider-keys/{provider}` → 204; platform keys apply again from the next call

## Storage & distribution

- New `organisation_keys` table (schema **v58 → v59**), values AES-256-GCM encrypted under the existing `CREDENTIALS_KEY`, unique per (org, provider), masked `hint` stored separately at write time.
- Decryption happens only server-side. Workers receive keys per call inside the agent-db document they already fetch (`organisationKeys`, x-shared-token-only), filtered **need-to-know** to the providers the call can use — the filter mirrors worker-side vendor defaulting (unset STT/TTS vendor ships the defaults the worker would pick; explicit vendors narrow; jambonz family ships nothing). No worker caching, so rotation/revocation applies on the next call.
- **Org key wins, no silent fallback**: an invalid/unreadable stored key fails the session with a clear error rather than silently spending platform credit.

## Injection points

- **pipecat**: `_resolve_provider_key` before `_require_env` at every service construction site (realtime openai/google/ultravox, pipeline LLM, deepgram STT, cartesia/elevenlabs/deepgram TTS), bridged-transfer transcription taps, transfer/fallback/consult/takeover paths re-resolve per agent.
- **livekit**: realtime `apiKey` (openai/google/vendored ultravox plugins), pipeline components with an org key switch to direct provider plugins with explicit `apiKey` (even without `LIVEKIT_PIPELINE_USE_PROVIDER_KEYS`; other components keep today's behaviour), bridge transcription STT included; transfer + fallback restarts use the fresh agent's bag.
- **ultravox**: handler resolves the org key itself (works identically in the main server and the jambonz bridge process) with a per-call client for `join`/`destroy`/`callEnded` — including the end-of-call webhook, which constructs a fresh handler.
- **text (Node)**: `apiKey` constructor overrides in the openai/gemini/openai-compatible/anthropic drivers (anthropic keeps its module singleton — and prompt-cache behaviour — for platform traffic).
- **Out of scope (v1)**: jambonz family entirely, Google service-account auth (pipeline Google STT/TTS), LiveKit Inference components without org keys, voice-catalogue browsing, automatic billing zero-rating (calls stamp `metadata.aplisay.byokProviders` informationally; pricing stays on rate cards), builtin platform agents (set-builder keeps platform keys).

## Secret hygiene

Keys never reach logs, telemetry, dispatch/room metadata, or any public API response: livekit re-attaches the bag non-enumerably (spreads/`JSON.stringify` drop it), pipecat pops it into `repr=False` fields and runs loguru with `diagnose=False`, the ultravox handler logs axios failures via pino's `err` serializer only (raw AxiosError `toJSON()` would emit the `X-API-Key` header). Implemented by three parallel agents against the docs/byok.md contract, then adversarially reviewed through leak/correctness/parity lenses; all 13 findings fixed or dispositioned.

## Verification

- Root DB suite: **755/756** — the 1 failure (`phone-endpoints-comprehensive › filter by outbound status`) reproduces identically on clean `next`, pre-existing and unrelated
- New suites: organisation-provider-keys 12/12 (real Postgres: encryption-at-rest asserted on the raw column, RBAC matrix, agent-db filtering), byok-driver-injection 11/11
- pipecat: **338/338** (`uv run --with pytest pytest tests`) incl. new `test_byok_keys.py` (31 cases)
- livekit: `tsc --noEmit` clean

## Deploy notes

- Schema bump ⇒ one boot with `DB_FORCE_SYNC=true` per environment (table also has an unconditional create-if-missing sync as a belt-and-braces)
- `CREDENTIALS_KEY` must be set or all BYOK writes are refused
- livekit + pipecat worker images need rolling; no new worker env vars

## Follow-ups (pre-existing, spotted during review)

- `lib/handlers/ultravox.js destroy()` has an inverted `!callId` guard (platform call delete never fires) — pre-existing, preserved verbatim, task spun off

