### PR TITLE
feat(auth): configurable sender personas for the verification/reset emails

### DIFF
--- a/api/paths/users/signup.js
+++ b/api/paths/users/signup.js
@@ -48,6 +48,12 @@ export default function (logger) {
     const rawName = typeof req.body?.name === 'string' ? req.body.name.trim() : '';
     const name = rawName.slice(0, 200) || email.split('@')[0]; // fall back to the email local-part
     const orgName = (typeof req.body?.organisation === 'string' ? req.body.organisation.trim() : '').slice(0, 200);
+    // The sender persona for the double opt-in email (lib/auth/email-brands.js).
+    // Server-side auth.api calls carry no request of their own, so the hooks see
+    // a persona only if we hand them one; unknown/absent falls to the operator's
+    // default, so this can never select an unapproved sender.
+    const brand = (typeof req.body?.brand === 'string' ? req.body.brand.trim() : '').slice(0, 64);
+    const brandHeaders = brand ? new Headers({ 'x-email-brand': brand }) : undefined;
     const callbackURL = process.env.WAITLIST_CALLBACK_URL;
     if (!callbackURL) {
       logger.error('WAITLIST_CALLBACK_URL is unset; cannot build the confirmation link');
@@ -73,6 +79,7 @@ export default function (logger) {
         // signUpEmail to avoid enabling the admin() plugin.)
         await auth.api.signUpEmail({
           body: { email, password, name, callbackURL },
+          ...(brandHeaders ? { headers: brandHeaders } : {}),
         });
         const organisationId = await createProvisionalOrg(orgName);
         await User.update(
@@ -104,7 +111,10 @@ export default function (logger) {
       // re-submit. Enumeration-safe (no-ops for missing/verified user), so the row
       // MUST exist by here. No request headers => not session-scoped.
       try {
-        await auth.api.sendVerificationEmail({ body: { email, callbackURL } });
+        await auth.api.sendVerificationEmail({
+          body: { email, callbackURL },
+          ...(brandHeaders ? { headers: brandHeaders } : {}),
+        });
       } catch (err) {
         // The auth hooks 429 a re-submit once the address's send budget is
         // spent (lib/auth/send-budget.js) — earlier emails already went out, so
@@ -134,6 +144,7 @@ export default function (logger) {
               name: { type: 'string', maxLength: 200, description: "Optional display name. Falls back to the email's local-part." },
               organisation: { type: 'string', maxLength: 200, description: 'Optional. Creates a PROVISIONAL organisation and links the user to it.' },
               password: { type: 'string', minLength: 8, description: 'Optional. The user is provisional either way.' },
+              brand: { type: 'string', maxLength: 64, description: 'Optional. Sender persona for the confirmation email, from the deployment\'s configured set. Unknown values fall back to its default.' },
             },
             required: ['email'],
           },

--- a/environment-example
+++ b/environment-example
@@ -84,6 +84,17 @@ EMAIL_SEND_KEY=<SMTP2GO API KEY>
 EMAIL_FROM_ADDRESS=hello@aplisay.com
 EMAIL_FROM_NAME="polite.ai"
 
+# Sender personas for the verification/reset emails (lib/auth/email-brands.js).
+# The caller names one per request with `x-email-brand`; the persona supplies the
+# sender, the product name, the tagline and — optionally — the whole copy, so a
+# front end can speak in its own voice without a change in this repo. Unset =
+# the addresses above plus the built-in product-neutral wording. Either a path to
+# a JSON document (mounted Secret/ConfigMap, preferred) or the same JSON inline;
+# a persona without a `from` is ignored, and any parse error degrades to the
+# built-ins rather than failing the boot.
+# EMAIL_BRANDS_FILE=/etc/llm-agent/email-brands.json
+# EMAIL_BRANDS={"default":"aplisay","brands":{"aplisay":{"from":"hello@aplisay.com"},"example":{"from":"hello@example.com","fromName":"Example","productName":"Example","tagline":"Your tagline here."}}}
+
 # ── Core service ─────────────────────────────────────────────────────────────
 # HTTP/WS listen port for this API service (also the better-auth baseURL
 # fallback port when BETTER_AUTH_URL is unset).

--- a/lib/auth/email-brands.js
+++ b/lib/auth/email-brands.js
@@ -1,0 +1,201 @@
+/**
+ * Sender personas ("brands") for the outbound auth emails.
+ *
+ * The verification and password-reset emails are the only two this service
+ * composes itself, and they are the only two a deployment cannot re-word
+ * without a code change — which is wrong for a shared, generic service: the
+ * front end that ASKED for the email knows whose product the reader thinks
+ * they signed up to, and this repo should not.
+ *
+ * So the caller names a persona per request (`x-email-brand` on the auth
+ * endpoint, see email-hooks.js) and the operator supplies the persona table in
+ * the environment. Nothing here — sender address, product name, tagline, or
+ * the sentences themselves — is compiled in; the built-in copy below is
+ * deliberately product-neutral and is what an unconfigured deployment sends.
+ *
+ * CONFIG (first one set wins; unset = built-in defaults + the client's own
+ * EMAIL_FROM_ADDRESS):
+ *
+ *   EMAIL_BRANDS_FILE   path to a JSON document (mounted Secret/ConfigMap)
+ *   EMAIL_BRANDS        the same JSON document, inline
+ *
+ *   {
+ *     "default": "aplisay",                  // persona for un-branded requests
+ *     "brands": {
+ *       "aplisay":   { "from": "hello@aplisay.com" },
+ *       "polite-ai": {
+ *         "from": "hello@polite.ai",
+ *         "fromName": "polite.ai",
+ *         "productName": "polite.ai",
+ *         "tagline": "Communication, reimagined.",
+ *         "templates": {                     // OPTIONAL, overrides the copy
+ *           "verification":   { "subject": "…{{productName}}…", "text": "…{{url}}…" },
+ *           "reset-password": { "subject": "…", "text": "…" }
+ *         }
+ *       }
+ *     }
+ *   }
+ *
+ * A persona is an INDEX into this table, never an address: an unrecognised (or
+ * forged) `x-email-brand` selects the default persona, so the header can only
+ * ever choose between senders the operator already approved. That is why it is
+ * not behind the AUTH_PROXY_SECRET gate that `x-client-ip` needs.
+ *
+ * Misconfiguration NEVER stops the process: a missing file, bad JSON or a
+ * persona without a `from` is logged at boot and the built-ins carry on. Email
+ * config is not worth refusing to serve the API for, and the built-in path is
+ * always safe.
+ */
+import { readFileSync } from 'node:fs';
+
+// Only these are substituted into operator-supplied templates. No template
+// engine, no conditionals: config is trusted-operator input, but a language is
+// still a needless surface, and an unknown {{token}} should vanish rather than
+// leak its own name into someone's inbox.
+const VARS = ['url', 'productName', 'tagline', 'name'];
+
+const KINDS = ['verification', 'reset-password'];
+
+/**
+ * The product-neutral built-ins, as FUNCTIONS of the persona rather than
+ * template strings: a persona that names no product must read as clean English
+ * ("your account"), not as a string with the gaps papered over.
+ */
+const DEFAULT_COPY = {
+  verification: ({ productName, tagline }) => ({
+    subject: productName ? `Confirm your ${productName} email address` : 'Confirm your email address',
+    text: [
+      productName
+        ? `Confirm the email address on your ${productName} account by opening this link:`
+        : 'Confirm the email address on your account by opening this link:',
+      '',
+      '{{url}}',
+      '',
+      "If you didn't request this, you can safely ignore this email.",
+      ...(tagline ? ['', `— ${productName || ''}${productName ? ' · ' : ''}${tagline}`] : []),
+    ].join('\n'),
+  }),
+  'reset-password': ({ productName, tagline }) => ({
+    subject: productName ? `Set your ${productName} password` : 'Set your password',
+    text: [
+      productName
+        ? `Open this link to set your ${productName} password:`
+        : 'Open this link to set your password:',
+      '',
+      '{{url}}',
+      '',
+      "If you didn't request this, you can safely ignore this email.",
+      ...(tagline ? ['', `— ${productName || ''}${productName ? ' · ' : ''}${tagline}`] : []),
+    ].join('\n'),
+  }),
+};
+
+const str = (v) => (typeof v === 'string' ? v.trim() : '');
+
+/** Substitute {{var}} for the whitelisted values; anything else is dropped. */
+export function render(template, vars) {
+  return String(template).replace(/\{\{\s*(\w+)\s*\}\}/g, (_, key) => (
+    VARS.includes(key) ? (vars[key] ?? '') : ''
+  ));
+}
+
+/**
+ * Parse the persona table out of the environment. Returns
+ * `{ defaultKey, brands }` — `brands` is always an object, empty when nothing
+ * is configured (every lookup then falls through to the built-ins).
+ */
+export function loadBrands(env = process.env, { logger, readFile = readFileSync } = {}) {
+  const empty = { defaultKey: null, brands: {} };
+  const path = str(env.EMAIL_BRANDS_FILE);
+  const inline = str(env.EMAIL_BRANDS);
+  if (!path && !inline) return empty;
+
+  let raw;
+  try {
+    raw = path ? String(readFile(path, 'utf8')) : inline;
+  } catch (err) {
+    logger?.error({ err: err?.message, path }, 'EMAIL_BRANDS_FILE unreadable — falling back to the built-in sender and copy');
+    return empty;
+  }
+
+  let doc;
+  try {
+    doc = JSON.parse(raw);
+  } catch (err) {
+    logger?.error({ err: err?.message, source: path || 'EMAIL_BRANDS' }, 'email brand table is not valid JSON — falling back to the built-in sender and copy');
+    return empty;
+  }
+
+  const source = doc?.brands;
+  if (!source || typeof source !== 'object') {
+    logger?.error({ source: path || 'EMAIL_BRANDS' }, 'email brand table has no "brands" object — falling back to the built-in sender and copy');
+    return empty;
+  }
+
+  const brands = {};
+  for (const [key, value] of Object.entries(source)) {
+    // `from` is the whole point of a persona; one without it would silently
+    // send as somebody else, which is worse than not offering the persona.
+    if (!value || typeof value !== 'object' || !str(value.from)) {
+      logger?.error({ brand: key }, 'email brand ignored — no "from" address');
+      continue;
+    }
+    const templates = {};
+    for (const kind of KINDS) {
+      const t = value.templates?.[kind];
+      if (t && str(t.subject) && str(t.text)) templates[kind] = { subject: str(t.subject), text: String(t.text) };
+      else if (t) logger?.error({ brand: key, kind }, 'email brand template ignored — needs both "subject" and "text"');
+    }
+    brands[key] = {
+      from: str(value.from),
+      fromName: str(value.fromName) || undefined,
+      productName: str(value.productName) || undefined,
+      tagline: str(value.tagline) || undefined,
+      templates,
+    };
+  }
+
+  const defaultKey = str(doc.default) || null;
+  if (defaultKey && !brands[defaultKey]) {
+    logger?.error({ default: defaultKey }, 'email brand table names an unknown default — un-branded sends use the built-in sender');
+    return { defaultKey: null, brands };
+  }
+  return { defaultKey, brands };
+}
+
+/**
+ * Resolve a requested persona key. An unknown key is NOT an error the caller
+ * can exploit — it lands on the default persona (or on the built-ins), which
+ * is the same place an un-branded request lands.
+ */
+export function resolveBrand(table, key) {
+  const brands = table?.brands || {};
+  const wanted = str(key);
+  if (wanted && brands[wanted]) return brands[wanted];
+  if (table?.defaultKey && brands[table.defaultKey]) return brands[table.defaultKey];
+  return null;
+}
+
+/**
+ * Compose the message for one email `kind` in one persona. `from` is omitted
+ * when no persona applies, so the email client's own configured default sender
+ * (EMAIL_FROM_ADDRESS) still applies exactly as it did before personas existed.
+ */
+export function composeMessage({ brand, kind, to, url, name }) {
+  const persona = brand || {};
+  const vars = {
+    url,
+    name: name || '',
+    productName: persona.productName || '',
+    tagline: persona.tagline || '',
+  };
+  const copy = persona.templates?.[kind] || DEFAULT_COPY[kind](persona);
+  return {
+    ...(persona.from ? { from: { email: persona.from, ...(persona.fromName ? { name: persona.fromName } : {}) } } : {}),
+    to,
+    subject: render(copy.subject, vars),
+    text: render(copy.text, vars),
+  };
+}
+
+export default loadBrands;

--- a/lib/auth/email-hooks.js
+++ b/lib/auth/email-hooks.js
@@ -27,7 +27,19 @@
  * detached, still logging its own outcome through the same swallow. Do NOT
  * convert these into a bare unawaited dispatch — awaiting the *bounded* race is
  * what keeps success/failure logging (and the tests) deterministic.
+ *
+ * CONTRACT 3 — the SENDER and the COPY belong to the caller, not to this repo.
+ * Both hooks read the persona named on the originating request
+ * (`x-email-brand`) and compose from the operator's brand table
+ * (email-brands.js), so no product's wording is compiled in here. Resolution is
+ * a map lookup, costing nothing against the deadline above, and a forged header
+ * can only select another operator-approved persona. With no table configured
+ * the product-neutral built-ins are sent from the client's own default address,
+ * exactly as before personas existed.
  */
+import { composeMessage, resolveBrand } from './email-brands.js';
+
+const BRAND_HEADER = 'x-email-brand';
 
 // Below better-auth's MINIMUM_MS = 500 constant-time floor on
 // /send-verification-email, so a slow or hanging send can never push the
@@ -46,7 +58,7 @@ function bounded(sendPromise) {
   ]);
 }
 
-export function createSendHooks({ emailClient, logger }) {
+export function createSendHooks({ emailClient, logger, brands }) {
   const send = async (message, kind) => {
     try {
       const info = await emailClient.send(message);
@@ -56,23 +68,29 @@ export function createSendHooks({ emailClient, logger }) {
     }
   };
 
+  // The persona the caller asked for, or the operator's default. Never throws
+  // and never rejects a key: an unknown one lands where an absent one does.
+  const compose = ({ kind, user, url, request }) => composeMessage({
+    brand: resolveBrand(brands, request?.headers?.get(BRAND_HEADER)),
+    kind,
+    to: user.email,
+    url,
+    name: user.name,
+  });
+
   return {
     // Enabling sendResetPassword also turns on the Firebase->Better-Auth bridge
     // for PASSWORD users: a migrating Firebase row has no Better-Auth credential,
     // and resetPassword *creates* a `credential` account on that existing row
     // when none exists — so setting a password lands on the existing user
     // (id + data preserved), never a dup.
-    sendResetPassword: ({ user, url }) => bounded(send({
-      to: user.email,
-      subject: 'Set your polite.ai password',
-      text: [
-        'Open this link to set your polite.ai password:',
-        '',
-        url,
-        '',
-        "If you didn't request this, you can safely ignore this email.",
-      ].join('\n'),
-    }, 'reset-password')),
+    //
+    // better-auth passes the originating request as the second argument here
+    // too (dist/api/routes/password.mjs), which is what carries the persona.
+    sendResetPassword: ({ user, url }, request) => bounded(send(
+      compose({ kind: 'reset-password', user, url, request }),
+      'reset-password',
+    )),
 
     sendVerificationEmail: ({ user, url }, request) => {
       // Invite-completion signups (polite-ai onboarding) already proved address
@@ -83,20 +101,10 @@ export function createSendHooks({ emailClient, logger }) {
         logger.info({ to: user.email }, 'verification email suppressed (invite-completion signup)');
         return Promise.resolve();
       }
-      return bounded(send({
-        to: user.email,
-        subject: 'Confirm your polite.ai subscription',
-        text: [
-          'Thanks for registering your interest in polite.ai.',
-          '',
-          'Please confirm your subscription by opening this link:',
-          url,
-          '',
-          "If you didn't request this, you can safely ignore this email.",
-          '',
-          '— polite.ai · Communication, reimagined.',
-        ].join('\n'),
-      }, 'verification'));
+      return bounded(send(
+        compose({ kind: 'verification', user, url, request }),
+        'verification',
+      ));
     },
   };
 }

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -54,6 +54,7 @@ if (enabled) {
   const { createEmailClient } = await import('@aplisay/email');
   const { createSendBudget } = await import('./send-budget.js');
   const { createSendHooks } = await import('./email-hooks.js');
+  const { loadBrands } = await import('./email-brands.js');
 
   if (!BETTER_AUTH_SECRET) {
     logger.error('BETTER_AUTH_ENABLED=true but BETTER_AUTH_SECRET is unset — refusing to boot with broken token signing');
@@ -79,7 +80,19 @@ if (enabled) {
     );
   }
 
-  const sendHooks = createSendHooks({ emailClient, logger });
+  // Sender personas (EMAIL_BRANDS_FILE / EMAIL_BRANDS). The caller names one per
+  // request via `x-email-brand`; see email-brands.js. Logged at boot because a
+  // misconfigured table is deliberately non-fatal — the only other symptom is an
+  // email that goes out in the wrong voice.
+  const brands = loadBrands(process.env, { logger });
+  logger.info(
+    { brands: Object.keys(brands.brands), default: brands.defaultKey },
+    Object.keys(brands.brands).length
+      ? 'Email sender personas loaded'
+      : 'No email sender personas configured — auth emails use the default sender and built-in copy',
+  );
+
+  const sendHooks = createSendHooks({ emailClient, logger, brands });
 
   // Its own pool to the same database (Better-Auth uses the Kysely adapter; it
   // cannot share Sequelize's pool). Mirrors the SSL config in lib/database.js.

--- a/tests/auth-email-brands.test.mjs
+++ b/tests/auth-email-brands.test.mjs
@@ -1,0 +1,133 @@
+// Sender personas for the auth emails (lib/auth/email-brands.js). Two things
+// are load-bearing: a persona is an INDEX, never an address (so a forged
+// x-email-brand cannot invent a sender), and every misconfiguration degrades to
+// the built-in copy instead of throwing at boot.
+import { loadBrands, resolveBrand, composeMessage, render } from '../lib/auth/email-brands.js';
+
+const POLITE = {
+  from: 'hello@polite.ai',
+  fromName: 'polite.ai',
+  productName: 'polite.ai',
+  tagline: 'Communication, reimagined.',
+};
+
+const table = (doc) => loadBrands({ EMAIL_BRANDS: JSON.stringify(doc) }, { logger: quietLogger() });
+
+function quietLogger() {
+  const errors = [];
+  return { info: () => {}, error: (...a) => errors.push(a), errors };
+}
+
+describe('loadBrands', () => {
+  it('is empty when nothing is configured', () => {
+    expect(loadBrands({}, { logger: quietLogger() })).toEqual({ defaultKey: null, brands: {} });
+  });
+
+  it('parses the inline JSON document', () => {
+    const t = table({ default: 'aplisay', brands: { aplisay: { from: 'hello@aplisay.com' }, 'polite-ai': POLITE } });
+    expect(t.defaultKey).toBe('aplisay');
+    expect(Object.keys(t.brands).sort()).toEqual(['aplisay', 'polite-ai']);
+    expect(t.brands['polite-ai'].tagline).toBe('Communication, reimagined.');
+  });
+
+  it('reads the file form in preference to the inline form', () => {
+    const readFile = () => JSON.stringify({ brands: { fromfile: { from: 'a@b.com' } } });
+    const t = loadBrands(
+      { EMAIL_BRANDS_FILE: '/etc/brands.json', EMAIL_BRANDS: JSON.stringify({ brands: { inline: { from: 'c@d.com' } } }) },
+      { logger: quietLogger(), readFile },
+    );
+    expect(Object.keys(t.brands)).toEqual(['fromfile']);
+  });
+
+  it('DEGRADES to the built-ins (never throws) on bad JSON, a missing file, or no brands object', () => {
+    const logger = quietLogger();
+    expect(loadBrands({ EMAIL_BRANDS: '{not json' }, { logger })).toEqual({ defaultKey: null, brands: {} });
+    expect(loadBrands({ EMAIL_BRANDS: '{"nope":1}' }, { logger })).toEqual({ defaultKey: null, brands: {} });
+    const readFile = () => { throw new Error('ENOENT'); };
+    expect(loadBrands({ EMAIL_BRANDS_FILE: '/nope.json' }, { logger, readFile })).toEqual({ defaultKey: null, brands: {} });
+    expect(logger.errors).toHaveLength(3);
+  });
+
+  it('drops a persona with no from address, and an unknown default', () => {
+    const t = table({ default: 'ghost', brands: { broken: { productName: 'X' }, ok: { from: 'a@b.com' } } });
+    expect(Object.keys(t.brands)).toEqual(['ok']);
+    expect(t.defaultKey).toBeNull();
+  });
+
+  it('drops a half-written template but keeps the persona', () => {
+    const t = table({ brands: { x: { from: 'a@b.com', templates: { verification: { subject: 'Hi' } } } } });
+    expect(t.brands.x.templates).toEqual({});
+  });
+});
+
+describe('resolveBrand', () => {
+  const t = table({ default: 'aplisay', brands: { aplisay: { from: 'hello@aplisay.com' }, 'polite-ai': POLITE } });
+
+  it('resolves a named persona', () => {
+    expect(resolveBrand(t, 'polite-ai').from).toBe('hello@polite.ai');
+  });
+
+  it('falls back to the default for an absent or FORGED key — never to an arbitrary sender', () => {
+    expect(resolveBrand(t, undefined).from).toBe('hello@aplisay.com');
+    expect(resolveBrand(t, 'evil@attacker.example').from).toBe('hello@aplisay.com');
+    expect(resolveBrand(t, '../../etc/passwd').from).toBe('hello@aplisay.com');
+  });
+
+  it('returns null (client default sender, built-in copy) when nothing is configured', () => {
+    expect(resolveBrand({ defaultKey: null, brands: {} }, 'polite-ai')).toBeNull();
+  });
+});
+
+describe('render', () => {
+  it('substitutes whitelisted vars and DROPS everything else', () => {
+    expect(render('{{url}} {{productName}} {{secret}} {{ tagline }}', {
+      url: 'https://x/v', productName: 'p', tagline: 't',
+    })).toBe('https://x/v p  t');
+  });
+});
+
+describe('composeMessage', () => {
+  const t = table({ default: 'aplisay', brands: { aplisay: { from: 'hello@aplisay.com' }, 'polite-ai': POLITE } });
+
+  it('names the product and signs off with the tagline for a full persona', () => {
+    const msg = composeMessage({ brand: resolveBrand(t, 'polite-ai'), kind: 'verification', to: 'a@b.com', url: 'https://x/v' });
+    expect(msg.from).toEqual({ email: 'hello@polite.ai', name: 'polite.ai' });
+    expect(msg.subject).toBe('Confirm your polite.ai email address');
+    expect(msg.text).toContain('polite.ai account');
+    expect(msg.text).toContain('https://x/v');
+    expect(msg.text.trim().endsWith('— polite.ai · Communication, reimagined.')).toBe(true);
+    // Account-address confirmation, NOT a newsletter double opt-in: the old
+    // hard-coded copy called it a "subscription" the reader had "registered
+    // interest" in, which is a different audience entirely.
+    expect(msg.text.toLowerCase()).not.toContain('subscription');
+    expect(msg.text.toLowerCase()).not.toContain('registering your interest');
+  });
+
+  it('reads as clean English for an address-only persona (no product name, no dangling separator)', () => {
+    const msg = composeMessage({ brand: resolveBrand(t, 'aplisay'), kind: 'reset-password', to: 'a@b.com', url: 'https://x/r' });
+    expect(msg.from).toEqual({ email: 'hello@aplisay.com' });
+    expect(msg.subject).toBe('Set your password');
+    expect(msg.text).not.toMatch(/ {2}|·/);
+  });
+
+  it('omits `from` entirely with no persona, leaving the email client default in charge', () => {
+    const msg = composeMessage({ brand: null, kind: 'verification', to: 'a@b.com', url: 'https://x/v' });
+    expect(msg.from).toBeUndefined();
+    expect(msg.subject).toBe('Confirm your email address');
+  });
+
+  it('lets a persona override the copy outright', () => {
+    const custom = table({
+      brands: {
+        x: {
+          from: 'a@b.com',
+          productName: 'Widget',
+          templates: { verification: { subject: 'Verify for {{productName}}', text: 'Go to {{url}} now' } },
+        },
+      },
+    });
+    const msg = composeMessage({ brand: resolveBrand(custom, 'x'), kind: 'verification', to: 'a@b.com', url: 'https://x/v' });
+    expect(msg.subject).toBe('Verify for Widget');
+    expect(msg.text).toBe('Go to https://x/v now');
+  });
+});

--- a/tests/auth-email-hooks.test.mjs
+++ b/tests/auth-email-hooks.test.mjs
@@ -3,8 +3,9 @@
 // becomes better-call's bare 500, which fires only for registered-and-
 // unverified addresses (an enumeration oracle during any mail outage).
 import { createSendHooks } from '../lib/auth/email-hooks.js';
+import { loadBrands } from '../lib/auth/email-brands.js';
 
-function harness({ sendFails = false } = {}) {
+function harness({ sendFails = false, brands } = {}) {
   const sent = [];
   const logs = { info: [], error: [] };
   const emailClient = {
@@ -19,10 +20,27 @@ function harness({ sendFails = false } = {}) {
     info: (...a) => logs.info.push(a),
     error: (...a) => logs.error.push(a),
   };
-  return { hooks: createSendHooks({ emailClient, logger }), sent, logs };
+  return { hooks: createSendHooks({ emailClient, logger, brands }), sent, logs };
 }
 
 const user = { email: 'someone@example.com' };
+
+const BRANDS = loadBrands({
+  EMAIL_BRANDS: JSON.stringify({
+    default: 'aplisay',
+    brands: {
+      aplisay: { from: 'hello@aplisay.com' },
+      'polite-ai': {
+        from: 'hello@polite.ai',
+        fromName: 'polite.ai',
+        productName: 'polite.ai',
+        tagline: 'Communication, reimagined.',
+      },
+    },
+  }),
+}, { logger: { info: () => {}, error: () => {} } });
+
+const branded = (key) => ({ headers: new Headers({ 'x-email-brand': key }) });
 
 describe('sendResetPassword', () => {
   it('sends and logs on success', async () => {
@@ -65,5 +83,39 @@ describe('sendVerificationEmail', () => {
     await hooks.sendVerificationEmail({ user, url: 'https://x/v' }, request);
     expect(sent).toHaveLength(0);
     expect(logs.info.some(([, msg]) => String(msg).includes('suppressed'))).toBe(true);
+  });
+});
+
+// The persona named on the request decides sender AND wording. Both hooks read
+// it from the request better-auth hands them — the reset one gets `ctx.request`
+// from dist/api/routes/password.mjs, the verification one already used it for
+// x-onboarding-invite.
+describe('sender personas (x-email-brand)', () => {
+  it('sends verification in the requested persona', async () => {
+    const { hooks, sent } = harness({ brands: BRANDS });
+    await hooks.sendVerificationEmail({ user, url: 'https://x/v' }, branded('polite-ai'));
+    expect(sent[0].from).toEqual({ email: 'hello@polite.ai', name: 'polite.ai' });
+    expect(sent[0].subject).toBe('Confirm your polite.ai email address');
+  });
+
+  it('sends reset-password in the requested persona', async () => {
+    const { hooks, sent } = harness({ brands: BRANDS });
+    await hooks.sendResetPassword({ user, url: 'https://x/r' }, branded('polite-ai'));
+    expect(sent[0].from).toEqual({ email: 'hello@polite.ai', name: 'polite.ai' });
+    expect(sent[0].subject).toBe('Set your polite.ai password');
+  });
+
+  it('falls back to the default persona when the header is absent or forged', async () => {
+    const { hooks, sent } = harness({ brands: BRANDS });
+    await hooks.sendVerificationEmail({ user, url: 'https://x/v' }, undefined);
+    await hooks.sendVerificationEmail({ user, url: 'https://x/v' }, branded('evil@attacker.example'));
+    expect(sent.map((m) => m.from.email)).toEqual(['hello@aplisay.com', 'hello@aplisay.com']);
+  });
+
+  it('omits `from` with no personas configured, leaving the client default sender', async () => {
+    const { hooks, sent } = harness();
+    await hooks.sendVerificationEmail({ user, url: 'https://x/v' }, branded('polite-ai'));
+    expect(sent[0].from).toBeUndefined();
+    expect(sent[0].subject).toBe('Confirm your email address');
   });
 });


### PR DESCRIPTION
## What

`sendVerificationEmail` and `sendResetPassword` are the only two emails this service composes itself, and both had one product's identity compiled in — the sender came from `EMAIL_FROM_ADDRESS`, and the copy named a specific product and described account verification as confirming a "subscription" the reader had "registered interest" in.

This makes both the sender and the wording a per-request choice:

- the caller names a persona on the request — `x-email-brand: <key>`
- the operator supplies the table — `EMAIL_BRANDS` (inline JSON) or `EMAIL_BRANDS_FILE` (a path, for a mounted Secret/ConfigMap)
- a persona carries `from`, `fromName`, `productName`, `tagline`, and optionally a full `templates` override per kind
- the built-in copy is now product-neutral, and is what an unconfigured deployment sends

```json
{
  "default": "aplisay",
  "brands": {
    "aplisay":  { "from": "hello@aplisay.com" },
    "example":  { "from": "hello@example.com", "fromName": "Example",
                  "productName": "Example", "tagline": "Your tagline here." }
  }
}
```

`POST /api/users/signup` gains an optional `brand` for the same reason: its double opt-in goes out through a server-side `auth.api` call that carries no request of its own, so the persona must be passed explicitly.

## Safety properties preserved

- **A persona is an index, never an address.** An unknown or forged `x-email-brand` resolves to the operator's default, so the header can only ever pick between senders the operator already approved — which is why, unlike `x-client-ip`, it needs no `AUTH_PROXY_SECRET` gate.
- **The 250ms deadline is untouched.** Resolution is a map lookup with no I/O, so it cannot push the sending branch past better-auth's 500ms constant-time floor on `/send-verification-email` — the asymmetry that would otherwise be an account-enumeration oracle (#208).
- **Log-and-swallow is untouched.** Neither hook can reject; a send failure is still only an operator signal in the logs (#199).
- **Misconfiguration never stops the boot.** An unreadable file, invalid JSON, a persona with no `from`, or a `default` naming a persona that isn't there: each is logged and degrades to the built-ins. Email config is not worth refusing to serve the API for.

## Tests

`tests/auth-email-brands.test.mjs` (new) and `tests/auth-email-hooks.test.mjs` (extended) — 23 tests covering parse/degrade paths, forged-key resolution, both hooks' persona selection, template override, and the no-config path. Also confirmed better-auth passes `ctx.request` to `sendResetPassword` (`dist/api/routes/password.mjs`), which is what carries the persona on the reset path.

## Deploy

Backwards compatible in both directions: no `EMAIL_BRANDS` means today's behaviour with neutral copy, and an `x-email-brand` header against a deployment with no table configured is ignored. Deploy this before any caller starts sending the header.