### PR TITLE
fix(deploy): bind the k8s secret target to the environment, not the current kubectl context

### DIFF
--- a/agents/pipecat/deploy/bundle-secretenv.sh
+++ b/agents/pipecat/deploy/bundle-secretenv.sh
@@ -14,7 +14,10 @@
 #                                      (the loader appends _KEY / _BUNDLE).
 #
 #   .../agents/pipecat/deploy/k8s   →  Kubernetes Secret in the `pipecat`
-#                                      namespace:
+#                                      namespace, on the cluster BOUND to the
+#                                      environment (staging -> AMS3,
+#                                      beta -> LON1; --k8s-context overrides,
+#                                      and dev/production have no binding):
 #                                        pipecat-secretenv-{env}   (per env)
 #                                        pipecat-secretenv         (alias to the
 #                                                                   one just
@@ -53,6 +56,9 @@ ENVIRONMENT=""
 ENV_FILE=""
 ASSUME_YES=0
 DRY_RUN=0
+# Empty = derive from the environment (see "k8s cluster binding" below); set by
+# --k8s-context for a cluster this script knows nothing about.
+K8S_CONTEXT=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -62,6 +68,8 @@ while [ $# -gt 0 ]; do
         --env)          ENVIRONMENT="${2:-}"; shift 2 ;;
         --file=*)       ENV_FILE="${1#*=}"; shift ;;
         --file)         ENV_FILE="${2:-}"; shift 2 ;;
+        --k8s-context=*) K8S_CONTEXT="${1#*=}"; shift ;;
+        --k8s-context)   K8S_CONTEXT="${2:-}"; shift 2 ;;
         --yes|-y)       ASSUME_YES=1; shift ;;
         --dry-run)      DRY_RUN=1; shift ;;
         -h|--help)
@@ -141,6 +149,47 @@ case "$BACKEND" in
     k8s) require kubectl ;;
 esac
 
+# ---- k8s cluster binding -----------------------------------------------------
+#
+# The k8s backend used to publish to whatever `kubectl config current-context`
+# happened to be. Every environment writes the SAME Secret names into the SAME
+# namespace, so aiming at the wrong cluster fails SILENTLY: the write succeeds,
+# the intended cluster keeps its old bundle, and the only symptom is config that
+# "didn't take" (2026-08-14, the sibling bundlers: a beta bundle landed on the
+# staging cluster and beta restarted onto month-old values).
+#
+# So the environment BINDS the cluster — staging -> AMS3, beta -> LON1 — matched
+# by REGION substring against the configured contexts, which survives a cluster
+# rebuild (the DOKS id in the context name changes, the region does not). No
+# match, or more than one, is a hard error: never a silent fall back to whatever
+# context happens to be current.
+#
+# dev and production have NO binding: this agent's production overlay has run on
+# more than one cluster, so guessing is exactly the failure being fixed. Name the
+# cluster with --k8s-context there.
+
+k8s_context_for_env() {
+    local pattern matches count
+    case "$1" in
+        staging) pattern="ams3" ;;
+        beta)    pattern="lon1" ;;
+        *)
+            echo -e "${RED}No cluster is bound to environment '$1'. Pass --k8s-context=<context>.${NC}" >&2
+            exit 2
+            ;;
+    esac
+    matches=$(kubectl config get-contexts -o name | grep -- "$pattern" || true)
+    count=$(printf '%s\n' "$matches" | grep -c . || true)
+    if [ "$count" -ne 1 ]; then
+        echo -e "${RED}Expected exactly one kubectl context matching '$pattern' for environment '$1'; found $count.${NC}" >&2
+        echo -e "${RED}Configured contexts:${NC}" >&2
+        kubectl config get-contexts -o name | sed 's/^/  /' >&2
+        echo -e "${RED}Pass --k8s-context=<context> to choose explicitly.${NC}" >&2
+        exit 1
+    fi
+    printf '%s' "$matches"
+}
+
 # ---- Confirm -----------------------------------------------------------------
 
 case "$BACKEND" in
@@ -158,7 +207,15 @@ case "$BACKEND" in
         ;;
     k8s)
         NAMESPACE=${NAMESPACE:-pipecat}
-        TARGET_DESC="Kubernetes namespace ${GREEN}$NAMESPACE${NC} — secrets ${GREEN}pipecat-secretenv-${ENVIRONMENT}${NC} + alias ${GREEN}pipecat-secretenv${NC}"
+        if [ -n "$K8S_CONTEXT" ]; then
+            kubectl config get-contexts -o name | grep -Fxq -- "$K8S_CONTEXT" || {
+                echo -e "${RED}kubectl context '$K8S_CONTEXT' is not configured.${NC}" >&2
+                exit 1
+            }
+        else
+            K8S_CONTEXT=$(k8s_context_for_env "$ENVIRONMENT")
+        fi
+        TARGET_DESC="Kubernetes context ${GREEN}$K8S_CONTEXT${NC}, namespace ${GREEN}$NAMESPACE${NC} — secrets ${GREEN}pipecat-secretenv-${ENVIRONMENT}${NC} + alias ${GREEN}pipecat-secretenv${NC}"
         ;;
 esac
 
@@ -254,10 +311,10 @@ publish_k8s() {
         [ -f "$cand" ] && { NS_MANIFEST="$cand"; break; }
     done
     if [ -n "$NS_MANIFEST" ]; then
-        kubectl apply -f "$NS_MANIFEST" >/dev/null
-    elif ! kubectl get namespace "$NAMESPACE" >/dev/null 2>&1; then
+        kubectl --context="$K8S_CONTEXT" apply -f "$NS_MANIFEST" >/dev/null
+    elif ! kubectl --context="$K8S_CONTEXT" get namespace "$NAMESPACE" >/dev/null 2>&1; then
         echo -e "${YELLOW}  Creating namespace $NAMESPACE (without PSA labels — apply the overlay to add them)${NC}"
-        kubectl create namespace "$NAMESPACE" >/dev/null
+        kubectl --context="$K8S_CONTEXT" create namespace "$NAMESPACE" >/dev/null
     fi
 
     apply_secret() {
@@ -267,13 +324,13 @@ publish_k8s() {
         # values to `ps`, but the alternative (a temp file on disk) is worse for
         # the constraint "no secrets on the filesystem". The wrapper exits in
         # well under a second.
-        kubectl create secret generic "$name" \
+        kubectl --context="$K8S_CONTEXT" create secret generic "$name" \
             --namespace="$NAMESPACE" \
             --from-literal=SECRETENV_KEY="$SECRETENV_KEY" \
             --from-literal=SECRETENV_BUNDLE="$SECRETENV_BUNDLE" \
-            --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+            --dry-run=client -o yaml | kubectl --context="$K8S_CONTEXT" apply -f - >/dev/null
         # Label so it's obvious which env the secret belongs to.
-        kubectl label secret "$name" --namespace="$NAMESPACE" --overwrite \
+        kubectl --context="$K8S_CONTEXT" label secret "$name" --namespace="$NAMESPACE" --overwrite \
             app.kubernetes.io/name=pipecat-agent \
             aplisay.com/pipecat-env="$ENVIRONMENT" >/dev/null
     }
@@ -285,11 +342,11 @@ publish_k8s() {
     echo
     echo -e "${GREEN}Done.${NC} The overlays' envFrom resolves $alias_name; you don't need to change anything in kustomize."
     echo -e "Per-env copies ($per_env_name) are retained so you can roll back with:"
-    echo -e "  ${YELLOW}kubectl get secret $per_env_name -n $NAMESPACE -o yaml \\${NC}"
-    echo -e "  ${YELLOW}  | sed 's/$per_env_name/$alias_name/' | kubectl apply -f -${NC}"
+    echo -e "  ${YELLOW}kubectl --context=$K8S_CONTEXT get secret $per_env_name -n $NAMESPACE -o yaml \\${NC}"
+    echo -e "  ${YELLOW}  | sed 's/$per_env_name/$alias_name/' | kubectl --context=$K8S_CONTEXT apply -f -${NC}"
     echo
     echo -e "If your DaemonSet pods are already running, restart them to pick up the new env:"
-    echo -e "  ${YELLOW}kubectl rollout restart daemonset/pipecat-sip -n $NAMESPACE${NC}"
+    echo -e "  ${YELLOW}kubectl --context=$K8S_CONTEXT rollout restart daemonset/pipecat-sip -n $NAMESPACE${NC}"
 }
 
 case "$BACKEND" in

--- a/agents/pipecat/deploy/k8s/README.md
+++ b/agents/pipecat/deploy/k8s/README.md
@@ -126,6 +126,12 @@ kubectl apply -k overlays/sipbridge
 # 6. Verify (see "Verification" below).
 ```
 
+> **Which cluster:** the bundler binds `--env=staging` to AMS3 and `--env=beta`
+> to LON1, and pins `--context` on every kubectl call, so your current context is
+> irrelevant and a bundle cannot land on the wrong cluster. `dev` and
+> `production` have no binding — name the cluster with `--k8s-context=<context>`
+> (production's overlay has run on more than one cluster, so it is not guessed).
+
 `PIPECAT_DISPATCH_TOKEN`, `PIPECAT_JOIN_SECRET`, and `SHARED_API_TOKEN` in the
 bundle **must match the llm-agent server side**. Also set `SERVICE_BASE_URI` (the
 llm-agent REST base) in `base/configmap.yaml`.

--- a/agents/pipecat/deploy/k8s/RUNBOOK-production-do.md
+++ b/agents/pipecat/deploy/k8s/RUNBOOK-production-do.md
@@ -158,7 +158,10 @@ base) and, for outbound, `PIPECAT_SIP_OUTBOUND` + `PIPECAT_SIP_FROM_DOMAIN`.
 ```bash
 kubectl config use-context do-lon1-k8s-1-36-0-do-2-lon1-1782604340196
 cd agents/pipecat/deploy/k8s
-../bundle-secretenv.sh --env=production      # creates ns (PSA privileged) +
+# NB --env=production has no cluster binding in the bundler (staging->AMS3 and
+# beta->LON1 are the only two), so name this cluster explicitly:
+../bundle-secretenv.sh --env=production \
+    --k8s-context=do-lon1-k8s-1-36-0-do-2-lon1-1782604340196  # creates ns (PSA privileged) +
                                              # pipecat-secretenv-production + alias
 ```
 

--- a/deploy/bundle-secretenv.sh
+++ b/deploy/bundle-secretenv.sh
@@ -12,7 +12,9 @@
 #                             SECRETENV_{ENV}_BUNDLE
 #   --target=k8s            Kubernetes Secret `llm-agent-secretenv` (keys
 #                           SECRETENV_KEY + SECRETENV_BUNDLE) in namespace
-#                           `llm-agent` on the CURRENT kubectl context — the
+#                           `llm-agent` on the cluster BOUND to the environment
+#                           (staging -> AMS3, beta -> LON1; --k8s-context
+#                           overrides, and no other env has a binding) — the
 #                           pair deploy/k8s/beta mounts via envFrom. Override
 #                           with --k8s-secret / --k8s-namespace /
 #                           --k8s-deployment (rollout hint only).
@@ -24,7 +26,7 @@
 # Usage (from the repo root or deploy/):
 #   ./bundle-secretenv.sh                       # interactive
 #   ./bundle-secretenv.sh --env=staging --yes
-#   ./bundle-secretenv.sh --env=beta --target=k8s   # kubectl context = beta cluster
+#   ./bundle-secretenv.sh --env=beta --target=k8s   # LON1, whatever context is current
 #   ./bundle-secretenv.sh --env=production --file=path/to/.env
 #   ./bundle-secretenv.sh --dry-run             # plan only, no writes
 #
@@ -50,6 +52,9 @@ DRY_RUN=0
 # k8s target details (defaults match deploy/k8s/beta).
 K8S_NAMESPACE="llm-agent"
 K8S_SECRET_NAME="llm-agent-secretenv"
+# Empty = derive from the environment (see "k8s cluster binding" below); set by
+# --k8s-context for a cluster this script knows nothing about.
+K8S_CONTEXT=""
 K8S_DEPLOYMENT="llm-agent"   # only used in the post-publish rollout hint
 
 while [ $# -gt 0 ]; do
@@ -66,6 +71,8 @@ while [ $# -gt 0 ]; do
         --k8s-namespace)   K8S_NAMESPACE="${2:-}"; shift 2 ;;
         --k8s-deployment=*) K8S_DEPLOYMENT="${1#*=}"; shift ;;
         --k8s-deployment)   K8S_DEPLOYMENT="${2:-}"; shift 2 ;;
+        --k8s-context=*)   K8S_CONTEXT="${1#*=}"; shift ;;
+        --k8s-context)     K8S_CONTEXT="${2:-}"; shift 2 ;;
         --yes|-y)  ASSUME_YES=1; shift ;;
         --dry-run) DRY_RUN=1; shift ;;
         -h|--help)
@@ -123,12 +130,50 @@ require node
 [ "$TARGET" = gcp ] && require gcloud
 [ "$TARGET" = k8s ] && require kubectl
 
+# ---- k8s cluster binding -----------------------------------------------------
+#
+# The k8s target used to publish to whatever `kubectl config current-context`
+# happened to be. Every environment writes the SAME Secret name into the SAME
+# namespace, so aiming at the wrong cluster fails SILENTLY: the write succeeds,
+# the intended cluster keeps its old bundle, and the only symptom is config that
+# "didn't take" (2026-08-14: a beta bundle landed on the staging cluster — into a
+# namespace with no pods, staging's server being on Cloud Run — while beta
+# restarted onto month-old values).
+#
+# So the environment BINDS the cluster — staging -> AMS3, beta -> LON1 — matched
+# by REGION substring against the configured contexts, which survives a cluster
+# rebuild (the DOKS id in the context name changes, the region does not). No
+# match, or more than one, is a hard error: never a silent fall back to whatever
+# context happens to be current. Environments with no binding here must name a
+# context explicitly with --k8s-context.
+
+k8s_context_for_env() {
+    local pattern matches count
+    case "$1" in
+        staging) pattern="ams3" ;;
+        beta)    pattern="lon1" ;;
+        *)
+            echo -e "${RED}No cluster is bound to environment '$1'. Pass --k8s-context=<context>.${NC}" >&2
+            exit 2
+            ;;
+    esac
+    matches=$(kubectl config get-contexts -o name | grep -- "$pattern" || true)
+    count=$(printf '%s\n' "$matches" | grep -c . || true)
+    if [ "$count" -ne 1 ]; then
+        echo -e "${RED}Expected exactly one kubectl context matching '$pattern' for environment '$1'; found $count.${NC}" >&2
+        echo -e "${RED}Configured contexts:${NC}" >&2
+        kubectl config get-contexts -o name | sed 's/^/  /' >&2
+        echo -e "${RED}Pass --k8s-context=<context> to choose explicitly.${NC}" >&2
+        exit 1
+    fi
+    printf '%s' "$matches"
+}
+
 # ---- Target details ----------------------------------------------------------
 # gcp: PROJECT_ID from the deploy config (not the secrets source).
-# k8s: the CURRENT kubectl context — point it at the right cluster first.
+# k8s: the context BOUND to the environment above.
 
 PROJECT_ID=""
-K8S_CONTEXT=""
 if [ "$TARGET" = gcp ]; then
     PROJECT_ID="llm-voice"
     for f in "$SCRIPT_DIR/.env.$ENVIRONMENT" "$SCRIPT_DIR/env-example-$ENVIRONMENT"; do
@@ -141,12 +186,13 @@ if [ "$TARGET" = gcp ]; then
         echo -e "${RED}Could not determine GCP PROJECT_ID (not in deploy/gcp/.env.$ENVIRONMENT or env-example-$ENVIRONMENT, no gcloud default).${NC}" >&2
         exit 1
     fi
-else
-    K8S_CONTEXT=$(kubectl config current-context 2>/dev/null || true)
-    if [ -z "$K8S_CONTEXT" ]; then
-        echo -e "${RED}No current kubectl context.${NC}" >&2
+elif [ -n "$K8S_CONTEXT" ]; then
+    kubectl config get-contexts -o name | grep -Fxq -- "$K8S_CONTEXT" || {
+        echo -e "${RED}kubectl context '$K8S_CONTEXT' is not configured.${NC}" >&2
         exit 1
-    fi
+    }
+else
+    K8S_CONTEXT=$(k8s_context_for_env "$ENVIRONMENT")
 fi
 
 # ---- Plan + confirm ----------------------------------------------------------
@@ -234,21 +280,23 @@ publish_gcp() {
 }
 
 publish_k8s() {
-    if ! kubectl get namespace "$K8S_NAMESPACE" >/dev/null 2>&1; then
+    # EVERY call is --context pinned: an inherited current-context is exactly the
+    # foot-gun this script no longer has.
+    if ! kubectl --context="$K8S_CONTEXT" get namespace "$K8S_NAMESPACE" >/dev/null 2>&1; then
         echo -e "${YELLOW}  Creating namespace $K8S_NAMESPACE${NC}"
-        kubectl create namespace "$K8S_NAMESPACE" >/dev/null
+        kubectl --context="$K8S_CONTEXT" create namespace "$K8S_NAMESPACE" >/dev/null
     fi
-    echo -e "${YELLOW}  Writing Secret $K8S_SECRET_NAME (namespace $K8S_NAMESPACE)${NC}"
-    kubectl create secret generic "$K8S_SECRET_NAME" -n "$K8S_NAMESPACE" \
+    echo -e "${YELLOW}  Writing Secret $K8S_SECRET_NAME (namespace $K8S_NAMESPACE, context $K8S_CONTEXT)${NC}"
+    kubectl --context="$K8S_CONTEXT" create secret generic "$K8S_SECRET_NAME" -n "$K8S_NAMESPACE" \
         --from-literal=SECRETENV_KEY="$SECRETENV_KEY" \
         --from-literal=SECRETENV_BUNDLE="$SECRETENV_BUNDLE" \
-        --dry-run=client -o yaml | kubectl apply -f - >/dev/null
-    kubectl annotate secret "$K8S_SECRET_NAME" -n "$K8S_NAMESPACE" --overwrite \
+        --dry-run=client -o yaml | kubectl --context="$K8S_CONTEXT" apply -f - >/dev/null
+    kubectl --context="$K8S_CONTEXT" annotate secret "$K8S_SECRET_NAME" -n "$K8S_NAMESPACE" --overwrite \
         aplisay.com/llm-agent-env="$ENVIRONMENT" >/dev/null
 
     echo
     echo -e "${GREEN}Done.${NC} Roll the pods onto the new values:"
-    echo -e "  ${YELLOW}kubectl rollout restart deployment/$K8S_DEPLOYMENT -n $K8S_NAMESPACE${NC}"
+    echo -e "  ${YELLOW}kubectl --context=$K8S_CONTEXT rollout restart deployment/$K8S_DEPLOYMENT -n $K8S_NAMESPACE${NC}"
 }
 
 if [ "$TARGET" = gcp ]; then publish_gcp; else publish_k8s; fi


### PR DESCRIPTION
## The failure this fixes

`bundle-secretenv.sh --target=k8s` published to whatever `kubectl config current-context` happened to be. Every environment writes the **same Secret name** into the **same namespace**, so pointing at the wrong cluster fails completely silently — the write succeeds, the intended cluster keeps its old bundle, and the only symptom is configuration that "didn't take".

That happened on 2026-08-14. All of that day's beta bundles went to the staging (AMS3) cluster because that was the current context; the beta (LON1) website Secret was last written on 2026-08-07 and beta's llm-agent Secret on 2026-07-25. Beta was then restarted onto month-old values, and nothing anywhere reported an error. The llm-agent copy landed in a staging namespace with **no pods at all** (staging's server runs on Cloud Run), so it did nothing whatsoever.

## The fix

The environment now **binds** the cluster:

| `--env` | cluster |
|---|---|
| `staging` | AMS3 |
| `beta` | LON1 |
| `dev`, `production` | no binding — must pass `--k8s-context` |

- Matched by **region substring** against `kubectl config get-contexts`, so a rebuilt cluster (new DOKS id in the context name) needs no edit here.
- Zero matches or more than one is a **hard error** that lists the configured contexts. There is no fall back to the current context.
- **Every** kubectl call in the publish path is `--context` pinned — namespace check, create, secret apply, annotate/label — and the printed rollout hints carry it too.
- The plan block names the cluster before the confirm prompt, so a wrong target is visible before you type `y`.
- New `--k8s-context=<context>` overrides the binding, and is validated against the configured contexts.

`dev` and `production` are deliberately unbound rather than guessed.

## Verified

Dry-run matrix across every k8s-capable bundler:

| bundler | `--env=staging` | `--env=beta` |
|---|---|---|
| website | AMS3 | LON1 |
| crawler (wrapper) | AMS3 | LON1 |
| integrations (wrapper) | AMS3 | LON1 |
| llm-agent server | AMS3 | LON1 |
| pipecat | AMS3 | LON1 |

Plus: `--env=production --target=k8s` refuses with the remediation; `--k8s-context=nope` refuses; `--k8s-context=microk8s` is honoured; the `gcp` target is untouched. `bash -n` clean.

The crawler and integrations wrappers needed no change — they `exec` the shared script with their own secret names pinned and pass every other flag through, so they inherit the binding and `--k8s-context` for free. The livekit bundler has no k8s branch at all (Secret Manager only), so it is out of scope.
