### PR TITLE
docs(pipecat): label the SIP node POOL, not the nodes

### DIFF
--- a/agents/pipecat/deploy/k8s/README.md
+++ b/agents/pipecat/deploy/k8s/README.md
@@ -73,10 +73,20 @@ deploy/k8s/
 ## Prerequisites
 
 1. **A dedicated SIP node pool** whose nodes have **public/external IPs** (or 1:1
-   NAT) reachable by your SBCs, labelled so the DaemonSet lands only there:
+   NAT) reachable by your SBCs, labelled so the DaemonSet lands only there.
+   Label the **POOL**, not the nodes, so that every node the pool ever creates
+   carries it — an autoscaled node, or a node replaced by an upgrade or an
+   auto-repair, comes up bare otherwise and silently runs no SIP pod:
    ```
-   kubectl label node <node> aplisay.com/pipecat-sip=true
+   # DigitalOcean (--label REPLACES the pool's label set, so pass them all):
+   doctl kubernetes cluster node-pool update <cluster-id> <pool> \
+       --label aplisay.com/pipecat-sip=true
+   # GKE:  gcloud container node-pools create … --node-labels=aplisay.com/pipecat-sip=true
+   # EKS:  eksctl … --node-labels aplisay.com/pipecat-sip=true
    ```
+   `kubectl label node <node> aplisay.com/pipecat-sip=true` is for
+   single-node/test clusters only: it labels the node that exists right now, and
+   nothing the cluster creates later.
 2. **Firewall** opened on those nodes:
    - `TCP 5061` (SIP TLS) — from your SBC source ranges
    - `UDP 10000-20000` (RTP — sipbridge / voiceblender) **or** `UDP 16384-16484`
@@ -112,8 +122,8 @@ cd deploy/k8s
 
 # 3. Label the node(s) the SIP pod should run on. The DaemonSet ONLY schedules
 #    on nodes with this label — without it you get a DaemonSet with 0 pods.
-#    On a dedicated SIP node pool, label that pool (see Prerequisites). On a
-#    single-node / test cluster:
+#    On a real cluster label the POOL (see Prerequisites) so autoscaled and
+#    replacement nodes inherit it. On a single-node / test cluster:
 kubectl label nodes --all aplisay.com/pipecat-sip=true
 
 # 4. (Optional) a CA-signed SIP TLS cert; otherwise the gateway self-signs.
@@ -512,6 +522,22 @@ kubectl get nodes -L aplisay.com/pipecat-sip    # is any node labelled?
 kubectl label nodes --all aplisay.com/pipecat-sip=true   # label them (test cluster)
 ```
 
+**Fewer pods than nodes after a scale-up?** Same cause, quieter: the DaemonSet
+looks healthy (all its pods Ready) and only `DESIRED` fails to grow, so nothing
+alerts. It means the label is on the NODES rather than on the POOL, so nodes the
+autoscaler added came up bare. Compare the two:
+
+```bash
+kubectl get nodes -L aplisay.com/pipecat-sip                  # which nodes have it
+doctl kubernetes cluster node-pool list <cluster-id>          # does the POOL have it
+```
+
+Fix it at the pool (Prerequisites step 1) rather than re-labelling by hand —
+otherwise it recurs on the next scale-up or node replacement. Node replacement is
+the worse direction: capacity silently DROPS. Watch for it on the LB too, since
+`externalTrafficPolicy: Local` means an unlabelled node has no local pod to serve
+the tcp/5061 health check and shows up as an unhealthy backend.
+
 If pods exist but stay in `Init:` or `ImagePullBackOff`, `kubectl describe pod
 -n pipecat <pod>` shows why — commonly the private Artifact Registry images need
 an `imagePullSecret` (see *imagePullSecret for Artifact Registry* above), or
@@ -525,8 +551,9 @@ UDP ranges are intentionally open to all sources (direct media from any source I
 
 ## Out of scope (follow-ups)
 
-- **Autoscaling** — a DaemonSet scales with the node pool; size the SIP pool for
-  peak concurrent calls (each call uses 2 RTP ports).
+- **Autoscaling** — a DaemonSet scales with the node pool *provided the
+  nodeSelector label is set on the POOL* (Prerequisites step 1); size the SIP
+  pool for peak concurrent calls (each call uses 2 RTP ports).
 - **Production secret backend** — only templates + guidance here; wire
   sealed-secrets / SOPS / External Secrets Operator for real deployments.
 - **Dedicated k8s image pipeline** — the deploy reuses the existing Artifact

--- a/agents/pipecat/deploy/k8s/RUNBOOK-cutover.md
+++ b/agents/pipecat/deploy/k8s/RUNBOOK-cutover.md
@@ -61,7 +61,12 @@ Run against the **target cluster context** (`kubectl config use-context <ctx>`).
    kubectl get ns pipecat                                   # namespace exists
    kubectl get secret -n pipecat ar-pull pipecat-secretenv  # pull + secretenv secrets
    kubectl get nodes -l aplisay.com/pipecat-sip=true        # SIP nodes labelled
+   doctl kubernetes cluster node-pool list <cluster-id>     # ...and the POOL too
    ```
+
+   The pool label is the one that matters: without it, autoscaled and replacement
+   nodes come up bare and quietly run no SIP pod (see the k8s README's
+   *Prerequisites*).
 
    Confirm the right secretenv bundle is loaded for the env
    (`SECRETENV_PIPECAT_{staging|production}_*`).

--- a/agents/pipecat/deploy/k8s/RUNBOOK-production-do.md
+++ b/agents/pipecat/deploy/k8s/RUNBOOK-production-do.md
@@ -23,7 +23,7 @@ because it adds the steps the cutover doc assumes are already done — chiefly
 | DO cluster id | `51e21669-564d-41da-b5fb-26a7c26e127a` | `76c8a432-7d14-4946-b667-e71078bd60bb` |
 | Node firewall tag | `k8s:51e21669-564d-41da-b5fb-26a7c26e127a` | `k8s:76c8a432-7d14-4946-b667-e71078bd60bb` |
 | Region | ams3 | lon1 |
-| SIP node pool | `pool-741oen40n` (1 node, labelled) | `llm-voice-prod` (2 nodes, **unlabelled**) |
+| SIP node pool | `pool-741oen40n` (1 node, pool-labelled) | `llm-voice-prod` (2 nodes, pool-labelled 2026-08-15; autoscales 2→5) |
 | Node external IPs | 164.92.154.188 | 138.68.185.22, 138.68.162.72 |
 | Overlay | `do-staging` | `do-production` |
 | Gateway | sipbridge (RTP **10000-20000**) | sipbridge (RTP **10000-20000**) |
@@ -60,7 +60,9 @@ These are the things that will silently break a naïve `kubectl apply -k do-prod
 2. **Cert placeholder.** `REPLACE_WITH_PRODUCTION_DO_CERT_ID` is still in the
    overlay. Apply with it → the DO LB drops the 443 TLS listener (SIP 5061 still
    works → *silent partial failure*; WebRTC/dispatch unreachable over HTTPS).
-3. **Prod nodes are unlabelled.** DaemonSet `nodeSelector: aplisay.com/pipecat-sip=true`.
+3. **Prod nodes are unlabelled.** DaemonSet `nodeSelector: aplisay.com/pipecat-sip=true`
+   — and the label belongs on the node POOL (Step 6), or it is lost on every
+   autoscale and node replacement.
    Apply without labelling → DaemonSet `DESIRED=0`, **no pods**, no Service
    endpoints → with `externalTrafficPolicy: Local` the LB health check (tcp/5061)
    fails on every node → the LB gets an IP but **both 5061 and 443 are dead**.
@@ -180,15 +182,24 @@ kubectl -n pipecat patch serviceaccount default \
     -p '{"imagePullSecrets":[{"name":"ar-pull"}]}'
 ```
 
-### Step 6 — Label the SIP nodes (else 0 pods)
+### Step 6 — Label the SIP node POOL (else 0 pods)
 
 ```bash
-kubectl label node llm-voice-prod-3cadsb llm-voice-prod-3cadsw \
-    aplisay.com/pipecat-sip=true
+doctl kubernetes cluster node-pool update 76c8a432-7d14-4946-b667-e71078bd60bb \
+    llm-voice-prod --label aplisay.com/pipecat-sip=true
 ```
 
-(Both nodes → HA: one DaemonSet pod each, each advertising its own public IP for
-media; the LB spreads 5061 across both.)
+(Every node in the pool → HA: one DaemonSet pod each, each advertising its own
+public IP for media; the LB spreads 5061 across all of them.)
+
+> Label the **POOL**, not the nodes. A pool label is stamped on every node DOKS
+> creates from then on; `kubectl label node …` only marks the nodes that exist at
+> that moment. This pool autoscales 2→5, so hand-labelling means an autoscaled
+> node runs no SIP pod (`DESIRED` just stays put — nothing alerts), and a node
+> replaced by an upgrade or auto-repair takes SIP capacity down with it. That is
+> exactly what happened here: the pool was labelled only at the node level and
+> was corrected on 2026-08-15. Pool labels apply to NEW nodes, so if the existing
+> nodes were never labelled by hand, recycle them after setting it.
 
 ### Step 7 — Apply
 


### PR DESCRIPTION
## The problem

The SIP DaemonSet pins `nodeSelector: aplisay.com/pipecat-sip=true`, and every document in this directory told you to satisfy it with `kubectl label node …`. That labels the nodes that exist at that moment and **nothing the cluster creates afterwards**.

On an autoscaling pool the DaemonSet therefore never grows. The failure is unusually quiet: a scaled-up node comes up bare, `DESIRED` simply stays where it was, every existing pod stays `Ready`, and nothing alerts. Node replacement — upgrade, recycle, auto-repair — is the worse direction, because SIP capacity silently *drops*.

Found on the LON1 beta cluster, and the two clusters make the contrast exactly:

| | staging (AMS3) `pool-741oen40n` | beta (LON1) `llm-voice-prod` |
|---|---|---|
| autoscale | on, 2→3 | on, **2→5** |
| pool labels | `aplisay.com/pipecat-sip: "true"` | **none** — nodes labelled by hand |

Staging scaled correctly all along. Beta's pool label was set on 2026-08-15 (`doctl kubernetes cluster node-pool update … --label aplisay.com/pipecat-sip=true`); this PR is the documentation catching up so it does not drift back.

Not implicated, having checked: the DO firewalls (`pipecat-sip-signal-prod`, `pipecat-rtp-prod`, `pipecat-webrtc-prod`) are all scoped by the `k8s:<cluster-id>` tag, which DOKS applies to every new node automatically, and the SIP LoadBalancer adds new nodes to its backend pool by itself. The node label was the only gap.

## Changes

- **`README.md` Prerequisites** — leads with the pool-level command for DO, GKE and EKS, and explains *why*; `kubectl label node` is now explicitly the single-node/test-cluster form. Notes that DO's `--label` replaces the pool's whole label set.
- **`README.md` Quick start step 3** — points at the pool for real clusters.
- **`README.md` troubleshooting** — adds the quiet case ("fewer pods than nodes after a scale-up"), how to tell node-labels from pool-labels, and its LB symptom: with `externalTrafficPolicy: Local` an unlabelled node has no local pod to answer the tcp/5061 health check and shows as an unhealthy backend — a convincing red herring mid-incident.
- **`README.md` out-of-scope** — the "a DaemonSet scales with the node pool" claim now carries its precondition.
- **`RUNBOOK-production-do.md`** — Step 6 becomes "Label the SIP node POOL", with the real command for this cluster, the autoscale caveat, and the note that pool labels apply to new nodes (recycle if the current ones were never labelled). The facts table records both pools as pool-labelled.
- **`RUNBOOK-cutover.md`** — the pre-flight now checks the pool as well as the nodes.

Documentation only; no manifest or script changes.
