### PR TITLE
fix(openai): hosted-MCP results lost from stateless replay history

### DIFF
--- a/lib/models/openai.js
+++ b/lib/models/openai.js
@@ -24,7 +24,10 @@ const NO_MAX_EFFORT = /^gpt-5\.5/;
  * - Statefulness: store:false + full input replay — response.output items
  *   (including reasoning items) are replayed verbatim; the API errors if
  *   reasoning/function_call items are dropped. Prompt caching is automatic on
- *   >=1024-token prefixes (usage.input_tokens_details.cached_tokens).
+ *   >=1024-token prefixes (usage.input_tokens_details.cached_tokens). The one
+ *   exception is hosted-MCP `mcp_call` items, whose output the replay
+ *   silently discards — toReplayItems rewrites each into a retained
+ *   function_call/function_call_output pair so MCP results survive the turn.
  * - Tools: flat Responses-API function tools; results returned as
  *   function_call_output items keyed by call_id.
  * - MCP: top-level `mcpServers` map to the HOSTED MCP tool (server-side
@@ -188,7 +191,11 @@ class OpenAi extends Llm {
     // ANNOTATES items with parse artifacts (function_call.parsed_arguments,
     // output_text content .parsed) that are not valid REQUEST fields — strip
     // them or the replay 400s ("Unknown parameter: 'input[N].parsed_arguments'").
-    this.gpt.input.push(...(response.output || []).map(OpenAi.stripParseArtifacts));
+    // Hosted-MCP items need more than stripping: a replayed `mcp_call` is
+    // ACCEPTED but its `output` is silently DISCARDED (unseen by the model,
+    // not even token-charged — verified live), so toReplayItems rewrites each
+    // one as a function_call/function_call_output pair, which IS retained.
+    this.gpt.input.push(...(response.output || []).flatMap(OpenAi.toReplayItems));
 
     let text = '';
     const calls = [];
@@ -258,6 +265,39 @@ class OpenAi extends Llm {
     } catch {
       return { _raw: raw };
     }
+  }
+
+  /**
+   * One response output item → the item(s) replayed as INPUT on later
+   * stateless requests.
+   *
+   * Most items replay verbatim (parse artifacts stripped), but a hosted-MCP
+   * `mcp_call` cannot: the Responses API accepts the replayed item and then
+   * silently drops its `output` — the model never sees the content again and
+   * it isn't even charged as input (verified against the live API). With
+   * store:false that makes every MCP result AMNESIC one request later: a
+   * session whose instructions depend on remembering an MCP result (the
+   * builder's get_playbook gate) re-fetches it on every turn — paying the
+   * full result as fresh input each time — and can loop on the re-fetch
+   * instead of progressing. A function_call/function_call_output pair IS
+   * retained by the replay, so each completed mcp_call becomes that pair:
+   * same name and arguments, the output (or error) preserved verbatim, keyed
+   * by the mcp item's own id. mcp_list_tools discovery items still replay
+   * as-is — they carry no output the model needs back.
+   */
+  static toReplayItems(item) {
+    const clean = OpenAi.stripParseArtifacts(item);
+    if (clean?.type !== 'mcp_call') return [clean];
+    const callId = clean.id || `mcp_${Math.random().toString(36).slice(2)}`;
+    const output = typeof clean.output === 'string' && clean.output.length
+      ? clean.output
+      : clean.error
+        ? `ERROR: ${typeof clean.error === 'string' ? clean.error : JSON.stringify(clean.error)}`
+        : 'ERROR: tool returned no result';
+    return [
+      { type: 'function_call', call_id: callId, name: clean.name, arguments: clean.arguments || '{}' },
+      { type: 'function_call_output', call_id: callId, output },
+    ];
   }
 
   /**

--- a/tests/openai-mcp-replay.test.mjs
+++ b/tests/openai-mcp-replay.test.mjs
@@ -1,0 +1,137 @@
+// Hosted-MCP replay retention: the Responses API ACCEPTS a replayed
+// `mcp_call` input item but silently DISCARDS its `output` — the model never
+// sees the content again and it is not token-charged (verified against the
+// live API: a replayed mcp_call whose output named a magic token got "NONE"
+// back at 46 input tokens; the same content as a function_call/
+// function_call_output pair was quoted back at 90). With store:false that
+// made every MCP result amnesic one request later — the builder's playbook
+// gate then re-fetched get_playbook on every turn and could loop without
+// ever reaching its save. These tests pin the driver-side cure: each
+// completed mcp_call is rewritten into a retained function pair when pushed
+// onto the replay history; everything else replays verbatim.
+// No network: fake stream helpers stand in for the SDK stream objects.
+process.env.OPENAI_API_KEY ||= 'test-key';
+
+const { default: OpenAi } = await import('../lib/models/openai.js');
+
+const logger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const baseArgs = {
+  logger,
+  user: 'test',
+  prompt: 'You are a test agent.',
+  options: { maxTokens: 4096 },
+  model: 'text:openai/gpt-5.6-terra',
+  modelName: 'text:openai/gpt-5.6-terra',
+  mcpServers: [],
+  keys: [],
+};
+
+/** Stand-in for the SDK stream helper (events replayed, then the final). */
+function fakeStream({ events = [], final }) {
+  const listeners = [];
+  const finish = async () => {
+    for (const e of events) listeners.forEach((cb) => cb(e));
+    return final;
+  };
+  return {
+    on(name, cb) {
+      if (name === 'event') listeners.push(cb);
+      return this;
+    },
+    abort() {},
+    finalResponse: finish,
+  };
+}
+
+const driverWith = (final) => {
+  const oa = new OpenAi(baseArgs);
+  oa.client = { responses: { stream: () => fakeStream({ final }) } };
+  return oa;
+};
+
+describe('openai (Responses) hosted-MCP replay retention', () => {
+  test('a completed mcp_call is replayed as a function pair carrying its output', async () => {
+    const oa = driverWith({
+      status: 'completed',
+      output: [
+        {
+          type: 'mcp_call',
+          id: 'mcp_abc123',
+          name: 'get_playbook',
+          server_label: 'polite',
+          arguments: '{}',
+          output: 'PLAYBOOK CONTENT',
+        },
+        { type: 'message', content: [{ type: 'output_text', text: 'Read it.' }] },
+      ],
+      usage: { input_tokens: 10, output_tokens: 2, input_tokens_details: { cached_tokens: 0 } },
+    });
+    const events = [];
+    const round = await oa.rawCompletion('fetch the playbook', (ev) => events.push(ev));
+
+    // No mcp_call item survives into the replay history…
+    expect(oa.gpt.input.some((i) => i?.type === 'mcp_call')).toBe(false);
+    // …its content rides a retained function pair instead, keyed by the mcp id.
+    expect(oa.gpt.input).toEqual(expect.arrayContaining([
+      { type: 'function_call', call_id: 'mcp_abc123', name: 'get_playbook', arguments: '{}' },
+      { type: 'function_call_output', call_id: 'mcp_abc123', output: 'PLAYBOOK CONTENT' },
+    ]));
+    // The pair sits where the mcp_call sat: before the assistant message.
+    const callIdx = oa.gpt.input.findIndex((i) => i?.type === 'function_call');
+    const outIdx = oa.gpt.input.findIndex((i) => i?.type === 'function_call_output');
+    const msgIdx = oa.gpt.input.findIndex((i) => i?.type === 'message');
+    expect(callIdx).toBeLessThan(outIdx);
+    expect(outIdx).toBeLessThan(msgIdx);
+
+    // The round contract is untouched: hosted calls are not client calls…
+    expect(round.calls).toEqual([]);
+    expect(round.text).toBe('Read it.');
+    // …and the mcp completion still surfaces to the client callback.
+    expect(events.some((e) => e.mcp_tool_use?.name === 'get_playbook')).toBe(true);
+  });
+
+  test('a FAILED mcp_call replays its error, so the failure is remembered too', async () => {
+    const oa = driverWith({
+      status: 'completed',
+      output: [
+        {
+          type: 'mcp_call',
+          id: 'mcp_err1',
+          name: 'get_playbook',
+          server_label: 'polite',
+          arguments: '{}',
+          output: null,
+          error: 'upstream 502',
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 1, input_tokens_details: { cached_tokens: 0 } },
+    });
+    await oa.rawCompletion('fetch the playbook');
+    expect(oa.gpt.input).toEqual(expect.arrayContaining([
+      { type: 'function_call_output', call_id: 'mcp_err1', output: 'ERROR: upstream 502' },
+    ]));
+  });
+
+  test('non-MCP items replay verbatim with parse artifacts stripped (unchanged contract)', async () => {
+    const oa = driverWith({
+      status: 'completed',
+      output: [
+        { type: 'reasoning', id: 'rs_1', encrypted_content: 'opaque' },
+        { type: 'function_call', call_id: 'c1', name: 'update_agent_set', arguments: '{"id":"s1"}', parsed_arguments: null },
+        { type: 'mcp_list_tools', server_label: 'polite', tools: [{ name: 'get_playbook' }] },
+      ],
+      usage: { input_tokens: 5, output_tokens: 1, input_tokens_details: { cached_tokens: 0 } },
+    });
+    await oa.rawCompletion('go');
+    expect(oa.gpt.input).toEqual(expect.arrayContaining([
+      { type: 'reasoning', id: 'rs_1', encrypted_content: 'opaque' },
+      { type: 'function_call', call_id: 'c1', name: 'update_agent_set', arguments: '{"id":"s1"}' },
+      { type: 'mcp_list_tools', server_label: 'polite', tools: [{ name: 'get_playbook' }] },
+    ]));
+    for (const item of oa.gpt.input) expect(item).not.toHaveProperty('parsed_arguments');
+  });
+});


### PR DESCRIPTION
## Problem

The OpenAI Responses driver runs `store:false` and replays history by appending `response.output` items to the next request's `input`. For hosted-MCP tools this replay is broken at the API: a replayed `mcp_call` item is **accepted but its `output` is silently discarded** — the model never sees the content again, and it is not even charged as input.

Verified against the live API:
- input containing an `mcp_call` item whose output named a magic token → model answers `NONE`, `input_tokens: 46` (content not charged);
- the same content as a `function_call`/`function_call_output` pair → model quotes the token, `input_tokens: 90` (content retained). Adding `status`/`approval_request_id` fields to the mcp_call makes no difference.

Consequence: every hosted-MCP result is amnesic one request later. A session whose instructions depend on remembering an MCP result re-fetches it **every turn** (paying the full result as fresh, uncacheable input each time — observable in production logs as repeated identical MCP fetches with flat cache growth), and can loop on the re-fetch instead of progressing to its real action.

## Fix

`toReplayItems` rewrites each completed `mcp_call` into a retained `function_call` + `function_call_output` pair when pushing onto the replay history — same name and arguments, output (or `ERROR: …`) preserved verbatim, keyed by the mcp item's own id. All other items replay exactly as before (parse artifacts stripped); `mcp_list_tools` discovery items are untouched.

## Tests

New `tests/openai-mcp-replay.test.mjs` (fake-stream pattern, no network): completed mcp_call → pair in position with output; failed mcp_call → `ERROR:` output retained; non-MCP items verbatim. Existing driver contract suites (`driver-streaming-tool-start`, `driver-upgrades`) pass unchanged.