### PR TITLE
fix(agent-db): outbound-authorisation rejects the worker's null fields before the policy can decide

### DIFF
--- a/api/paths/agent-db/outbound-authorisation.js
+++ b/api/paths/agent-db/outbound-authorisation.js
@@ -105,28 +105,39 @@ authoriseOutbound.apiDoc = {
   requestBody: {
     content: {
       'application/json': {
+        // Every optional field is NULLABLE, not just omittable: the pipecat
+        // worker serialises unknowns as literal nulls (a WebRTC-origin
+        // transfer has no callerId or aplisayId to send), and a bare
+        // `type: 'string'` made express-openapi 400 the request before the
+        // handler — which already guards every field for null — could decide.
+        // The worker fails CLOSED on any non-200, so that validation gap
+        // refused every human transfer out of a browser test call.
         schema: {
           type: 'object',
           properties: {
             calledId: { type: 'string', description: 'The destination as dialled' },
             callerId: {
               type: 'string',
-              description: "Caller-ID for the leg. Used to resolve the egress trunk when aplisayId isn't known (e.g. a WebRTC-origin transfer). Ignored when registrationOriginated is true.",
+              nullable: true,
+              description: "Caller-ID for the leg, when known. Used to resolve the egress trunk when aplisayId isn't known (e.g. a WebRTC-origin transfer). Ignored when registrationOriginated is true.",
             },
             agentId: {
               type: 'string',
+              nullable: true,
               description: 'Agent whose stored options.outboundCallFilter applies. Preferred over agentOptions.',
             },
             agentOptions: {
               type: 'object',
+              nullable: true,
               description: 'Resolved agent options when the caller already holds them (reads outboundCallFilter). Ignored when agentId is supplied.',
             },
-            organisationId: { type: 'string', description: 'Owning organisation, for the rating check' },
-            userId: { type: 'string', description: 'Owning user, for a per-user rate override' },
-            aplisayId: { type: 'string', description: "The caller number's trunk id" },
-            outboundTrunkId: { type: 'string', description: 'Explicit egress trunk id when the caller knows it' },
+            organisationId: { type: 'string', nullable: true, description: 'Owning organisation, for the rating check' },
+            userId: { type: 'string', nullable: true, description: 'Owning user, for a per-user rate override' },
+            aplisayId: { type: 'string', nullable: true, description: "The caller number's trunk id" },
+            outboundTrunkId: { type: 'string', nullable: true, description: 'Explicit egress trunk id when the caller knows it' },
             registrationOriginated: {
               type: 'boolean',
+              nullable: true,
               description: 'True when the leg egresses a customer B2BUA (never our carrier, so never chargeable)',
             },
           },

--- a/tests/outbound-authorisation-schema.test.mjs
+++ b/tests/outbound-authorisation-schema.test.mjs
@@ -1,0 +1,80 @@
+// The outbound-authorisation request schema must accept the pipecat worker's
+// actual payload, which serialises unknown fields as literal NULLS (a
+// WebRTC-origin transfer has no callerId or aplisayId to send). The handler
+// was always written for that shape (`callerId &&` guards, `aplisayId ||
+// null`), but bare `type: 'string'` properties made express-openapi 400 the
+// request before the handler ran — and the worker fails CLOSED on any
+// non-200, so every human transfer out of a browser test call was refused
+// with "destination could not be authorised" (beta call
+// 99d15781-7e3f-436d-bdc9-9157c588eded). These tests pin the contract at the
+// schema itself: every optional property is nullable, and the worker's
+// real null-bearing payload validates.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const Ajv = require('ajv');
+
+describe('outbound-authorisation request schema', () => {
+  let schema;
+
+  beforeAll(async () => {
+    // The endpoint module reaches lib/database.js at import time, so the test
+    // database must be up before it loads (same pattern as the agent-db tests).
+    await setupRealDatabase();
+    const endpointModule = await import('../api/paths/agent-db/outbound-authorisation.js');
+    const noopLogger = { info() {}, error() {}, warn() {}, debug() {}, child() { return this; } };
+    const handlers = endpointModule.default(noopLogger, {}, {});
+    schema = handlers.POST.apiDoc.requestBody.content['application/json'].schema;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 30000);
+
+  test('every optional property is nullable (workers send literal nulls)', () => {
+    const required = new Set(schema.required || []);
+    for (const [name, prop] of Object.entries(schema.properties)) {
+      if (required.has(name)) continue;
+      expect({ name, nullable: prop.nullable }).toEqual({ name, nullable: true });
+    }
+  });
+
+  // Plain ajv is draft-07 and ignores OpenAPI's `nullable`; express-openapi
+  // translates it to a type union before validating. Mirror that translation
+  // so the test exercises the same semantics the middleware enforces.
+  const openapiToJsonSchema = (node) => {
+    if (Array.isArray(node)) return node.map(openapiToJsonSchema);
+    if (!node || typeof node !== 'object') return node;
+    const out = {};
+    for (const [k, v] of Object.entries(node)) {
+      if (k === 'nullable') continue;
+      out[k] = openapiToJsonSchema(v);
+    }
+    if (node.nullable === true && typeof node.type === 'string') out.type = [node.type, 'null'];
+    return out;
+  };
+
+  test("the worker's WebRTC-transfer payload (nulls for unknowns) validates", () => {
+    const ajv = new Ajv({ strict: false });
+    const validate = ajv.compile(openapiToJsonSchema(schema));
+    const payload = {
+      calledId: '+447970939456',
+      callerId: null,
+      aplisayId: null,
+      agentId: null,
+      agentOptions: null,
+      organisationId: 'df56af30-070a-4290-afbb-9082c2f34020',
+      userId: null,
+      outboundTrunkId: null,
+      registrationOriginated: null,
+    };
+    const ok = validate(payload);
+    expect({ ok, errors: validate.errors ?? null }).toEqual({ ok: true, errors: null });
+  });
+
+  test('calledId stays required', () => {
+    const ajv = new Ajv({ strict: false });
+    const validate = ajv.compile(openapiToJsonSchema(schema));
+    expect(validate({ callerId: null })).toBe(false);
+  });
+});


### PR DESCRIPTION
A WebRTC-origin transfer has no `callerId` or `aplisayId`; the pipecat worker sends them as literal `null`s. The endpoint handler has always tolerated that (`callerId &&` guards, `aplisayId || null`), but the request schema typed every optional property as a bare `string`/`object`/`boolean`, so express-openapi returns 400 (`callerId: must be string`, `aplisayId: must be string`) before the handler runs. The worker fails closed on any non-200, so the transfer is refused with **"destination could not be authorised"** — a validation artefact presenting as an authorisation decision. Observed live: beta call `99d15781-7e3f-436d-bdc9-9157c588eded` refused a `to_human` transfer to a valid, filter-passing UK mobile.

Fix: every optional property is now `nullable: true` (the handler is unchanged — it was already correct).

Tests: `tests/outbound-authorisation-schema.test.mjs` pins the contract — all optional properties nullable; the worker's exact null-bearing payload validates under the same nullable→type-union semantics the middleware applies; `calledId` stays required. Existing policy suite unaffected (25 passing across both files).