### PR TITLE
fix(docker): copy yarn.lock and freeze it — the image was floating every dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,16 @@ ARG TAG_NAME
 ENV BUILD_COMMIT=$COMMIT_SHA BUILD_BRANCH=$BRANCH_NAME BUILD_TAG=$TAG_NAME
 EXPOSE $PORT
 WORKDIR /usr/src/app
-COPY package*.json ./
-RUN yarn install
+# yarn.lock must be copied too: `package*.json` does NOT match it, so without
+# it `yarn install` re-resolves every semver range from scratch and the image
+# floats onto whatever is newest at build time — the committed lockfile (and
+# every lockfile-only Dependabot patch) has no effect on what actually ships.
+# That is how better-auth silently moved 1.6.25 -> 1.7.1 and took its breaking
+# `account.issuer` schema change to beta/staging (see
+# scripts/auth-issuer-backfill.mjs). --frozen-lockfile makes any drift between
+# package.json and yarn.lock fail the build instead of shipping a surprise.
+COPY package*.json yarn.lock ./
+RUN yarn install --frozen-lockfile
 RUN mkdir -p credentials
 RUN npx secretenv -r GOOGLE_CREDENTIAL > credentials/google.json
 COPY . .

--- a/scripts/auth-issuer-backfill.mjs
+++ b/scripts/auth-issuer-backfill.mjs
@@ -1,0 +1,139 @@
+/**
+ * One-shot better-auth 1.7 upgrade step: `account.issuer`.
+ *
+ * better-auth 1.7.0 scoped account identity by issuer — a new REQUIRED
+ * `account.issuer` column plus a unique index on (issuer, accountId). Its own
+ * `getMigrations()` REFUSES to apply that to a populated table
+ * (UnsafeMigrationError: a required column with no default has nothing to
+ * backfill), so `runAuthMigrate` / `agent-admin --command upgrade-db` cannot
+ * carry this one. This script performs the exact sequence better-auth's refusal
+ * message prescribes: add nullable -> backfill every row -> enforce NOT NULL ->
+ * create the unique index.
+ *
+ * Issuer values mirror @better-auth/core/db exactly (sign-in matches on them,
+ * so a wrong value silently breaks password login):
+ *   createLocalAccountIssuer(id) -> `local:${id}`        -- providerId 'credential'
+ *   createOAuthAccountIssuer(id) -> `local:oauth:${id}`  -- OAuth providers with
+ *                                                          no accountIssuer override
+ *
+ * Idempotent: re-running after success reports nothing to do.
+ *
+ * Usage:
+ *   node scripts/auth-issuer-backfill.mjs --path .env.beta            # dry run
+ *   node scripts/auth-issuer-backfill.mjs --path .env.beta --apply    # apply
+ */
+import dotenv from 'dotenv';
+import path from 'path';
+
+const argv = process.argv.slice(2);
+const pathIdx = argv.findIndex((a) => a === '--path' || a === '-p');
+const envPath = pathIdx > -1 ? argv[pathIdx + 1] : process.env.DOTENV_CONFIG_PATH;
+const apply = argv.includes('--apply');
+if (pathIdx > -1 && !envPath) {
+  console.error('Missing value for -p/--path');
+  process.exit(1);
+}
+dotenv.config(envPath ? { path: path.resolve(process.cwd(), envPath) } : undefined);
+
+const { default: pg } = await import('pg');
+const client = new pg.Client({
+  host: process.env.POSTGRES_HOST,
+  port: +(process.env.POSTGRES_PORT || 5432),
+  database: process.env.POSTGRES_DB,
+  user: process.env.POSTGRES_USER,
+  password: process.env.POSTGRES_PASSWORD,
+  ssl: {
+    rejectUnauthorized: false,
+    ca: process.env.POSTGRES_CA,
+    key: process.env.POSTGRES_KEY,
+    cert: process.env.POSTGRES_CERT,
+  },
+});
+
+// The backfill expression, shared by the preflight and the UPDATE so the
+// collision check can never disagree with what actually gets written.
+const ISSUER_EXPR = `case when "providerId" = 'credential'
+                          then 'local:credential'
+                          else 'local:oauth:' || "providerId"
+                     end`;
+
+await client.connect();
+console.log(`db = ${process.env.POSTGRES_DB} @ ${process.env.POSTGRES_HOST}`);
+console.log(`mode = ${apply ? 'APPLY' : 'dry run'}\n`);
+
+const present = await client.query(
+  `select is_nullable from information_schema.columns
+    where table_name = 'account' and column_name = 'issuer'`
+);
+const hasIssuer = present.rowCount > 0;
+
+// Preflight: the new index is UNIQUE, so a duplicate (issuer, accountId) after
+// backfill would abort the transaction. Surface it before touching anything.
+const collisions = await client.query(
+  `select issuer, "accountId", count(*)::int as n
+     from (select ${ISSUER_EXPR} as issuer, "accountId" from account) t
+    group by 1, 2 having count(*) > 1`
+);
+
+// sign-in.mjs requires a credential account's accountId to equal the user id;
+// rows that violate it are already broken, and worth knowing about now.
+const badAccountId = await client.query(
+  `select count(*)::int as n from account
+    where "providerId" = 'credential' and "accountId" <> "userId"`
+);
+
+const plan = await client.query(
+  `select ${ISSUER_EXPR} as issuer, "providerId", count(*)::int as n
+     from account group by 1, 2 order by 1, 2`
+);
+console.log('planned issuer values:');
+console.table(plan.rows);
+console.log(`account.issuer column present: ${hasIssuer}${hasIssuer ? ` (nullable=${present.rows[0].is_nullable})` : ''}`);
+console.log(`unique-index collisions: ${collisions.rowCount}`);
+console.log(`credential rows with accountId <> userId: ${badAccountId.rows[0].n}\n`);
+
+if (collisions.rowCount > 0) {
+  console.table(collisions.rows);
+  console.error('REFUSING: backfill would violate the unique (issuer, accountId) index.');
+  await client.end();
+  process.exit(1);
+}
+
+if (!apply) {
+  console.log('Dry run only — re-run with --apply to execute.');
+  await client.end();
+  process.exit(0);
+}
+
+try {
+  await client.query('begin');
+  await client.query(`alter table account add column if not exists issuer text`);
+  const filled = await client.query(
+    `update account set issuer = ${ISSUER_EXPR} where issuer is null`
+  );
+  await client.query(`alter table account alter column issuer set not null`);
+  await client.query(
+    `create unique index if not exists "account_issuer_accountId_uidx"
+       on account (issuer, "accountId")`
+  );
+  await client.query('commit');
+  console.log(`backfilled ${filled.rowCount} row(s) — committed`);
+} catch (e) {
+  await client.query('rollback').catch(() => {});
+  console.error('ROLLED BACK:', e.message);
+  await client.end();
+  process.exit(1);
+}
+
+const after = await client.query(
+  `select a."providerId", a.issuer, count(*)::int as n
+     from account a group by 1, 2 order by 1, 2`
+);
+console.log('\n=== issuer after migration ===');
+console.table(after.rows);
+const idx = await client.query(
+  `select indexname from pg_indexes where tablename = 'account' order by 1`
+);
+console.log('account indexes:', idx.rows.map((r) => r.indexname).join(', '));
+
+await client.end();


### PR DESCRIPTION
## The bug

`Dockerfile` did:

```dockerfile
COPY package*.json ./
RUN yarn install
```

`package*.json` **does not match `yarn.lock`**. So `yarn install` ran with no lockfile present and re-resolved every semver range from scratch at build time. The committed lockfile only arrived later via `COPY . .` — after `node_modules` was already built, where it had no effect.

Consequences:

- Every image build floated onto whatever was newest on npm, not what the lockfile pinned.
- Every lockfile-only Dependabot patch had **zero effect on shipped images**.
- `Dockerfile.test` already did this correctly (`COPY package.json yarn.lock ./` + `--frozen-lockfile`), so **CI tested the pinned tree while the deployed image ran a different one**. The drift was invisible to tests.

## How it surfaced

Proof from a running pod — its own `yarn.lock` next to its own `node_modules`:

```
lockfile says: better-auth@^1.6.20, ^1.6.25 → version "1.6.25"
node_modules has: 1.7.1
```

better-auth 1.7.0 (npm 2026-08-18) introduced [account identity is scoped by issuer](https://better-auth.com/docs/guides/1-7-upgrade-guide#account-identity-is-scoped-by-issuer): a new **required** `account.issuer` column plus a unique index on `(issuer, accountId)`. Any image built after that date carried the breaking schema change, and password reset and credential sign-in both started failing against databases that predate it:

```
ERROR [Better Auth]: column account.issuer does not exist
```

No code change to point at — a dependency floated into a breaking migration.

## The changes

**1. `Dockerfile` — copy the lockfile and enforce it.**

```dockerfile
COPY package*.json yarn.lock ./
RUN yarn install --frozen-lockfile
```

`--frozen-lockfile` turns any future `package.json` / `yarn.lock` drift into a build failure instead of a silent production surprise.

**2. `scripts/auth-issuer-backfill.mjs` — the migration better-auth's own migrator refuses.**

`getMigrations()` will not add a required column with no default to a populated table (it throws `UnsafeMigrationError`), so `agent-admin --command upgrade-db` cannot carry this upgrade — its plan is `alter table "account" add column "issuer" text not null`, which Postgres rejects outright on a populated table.

This script performs exactly the sequence better-auth's refusal message prescribes, in one transaction: add nullable → backfill every row → `SET NOT NULL` → create the unique index.

Issuer values mirror `createLocalAccountIssuer` / `createOAuthAccountIssuer` exactly, because `sign-in.mjs` matches on the issuer string — a wrong value would leave password login silently broken rather than loudly failing:

- `providerId = 'credential'` → `local:credential`
- OAuth providers with no `accountIssuer` override → `local:oauth:<providerId>`

Dry run by default, `--apply` to execute. Refuses up front if the backfill would collide on the new unique index. Idempotent.

```bash
node scripts/auth-issuer-backfill.mjs --path .env.<env>            # dry run
node scripts/auth-issuer-backfill.mjs --path .env.<env> --apply    # apply
```

## Verification

- Isolated `yarn install --frozen-lockfile` from the current `package.json` + `yarn.lock` pair **succeeds** and pins better-auth `1.6.25`, so this does not break the build. (Checking this locally needs `--ignore-engines` on Node 23 — jest declares `^22.0.0`; the image is `node:22` and unaffected.)
- Backfill applied to the beta and staging databases. better-auth's own migration planner reports `CREATE: [] ADD: [] UNSAFE: []` afterwards, and the account lookup that was throwing now returns correctly.

## Note for any future deploy onto an existing database

A database populated before better-auth 1.7 needs `scripts/auth-issuer-backfill.mjs` run against it once. `upgrade-db` will not do it.

## Follow-up, not in this PR

`agents/jambonz/Dockerfile` has the identical `COPY package*.json ./` + bare `yarn install`; `agents/livekit/Dockerfile` gets its lockfile via a whole-directory copy but runs `yarn install --development` unfrozen. Left alone here because neither was verified against its own lockfile. `uk-number-validator/Dockerfile` is already correct.
