### PR TITLE
fix(docker): freeze the lockfile in the jambonz and livekit agent images too

### DIFF
--- a/agents/jambonz/Dockerfile
+++ b/agents/jambonz/Dockerfile
@@ -4,8 +4,22 @@ ARG SECRETENV_BUNDLE
 ARG SECRETENV_KEY
 EXPOSE $PORT
 WORKDIR /usr/src/app
-COPY package*.json ./
-RUN yarn install
+# Build context is the repo ROOT (`docker build -f agents/jambonz/Dockerfile .`),
+# so `package*.json` here is the root manifest, not agents/jambonz's — and that
+# is load-bearing: this image's code, including the shared `lib` copied to
+# agent-lib below, imports better-auth, express, openai, @google/genai and
+# @modelcontextprotocol/sdk, none of which agents/jambonz/package.json declares.
+# agents/jambonz/package.json and its yarn.lock land later via `COPY agents/jambonz .`,
+# after node_modules is already built, and are not what gets installed.
+#
+# yarn.lock must be copied alongside it: `package*.json` does NOT match it, so
+# without it `yarn install` re-resolved every semver range at build time and the
+# image floated onto whatever was newest on npm. That is how better-auth silently
+# moved 1.6.25 -> 1.7.1 in the main image and took its breaking `account.issuer`
+# schema change to beta/staging. --frozen-lockfile makes any future drift between
+# package.json and yarn.lock fail the build instead of shipping a surprise.
+COPY package*.json yarn.lock ./
+RUN yarn install --frozen-lockfile
 RUN mkdir -p credentials
 RUN npx secretenv -r GOOGLE_CREDENTIAL > credentials/google.json
 COPY agents/jambonz .

--- a/agents/livekit/Dockerfile
+++ b/agents/livekit/Dockerfile
@@ -11,7 +11,11 @@ RUN apt-get install -y ca-certificates git
 COPY agents/livekit ./
 COPY lib/* ./agent-lib/
 RUN npm install -g pnpm@latest-10
-RUN yarn install --development
+# --frozen-lockfile: the whole-directory COPY above does bring yarn.lock in, but
+# without this yarn would still silently re-resolve on any package.json/yarn.lock
+# drift and the image would float off the committed tree (see the main image's
+# better-auth 1.6.25 -> 1.7.1 incident). Drift should fail the build instead.
+RUN yarn install --development --frozen-lockfile
 RUN yarn build
 ENV NODE_ENV production
 RUN chmod +x entrypoint.sh


### PR DESCRIPTION
Follow-up to #227, which fixed this in the root `Dockerfile`. The same defect is present in both agent images. Neither handler runs on beta today — both are env-kill-switched off — so this closes a latent reproducibility hole rather than a live incident.

## `agents/jambonz/Dockerfile`

`COPY package*.json ./` does not match `yarn.lock`, so `yarn install` re-resolved every semver range at build time and the image floated onto whatever was newest on npm. That is precisely how better-auth moved 1.6.25 → 1.7.1 in the main image and carried its breaking `account.issuer` schema change into beta and staging.

Worth being explicit about *which* manifest that is, because it is not the obvious one. The build context is the repo root (`docker build -f agents/jambonz/Dockerfile .`, see `deploy/gcp/cloudrun/cloudbuild-jambonz.yaml`), so `package*.json` resolves to the **root** `package.json`, not `agents/jambonz/package.json`.

That is load-bearing, not a bug to tidy away: the image's own code plus the shared `lib` it copies to `agent-lib` import `better-auth`, `express`, `openai`, `@google/genai` and `@modelcontextprotocol/sdk`, none of which `agents/jambonz/package.json` declares. Installing the jambonz manifest instead would break the image. Its `package.json` and `yarn.lock` arrive later via `COPY agents/jambonz .`, after `node_modules` is already built, and are inert as far as the image is concerned. So this pairs the root manifest with the root lockfile — the pair that was always meant to be installed here — and says so in a comment, so the next reader doesn't "correct" it.

## `agents/livekit/Dockerfile`

The whole-directory `COPY agents/livekit ./` does bring `yarn.lock` in, so this image was at least building from the committed tree — but nothing enforced it, and any `package.json`/`yarn.lock` drift would have silently re-resolved instead of failing the build.

## Verification

`--frozen-lockfile` turns an inconsistent pair into a hard build failure, so each was checked before the flag went in:

- Isolated `yarn install --frozen-lockfile --ignore-scripts --ignore-engines` passes for all three pairs (root, `agents/livekit`, `agents/jambonz`) and leaves every lockfile byte-identical. Re-checked against the tip of `next` after #228 landed, so the pair this now freezes is current.
- `agents/livekit/Dockerfile` builds end to end, `yarn build` included, and pins `@livekit/agents` 1.0.46, zod 4.4.3, axios 1.18.1, ws 8.21.1.
- The jambonz install layer builds on `node:24-alpine` against the root context, with all five root-only imports present. It pins better-auth to whatever the root lockfile says — 1.6.25 at this branch's point, 1.7.1 since #228 adopted it deliberately. Either way the version is now the lockfile's decision rather than a build-time race, which is the whole point. (The full jambonz build needs the `SECRETENV_*` build args, so only the layer this PR touches was built.)

## Follow-up, not in this PR

`agents/jambonz/yarn.lock` being inert has a side effect worth knowing: Dependabot PRs against it read as if they harden the jambonz image but change nothing that ships, and two deps it declares (`@google-cloud/aiplatform`, `link`) are not imported anywhere under `agents/jambonz` or `lib/`. Left alone here.
