### PR TITLE
feat(rbac): let billingService assign an organisation's rate card

### DIFF
--- a/lib/auth/permissions.js
+++ b/lib/auth/permissions.js
@@ -155,14 +155,37 @@ export const roles = {
     },
   },
 
-  // Machine identity for the polite-ai Stripe-webhook → balance-credit seam. A
-  // synthetic service user holds an AuthKey with this role; it can ONLY adjust an
-  // org's balance (signed credits) and billing controls (block flag + balance
-  // callbacks) — no rate assignment, no product access — least privilege for a
-  // server-to-server credential that lives in another process.
+  // Machine identity for the polite-ai billing seam. A synthetic service user
+  // holds an AuthKey with this role; it adjusts an org's balance (signed
+  // credits), its billing controls (block flag + balance callbacks), and the
+  // rate card the org's subscription package implies — no product access, no
+  // user administration. Least privilege for a server-to-server credential that
+  // lives in another process.
+  //
+  // `rate:read` + `organisation:read`/`readAll`/`setRate` are what let the seam
+  // put an org on the card its package implies when an account is approved or
+  // its subscription changes. WHICH card a package maps to is the client's
+  // pricing policy and stays entirely on its side; this vocabulary only says the
+  // seam may assign one. Without these three the assignment 403s at its first
+  // call (`Requires rate:read`) — and because that path is fail-soft by design
+  // it fails SILENTLY, leaving every org it touches unrated: usage rows land
+  // `cost_status='no_rate'`, so they are metered but never charged.
+  //
+  // `readAll` is required, not optional: this principal has no `organisationId`
+  // of its own, so `targetInScope` (lib/auth/admin-scope.js) would 404 every org
+  // row without the cross-tenant capability. Reading is likewise not optional —
+  // assignment must be idempotent, which means reading the existing timeline
+  // before deciding whether to write a new one.
+  //
+  // Keys minted by scripts/provision-billing-service.mjs store role_restriction
+  // as the ROLE NAME, so existing keys pick these widened statements up on the
+  // next deploy with no re-mint and no secret rotation; any key whose
+  // role_restriction is a literal statement MAP is frozen at its minted actions
+  // and must be re-minted (scripts/verify-billing-service.mjs reports which).
   billingService: {
     statements: {
-      organisation: ['credit', 'billing'],
+      organisation: ['read', 'readAll', 'setRate', 'credit', 'billing'],
+      rate: ['read'],
       // Retention seam: the client's billing service applies its own
       // call-artifact retention policies via POST /calls/prune. Artifact
       // deletion only — no call read/listen, no product access.

--- a/scripts/provision-billing-service.mjs
+++ b/scripts/provision-billing-service.mjs
@@ -1,8 +1,14 @@
 /**
- * Provision the least-privilege billing-service identity for the polite-ai Stripe
- * → balance/credit seam (Phase 4). Idempotently creates a synthetic user with role
- * `billingService` (which grants ONLY organisation:credit) and an AuthKey, then
- * prints the bearer token for polite-ai's LLM_AGENT_BILLING_TOKEN.
+ * Provision the least-privilege billing-service identity for the polite-ai
+ * billing seam (Phase 4). Idempotently creates a synthetic user with role
+ * `billingService` — balance credits, billing controls, call-artifact pruning
+ * and rate-card assignment, and nothing else; lib/auth/permissions.js holds the
+ * exact vocabulary — plus an AuthKey, then prints the bearer token for
+ * polite-ai's LLM_AGENT_BILLING_TOKEN.
+ *
+ * To CHECK (or repair) an environment's existing credential, use
+ * scripts/verify-billing-service.mjs instead: re-running THIS script mints a new
+ * token, which means a secret-store update on the client side.
  *
  *   node scripts/provision-billing-service.mjs                       # repo-root .env
  *   node scripts/provision-billing-service.mjs -p /path/to/staging.env  # per environment
@@ -65,8 +71,12 @@ async function main() {
     console.log(`created billingService user ${userId} (${EMAIL})`);
   }
 
-  // Upsert the AuthKey. role_restriction='billingService' pins the key to
-  // organisation:credit even if the user's role ever changes (defence in depth).
+  // Upsert the AuthKey. role_restriction='billingService' pins the key to the
+  // billingService vocabulary even if the user's role ever changes (defence in
+  // depth). Stored as the role NAME, never as a literal statement map: a name
+  // resolves against the CURRENT vocabulary, so a later widening of the role
+  // reaches this key on the next deploy with no re-mint; a frozen map would
+  // silently miss it (verify-billing-service.mjs reports and repairs that).
   await client.query(
     `INSERT INTO auth_keys (key, user_id, role_restriction, expires, created_at, updated_at)
      VALUES ($1, $2, $3::jsonb, $4, now(), now())

--- a/scripts/verify-billing-service.mjs
+++ b/scripts/verify-billing-service.mjs
@@ -1,0 +1,212 @@
+/**
+ * Verify — and where possible repair — the billing-service credential an
+ * environment holds, WITHOUT rotating it.
+ *
+ *   node scripts/verify-billing-service.mjs                          # repo-root .env
+ *   node scripts/verify-billing-service.mjs -p /path/to/beta.env     # per environment
+ *   node scripts/verify-billing-service.mjs -p ... --fix             # apply repairs
+ *   node scripts/verify-billing-service.mjs -p ... --probe https://api.example.com
+ *
+ * Why this exists: the client billing seam's rate-card assignment is fail-soft,
+ * so a credential that cannot assign rates does not raise an error anywhere —
+ * it just leaves every organisation unrated, and their usage rows land
+ * `cost_status='no_rate'`: metered, never charged. That is invisible until
+ * someone reads the ledger. This script makes the credential's actual
+ * capability legible before it matters.
+ *
+ * Three checks:
+ *
+ *  1. **user role** — the synthetic user must be role `billingService`, active.
+ *  2. **key restriction shape** — an AuthKey whose `role_restriction` is the
+ *     ROLE NAME resolves against the CURRENT vocabulary, so widening the role
+ *     reaches it on the next deploy. One frozen as a literal statement MAP is
+ *     pinned to whatever it was minted with and silently misses every later
+ *     grant. `--fix` rewrites such a key's restriction to the role name — the
+ *     key VALUE is untouched, so no secret rotation and no env change.
+ *  3. **deployed build** (`--probe <baseUrl>`) — asks the RUNNING service what
+ *     the key can actually do. The vocabulary in this repo is only the intent;
+ *     the deployed image is the fact, and the two diverge until it ships.
+ *
+ * Read-only unless `--fix` is passed. Talks to Postgres directly (it does NOT
+ * import the app's database module, so it avoids the LISTEN subscriber / model
+ * sync boot), mirroring provision-billing-service.mjs.
+ */
+import pg from 'pg';
+import { loadEnv } from './env.mjs';
+import { statementsFor } from '../lib/auth/permissions.js';
+
+loadEnv();
+
+const ROLE = 'billingService';
+const EMAIL = process.env.BILLING_EMAIL || 'stripe-billing-service@aplisay.internal';
+const FIX = process.argv.includes('--fix');
+const probeArg = process.argv.indexOf('--probe');
+const PROBE_URL = probeArg > -1 ? process.argv[probeArg + 1] : process.env.LLM_AGENT_URL || null;
+
+/**
+ * The capabilities the client billing seam actually exercises, each named with
+ * the call that needs it, so a failure report says what will break rather than
+ * just which action is missing.
+ */
+const REQUIRED = [
+  ['organisation', 'credit', 'credit a wallet top-up to the org balance'],
+  ['organisation', 'billing', 'set the balance-callback config / block flag'],
+  ['call', 'prune', 'apply the plan retention window to call artifacts'],
+  ['rate', 'read', 'list the rate cards (GET /rates)'],
+  ['organisation', 'read', "read the org's rate-name timeline"],
+  ['organisation', 'readAll', 'reach an org at all — this principal has no org of its own'],
+  ['organisation', 'setRate', "write the org's rate-name timeline"],
+];
+
+const client = new pg.Client({
+  host: process.env.POSTGRES_HOST,
+  port: Number(process.env.POSTGRES_PORT),
+  user: process.env.POSTGRES_USER,
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB,
+  ssl: process.env.POSTGRES_CA
+    ? {
+      ca: process.env.POSTGRES_CA,
+      key: process.env.POSTGRES_KEY,
+      cert: process.env.POSTGRES_CERT,
+      servername: process.env.POSTGRES_RO_SERVER_NAME,
+      rejectUnauthorized: false,
+    }
+    : false,
+});
+
+const problems = [];
+const note = (ok, message) => {
+  console.log(`${ok ? '  ok   ' : '  FAIL '} ${message}`);
+  if (!ok) problems.push(message);
+};
+
+/** What THIS build's vocabulary grants the role — the intent, not the deployment. */
+function checkVocabulary() {
+  console.log(`\nrole vocabulary in this checkout (${ROLE}):`);
+  const statements = statementsFor(ROLE) || {};
+  for (const [resource, action, why] of REQUIRED) {
+    note((statements[resource] || []).includes(action), `${resource}:${action} — ${why}`);
+  }
+}
+
+async function checkUser() {
+  console.log(`\nservice user (${EMAIL}):`);
+  const { rows } = await client.query('SELECT id, role, status FROM users WHERE email = $1', [EMAIL]);
+  if (!rows.length) {
+    note(false, 'no service user — run scripts/provision-billing-service.mjs first');
+    return null;
+  }
+  const user = rows[0];
+  note(user.role === ROLE, `role is '${user.role}' (want '${ROLE}')`);
+  note(user.status === 'active', `status is '${user.status}' (want 'active')`);
+  if (FIX && (user.role !== ROLE || user.status !== 'active')) {
+    await client.query(
+      `UPDATE users SET role = $2, status = 'active', updated_at = now() WHERE id = $1`,
+      [user.id, ROLE],
+    );
+    console.log(`  fixed  user ${user.id} → role=${ROLE}, status=active`);
+  }
+  return user;
+}
+
+async function checkKeys(user) {
+  if (!user) return [];
+  console.log('\nauth keys:');
+  const { rows } = await client.query(
+    'SELECT key, role_restriction, expires FROM auth_keys WHERE user_id = $1 ORDER BY created_at',
+    [user.id],
+  );
+  if (!rows.length) {
+    note(false, 'no AuthKey for the service user — run scripts/provision-billing-service.mjs');
+    return [];
+  }
+  if (rows.length > 1) {
+    // Not a fault — an environment may hold a rotated pair — but every one of
+    // them can authenticate, so every one of them has to be sound.
+    console.log(`  note   ${rows.length} keys exist; all are live credentials`);
+  }
+  for (const row of rows) {
+    const label = `${String(row.key).slice(0, 8)}…`;
+    const restriction = row.role_restriction;
+    const frozen = restriction && typeof restriction === 'object' && !Array.isArray(restriction);
+    if (frozen) {
+      note(false, `${label} role_restriction is a literal statement map — FROZEN at its minted actions, it will never pick up a widened role`);
+      if (FIX) {
+        await client.query(
+          `UPDATE auth_keys SET role_restriction = $2::jsonb, updated_at = now() WHERE key = $1`,
+          [row.key, JSON.stringify(ROLE)],
+        );
+        console.log(`  fixed  ${label} role_restriction → "${ROLE}" (key value unchanged — no rotation needed)`);
+      }
+    } else {
+      note(restriction === ROLE, `${label} role_restriction is ${JSON.stringify(restriction)} (want "${ROLE}")`);
+    }
+    const expires = row.expires ? new Date(row.expires) : null;
+    note(!expires || expires.getTime() > Date.now(), `${label} expires ${expires ? expires.toISOString() : 'never'}`);
+  }
+  return rows.map((r) => r.key);
+}
+
+/**
+ * Ask the RUNNING service, using the credential this environment actually holds
+ * (read from the DB above — no need to have the secret to hand). `GET /api/rates`
+ * is the exact call the client seam makes first, so a 403 here IS the production
+ * failure, reproduced; 200 proves the deployed build carries the widened role.
+ */
+async function probe(url, keys) {
+  if (!url) {
+    console.log('\ndeployed build: skipped (pass --probe <baseUrl> to check the running service)');
+    return;
+  }
+  if (!keys.length) {
+    console.log(`\ndeployed build at ${url}: skipped (no key to probe with)`);
+    return;
+  }
+  console.log(`\ndeployed build at ${url}:`);
+  for (const key of keys) {
+    const label = `${String(key).slice(0, 8)}…`;
+    try {
+      const res = await fetch(`${url.replace(/\/+$/, '')}/api/rates`, {
+        headers: { authorization: `Bearer ${key}`, accept: 'application/json' },
+      });
+      const body = await res.json().catch(() => ({}));
+      if (res.ok) {
+        const names = (body.rates || []).map((r) => r.name);
+        note(true, `${label} GET /api/rates → 200, cards: ${names.length ? names.join(', ') : '(none)'}`);
+        if (!names.length) note(false, 'no rate cards exist in this environment — there is nothing to assign');
+      } else {
+        note(false, `${label} GET /api/rates → ${res.status} ${body.detail || body.message || ''} — the RUNNING build predates the widened role; deploy it`);
+      }
+    } catch (e) {
+      note(false, `${label} GET /api/rates failed: ${e.message}`);
+    }
+  }
+}
+
+async function main() {
+  if (!process.env.POSTGRES_HOST) {
+    throw new Error('POSTGRES_* not set — is .env present? (select one with -p /path/to/.env)');
+  }
+  console.log(`checking billing service against postgres ${process.env.POSTGRES_HOST}/${process.env.POSTGRES_DB}`);
+  console.log(FIX ? 'mode: FIX (repairs will be written)' : 'mode: read-only (pass --fix to repair)');
+  await client.connect();
+
+  checkVocabulary();
+  const user = await checkUser();
+  const keys = await checkKeys(user);
+  await client.end();
+  await probe(PROBE_URL, keys);
+
+  if (problems.length) {
+    console.error(`\n${problems.length} problem(s) found.`);
+    process.exit(1);
+  }
+  console.log('\nall checks passed.');
+}
+
+main().catch(async (e) => {
+  console.error('verification failed:', e?.message || e);
+  try { await client.end(); } catch { /* already closed */ }
+  process.exit(1);
+});

--- a/tests/rbac-permissions.test.mjs
+++ b/tests/rbac-permissions.test.mjs
@@ -54,13 +54,35 @@ describe('permissions — roles vocabulary', () => {
     expect(can({ role: 'orgAdmin' }, 'rate', 'create')).toBe(false);
     expect(can({ role: 'orgAdmin' }, 'organisation', 'setRate')).toBe(false);
   });
-  test('billingService can ONLY credit balance (least privilege)', () => {
+  test('billingService can credit balance and assign an org its rate card', () => {
     expect(can({ role: 'billingService' }, 'organisation', 'credit')).toBe(true);
-    // Nothing else — not setRate, not read, not product.
-    expect(can({ role: 'billingService' }, 'organisation', 'setRate')).toBe(false);
-    expect(can({ role: 'billingService' }, 'organisation', 'read')).toBe(false);
+    expect(can({ role: 'billingService' }, 'organisation', 'billing')).toBe(true);
+    expect(can({ role: 'billingService' }, 'call', 'prune')).toBe(true);
+    // Rate assignment: the client's billing service puts an org on the card its
+    // subscription package implies. All four are needed for ONE operation —
+    // list the cards, read the org's existing timeline, write the new one — so
+    // any of them missing silently leaves orgs unrated.
+    expect(can({ role: 'billingService' }, 'rate', 'read')).toBe(true);
+    expect(can({ role: 'billingService' }, 'organisation', 'read')).toBe(true);
+    expect(can({ role: 'billingService' }, 'organisation', 'setRate')).toBe(true);
+    // readAll, because this principal has no organisation of its own: without
+    // the cross-tenant capability targetInScope 404s every org it is asked about.
+    expect(can({ role: 'billingService' }, 'organisation', 'readAll')).toBe(true);
+    expect(targetInScope({ role: 'billingService' }, 'organisation', { id: 'org-1' })).toBe(true);
+  });
+  test('billingService holds no product access and cannot administer rates or users', () => {
+    // Still least-privilege: it prices ITS OWN tenants against cards someone
+    // else authors, and it never reads or changes the product.
+    expect(can({ role: 'billingService' }, 'rate', 'create')).toBe(false);
+    expect(can({ role: 'billingService' }, 'rate', 'update')).toBe(false);
+    expect(can({ role: 'billingService' }, 'rate', 'delete')).toBe(false);
+    expect(can({ role: 'billingService' }, 'tariff', 'update')).toBe(false);
+    expect(can({ role: 'billingService' }, 'organisation', 'delete')).toBe(false);
+    expect(can({ role: 'billingService' }, 'organisation', 'update')).toBe(false);
+    expect(can({ role: 'billingService' }, 'user', 'read')).toBe(false);
     expect(can({ role: 'billingService' }, 'agent', 'read')).toBe(false);
-    expect(can({ role: 'billingService' }, 'rate', 'read')).toBe(false);
+    expect(can({ role: 'billingService' }, 'call', 'read')).toBe(false);
+    expect(can({ role: 'billingService' }, 'usage', 'read')).toBe(false);
     // superAdmin still holds credit (superset).
     expect(can({ role: 'superAdmin' }, 'organisation', 'credit')).toBe(true);
   });


### PR DESCRIPTION
## What

Widens the `billingService` role so it can put an organisation on a rate card:

| resource | actions added | why |
|---|---|---|
| `rate` | `read` | `GET /rates` — list the cards |
| `organisation` | `read`, `readAll` | read the org's rate-name timeline; `readAll` because this principal has no organisation of its own, so `targetInScope` would 404 every row |
| `organisation` | `setRate` | `PUT /organisations/{id}/rate-history` — write it |

All four serve **one** operation, so any of them missing fails the whole assignment at its first call.

## Why

The client billing seam that credits balances and applies retention policies is also what assigns an organisation the rate card its subscription package implies. That assignment is fail-soft by design — a rate miss must never break a signup — so a `403 Requires rate:read` is swallowed and the organisation is simply left with **no rate card at all**: its `usage_records` stay `cost_status='no_rate'` and never resolve a price.

## Still least privilege

No `rate:create/update/delete`, no `tariff` writes, no `organisation:update/delete`, no user administration, no product access (`agent`, `call:read`, `usage`). The role can price its own tenants against cards somebody else authors. *Which* card a package maps to remains entirely the client's pricing policy; this only says the seam may assign one.

## Deployment

Keys minted by `scripts/provision-billing-service.mjs` store `role_restriction` as the **role name**, so existing credentials pick the widened statements up on the next deploy — no re-mint, no secret rotation, no client env change.

## Also adds `scripts/verify-billing-service.mjs`

Checks an environment's credential *without* rotating it:

- role and status of the synthetic user;
- whether each key's `role_restriction` is a resolvable role name or a statement map **frozen** at mint time — `--fix` repairs the latter in place, leaving the key value untouched;
- `--probe <baseUrl>` asks the **running** service what the key can actually do, using the environment's own key. The vocabulary in the repo is the intent; the deployed image is the fact, and the two diverge until this ships.

```
node scripts/verify-billing-service.mjs -p /path/to/env --probe https://api.example.com
```

## Tests

`tests/rbac-permissions.test.mjs` rewritten for the new shape — one test pinning what the role *can* now do (including `targetInScope`), one pinning the boundaries it still must not cross. 38 pass.
