### PR TITLE
fix(rates): drop the rate-card period-overlap constraint (schema v59)

### DIFF
--- a/api/paths/rates.js
+++ b/api/paths/rates.js
@@ -6,7 +6,8 @@ import { validateRateLines, getDefaultRateName } from '../../lib/rates.js';
  * /api/rates (collection) — the named, date-ranged pricing rate cards that value
  * usage at transaction end (Phase 2/3 billing). Global platform config, NOT
  * org-scoped: gated purely on the `rate` resource (superAdmin). The per-name
- * non-overlap + immutable-once-referenced invariants are enforced in the model.
+ * immutable-once-referenced invariant is enforced in the model. Same-name cards
+ * may overlap: the latest start covering the billing instant wins.
  *   GET   list cards (optional ?name= filter), newest interval last.
  *   POST  create a card (supersede an existing name with a later startDate).
  */
@@ -52,9 +53,13 @@ export default function (logger) {
       });
       return res.status(201).send(card);
     } catch (err) {
-      // Per-name overlap (EXCLUDE gist) or duplicate (name,startDate) -> 409 conflict.
+      // Duplicate (name, startDate) -> 409 conflict. Overlapping PERIODS are fine
+      // (schema v59) — only an identical start for the same name is rejected,
+      // because that is the one case resolveRateCard's ordering cannot resolve.
+      // The exclusion branch is kept for a DB still carrying the pre-v59
+      // constraint, so it answers 409 rather than a bare 400.
       if (err?.name === 'SequelizeExclusionConstraintError' || err?.name === 'SequelizeUniqueConstraintError') {
-        return res.status(409).send({ message: `A rate card for "${name}" already covers that period; supersede with a later startDate.` });
+        return res.status(409).send({ message: `A rate card for "${name}" already starts at that instant; give the superseding card a different startDate.` });
       }
       req.log.error(err, 'creating rate card');
       return res.status(400).send({ message: err?.message || 'Failed to create rate card' });
@@ -89,7 +94,7 @@ export default function (logger) {
     responses: {
       201: { description: 'Created rate card' },
       400: { description: 'Invalid', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
-      409: { description: 'Overlaps an existing card for this name' },
+      409: { description: 'A card for this name already starts at that instant' },
       default: { description: 'An error occurred', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     },
   };

--- a/api/paths/rates/{rateId}.js
+++ b/api/paths/rates/{rateId}.js
@@ -60,7 +60,7 @@ export default function (logger) {
         return res.status(409).send({ message: err.message });
       }
       if (err?.name === 'SequelizeExclusionConstraintError' || err?.name === 'SequelizeUniqueConstraintError') {
-        return res.status(409).send({ message: 'That change overlaps another card for this name.' });
+        return res.status(409).send({ message: 'A card for this name already starts at that instant.' });
       }
       req.log.error(err, 'updating rate card');
       return res.status(400).send({ message: err?.message || 'Failed to update rate card' });
@@ -91,7 +91,7 @@ export default function (logger) {
     responses: {
       200: { description: 'Updated rate card' },
       404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
-      409: { description: 'Immutable once referenced / overlaps another card' },
+      409: { description: 'Immutable once referenced / duplicate start for this name' },
       default: { description: 'An error occurred', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     },
   };

--- a/lib/database.js
+++ b/lib/database.js
@@ -15,7 +15,13 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 58;  // 58: `trunks.outbound_call_filter` — the operator's per-trunk allow pattern for
+const schemaVersion = 59;  // 59: billing — DROP the rate_cards period-overlap EXCLUDE constraint, exactly as
+                           //     v53 did for tariffs. resolveRateCard (greatest start_date <= billedAt wins)
+                           //     makes overlapping / open-ended same-name cards unambiguous, so the constraint
+                           //     was too strict: it made the sanctioned "supersede with a later card" workflow
+                           //     impossible for a card already in use, since the incumbent cannot be end-dated
+                           //     once costed usage references it. Unique (name, start_date) remains the guard.
+                           // 58: `trunks.outbound_call_filter` — the operator's per-trunk allow pattern for
                            //     outbound destinations on a chargeable (our-carrier) trunk. Authoritative over
                            //     the tenant-supplied `agents.options.outboundCallFilter`, which may only narrow
                            //     it. Null = the UK geographic/mobile default (lib/outbound-authorisation.js).
@@ -1594,9 +1600,10 @@ ChatSession.init({
  * the effective interval is [startDate, endDate) where a null endDate is open
  * until a later card for the same name supersedes it. `detail` JSONB holds the
  * additive, per-dimension rate lines (audio-path | model | tts | stt). Cards are
- * IMMUTABLE once referenced — a price change is a NEW card with a later startDate.
- * Per-name non-overlap is enforced at the DB level by an EXCLUDE gist constraint
- * (addRateCardOverlapConstraint), which Sequelize sync() cannot emit.
+ * IMMUTABLE once referenced — a price change is a NEW card with a later startDate,
+ * which simply takes over from its own start: same-name cards MAY overlap in time
+ * and resolveRateCard picks the greatest start_date <= billedAt (schema v59, and
+ * v53 for tariffs). The unique (name, start_date) index is the guard.
  * @class RateCard
  */
 class RateCard extends Model {}
@@ -2462,28 +2469,25 @@ async function migrateUsersRoleToString() {
   }
 }
 
-// Per-name non-overlap for rate cards, enforced at the DB level. Sequelize's
-// sync() can't emit an EXCLUDE constraint, so add it idempotently here (run after
-// RateCard.sync in the upgrade chain). The `name WITH =` equality member needs the
-// btree_gist extension. Best-effort: if the extension can't be created (privileges)
-// the app-level validation in the rate API remains the primary guard, so we log
-// and continue. tstzrange(start_date, end_date) is '[)' (end exclusive), so
-// adjacent cards [t0,t1) and [t1,t2) do not collide; a null end_date is unbounded.
-async function addRateCardOverlapConstraint() {
+// Rate cards intentionally have NO period-overlap constraint (schema v59), for
+// the same reason tariffs lost theirs at v53. resolveRateCard is deterministic —
+// the card with the greatest start_date <= billedAt wins — so overlapping (or two
+// open-ended) same-name cards are unambiguous: 'default' [1/1, null) and
+// 'default' [1/3, null) mean "default from 1/1, superseded by default from 1/3".
+// The unique (name, start_date) index is the only guard, and it is the one that
+// matters: two cards sharing a start WOULD make the resolver's ORDER BY
+// start_date DESC arbitrary.
+//
+// The EXCLUDE constraint also made the documented "supersede with a later card"
+// workflow impossible for any card actually in use: placing the successor
+// required end-dating the incumbent, and the beforeUpdate guard above refuses an
+// endDate change once costed usage references that card. This DROP removes the
+// earlier constraint on existing DBs.
+async function dropRateCardOverlapConstraint() {
   try {
-    await sequelize.query('CREATE EXTENSION IF NOT EXISTS btree_gist');
-    await sequelize.query(`
-      DO $$ BEGIN
-        IF NOT EXISTS (
-          SELECT 1 FROM pg_constraint WHERE conname = 'rate_cards_name_period_excl'
-        ) THEN
-          ALTER TABLE "rate_cards" ADD CONSTRAINT rate_cards_name_period_excl
-            EXCLUDE USING gist (name WITH =, tstzrange(start_date, end_date) WITH &&);
-        END IF;
-      END $$;
-    `);
+    await sequelize.query('ALTER TABLE "rate_cards" DROP CONSTRAINT IF EXISTS rate_cards_name_period_excl');
   } catch (err) {
-    logger.warn({ err: err?.message }, 'addRateCardOverlapConstraint: ignoring');
+    logger.warn({ err: err?.message }, 'dropRateCardOverlapConstraint: ignoring');
   }
 }
 
@@ -2553,7 +2557,7 @@ const databaseStarted = sequelize.authenticate()
     .then(() => UsageRecord.sync({ alter: true }))
     .then(() => ChatSession.sync({ alter: true }))
     .then(() => RateCard.sync({ alter: true }))
-    .then(() => addRateCardOverlapConstraint())
+    .then(() => dropRateCardOverlapConstraint())
     .then(() => BalanceCredit.sync({ alter: true }))
     .then(() => Tariff.sync({ alter: true }))
     .then(() => dropTariffOverlapConstraint())

--- a/lib/rates.js
+++ b/lib/rates.js
@@ -293,7 +293,13 @@ export function resolveOrgRateName(org, billedAt) {
 /**
  * The RateCard for `name` effective at `billedAt`: stored interval is
  * [startDate, endDate) with a null endDate open until a later same-name card
- * supersedes. Non-overlap is DB-enforced, so at most one card matches.
+ * supersedes. Same-name cards MAY overlap (the EXCLUDE constraint was dropped at
+ * schema v59, as it was for tariffs at v53), so several may match — the greatest
+ * `startDate <= billedAt` wins. That ORDER BY is the disambiguation, not a
+ * tie-break: a later card takes over from its own start with no need to
+ * end-date the incumbent, which is what makes superseding an in-use card
+ * possible at all. Unique (name, startDate) stops two cards sharing a start,
+ * which is the one case the ordering could not resolve.
  *
  * @returns {Promise<RateCard|null>}
  */

--- a/tests/rate-card-model.test.mjs
+++ b/tests/rate-card-model.test.mjs
@@ -2,17 +2,20 @@ import {
   setupRealDatabase, teardownRealDatabase,
   RateCard, Op, databaseStarted,
 } from './setup/database-test-wrapper.js';
+import { resolveRateCard } from '../lib/rates.js';
 import { randomUUID } from 'crypto';
 
-// Phase-0 schema smoke tests for the billing RateCard model (schema v44): the
-// table syncs, column defaults apply, and the per-name EXCLUDE-gist non-overlap
-// constraint (rate_cards_name_period_excl) actually enforces [start, end) ranges
-// — overlap rejected, adjacency allowed, different names independent.
+// Schema smoke tests for the billing RateCard model: the table syncs, column
+// defaults apply, and same-name cards resolve temporally. Since schema v59 there
+// is NO period-overlap constraint (as for tariffs at v53) — overlapping and
+// open-ended same-name cards are allowed and resolveRateCard disambiguates by
+// the greatest start_date <= billedAt. The unique (name, start_date) index is
+// the remaining guard: it is the one case the ordering cannot resolve.
 
 const PREFIX = `rc-test-${randomUUID()}-`;
 const d = (iso) => new Date(iso);
 
-describe('RateCard model + non-overlap constraint (schema v44)', () => {
+describe('RateCard model + temporal resolution (schema v59)', () => {
   beforeAll(async () => {
     await setupRealDatabase();
     await databaseStarted;
@@ -38,21 +41,59 @@ describe('RateCard model + non-overlap constraint (schema v44)', () => {
     expect(reread.name).toBe(name);
   });
 
-  it('rejects two OVERLAPPING cards for the same name (exclusion constraint)', async () => {
+  it('ALLOWS overlapping / open-ended same-name cards; resolveRateCard disambiguates by latest start', async () => {
     const name = `${PREFIX}overlap`;
-    await RateCard.create({
-      name, startDate: d('2026-01-01T00:00:00Z'), endDate: d('2026-06-01T00:00:00Z'),
-    });
+    // Two open-ended cards for one name — the shape a supersede actually takes,
+    // since the incumbent cannot be end-dated once costed usage references it.
+    await RateCard.create({ name, startDate: d('2026-01-01T00:00:00Z'), endDate: null });
+    await expect(
+      RateCard.create({ name, startDate: d('2026-03-01T00:00:00Z'), endDate: null }),
+    ).resolves.toBeTruthy();
+    // The greatest start_date <= billedAt wins: 1/1 covers February, 3/1 takes
+    // over from March onwards without anything being closed.
+    expect((await resolveRateCard(name, d('2026-02-01T00:00:00Z'))).startDate.toISOString())
+      .toBe('2026-01-01T00:00:00.000Z');
+    expect((await resolveRateCard(name, d('2026-04-01T00:00:00Z'))).startDate.toISOString())
+      .toBe('2026-03-01T00:00:00.000Z');
+    // Before any card exists for the name, nothing resolves.
+    expect(await resolveRateCard(name, d('2025-12-01T00:00:00Z'))).toBeNull();
+  });
+
+  it('still rejects two cards for the same name sharing a start_date (unique index)', async () => {
+    // The one ambiguity the ORDER BY start_date DESC cannot resolve, so this
+    // guard has to stay even though the period constraint is gone.
+    const name = `${PREFIX}dupe-start`;
+    await RateCard.create({ name, startDate: d('2026-01-01T00:00:00Z'), endDate: null });
     let err;
     try {
-      // [2026-03-01, open) overlaps [2026-01-01, 2026-06-01) for the same name.
-      await RateCard.create({ name, startDate: d('2026-03-01T00:00:00Z'), endDate: null });
+      await RateCard.create({ name, startDate: d('2026-01-01T00:00:00Z'), endDate: null });
     } catch (e) {
       err = e;
     }
     expect(err).toBeDefined();
-    const sig = `${err?.name} ${err?.message} ${err?.original?.code} ${err?.parent?.constraint}`.toLowerCase();
-    expect(sig).toMatch(/exclusion|rate_cards_name_period_excl|23p01/);
+    expect(`${err?.name}`.toLowerCase()).toMatch(/unique/);
+  });
+
+  it('an overlapping card supersedes WITHOUT the incumbent being end-dated', async () => {
+    // The workflow the dropped constraint made impossible: a card in use cannot
+    // have its endDate changed (beforeUpdate guard), so the successor has to be
+    // placeable while the incumbent stays open-ended.
+    const name = `${PREFIX}supersede`;
+    const incumbent = await RateCard.create({
+      name, startDate: d('2026-01-01T00:00:00Z'), endDate: null,
+      detail: { lines: [{ dim: 'model', match: { technology: 'voice' }, unit: 'minute', priceMicros: 60000 }] },
+    });
+    await RateCard.create({
+      name, startDate: d('2026-12-01T00:00:00Z'), endDate: null,
+      detail: { lines: [{ dim: 'model', match: { technology: 'voice' }, unit: 'minute', priceMicros: 125000 }] },
+    });
+    const before = await resolveRateCard(name, d('2026-11-30T23:59:59Z'));
+    const after = await resolveRateCard(name, d('2026-12-01T00:00:01Z'));
+    expect(before.detail.lines[0].priceMicros).toBe(60000);
+    expect(after.detail.lines[0].priceMicros).toBe(125000);
+    // The incumbent is untouched — still open-ended, still its own price.
+    await incumbent.reload();
+    expect(incumbent.endDate).toBeNull();
   });
 
   it('allows ADJACENT [start, end) cards for the same name (end is exclusive)', async () => {

--- a/tests/rates-api.test.mjs
+++ b/tests/rates-api.test.mjs
@@ -5,7 +5,8 @@ import {
 import { randomUUID } from 'crypto';
 
 // Phase-3 admin API: /api/rates CRUD (super-admin gated via the `rate` resource),
-// honouring the per-name non-overlap + immutable-once-referenced invariants.
+// honouring the duplicate-start + immutable-once-referenced invariants. Periods
+// may overlap since v59 — the latest start covering the billing instant wins.
 
 const mockLogger = { info() {}, error() {}, warn() {}, debug() {}, trace() {}, child() { return mockLogger; } };
 
@@ -75,10 +76,18 @@ describe('/api/rates CRUD (super admin)', () => {
     expect(missing.statusCode).toBe(400);
   });
 
-  it('409s when a new card overlaps an existing interval for the same name', async () => {
+  it('201s a card that overlaps an open-ended one for the same name (it supersedes)', async () => {
+    // Since v59 there is no period constraint: the later card simply takes over
+    // from its own start, which is what lets an in-use card be superseded at all.
     const name = `${PREFIX}ov`;
     expect((await create({ name, startDate: '2026-01-01Z' })).statusCode).toBe(201); // open-ended
-    const dup = await create({ name, startDate: '2026-06-01Z' }); // overlaps the open interval
+    expect((await create({ name, startDate: '2026-06-01Z' })).statusCode).toBe(201); // overlaps it
+  });
+
+  it('409s a second card starting at the SAME instant for one name', async () => {
+    const name = `${PREFIX}same-start`;
+    expect((await create({ name, startDate: '2026-01-01Z' })).statusCode).toBe(201);
+    const dup = await create({ name, startDate: '2026-01-01Z' });
     expect(dup.statusCode).toBe(409);
   });
 


### PR DESCRIPTION
## What changed

Drops the `rate_cards_name_period_excl` EXCLUDE gist constraint and bumps the schema to **v59**. This is the same change tariffs had at **v53**, for the same reason.

## Why

`resolveRateCard` is already deterministic:

```js
where: { name, startDate: { [op.lte]: at },
         [op.or]: [{ endDate: null }, { endDate: { [op.gt]: at } }] },
order: [['startDate', 'DESC']],
```

The card with the greatest `start_date <= billedAt` wins, so overlapping (or two open-ended) same-name cards are unambiguous: `default [1/1, null)` and `default [1/3, null)` mean "default from 1/1, superseded by default from 1/3". The constraint was stricter than the resolver required — exactly the v53 finding:

> DROP the tariffs period-overlap EXCLUDE constraint; resolveTariff (latest start_date <= billedAt wins) makes overlapping / open-ended same-name versions unambiguous, so the constraint was too strict.

`resolveTariff` and `resolveRateCard` are the same query, so the behaviour being relied on here has been in production for tariffs since v53.

**It was also self-defeating.** The documented way to change a price is to supersede with a later card, never to edit one in place. But the constraint meant placing that successor first required end-dating the incumbent — and `endDate` is in the `beforeUpdate` guard's `pricingFields`, so a card with costed usage against it refuses the edit. The sanctioned workflow was impossible for precisely the cards it exists for; repricing a live card meant leaving a gap or deleting history.

## What stays

- **Unique `(name, start_date)`** — untouched, and the guard that matters: two cards sharing a start are the one case `ORDER BY start_date DESC` cannot resolve.
- **`beforeUpdate` immutability** — untouched. A referenced card still cannot be repriced; it is superseded instead, which now actually works.
- The `SequelizeExclusionConstraintError` branch in the rates API is kept so a DB still carrying the pre-v59 constraint answers 409 rather than a bare 400. Its message now describes a duplicate start rather than an overlapping period.

## Blast radius

`resolveRateCard` is the only temporal read of `rate_cards` — `GET /rates` lists (ordered by name, start) and `GET /rates/{id}` is by id. `validateRateHistory` goes through `resolveRateCard` and inherits the behaviour. There was no application-level overlap check anywhere; the constraint was the sole enforcement.

## Tests

Inverted to pin the new behaviour rather than the old constraint:

- overlapping / open-ended same-name cards are accepted, and `resolveRateCard` picks 1/1 for February and 3/1 for April;
- a second card starting at the **same instant** is still rejected (unique index);
- a successor supersedes with the incumbent left open-ended and untouched — the workflow the constraint blocked;
- `POST /rates` returns 201 for an overlapping card and 409 for a duplicate start.

```
jest --config jest.config.db.js   → 71 suites passed, 760 passed / 2 skipped
```

Run on a clean tmpfs volume (`down -v` then `up -d`), so the v58 → v59 upgrade path is exercised from a fresh sync as well.

## Deploy note

Schema bump: `dbVersion` moves 58 → 59 and the upgrade chain runs `DROP CONSTRAINT IF EXISTS`, so it is idempotent and safe to re-run. The drop is not reversible by downgrade while overlapping rows exist — a rollback to v58 would fail to re-add the constraint if any same-name cards then overlap (logged and ignored, as the helper already does).
