### PR TITLE
fix(rates): say which conflict a 409 actually is

### DIFF
--- a/api/paths/rates.js
+++ b/api/paths/rates.js
@@ -53,13 +53,24 @@ export default function (logger) {
       });
       return res.status(201).send(card);
     } catch (err) {
-      // Duplicate (name, startDate) -> 409 conflict. Overlapping PERIODS are fine
-      // (schema v59) — only an identical start for the same name is rejected,
-      // because that is the one case resolveRateCard's ordering cannot resolve.
-      // The exclusion branch is kept for a DB still carrying the pre-v59
-      // constraint, so it answers 409 rather than a bare 400.
-      if (err?.name === 'SequelizeExclusionConstraintError' || err?.name === 'SequelizeUniqueConstraintError') {
+      // Two DIFFERENT conflicts, and conflating them sends the operator hunting
+      // for the wrong thing — so they say different things.
+      //
+      // Unique (name, start_date): a real duplicate. The only case
+      // resolveRateCard's ORDER BY start_date DESC cannot resolve, so it stays
+      // rejected however the schema is versioned.
+      if (err?.name === 'SequelizeUniqueConstraintError') {
         return res.status(409).send({ message: `A rate card for "${name}" already starts at that instant; give the superseding card a different startDate.` });
+      }
+      // Exclusion: overlapping PERIODS, which schema v59 stopped rejecting. Only
+      // a database still carrying rate_cards_name_period_excl can raise this, so
+      // it is a deployment state, not a fault in the request — say so, because
+      // the card being created is perfectly valid and will import unchanged once
+      // the upgrade has run.
+      if (err?.name === 'SequelizeExclusionConstraintError') {
+        return res.status(409).send({
+          message: `This database still enforces the pre-v59 rate-card overlap constraint, so "${name}" cannot start while an existing card of that name is still open. Run the schema upgrade to v59 (which drops rate_cards_name_period_excl), or end-date the existing card first.`,
+        });
       }
       req.log.error(err, 'creating rate card');
       return res.status(400).send({ message: err?.message || 'Failed to create rate card' });

--- a/api/paths/rates/{rateId}.js
+++ b/api/paths/rates/{rateId}.js
@@ -59,8 +59,15 @@ export default function (logger) {
       if (/immutable once referenced/.test(err?.message || '')) {
         return res.status(409).send({ message: err.message });
       }
-      if (err?.name === 'SequelizeExclusionConstraintError' || err?.name === 'SequelizeUniqueConstraintError') {
+      if (err?.name === 'SequelizeUniqueConstraintError') {
         return res.status(409).send({ message: 'A card for this name already starts at that instant.' });
+      }
+      // Only reachable on a database still carrying the pre-v59 overlap
+      // constraint — a deployment state rather than a bad request.
+      if (err?.name === 'SequelizeExclusionConstraintError') {
+        return res.status(409).send({
+          message: 'This database still enforces the pre-v59 rate-card overlap constraint, so this period cannot overlap another card of the same name. Run the schema upgrade to v59, or end-date the other card first.',
+        });
       }
       req.log.error(err, 'updating rate card');
       return res.status(400).send({ message: err?.message || 'Failed to update rate card' });


### PR DESCRIPTION
## What changed

`POST /rates` and `PATCH /rates/{id}` answered both `SequelizeUniqueConstraintError` and `SequelizeExclusionConstraintError` with the same message — "already starts at that instant". They now say different things.

## Why

They are different problems:

- **Unique `(name, start_date)`** — a real duplicate start. The one case `resolveRateCard`'s `ORDER BY start_date DESC` cannot resolve, so it stays rejected whatever the schema version.
- **Exclusion** — overlapping *periods*, which v59 stopped rejecting. Only a database still carrying `rate_cards_name_period_excl` can raise it. That is a deployment state, not a fault in the request: the card is valid and will import unchanged once the upgrade has run.

Conflating them sent an operator hunting for a duplicate start date that did not exist. Seen for real: importing `default`/`pro`/`scale` into an environment still on `dbVersion` 58 created `pro` and `scale` (no incumbents) and rejected `default`, whose new period overlaps the open-ended incumbent — reported as though `2026-08-20` collided with a card that actually starts `2026-07-01`.

The exclusion branch is kept rather than removed, so a not-yet-upgraded database still answers 409 rather than a bare 400 — it just now names the constraint and the remedy.

## How verified

```
jest --config jest.config.db.js   -> 71 suites passed, 760 passed / 2 skipped
```

Clean tmpfs volume (`down -v` then `up -d`). Message-only change; no behaviour or schema change.
