### PR TITLE
feat(rates): let an organisation read the rate card it is charged on

### DIFF
--- a/api/paths/me/rates.js
+++ b/api/paths/me/rates.js
@@ -1,0 +1,129 @@
+import { requirePermission } from '../../../lib/auth/permissions.js';
+import { resolveEffectiveRateCard, BILLING_INCREMENT_SECONDS } from '../../../lib/rates.js';
+
+/**
+ * GET /api/me/rates — the rate card currently IN FORCE for the caller's OWN
+ * organisation, so a customer can see the prices their usage is valued at.
+ *
+ * Deliberately self-scoped, in the path as well as in the code: the org is taken
+ * from `res.locals.user` and an org id is never accepted from the caller, so
+ * there is no shape of this request that reads another tenant's pricing.
+ *
+ * Gated on `usage:read` — the capability that already means "may see what this
+ * organisation is being charged" (every `owner`/`member` holds it). NOT on
+ * `rate:read`: that is the superAdmin PLATFORM-CONFIG capability over the global
+ * card catalogue (GET /api/rates lists every customer's pricing), and widening it
+ * to customers would expose all of it.
+ *
+ * Resolution goes through {@link resolveEffectiveRateCard}, which is the same
+ * selection `costUsageRow` uses — per-user override first, then the org's, then
+ * the covering card version. Quoting from anything else would eventually show a
+ * customer a different card from the one their bill is computed on.
+ *
+ * `rated: false` is a REAL, current state, not an error, and is reported as a 200
+ * with a reason: an org with no rate card is metered but never charged
+ * (`cost_status='no_rate'`), and rendering that as an empty card would read as
+ * "free". Internal ids and `createdBy` are never returned.
+ */
+export default function (logger) {
+  const get = async (req, res) => {
+    if (!requirePermission(res, 'usage', 'read')) return;
+    const user = res.locals.user;
+    if (!user) return res.status(401).send({ message: 'Not authenticated' });
+    try {
+      const at = new Date();
+      const { rateName, card } = await resolveEffectiveRateCard({
+        organisationId: user.organisationId ?? null,
+        userId: user.id ?? null,
+        at,
+      });
+
+      if (!rateName) {
+        return res.send({
+          rated: false,
+          reason: 'This organisation has no rate assigned, so its usage is metered but not charged.',
+          name: null, currency: null, startDate: null, lines: [],
+          billingIncrementSeconds: BILLING_INCREMENT_SECONDS,
+          at: at.toISOString(),
+        });
+      }
+      if (!card) {
+        return res.send({
+          rated: false,
+          reason: `No version of rate card "${rateName}" is in force, so usage is metered but not charged.`,
+          name: rateName, currency: null, startDate: null, lines: [],
+          billingIncrementSeconds: BILLING_INCREMENT_SECONDS,
+          at: at.toISOString(),
+        });
+      }
+
+      const startDate = card.startDate instanceof Date ? card.startDate.toISOString() : card.startDate;
+      return res.send({
+        rated: true,
+        name: card.name,
+        description: card.description ?? null,
+        currency: card.currency || 'gbp',
+        startDate,
+        // The card's additive per-dimension lines, verbatim minus the row's
+        // identity: a call's price is the SUM of every dimension that matches it
+        // (audio-path + model + tts/stt + destination), so a single "per-minute
+        // rate" does not exist and must not be synthesised here.
+        lines: Array.isArray(card.detail?.lines) ? card.detail.lines : [],
+        // Time-metered lines priced per minute bill the duration rounded UP to
+        // this increment, which is what makes a short call cost more per minute
+        // than its wall-clock length suggests.
+        billingIncrementSeconds: BILLING_INCREMENT_SECONDS,
+        at: at.toISOString(),
+      });
+    } catch (err) {
+      req.log.error(err, 'reading own rate card');
+      return res.status(500).send({ error: err.message });
+    }
+  };
+  get.apiDoc = {
+    summary: "The rate card in force for the caller's own organisation.",
+    operationId: 'getMyRates',
+    tags: ['Rates'],
+    responses: {
+      200: {
+        description:
+          'The rate card in force now. `rated: false` (with a `reason`) is a real state — an unrated organisation is metered but never charged.',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                rated: { type: 'boolean' },
+                reason: { type: 'string', nullable: true, description: 'Why no card is in force (only when `rated` is false).' },
+                name: { type: 'string', nullable: true },
+                description: { type: 'string', nullable: true },
+                currency: { type: 'string', nullable: true },
+                startDate: { type: 'string', format: 'date-time', nullable: true },
+                lines: {
+                  type: 'array',
+                  description: 'Additive per-dimension lines: a usage row is priced by EVERY dimension that matches it, summed.',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      dim: { type: 'string', enum: ['audio-path', 'model', 'tts', 'stt', 'destination'] },
+                      match: { type: 'object' },
+                      unit: { type: 'string' },
+                      priceMicros: { type: 'number', description: 'Micro-pence (1e-6 GBP) per `unit`.' },
+                      tariff: { type: 'string', description: 'Destination lines only: the named prefix tariff that prices outbound carrier legs.' },
+                    },
+                  },
+                },
+                billingIncrementSeconds: { type: 'integer' },
+                at: { type: 'string', format: 'date-time' },
+              },
+            },
+          },
+        },
+      },
+      403: { description: 'Requires usage:read', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+      default: { description: 'An error occurred', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    },
+  };
+
+  return { GET: get };
+}

--- a/lib/outbound-authorisation.js
+++ b/lib/outbound-authorisation.js
@@ -41,7 +41,7 @@ import {
   Tariff as DefaultTariff,
   TariffPrefix as DefaultTariffPrefix,
 } from './database.js';
-import { resolveOrgRateName, resolveRateCard } from './rates.js';
+import { resolveEffectiveRateCard } from './rates.js';
 import { normaliseDestination, resolveTariff, matchTariffPrefix } from './tariffs.js';
 import {
   DEFAULT_AGENT_OUTBOUND_FILTER,
@@ -144,14 +144,10 @@ export async function isDestinationRateable({ organisationId, userId, calledId, 
   Organisation = DefaultOrganisation, User = DefaultUser, RateCard = DefaultRateCard,
   Tariff = DefaultTariff, TariffPrefix = DefaultTariffPrefix,
 } = {}) {
-  const org = organisationId ? await Organisation.findByPk(organisationId) : null;
-  const user = userId
-    ? await User.findByPk(userId, { attributes: ['rateHistory'] }).catch(() => null)
-    : null;
-  const rateName = (user && resolveOrgRateName(user, at)) || resolveOrgRateName(org, at);
+  const { rateName, card } = await resolveEffectiveRateCard(
+    { organisationId, userId, at }, { Organisation, User, RateCard },
+  );
   if (!rateName) return { rateable: false, reason: 'no rate assigned to this organisation' };
-
-  const card = await resolveRateCard(rateName, at, { RateCard });
   if (!card) return { rateable: false, reason: `no rate card "${rateName}" in force`, rateName };
 
   const lines = Array.isArray(card?.detail?.lines) ? card.detail.lines : [];

--- a/lib/rates.js
+++ b/lib/rates.js
@@ -318,6 +318,37 @@ export async function resolveRateCard(name, billedAt, { RateCard = DefaultRateCa
 }
 
 /**
+ * The rate card actually IN FORCE for a principal at `at` — the single
+ * resolution every "what am I charged?" question must go through.
+ *
+ * Mirrors {@link costUsageRow} exactly, and that is the whole point: the
+ * per-user rate override (Phase 5) wins over the organisation's, then the
+ * covering card is picked by {@link resolveRateCard} (greatest
+ * `start_date <= at`, since same-name cards may overlap from schema v59). Any
+ * surface that re-implements this selection will eventually quote a customer a
+ * different card from the one their usage is valued against.
+ *
+ * Both halves are reported separately because they are DIFFERENT states: no
+ * `rateName` means the org was never assigned a rate (usage meters but never
+ * charges — `cost_status='no_rate'`), whereas a `rateName` with no `card` means
+ * the assigned name has no version covering `at`. Neither is an error.
+ *
+ * @param {object} principal  { organisationId, userId, at }
+ * @returns {Promise<{rateName: string|null, card: RateCard|null}>}
+ */
+export async function resolveEffectiveRateCard({ organisationId, userId, at = new Date() }, {
+  Organisation = DefaultOrganisation, User = DefaultUser, RateCard = DefaultRateCard,
+} = {}) {
+  const org = organisationId ? await Organisation.findByPk(organisationId) : null;
+  const user = userId
+    ? await User.findByPk(userId, { attributes: ['rateHistory'] }).catch(() => null)
+    : null;
+  const rateName = (user && resolveOrgRateName(user, at)) || resolveOrgRateName(org, at);
+  if (!rateName) return { rateName: null, card: null };
+  return { rateName, card: await resolveRateCard(rateName, at, { RateCard }) };
+}
+
+/**
  * Metadata key holding the platform-wide DEFAULT rate NAME. A brand-new
  * organisation with no explicit `rateHistory` is stamped with this name at
  * creation (see {@link defaultRateHistoryEntry}), so no org is ever silently

--- a/tests/me-rates-api.test.mjs
+++ b/tests/me-rates-api.test.mjs
@@ -1,0 +1,174 @@
+import {
+  setupRealDatabase, teardownRealDatabase,
+  Organisation, User, RateCard, Op, databaseStarted,
+} from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+/**
+ * GET /api/me/rates — the SELF-SCOPED read of the rate card in force for the
+ * caller's own organisation (the customer-visible half of "your full rate card
+ * is visible in the dashboard").
+ *
+ * The two things that must hold whatever else changes:
+ *  - it is gated on `usage:read`, which an owner holds, and NOT on `rate:read`
+ *    (superAdmin platform config over EVERY customer's pricing);
+ *  - the org comes from the principal, never the request — so a user in org B
+ *    can never be shown org A's card.
+ * Plus: "not rated" is a real current state reported as a 200, not a 500 and not
+ * an empty card (an unrated org is metered but never charged).
+ */
+
+const mockLogger = { info() {}, error() {}, warn() {}, debug() {}, trace() {}, child() { return mockLogger; } };
+
+function callRoute(GET, user) {
+  const req = { params: {}, body: {}, query: {}, log: mockLogger };
+  const res = { locals: { user }, statusCode: 200, body: undefined };
+  res.status = (c) => { res.statusCode = c; return res; };
+  res.send = (b) => { res.body = b; return res; };
+  res.json = (b) => { res.body = b; return res; };
+  return GET(req, res).then(() => res);
+}
+
+describe('GET /api/me/rates (own organisation)', () => {
+  const PREFIX = `me-rates-${randomUUID()}-`;
+  const START = new Date('2020-01-01T00:00:00Z');
+  const cardA = `${PREFIX}a`;
+  const cardB = `${PREFIX}b`;
+  let GET;
+  let orgA; let orgB; let orgNone; let orgStale;
+  let userA; let userB; let userNone; let userStale; let userOverride;
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    await databaseStarted;
+    GET = (await import('../api/paths/me/rates.js')).default(mockLogger).GET;
+
+    await RateCard.create({
+      name: cardA,
+      startDate: START,
+      currency: 'gbp',
+      description: 'Org A pricing',
+      detail: { lines: [{ dim: 'audio-path', match: { technology: 'voice', media: 'telephony' }, unit: 'minute', priceMicros: 60_000 }] },
+    });
+    await RateCard.create({
+      name: cardB,
+      startDate: START,
+      currency: 'gbp',
+      detail: { lines: [{ dim: 'model', match: { technology: 'voice' }, unit: 'minute', priceMicros: 90_000 }] },
+    });
+
+    const mkOrg = async (name, rateHistory) => {
+      const id = randomUUID();
+      await Organisation.create({ id, name, ...(rateHistory ? { rateHistory } : {}) });
+      return id;
+    };
+    const mkUser = async (organisationId, extra = {}) => {
+      const id = randomUUID();
+      await User.create({
+        id, name: 'Rate Reader', email: `mr-${id}@example.com`,
+        emailVerified: true, phone: '', phoneVerified: false, picture: '',
+        role: 'owner', organisationId, ...extra,
+      });
+      return id;
+    };
+
+    orgA = await mkOrg(`${PREFIX}A`, [{ name: cardA, startDate: START.toISOString() }]);
+    orgB = await mkOrg(`${PREFIX}B`, [{ name: cardB, startDate: START.toISOString() }]);
+    orgNone = await mkOrg(`${PREFIX}none`, null);
+    // Assigned a name whose card only starts in 2099 — a name with no covering version.
+    orgStale = await mkOrg(`${PREFIX}stale`, [{ name: `${PREFIX}never`, startDate: START.toISOString() }]);
+
+    userA = await mkUser(orgA);
+    userB = await mkUser(orgB);
+    userNone = await mkUser(orgNone);
+    userStale = await mkUser(orgStale);
+    // Phase-5 per-user override: sits in org A but is priced on card B.
+    userOverride = await mkUser(orgA, { rateHistory: [{ name: cardB, startDate: START.toISOString() }] });
+  }, 30000);
+
+  afterAll(async () => {
+    await User.destroy({ where: { organisationId: { [Op.in]: [orgA, orgB, orgNone, orgStale] } } });
+    await Organisation.destroy({ where: { id: { [Op.in]: [orgA, orgB, orgNone, orgStale] } } });
+    await RateCard.destroy({ where: { name: { [Op.like]: `${PREFIX}%` } } });
+    await teardownRealDatabase();
+  }, 30000);
+
+  it('gives an owner their own card, with lines and no internal ids', async () => {
+    const res = await callRoute(GET, { id: userA, role: 'owner', organisationId: orgA });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.rated).toBe(true);
+    expect(res.body.name).toBe(cardA);
+    expect(res.body.currency).toBe('gbp');
+    expect(res.body.description).toBe('Org A pricing');
+    expect(new Date(res.body.startDate).toISOString()).toBe(START.toISOString());
+    expect(res.body.lines).toHaveLength(1);
+    expect(res.body.lines[0]).toMatchObject({ dim: 'audio-path', unit: 'minute', priceMicros: 60_000 });
+    // Billing arithmetic the customer needs to read the card correctly.
+    expect(res.body.billingIncrementSeconds).toBe(6);
+    // Never leak the card row's identity or authorship.
+    expect(res.body.id).toBeUndefined();
+    expect(res.body.createdBy).toBeUndefined();
+  });
+
+  it('gives a member the same card (usage:read, not rate:read)', async () => {
+    const res = await callRoute(GET, { id: userA, role: 'member', organisationId: orgA });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.name).toBe(cardA);
+  });
+
+  it('403s a principal without usage:read', async () => {
+    // billingService holds rate:read but NOT usage:read — proof the gate is the
+    // usage capability and not the platform-pricing one.
+    const res = await callRoute(GET, { id: userA, role: 'billingService', organisationId: orgA });
+    expect(res.statusCode).toBe(403);
+    expect(res.body.detail).toMatch(/usage:read/);
+  });
+
+  it("never shows another organisation's card", async () => {
+    const a = await callRoute(GET, { id: userA, role: 'owner', organisationId: orgA });
+    const b = await callRoute(GET, { id: userB, role: 'owner', organisationId: orgB });
+    expect(a.body.name).toBe(cardA);
+    expect(b.body.name).toBe(cardB);
+    expect(b.body.name).not.toBe(cardA);
+    expect(JSON.stringify(b.body.lines)).not.toContain('60000');
+  });
+
+  it('honours the per-user rate override, as costing does', async () => {
+    const res = await callRoute(GET, { id: userOverride, role: 'owner', organisationId: orgA });
+    // Same org as userA, different card — the user's own rateHistory wins.
+    expect(res.body.rated).toBe(true);
+    expect(res.body.name).toBe(cardB);
+  });
+
+  it('reports an unrated organisation as a 200 "not rated", not an empty card', async () => {
+    const res = await callRoute(GET, { id: userNone, role: 'owner', organisationId: orgNone });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.rated).toBe(false);
+    expect(res.body.reason).toMatch(/metered but not charged/);
+    expect(res.body.lines).toEqual([]);
+    expect(res.body.name).toBeNull();
+  });
+
+  it('reports an assigned name with no covering card as "not rated", naming it', async () => {
+    const res = await callRoute(GET, { id: userStale, role: 'owner', organisationId: orgStale });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.rated).toBe(false);
+    expect(res.body.name).toBe(`${PREFIX}never`);
+    expect(res.body.reason).toMatch(/in force/);
+  });
+
+  it('follows a superseding same-name card rather than the original', async () => {
+    // Same-name cards may overlap since schema v59: the greatest startDate <= now
+    // wins, and this endpoint must resolve exactly as costUsageRow does.
+    await RateCard.create({
+      name: cardA,
+      startDate: new Date(Date.now() - 60_000),
+      currency: 'gbp',
+      description: 'Org A pricing, superseded',
+      detail: { lines: [{ dim: 'audio-path', match: { technology: 'voice', media: 'telephony' }, unit: 'minute', priceMicros: 70_000 }] },
+    });
+    const res = await callRoute(GET, { id: userA, role: 'owner', organisationId: orgA });
+    expect(res.body.lines[0].priceMicros).toBe(70_000);
+    expect(res.body.description).toBe('Org A pricing, superseded');
+  });
+});


### PR DESCRIPTION
Adds `GET /api/me/rates` — the rate card in force for the **caller's own** organisation.

### Why

There is currently no way for a non-superAdmin principal to read the pricing their usage is valued against. `GET /rates` requires `rate:read` (superAdmin platform config over every customer's card), and `GET /organisations/{id}/rate-history` requires `organisation:read`, which `OWNER_STATEMENTS` does not grant at all — so an owner cannot read even the *name* of their card.

### What

- **Self-scoped by construction.** The organisation comes from `res.locals.user`; an org id is never accepted from the caller, so no shape of this request reads another tenant's pricing. The path says so too, which is why it is `/me/rates` rather than `/rates/effective`.
- **Gated on `usage:read`**, the capability that already means "may see what this organisation is being charged" (held by `owner` and `member`). Deliberately **not** `rate:read` — widening the superAdmin platform-config capability to customers would expose every org's pricing. **No `permissions.js` change.**
- **One resolution, shared.** New `resolveEffectiveRateCard()` in `lib/rates.js` does per-user override → organisation → covering card version, which is exactly what `costUsageRow` does; so what a customer is quoted is the card their bill is computed on. `isDestinationRateable` now calls it instead of carrying a third copy of the same selection.
- **"Not rated" is a real state, not an error.** An org with no card is metered but never charged (`cost_status='no_rate'`), so that returns `200` with `rated: false` and a reason — never a 500, and never an empty card that would read as "free".
- Internal ids and `createdBy` are never returned.

### Tests

`tests/me-rates-api.test.mjs` — 8 cases: an owner gets their own card; a member gets it too; a principal without `usage:read` gets 403; a second org never sees the first's; the per-user override wins as it does in costing; no rate and no covering card each report the not-rated shape; a superseding same-name card wins (schema v59 overlap).

Ran locally on a clean volume, as this repo's PRs get no CI:

    docker compose -f tests/docker-compose.test.yml down -v && docker compose -f tests/docker-compose.test.yml up -d
    jest --config jest.config.db.js
    → 72 suites passed, 768 tests passed, 2 skipped

Also exercised over HTTP against a real Postgres as two non-superAdmin owners in different organisations: each saw only its own card (`default` / `pro`, 181 lines each), and `GET /api/rates` still 403'd for both.

### Deployment

No schema change — no `DB_FORCE_SYNC` needed. Ships ahead of the polite-ai dashboard panel that consumes it.
