### PR TITLE
fix(pipecat): stop the confidence tone silencing every SIP agent handover

### DIFF
--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -32,6 +32,7 @@ from .agent_tools import build_agent_tools
 from .mcp_tools import close_mcp_servers, connect_mcp_servers
 from .prompt_metadata import prompt_with_metadata
 from .constants import DISCONNECT_REASONS, PLATFORM
+from .pipeline_error_alarm import PipelineErrorAlarm
 from .recording import RecordingSession
 from .sip_gateway.base import (
     GatewaySession,
@@ -263,6 +264,12 @@ class CallSession:
     # Rebuilt transport awaiting a manual client-connected kick (SmallWebRTC
     # only — its connected event has already fired for the old client).
     _handover_webrtc_kick: Optional[Any] = None
+    # True while building/running the continuation pipeline of a full-stack
+    # agent handover, so errors on that generation are reported as handover
+    # failures — the case where dead air is most likely and least visible.
+    _is_handover_generation: bool = False
+    # Escalates this generation's ErrorFrames (see pipeline_error_alarm).
+    _error_alarm: Optional[Any] = None
     # Closers for any MCP server connections opened in ``prepare_run`` (the
     # worker acts as the MCP client). Awaited in ``run_prepared``'s finally so
     # the remote sessions don't outlive the call. See mcp_tools.py.
@@ -566,6 +573,13 @@ class CallSession:
         # TODO if the playground UX needs uninterruptible greetings.
         await self._wire_greeting(transport, task, agent, mode, model_name)
 
+        # Listen for this generation's ErrorFrames. Nothing did before, which
+        # is why 1283 of them went unnoticed while a caller sat in silence.
+        self._error_alarm = PipelineErrorAlarm(
+            call_id=self.call.id, handover=self._is_handover_generation
+        )
+        self._error_alarm.attach(task)
+
         max_duration_secs = _parse_duration((agent.get("options") or {}).get("maxDuration"))
         return task, max_duration_secs
 
@@ -704,6 +718,7 @@ class CallSession:
                 agent_id=self.agent.get("id"),
                 model=self.agent.get("modelName"),
             ).info("agent handover: starting new agent stack on the live transport")
+            self._is_handover_generation = True
             task, max_duration_secs = await self.prepare_run(
                 self.agent, self.agent["modelName"], pending["system_prompt"]
             )
@@ -756,6 +771,13 @@ class CallSession:
                     kick_task.cancel()
                 if timeout_task and not timeout_task.done():
                     timeout_task.cancel()
+                # Before the InvocationLog is flushed, so a generation that
+                # errored says so IN the call's own debug log rather than only
+                # in pod logs. Silent on a clean generation.
+                alarm = self._error_alarm
+                self._error_alarm = None
+                if alarm is not None:
+                    alarm.log_final_summary()
                 # Tear down any WebRTC-origin relay leg / consult leg this session
                 # was bridged to, so the telephony side and its Call record don't
                 # outlive the browser caller.
@@ -2426,6 +2448,14 @@ def _resolve_recording_options(agent: dict, instance: dict) -> _RecordingOptions
     instance level; the instance value wins when set, otherwise the agent
     default applies. ``enabled`` is the gate; ``key`` (when present) selects
     client-side decryption per section 9.2.
+
+    The engine records only when it is ASKED to: an absent ``recording`` option
+    means no recording, full stop. This is deliberately not a product policy —
+    "record everything unless the customer opts out" is a statement a given
+    client application makes about its own users, and it belongs to that client
+    (polite-ai materialises it at its API boundary; see its
+    ``withRecordingPolicy``). An engine that recorded by default would record
+    for every API consumer, including ones whose users never agreed to it.
     """
     agent_opts = (agent.get("options") or {}).get("recording") or {}
     instance_opts = (instance.get("recording") if isinstance(instance, dict) else None) or {}

--- a/agents/pipecat/pipecat_aplisay/confidence_tone.py
+++ b/agents/pipecat/pipecat_aplisay/confidence_tone.py
@@ -33,10 +33,15 @@ Speaking detection is frame-driven: ``UserStarted/StoppedSpeakingFrame``
 here travelling upstream). A configurable quiet "grace" window after the last
 speech keeps the tone from blipping into normal turn-taking pauses.
 
-Tone frames are pushed at the same sample rate the local bot's own audio uses
-(learned from passing ``OutputAudioRawFrame``s, exactly like
-``media_relay._RelayInjector``) because the output transport's resampler
-locks onto the first input rate it sees and rejects changes.
+Tone frames are pushed at the output transport's own ``sample_rate`` (see
+``_out_rate``) because that transport's resampler locks onto the first input
+rate it sees and rejects changes — permanently, for the rest of the call.
+
+Asking the transport, rather than inferring the rate from passing
+``OutputAudioRawFrame``s the way ``media_relay._RelayInjector`` does, is what
+makes this safe on an agent handover: there the injector is rebuilt and armed
+BEFORE the incoming agent has rendered any audio, so there is nothing to infer
+from and a guess is what silences the leg.
 """
 
 from __future__ import annotations
@@ -63,9 +68,6 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 # 20 ms chunks — matches typical transport frame sizing.
 _CHUNK_SECS = 0.02
-# Fallback when no bot audio has been seen yet (telephony-standard 16 kHz,
-# the rate every SIP gateway transport here runs at).
-_DEFAULT_SAMPLE_RATE = 16000
 # Backstop for handover mode: a full-stack agent handover normally completes
 # (incoming agent's first BotStartedSpeakingFrame) within a few seconds. If
 # the new agent never speaks — a stuck/failed continuation — cap the comfort
@@ -170,11 +172,16 @@ class ConfidenceToneInjector(FrameProcessor):
         config: ToneConfig,
         *,
         get_transfer_state: Callable[[], Any],
+        output_transport: Any = None,
     ):
         super().__init__()
         self._config = config
         # Returns the owning CallSession's TransferState (``.state`` str).
         self._get_transfer_state = get_transfer_state
+        # The output transport processor we sit upstream of. Its ``sample_rate``
+        # is the ONLY authoritative answer to "what rate must our frames be" —
+        # see ``_out_rate``. Bound by voice_session at splice time.
+        self._output_transport = output_transport
         self._mode: Optional[str] = None  # None | "blind" | "consult"
         # True while covering a full-stack agent-to-agent handover gap. In this
         # mode play is gated only by speech grace, NOT by the transfer state
@@ -234,6 +241,43 @@ class ConfidenceToneInjector(FrameProcessor):
         self._last_voice = time.monotonic()
         logger.info("confidence tone started for agent handover")
 
+    def bind_output(self, output_transport: Any) -> None:
+        """Tell the injector which output transport it feeds.
+
+        Called by ``voice_session`` when the injector is spliced into the
+        pipeline. See :meth:`_out_rate` for why this matters.
+        """
+        self._output_transport = output_transport
+
+    def _out_rate(self) -> Optional[int]:
+        """The sample rate our frames MUST carry, or None if not yet knowable.
+
+        ``BaseOutputTransport`` resolves its own rate at StartFrame as
+        ``params.audio_out_sample_rate or frame.audio_out_sample_rate`` and
+        exposes it as the public ``sample_rate`` property. That is the only
+        authoritative value: the SIP gateways pin 16 kHz on the transport while
+        StartFrame still advertises pipecat's 24 kHz default.
+
+        This is load-bearing, not cosmetic. ``BaseOutputTransport`` owns ONE
+        ``SOXRStreamAudioResampler`` for the whole call and that resampler
+        latches the first (in_rate, out_rate) pair it is ever given — every
+        later frame at a different rate raises and is DROPPED, permanently. On
+        an agent handover the injector is rebuilt and armed before the incoming
+        agent's first audio, so a tone frame at the wrong rate is what latches
+        it, and the new agent is never heard again. (It went unnoticed on the
+        WebRTC path only because that transport leaves its rate unpinned, so
+        tone frames matched it and the resampler short-circuits on equal rates.)
+        """
+        rate = getattr(self._output_transport, "sample_rate", None)
+        if isinstance(rate, int) and rate > 0:
+            return rate
+        # Transport not started yet (or not a BaseOutputTransport): fall back to
+        # a rate learned from the bot's own rendered audio, which by definition
+        # already passed through this transport.
+        if isinstance(self._dst_rate, int) and self._dst_rate > 0:
+            return self._dst_rate
+        return None
+
     # ---- Frame plumbing ----
 
     async def process_frame(self, frame: Frame, direction: FrameDirection):
@@ -241,7 +285,13 @@ class ConfidenceToneInjector(FrameProcessor):
 
         if isinstance(frame, StartFrame):
             if self._dst_rate is None:
-                # Provisional until the first bot frame teaches us better.
+                # LAST-RESORT fallback only. StartFrame carries
+                # ``PipelineParams.audio_out_sample_rate``, which we never set,
+                # so it is pipecat's 24 kHz default — NOT the rate the output
+                # transport is pinned to (16 kHz on the SIP gateways). Emitting
+                # at this rate latches the transport's stream resampler at the
+                # wrong ratio and silences the whole leg; ``_out_rate`` prefers
+                # the transport's own value for exactly that reason.
                 rate = getattr(frame, "audio_out_sample_rate", None)
                 if isinstance(rate, int) and rate > 0:
                     self._dst_rate = rate
@@ -291,6 +341,17 @@ class ConfidenceToneInjector(FrameProcessor):
         if self._handover:
             # Handover backstop: the incoming agent never signalled speaking.
             if (time.monotonic() - self._handover_started_at) > _HANDOVER_MAX_SECS:
+                # This is a FAILED HANDOVER, not a tidy timeout: we covered the
+                # gap for the full backstop and the incoming agent never once
+                # spoke, so the caller is about to be dropped into dead air with
+                # the call still up. It is the earliest unambiguous signal of
+                # the 2026-08-21 silent-leg class of fault, so say so loudly —
+                # the tone then stops and the caller hears silence, which is
+                # exactly what nobody noticed for 55 seconds last time.
+                logger.error(
+                    f"agent handover FAILED: the incoming agent produced no audio in "
+                    f"{_HANDOVER_MAX_SECS:.0f}s; comfort tone exhausted, caller now in silence"
+                )
                 self.disarm()
                 return False
             # Otherwise fall straight through to the speech-grace gate below:
@@ -357,7 +418,12 @@ class ConfidenceToneInjector(FrameProcessor):
                 next_deadline = time.monotonic()
             if not self._should_play():
                 continue
-            rate = self._dst_rate or _DEFAULT_SAMPLE_RATE
+            rate = self._out_rate()
+            if rate is None:
+                # Never guess: a frame at the wrong rate permanently poisons the
+                # output transport's resampler (see _out_rate). Skipping this
+                # tick costs 20 ms of comfort tone; guessing costs the call.
+                continue
             samples = int(rate * _CHUNK_SECS)
             audio = self._make_chunk(rate, samples)
             try:

--- a/agents/pipecat/pipecat_aplisay/output_rate_guard.py
+++ b/agents/pipecat/pipecat_aplisay/output_rate_guard.py
@@ -1,0 +1,120 @@
+"""Last processor before the output transport: make every audio frame match the
+transport's sample rate, so nothing upstream can ever mute the call.
+
+WHY THIS EXISTS (beta incident, 2026-08-21)
+------------------------------------------
+``BaseOutputTransport`` hands all outbound audio to a single
+``SOXRStreamAudioResampler`` per ``MediaSender``, created once in
+``MediaSender.__init__`` and reused for the life of the call
+(``base_output.py:426``, used at ``:574``). That resampler LATCHES the first
+``(in_rate, out_rate)`` pair it is given: ``_maybe_initialize_sox_stream``
+raises ``ValueError`` on any later pair and pipecat surfaces this only as a
+NON-FATAL ``ErrorFrame``. The frame is dropped, the call carries on, and the
+caller hears nothing — for the rest of the call. On the live incident that was
+1283 dropped frames over 55 seconds while the agent talked to no one.
+
+``resample()`` short-circuits when ``in_rate == out_rate`` and never even builds
+the stream. So if every frame reaching the transport already carries the
+transport's own rate, the latch can never happen and the failure mode is gone
+by construction — which is exactly what this processor guarantees.
+
+That makes this defence in depth, not a duplicate of the transport's own
+resampling: the transport still resamples, it just always takes the
+equal-rates fast path. The specific bug that motivated this (the confidence
+tone emitting at ``StartFrame``'s 24 kHz into a 16 kHz-pinned SIP transport) is
+fixed at source in ``confidence_tone.py``; this stops the NEXT component that
+gets it wrong — a relay injector, a fallback TTS voice, a model swapped
+mid-handover — from costing a customer a call.
+
+We convert in place rather than rebuilding the frame so that subclass identity
+(``TTSAudioRawFrame`` and friends) and every other field survive; the transport
+keys off ``type(frame)`` downstream.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from loguru import logger
+from pipecat.audio.utils import create_stream_resampler
+from pipecat.frames.frames import Frame, OutputAudioRawFrame
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+
+class _RateAgileResampler:
+    """A stream resampler that survives a rate change by rebuilding itself.
+
+    ``SOXRStreamAudioResampler`` is stateful (it carries filter history across
+    chunks, which is what makes it right for a continuous stream) and therefore
+    refuses to change rates. Rebuilding on a genuine rate change costs one
+    chunk's worth of discontinuity — a click at worst — where the alternative is
+    silence for the remainder of the call.
+    """
+
+    def __init__(self) -> None:
+        self._resampler = create_stream_resampler()
+        self._pair: Optional[tuple[int, int]] = None
+
+    async def resample(self, audio: bytes, in_rate: int, out_rate: int) -> bytes:
+        if in_rate == out_rate:
+            return audio
+        pair = (in_rate, out_rate)
+        if self._pair is not None and self._pair != pair:
+            logger.warning(
+                f"output rate guard: resample rate changed {self._pair[0]}->{self._pair[1]} "
+                f"to {in_rate}->{out_rate}; rebuilding the stream resampler"
+            )
+            self._resampler = create_stream_resampler()
+        self._pair = pair
+        return await self._resampler.resample(audio, in_rate, out_rate)
+
+
+class OutputRateGuard(FrameProcessor):
+    """Normalise outbound audio to the output transport's sample rate.
+
+    Spliced immediately before ``transport.output()``. Inert until the
+    transport has started (``sample_rate`` is 0 until its StartFrame lands) and
+    inert for frames that already match — the common case, costing one integer
+    compare.
+    """
+
+    def __init__(self, output_transport: Any = None) -> None:
+        super().__init__()
+        self._output_transport = output_transport
+        self._resampler = _RateAgileResampler()
+
+    def bind_output(self, output_transport: Any) -> None:
+        self._output_transport = output_transport
+
+    def _target_rate(self) -> Optional[int]:
+        rate = getattr(self._output_transport, "sample_rate", None)
+        if isinstance(rate, int) and rate > 0:
+            return rate
+        return None
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+
+        if direction == FrameDirection.DOWNSTREAM and isinstance(
+            frame, OutputAudioRawFrame
+        ):
+            target = self._target_rate()
+            if target is not None and frame.sample_rate != target:
+                # NOT logged: a mismatch here is the NORMAL case, not a fault.
+                # Ultravox renders at 48 kHz and the SIP transports are pinned
+                # to 16 kHz, so every bot frame on a phone call needs
+                # converting — the transport would have done exactly this work
+                # one processor later. Only a rate CHANGE is newsworthy, and
+                # _RateAgileResampler logs that.
+                try:
+                    frame.audio = await self._resampler.resample(
+                        frame.audio, frame.sample_rate, target
+                    )
+                    frame.sample_rate = target
+                except Exception as e:  # noqa: BLE001
+                    # Never let the guard itself break the audio path: pass the
+                    # frame through untouched and let the transport do what it
+                    # would have done without us.
+                    logger.warning(f"output rate guard: resample failed, passing through: {e}")
+
+        await self.push_frame(frame, direction)

--- a/agents/pipecat/pipecat_aplisay/pipeline_error_alarm.py
+++ b/agents/pipecat/pipecat_aplisay/pipeline_error_alarm.py
@@ -1,0 +1,131 @@
+"""Escalate pipeline ``ErrorFrame``s into something a human will actually see.
+
+WHY THIS EXISTS (beta incident, 2026-08-21)
+------------------------------------------
+An agent handover left the caller in dead air for 55 seconds. The pipeline knew:
+1283 ``ErrorFrame``s went past, one per dropped audio frame. But pipecat treats
+a non-fatal ErrorFrame as a WARNING on the worker's own logger
+(``pipeline/worker.py:_source_push_frame``), the call completed, and the Call
+row was written "ended normally". Nothing distinguished it from a good call.
+
+``PipelineTask`` already fires an ``on_pipeline_error`` event for every
+ErrorFrame (``pipeline/worker.py:1109``); nobody was listening. This listens,
+and turns the flood into: one ERROR the first time each distinct fault appears,
+a periodic count while it persists, and one summary line when the pipeline
+ends. Everything is emitted inside the run's ``logger.contextualize(callId=…)``
+scope, so it lands in the call's InvocationLog and is visible in the call
+inspector rather than only in pod logs.
+
+It deliberately does NOT end the call. A pipeline error is not always fatal to
+the conversation, and hanging up on a caller because of a transient decode
+error would be a worse failure than the one it is reporting. The job here is to
+make silence loud in the logs, not to make policy.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+from loguru import logger
+
+# Log a running count no more often than this while a fault persists.
+_SUMMARY_INTERVAL_SECS = 10.0
+
+
+def _error_text(frame: Any) -> str:
+    """Best-effort human text for an ErrorFrame across pipecat versions."""
+    for attr in ("error", "message"):
+        value = getattr(frame, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    return repr(frame)
+
+
+def _fingerprint(text: str) -> str:
+    """Collapse a family of near-identical errors to one key.
+
+    The incident produced 1283 messages differing only in nothing at all, but
+    in general the tail of an exception (ids, offsets) varies while the head
+    identifies the fault. First line, first 160 chars is plenty to tell two
+    real faults apart without letting one fault log a thousand times.
+    """
+    return text.strip().splitlines()[0][:160] if text.strip() else text
+
+
+class PipelineErrorAlarm:
+    """Counts and escalates ErrorFrames for one pipeline generation."""
+
+    def __init__(self, *, call_id: str, handover: bool = False) -> None:
+        self._call_id = call_id
+        # True when this pipeline is the continuation side of a full-stack
+        # agent handover — the case where a silent leg is most likely and
+        # least visible, because the caller has already been told they are
+        # being put through.
+        self._handover = handover
+        self._total = 0
+        # fingerprint -> {count, first_at, last_logged_at, text}
+        self._faults: dict[str, dict[str, Any]] = {}
+
+    @property
+    def total(self) -> int:
+        return self._total
+
+    def attach(self, task: Any) -> None:
+        """Register on a PipelineTask. Safe no-op if the event is unavailable."""
+        try:
+
+            @task.event_handler("on_pipeline_error")
+            async def _on_pipeline_error(_task, frame):  # noqa: ANN001
+                self.record(frame)
+
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"pipeline error alarm: could not attach: {e}")
+
+    def record(self, frame: Any) -> None:
+        """Note one ErrorFrame, logging at most once per fault per interval."""
+        text = _error_text(frame)
+        key = _fingerprint(text)
+        now = time.monotonic()
+        self._total += 1
+
+        fault = self._faults.get(key)
+        if fault is None:
+            self._faults[key] = {
+                "count": 1,
+                "first_at": now,
+                "last_logged_at": now,
+                "text": text,
+            }
+            logger.bind(call_id=self._call_id, handover=self._handover).error(
+                f"pipeline error{' during agent handover' if self._handover else ''}: {text}"
+            )
+            return
+
+        fault["count"] += 1
+        if now - fault["last_logged_at"] >= _SUMMARY_INTERVAL_SECS:
+            fault["last_logged_at"] = now
+            secs = now - fault["first_at"]
+            logger.bind(call_id=self._call_id, handover=self._handover).error(
+                f"pipeline error STILL FIRING after {secs:.0f}s "
+                f"({fault['count']} occurrences): {key}"
+            )
+
+    def final_summary(self) -> Optional[str]:
+        """One line describing the generation's faults, or None if it was clean."""
+        if not self._total:
+            return None
+        parts = [
+            f"{f['count']}x {key} (over {f['last_logged_at'] - f['first_at']:.0f}s)"
+            for key, f in self._faults.items()
+        ]
+        return f"{self._total} pipeline error frame(s): " + "; ".join(parts)
+
+    def log_final_summary(self) -> None:
+        summary = self.final_summary()
+        if summary is None:
+            return
+        logger.bind(call_id=self._call_id, handover=self._handover).error(
+            f"pipeline ended with errors{' after an agent handover' if self._handover else ''}"
+            f" — {summary}"
+        )

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -38,6 +38,7 @@ from pipecat.turns.user_mute.mute_until_first_bot_complete_user_mute_strategy im
     MuteUntilFirstBotCompleteUserMuteStrategy,
 )
 
+from .output_rate_guard import OutputRateGuard
 from .tool_log import log_tool_call, log_tool_result
 
 
@@ -1201,7 +1202,16 @@ async def _build_realtime(
     relay_inject = [relay_endpoint.inject] if relay_endpoint is not None else []
     # Confidence tone (options.transferTone) sits upstream of the relay
     # injector so an engaged relay drops tone frames too — see confidence_tone.
+    # Bind it to the output transport it feeds: the tone MUST be emitted at that
+    # transport's own sample rate, not StartFrame's (see confidence_tone._out_rate).
     tone = [tone_injector] if tone_injector is not None else []
+    if tone_injector is not None:
+        tone_injector.bind_output(transport.output())
+    # Defence in depth, immediately before output(): normalise every outbound
+    # audio frame to the transport's rate so nothing upstream can latch its
+    # stream resampler at the wrong ratio and mute the call. See
+    # output_rate_guard for the incident this prevents recurring.
+    rate_guard = OutputRateGuard(output_transport=transport.output())
     # Buffer DTMF keypresses into a single user turn before the context
     # aggregator (see _dtmf_aggregator_for). Without this, InputDTMFFrames are
     # never consumed and digits are dropped.
@@ -1214,6 +1224,7 @@ async def _build_realtime(
         llm,
         *tone,
         *relay_inject,
+        rate_guard,
         transport.output(),
     ]
     # The recording docs require ``AudioBufferProcessor`` to sit AFTER
@@ -1311,7 +1322,16 @@ async def _build_pipeline(
     relay_inject = [relay_endpoint.inject] if relay_endpoint is not None else []
     # Confidence tone (options.transferTone) sits upstream of the relay
     # injector so an engaged relay drops tone frames too — see confidence_tone.
+    # Bind it to the output transport it feeds: the tone MUST be emitted at that
+    # transport's own sample rate, not StartFrame's (see confidence_tone._out_rate).
     tone = [tone_injector] if tone_injector is not None else []
+    if tone_injector is not None:
+        tone_injector.bind_output(transport.output())
+    # Defence in depth, immediately before output(): normalise every outbound
+    # audio frame to the transport's rate so nothing upstream can latch its
+    # stream resampler at the wrong ratio and mute the call. See
+    # output_rate_guard for the incident this prevents recurring.
+    rate_guard = OutputRateGuard(output_transport=transport.output())
     # Buffer DTMF keypresses into a single user turn before the context
     # aggregator (see _dtmf_aggregator_for). Sits after STT — STT only consumes
     # audio frames, so ordering relative to it is immaterial.
@@ -1326,6 +1346,7 @@ async def _build_pipeline(
         tts,
         *tone,
         *relay_inject,
+        rate_guard,
         transport.output(),
     ]
     if audio_buffer is not None:

--- a/agents/pipecat/tests/test_confidence_tone_sample_rate.py
+++ b/agents/pipecat/tests/test_confidence_tone_sample_rate.py
@@ -1,0 +1,118 @@
+"""Regression: the confidence tone must be emitted at the OUTPUT TRANSPORT's
+sample rate, never at StartFrame's.
+
+Beta incident 2026-08-21 (call 6de176b3-…, PSTN → +442030518682): an agent
+handover to the "Web support" member left the whole second leg silent. The
+chain was:
+
+  * ``BaseOutputTransport`` owns ONE ``SOXRStreamAudioResampler`` per call and
+    that resampler LATCHES the first ``(in_rate, out_rate)`` pair it is handed;
+    every later frame at a different rate raises and is dropped, for good.
+  * The SIP gateway transports pin ``audio_out_sample_rate=16000``, but
+    ``PipelineParams.audio_out_sample_rate`` is never set, so StartFrame still
+    advertises pipecat's 24000 default.
+  * On handover the injector is rebuilt (``_dst_rate is None``) and armed
+    before the incoming agent speaks, so its tone — at StartFrame's 24000 —
+    was the first audio to reach the fresh transport and latched it 24000→16000.
+  * Ultravox realtime then emitted at 48000 → ``ValueError`` on every frame →
+    total silence until the caller hung up.
+
+It stayed invisible on the WebRTC path only because that transport leaves its
+rate unpinned: tone frames matched it exactly and ``resample()`` short-circuits
+on equal rates, so the resampler was first latched by the agent's own audio.
+
+These tests pin the rule that fixes it: ask the output transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+from pipecat.pipeline.task import PipelineParams
+from pipecat.tests.utils import run_test
+
+from pipecat_aplisay.confidence_tone import ConfidenceToneInjector, ToneConfig
+
+
+def _injector(output_transport=None) -> ConfidenceToneInjector:
+    return ConfidenceToneInjector(
+        ToneConfig(grace_ms=1200),
+        get_transfer_state=lambda: SimpleNamespace(state="none"),
+        output_transport=output_transport,
+    )
+
+
+class TestOutRate:
+    def test_prefers_output_transport_over_start_frame(self) -> None:
+        """The exact incident shape: transport pinned to 16k, StartFrame 24k."""
+        inj = _injector(output_transport=SimpleNamespace(sample_rate=16000))
+        # Simulate the StartFrame having taught the (misleading) 24k fallback.
+        inj._dst_rate = 24000
+        assert inj._out_rate() == 16000
+
+    def test_falls_back_to_learned_rate_before_transport_starts(self) -> None:
+        # ``BaseOutputTransport.sample_rate`` is 0 until its StartFrame lands.
+        inj = _injector(output_transport=SimpleNamespace(sample_rate=0))
+        inj._dst_rate = 48000
+        assert inj._out_rate() == 48000
+
+    def test_unknown_rate_is_none_not_a_guess(self) -> None:
+        # Nothing authoritative yet: the generator must stay silent rather than
+        # emit at a guessed rate and poison the transport's resampler.
+        assert _injector()._out_rate() is None
+
+    def test_bind_output_supplies_the_transport_late(self) -> None:
+        inj = _injector()
+        assert inj._out_rate() is None
+        inj.bind_output(SimpleNamespace(sample_rate=16000))
+        assert inj._out_rate() == 16000
+
+    def test_non_transport_object_does_not_raise(self) -> None:
+        # Defensive: anything without a usable ``sample_rate`` is ignored.
+        inj = _injector(output_transport=object())
+        inj._dst_rate = 16000
+        assert inj._out_rate() == 16000
+
+
+class TestGeneratorEmitsAtTransportRate:
+    def test_tone_chunk_uses_transport_rate(self) -> None:
+        """A 20 ms chunk at 16 kHz is 320 samples → 640 bytes of s16le."""
+        inj = _injector(output_transport=SimpleNamespace(sample_rate=16000))
+        inj.arm_handover()
+        inj._last_voice = time.monotonic() - 5.0
+        assert inj._should_play() is True
+
+        rate = inj._out_rate()
+        assert rate == 16000
+        chunk = inj._make_chunk(rate, int(rate * 0.02))
+        assert len(chunk) == 640
+
+
+def test_start_frame_alone_does_not_set_the_emit_rate() -> None:
+    """StartFrame teaches the fallback but must not win over the transport.
+
+    Uses stock ``PipelineParams`` — exactly what ``voice_session`` builds — so
+    the 24 kHz that broke the live call is the value under test, not a
+    hand-picked number.
+    """
+
+    async def run() -> None:
+        assert PipelineParams().audio_out_sample_rate == 24000, (
+            "this regression is about pipecat's default leaking into StartFrame"
+        )
+        inj = _injector(output_transport=SimpleNamespace(sample_rate=16000))
+        await run_test(
+            inj,
+            frames_to_send=[],
+            expected_down_frames=[],
+            pipeline_params=PipelineParams(),
+        )
+        # StartFrame's 24 kHz is recorded only as the last-resort fallback...
+        assert inj._dst_rate == 24000
+        # ...the pinned transport rate still wins, which is what keeps the
+        # output transport's resampler from latching at the wrong ratio.
+        assert inj._out_rate() == 16000
+
+    asyncio.run(run())

--- a/agents/pipecat/tests/test_output_rate_guard.py
+++ b/agents/pipecat/tests/test_output_rate_guard.py
@@ -1,0 +1,205 @@
+"""The output rate guard makes the resampler-latch failure impossible.
+
+Background: ``BaseOutputTransport``'s ``MediaSender`` holds ONE
+``SOXRStreamAudioResampler`` for the whole call, and it latches the first
+``(in_rate, out_rate)`` pair it is handed — every later pair raises and the
+frame is DROPPED, silently and permanently (2026-08-21 beta incident: 1283
+frames lost over 55 s of dead air).
+
+The guard sits immediately before ``transport.output()`` and rewrites every
+outbound frame to the transport's own rate. Because ``resample()``
+short-circuits on equal rates, the transport's resampler is then never
+constructed at all and can never latch. That is the invariant these tests pin.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pipecat.audio.utils import create_stream_resampler
+from pipecat.frames.frames import OutputAudioRawFrame, TTSAudioRawFrame
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.tests.utils import run_test
+
+from pipecat_aplisay.output_rate_guard import OutputRateGuard, _RateAgileResampler
+
+
+def _pcm(samples: int) -> bytes:
+    """`samples` frames of s16le silence."""
+    return b"\x00\x00" * samples
+
+
+def _guard(rate) -> OutputRateGuard:
+    return OutputRateGuard(output_transport=SimpleNamespace(sample_rate=rate))
+
+
+class TestRateAgileResampler:
+    def test_equal_rates_pass_through_untouched(self) -> None:
+        async def run() -> None:
+            r = _RateAgileResampler()
+            audio = _pcm(160)
+            assert await r.resample(audio, 16000, 16000) is audio
+
+        asyncio.run(run())
+
+    def test_the_stock_resampler_really_does_latch(self) -> None:
+        """Guards the premise. If pipecat ever makes this survivable upstream,
+        this test fails and _RateAgileResampler can be deleted."""
+
+        async def run() -> None:
+            stock = create_stream_resampler()
+            await stock.resample(_pcm(480), 24000, 16000)
+            with pytest.raises(ValueError, match="cannot be reused"):
+                await stock.resample(_pcm(960), 48000, 16000)
+
+        asyncio.run(run())
+
+    def test_survives_a_rate_change_that_would_latch_the_stock_resampler(self) -> None:
+        """The exact incident sequence: 24k->16k, then 48k->16k.
+
+        soxr's ResampleStream emits in bursts (it holds filter delay), so an
+        individual chunk may legitimately return b"" — the invariant is that
+        the rate change does not RAISE and that audio keeps coming out
+        afterwards, which is precisely what the stock resampler stops doing.
+        """
+
+        async def run() -> None:
+            r = _RateAgileResampler()
+            before = 0
+            for _ in range(6):
+                before += len(await r.resample(_pcm(480), 24000, 16000))
+            assert before > 0
+            after = 0
+            for _ in range(6):
+                after += len(await r.resample(_pcm(960), 48000, 16000))
+            assert after > 0, "no audio survived the rate change"
+
+        asyncio.run(run())
+
+    def test_many_alternating_rates_all_produce_audio(self) -> None:
+        async def run() -> None:
+            r = _RateAgileResampler()
+            for rate in (24000, 48000, 24000, 8000, 48000):
+                out = 0
+                for _ in range(6):
+                    out += len(await r.resample(_pcm(rate // 50), rate, 16000))
+                assert out > 0, f"{rate} produced nothing"
+
+        asyncio.run(run())
+
+
+class TestGuardRewritesToTransportRate:
+    def test_mismatched_frame_is_converted(self) -> None:
+        async def run() -> None:
+            guard = _guard(16000)
+            frame = OutputAudioRawFrame(_pcm(1200), sample_rate=24000, num_channels=1)
+            await run_test(
+                guard,
+                frames_to_send=[frame],
+                expected_down_frames=[OutputAudioRawFrame],
+            )
+            # Converted IN PLACE, so the transport downstream sees its own rate
+            # and its resampler takes the equal-rates fast path.
+            assert frame.sample_rate == 16000
+
+        asyncio.run(run())
+
+    def test_matching_frame_is_left_alone(self) -> None:
+        async def run() -> None:
+            guard = _guard(16000)
+            audio = _pcm(320)
+            frame = OutputAudioRawFrame(audio, sample_rate=16000, num_channels=1)
+            await run_test(
+                guard,
+                frames_to_send=[frame],
+                expected_down_frames=[OutputAudioRawFrame],
+            )
+            assert frame.sample_rate == 16000
+            assert frame.audio is audio  # not round-tripped through soxr
+
+        asyncio.run(run())
+
+    def test_subclass_identity_survives(self) -> None:
+        """TTSAudioRawFrame must stay a TTSAudioRawFrame — base_output keys off
+        ``type(frame)`` when it chunks, and callers match on the subclass."""
+
+        async def run() -> None:
+            guard = _guard(16000)
+            frame = TTSAudioRawFrame(_pcm(1200), sample_rate=24000, num_channels=1)
+            await run_test(
+                guard,
+                frames_to_send=[frame],
+                expected_down_frames=[TTSAudioRawFrame],
+            )
+            assert isinstance(frame, TTSAudioRawFrame)
+            assert frame.sample_rate == 16000
+
+        asyncio.run(run())
+
+    def test_inert_before_the_transport_has_started(self) -> None:
+        """``BaseOutputTransport.sample_rate`` is 0 until its StartFrame lands;
+        the guard must pass frames through rather than resample to zero."""
+
+        async def run() -> None:
+            guard = _guard(0)
+            frame = OutputAudioRawFrame(_pcm(480), sample_rate=24000, num_channels=1)
+            await run_test(
+                guard,
+                frames_to_send=[frame],
+                expected_down_frames=[OutputAudioRawFrame],
+            )
+            assert frame.sample_rate == 24000
+
+        asyncio.run(run())
+
+    def test_a_resample_failure_never_swallows_the_frame(self) -> None:
+        """The guard must not become a new way to lose audio."""
+
+        async def run() -> None:
+            guard = _guard(16000)
+
+            class _Boom:
+                async def resample(self, *_a, **_k):
+                    raise RuntimeError("soxr exploded")
+
+            guard._resampler = _Boom()
+            frame = OutputAudioRawFrame(_pcm(480), sample_rate=24000, num_channels=1)
+            await run_test(
+                guard,
+                frames_to_send=[frame],
+                expected_down_frames=[OutputAudioRawFrame],
+            )
+            # Passed through untouched — the transport then behaves exactly as
+            # it would have without the guard, no worse.
+            assert frame.sample_rate == 24000
+
+        asyncio.run(run())
+
+
+class TestTheIncidentCannotRecur:
+    def test_tone_then_agent_audio_both_reach_the_transport_at_one_rate(self) -> None:
+        """Replays the live sequence through the guard.
+
+        24 kHz comfort tone first (what latched the resampler), then 48 kHz
+        Ultravox audio. Both must emerge at the transport's 16 kHz, so the
+        transport only ever sees equal rates and never builds a stream at all.
+        """
+
+        async def run() -> None:
+            guard = _guard(16000)
+            tone = OutputAudioRawFrame(_pcm(480), sample_rate=24000, num_channels=1)
+            speech = TTSAudioRawFrame(_pcm(960), sample_rate=48000, num_channels=1)
+            await run_test(
+                guard,
+                frames_to_send=[tone, speech],
+                expected_down_frames=[OutputAudioRawFrame, TTSAudioRawFrame],
+            )
+            assert tone.sample_rate == 16000
+            assert speech.sample_rate == 16000
+            # Both frames now carry the transport's rate, so downstream
+            # `resample(audio, 16000, 16000)` short-circuits and the transport
+            # never builds — and therefore never latches — a stream at all.
+
+        asyncio.run(run())

--- a/agents/pipecat/tests/test_pipeline_error_alarm.py
+++ b/agents/pipecat/tests/test_pipeline_error_alarm.py
@@ -1,0 +1,139 @@
+"""ErrorFrames must be loud, once — not silent, and not 1283 times.
+
+On the 2026-08-21 beta incident the pipeline emitted an ErrorFrame per dropped
+audio frame for 55 seconds. Pipecat logs those as WARNINGs on its own logger and
+the call still ends "normally", so nothing marked the call as bad. These tests
+pin the two halves of the fix: the first occurrence of each distinct fault
+escalates immediately, and a persistent flood collapses into a count rather than
+drowning the log it is supposed to make readable.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pipecat_aplisay.pipeline_error_alarm import (
+    _SUMMARY_INTERVAL_SECS,
+    PipelineErrorAlarm,
+    _error_text,
+    _fingerprint,
+)
+
+# The real message from the incident.
+_LATCH = (
+    "Error processing frame: SOXRStreamAudioResampler cannot be reused with "
+    "different sample rates: expected 24000->16000, got 48000->16000"
+)
+
+
+def _frame(text: str = _LATCH):
+    return SimpleNamespace(error=text)
+
+
+class TestErrorText:
+    def test_reads_the_error_attribute(self) -> None:
+        assert _error_text(_frame("boom")) == "boom"
+
+    def test_falls_back_to_message(self) -> None:
+        assert _error_text(SimpleNamespace(message="boom")) == "boom"
+
+    def test_never_raises_on_an_odd_frame(self) -> None:
+        assert _error_text(object())  # repr fallback, non-empty
+
+    def test_fingerprint_collapses_a_multiline_error_to_its_head(self) -> None:
+        assert _fingerprint("first line\nsecond line") == "first line"
+
+
+class TestEscalation:
+    def test_first_error_is_counted(self) -> None:
+        alarm = PipelineErrorAlarm(call_id="c1")
+        alarm.record(_frame())
+        assert alarm.total == 1
+
+    def test_a_flood_of_one_fault_is_counted_but_logged_once(self, capsys) -> None:
+        alarm = PipelineErrorAlarm(call_id="c1")
+        for _ in range(1283):  # the real incident volume
+            alarm.record(_frame())
+        assert alarm.total == 1283
+        # One distinct fault, so one entry — the log volume is bounded by the
+        # number of DISTINCT faults, not the number of frames dropped.
+        assert len(alarm._faults) == 1
+
+    def test_distinct_faults_are_tracked_separately(self) -> None:
+        alarm = PipelineErrorAlarm(call_id="c1")
+        alarm.record(_frame("resampler exploded"))
+        alarm.record(_frame("codec exploded"))
+        alarm.record(_frame("resampler exploded"))
+        assert alarm.total == 3
+        assert len(alarm._faults) == 2
+
+    def test_a_persistent_fault_re_logs_once_the_interval_passes(self) -> None:
+        alarm = PipelineErrorAlarm(call_id="c1")
+        alarm.record(_frame())
+        fault = alarm._faults[_fingerprint(_LATCH)]
+        logged_at = fault["last_logged_at"]
+        # Still inside the window: no re-log.
+        alarm.record(_frame())
+        assert alarm._faults[_fingerprint(_LATCH)]["last_logged_at"] == logged_at
+        # Pretend the interval elapsed.
+        fault["last_logged_at"] -= _SUMMARY_INTERVAL_SECS + 1
+        alarm.record(_frame())
+        assert alarm._faults[_fingerprint(_LATCH)]["last_logged_at"] > logged_at
+
+
+class TestFinalSummary:
+    def test_a_clean_generation_says_nothing(self) -> None:
+        assert PipelineErrorAlarm(call_id="c1").final_summary() is None
+
+    def test_summary_names_the_count_and_the_fault(self) -> None:
+        alarm = PipelineErrorAlarm(call_id="c1")
+        for _ in range(3):
+            alarm.record(_frame())
+        summary = alarm.final_summary()
+        assert "3 pipeline error frame(s)" in summary
+        assert "SOXRStreamAudioResampler" in summary
+
+    def test_log_final_summary_is_safe_when_clean(self) -> None:
+        PipelineErrorAlarm(call_id="c1").log_final_summary()  # must not raise
+
+
+class TestAttach:
+    def test_attaches_to_a_task_that_exposes_the_event(self) -> None:
+        registered = {}
+
+        class _Task:
+            def event_handler(self, name):
+                def deco(fn):
+                    registered[name] = fn
+                    return fn
+
+                return deco
+
+        PipelineErrorAlarm(call_id="c1").attach(_Task())
+        assert "on_pipeline_error" in registered
+
+    def test_a_task_without_the_event_does_not_break_the_call(self) -> None:
+        class _Task:
+            def event_handler(self, name):
+                raise RuntimeError("no such event")
+
+        # Monitoring is never worth failing a live call over.
+        PipelineErrorAlarm(call_id="c1").attach(_Task())
+
+    def test_the_registered_handler_records(self) -> None:
+        import asyncio
+
+        registered = {}
+
+        class _Task:
+            def event_handler(self, name):
+                def deco(fn):
+                    registered[name] = fn
+                    return fn
+
+                return deco
+
+        alarm = PipelineErrorAlarm(call_id="c1", handover=True)
+        alarm.attach(_Task())
+        asyncio.run(registered["on_pipeline_error"](None, _frame()))
+        assert alarm.total == 1

--- a/agents/pipecat/tests/test_recording_default.py
+++ b/agents/pipecat/tests/test_recording_default.py
@@ -1,0 +1,79 @@
+"""The engine records only when asked. Absence means no recording.
+
+This is a deliberate boundary, not an oversight. "Every call is recorded unless
+the customer turns it off" is a statement a CLIENT APPLICATION makes about its
+own users and its own consent flow — polite-ai makes exactly that promise and
+materialises it at its API boundary before calling us. llm-agent serves other
+consumers, so a default-on engine would record on behalf of operators whose
+callers never agreed to it. Recording people is not a sensible default for a
+general-purpose engine to assume.
+
+The practical consequence for callers: you cannot express "off" by deleting the
+option and you cannot express "on" by saying nothing. Say what you mean.
+"""
+
+from __future__ import annotations
+
+from pipecat_aplisay.call_session import _resolve_recording_options
+
+
+def _agent(recording=None) -> dict:
+    options = {} if recording is None else {"recording": recording}
+    return {"id": "a1", "options": options}
+
+
+class TestEngineIsOptIn:
+    def test_absent_option_does_not_record(self) -> None:
+        assert _resolve_recording_options(_agent(), {}).enabled is False
+
+    def test_empty_options_do_not_record(self) -> None:
+        assert _resolve_recording_options({"id": "a1"}, {}).enabled is False
+
+    def test_explicit_true_records(self) -> None:
+        assert _resolve_recording_options(_agent({"enabled": True}), {}).enabled is True
+
+    def test_explicit_false_does_not_record(self) -> None:
+        assert _resolve_recording_options(_agent({"enabled": False}), {}).enabled is False
+
+    def test_option_present_without_enabled_does_not_record(self) -> None:
+        # A stored encryption key is not consent to record — `enabled` is the
+        # only gate, and it has to be set.
+        opts = _resolve_recording_options(_agent({"key": "abc"}), {})
+        assert opts.enabled is False
+        assert opts.key == "abc"
+
+
+class TestInstanceOverride:
+    def test_instance_false_beats_agent_true(self) -> None:
+        agent = _agent({"enabled": True})
+        assert _resolve_recording_options(agent, {"recording": {"enabled": False}}).enabled is False
+
+    def test_instance_true_beats_agent_absent(self) -> None:
+        # How a client application arms recording per-listener without touching
+        # the agent — polite-ai's deploy path relies on this.
+        assert _resolve_recording_options(_agent(), {"recording": {"enabled": True}}).enabled is True
+
+    def test_instance_true_beats_agent_false(self) -> None:
+        agent = _agent({"enabled": False})
+        assert _resolve_recording_options(agent, {"recording": {"enabled": True}}).enabled is True
+
+    def test_instance_without_recording_falls_through_to_agent(self) -> None:
+        agent = _agent({"enabled": True})
+        assert _resolve_recording_options(agent, {"recording": None}).enabled is True
+
+    def test_instance_recording_without_enabled_falls_through_to_agent(self) -> None:
+        agent = _agent({"enabled": True})
+        instance = {"recording": {"key": "listener-key"}}
+        opts = _resolve_recording_options(agent, instance)
+        assert opts.enabled is True  # agent's opt-in still stands
+        assert opts.key == "listener-key"  # but the listener's key is used
+
+
+class TestKeyHandling:
+    def test_blank_key_is_treated_as_absent(self) -> None:
+        assert _resolve_recording_options(_agent({"enabled": True, "key": "   "}), {}).key is None
+
+    def test_instance_key_overrides_agent_key(self) -> None:
+        agent = _agent({"enabled": True, "key": "agent-key"})
+        instance = {"recording": {"key": "listener-key"}}
+        assert _resolve_recording_options(agent, instance).key == "listener-key"

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -435,7 +435,11 @@ components:
           description: |-
             Call recording configuration for this agent.
 
-            When enabled, calls handled by this agent can be recorded to a storage bucket.
+            Recording is OPT-IN: calls are recorded only when this object is present with
+            `enabled: true`. Omitting it means no recording. (A client application that wants
+            recording on by default is responsible for sending it — the API does not assume
+            consent on your users' behalf.)
+
             Recordings are always encrypted. If you provide a `key`, the recording will be
             encrypted with a key derived from that value and the server will not be able
             to decrypt it for you. If you omit `key`, a random per-call key will be
@@ -446,7 +450,9 @@ components:
           properties:
             enabled:
               type: boolean
-              description: Enable or disable call recording for this agent.
+              description: |-
+                Enable call recording for this agent. Absent or `false` means the call is not
+                recorded; only `true` arms recording.
             key:
               type: string
               nullable: true

--- a/api/paths/agents/{agentId}/listen.js
+++ b/api/paths/agents/{agentId}/listen.js
@@ -133,6 +133,25 @@ export default function (wsServer) {
                       type: "boolean",
                       description: "If true, then this is a debug instance which will post a live debug transcript as messages in a livekit room and/or socket",
                     },
+                    recording: {
+                      type: "object",
+                      description: `Per-listener override of the agent's \`options.recording\`. WINS over the agent-level
+                        value in both directions, so \`{ enabled: true }\` here records an agent that did not ask to be
+                        recorded and \`{ enabled: false }\` suppresses one that did — only send it when the override is
+                        genuinely intended. Omit it to inherit the agent's own setting. Recording is opt-in: with neither
+                        level set, the call is not recorded.`,
+                      properties: {
+                        enabled: {
+                          type: "boolean",
+                          description: "Record calls on this listener. Absent or false means no recording; only true arms it."
+                        },
+                        key: {
+                          type: "string",
+                          nullable: true,
+                          description: "Optional client-provided encryption key for this listener's recordings. When set, the server cannot decrypt them."
+                        }
+                      }
+                    },
                     metadata: {
                       type: "object",
                       description: "Metadata to be associated with this activation instance, can be overriden by the agent join for finer, per user control",


### PR DESCRIPTION
A real PSTN call on beta (`03300889471` → `+442030518682`, call `6de176b3-…`, 14:35 UTC 2026-08-21) handed over to a second agent and the caller heard nothing for the rest of the call. The incoming agent was talking throughout — **1283 of its audio frames were thrown away**.

## Root cause

`BaseOutputTransport`'s `MediaSender` owns **one** `SOXRStreamAudioResampler` for the whole call and it **latches the first `(in_rate, out_rate)` pair** it is handed. Every later pair raises, the frame is dropped, and pipecat surfaces it only as a *non-fatal* `ErrorFrame` — so the call carries on and ends "normally".

`ConfidenceToneInjector` took its emit rate from `StartFrame.audio_out_sample_rate`. That is `PipelineParams`' **24000** default (we never set it), **not** the transport's rate — the SIP gateways pin **16000**. On a handover the injector is rebuilt (`_dst_rate = None`) and armed ~1.2 s before the new agent speaks, so its 24 kHz tone was the first audio into the fresh transport and latched it `24000→16000`. Ultravox realtime emits at **48000**, so every subsequent frame raised.

```
SOXRStreamAudioResampler cannot be reused with different sample rates:
expected 24000->16000, got 48000->16000        ← ×1283, 14:36:31 → 14:37:26
```

**Why it survived to production:** WebRTC leaves its transport rate unpinned at 24000, so tone frames match exactly and `resample()` short-circuits on equal rates — the resampler gets latched by the agent's own audio instead. The bug is therefore invisible in browser testing, bites only real phone calls, and is a race between the tone and the agent's first audio.

⚠️ Corollary: "fixing parity" by pinning the WebRTC transport to 48000 would **arm** this on the browser path. The real invariant is "output transport pinned to any rate ≠ 24000", today the three SIP gateways only.

## Changes

- **`confidence_tone`** — resolve the emit rate from the output transport's own public `sample_rate` (bound at splice time), fall back to the frame-learned rate, and emit **nothing** rather than guess when neither is known.
- **`output_rate_guard`** (new) — defence in depth. Sits immediately before `transport.output()` and normalises every outbound frame to the transport's rate, so the transport only ever sees equal rates and its resampler is never constructed at all. Kills the whole failure class whatever upstream emits (relay injector, fallback TTS voice, model swapped mid-handover).
- **`pipeline_error_alarm`** (new) — nothing was listening to `PipelineTask`'s existing `on_pipeline_error` event, which is why 1283 ErrorFrames went unseen. Now: ERROR on the first of each distinct fault (fingerprinted, so a flood collapses to one entry), a count while it persists, and a summary written *before* the InvocationLog is flushed so it lands in the call's own debug log. It deliberately does **not** end the call.
- **`confidence_tone`** — hitting the handover backstop with no audio from the incoming agent now logs `agent handover FAILED` instead of quietly disarming. That one line would have caught this in seconds.

## API contract

Documents `options.recording` on the listen endpoint — the field that overrides everything was undeclared at the endpoint that sets it — and states the engine's rule explicitly: **recording is opt-in**, absent means no recording, only `enabled: true` arms it. A client application that wants recording on by default is responsible for sending it; the engine does not assume consent on its consumers' users' behalf. (polite.ai does exactly that, in a companion PR.)

## Testing

- `pytest tests/ -q` → **350 passed** (24 new)
- `yarn test` (`jest.config.db.js`, clean Postgres volume) → **770 passed / 73 suites**

New tests pin the mechanism, not just the fix: one asserts the *stock* resampler really does latch, so if pipecat ever fixes this upstream the workaround can be deleted; another replays the live tone-then-speech sequence.

Note for future test authors: soxr's `ResampleStream` buffers filter delay, so a single small chunk legitimately returns `b""` — assert cumulative output across chunks, never one.
