### PR TITLE
feat(failover): speak a fixed message when no agent can be started

### DIFF
--- a/agents/livekit/agent-lib/fallback-message
+++ b/agents/livekit/agent-lib/fallback-message
@@ -1,0 +1,1 @@
+../../../lib/fallback-message/

--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -195,9 +195,10 @@ export interface Agent {
      * how to recover when the primary model fails to connect or run.
      *
      * Precedence:
-     *  1. agent  - restart with a different agent (not yet implemented in worker).
-     *  2. model  - restart the session with a different modelName.
-     *  3. number - transfer the call to this number using the builtin transfer function.
+     *  1. agent   - restart with a different agent.
+     *  2. model   - restart the session with a different modelName.
+     *  3. message - play a fixed TTS announcement at the caller.
+     *  4. number  - transfer the call to this number using the builtin transfer function.
      */
     fallback?: {
       /**
@@ -208,6 +209,23 @@ export interface Agent {
        * Fallback model name to use if the primary model fails.
        */
       model?: string;
+      /**
+       * Fixed announcement played at the caller when no agent could be started.
+       * Always an object — there is no bare-string shorthand.
+       *
+       * `vendor`/`voice`/`language` may be overridden so the announcement is
+       * spoken by a stack that is known-good even when the agent's own is what
+       * failed. A pipeline agent defaults them from its `options.tts`; a
+       * realtime agent inherits only `language`, since its `tts.voice` names a
+       * timbre of the model that no TTS can render. See
+       * lib/fallback-message/CONTRACT.md.
+       */
+      message?: {
+        text?: string;
+        vendor?: string;
+        voice?: string;
+        language?: string;
+      };
       /**
        * Fallback transfer destination (phone number or endpoint ID).
        */

--- a/agents/livekit/lib/fallback-message.ts
+++ b/agents/livekit/lib/fallback-message.ts
@@ -1,0 +1,324 @@
+/**
+ * Fixed-message failover for LiveKit — `options.fallback.message`.
+ *
+ * Sits between `fallback.model` and `fallback.number` in the failover chain
+ * (see `docs/agent-failover.md`): when the agent could not be brought up, play
+ * the operator's announcement at the caller rather than dropping them into
+ * dead air or straight onto a transfer.
+ *
+ * Two properties shape everything here.
+ *
+ * **The audio is cached, so playout makes no vendor call.** The announcement
+ * cannot vary for a given configuration, so it is synthesised once, stored in
+ * GCS keyed by a digest of its own content, and replayed from then on. That is
+ * not just a latency win: because a cache hit calls no TTS vendor, it meters
+ * no usage, so it needs no `Call` record, so it never reserves an agent
+ * concurrency slot. Which matters enormously, because the single most useful
+ * moment to play a fixed message is when the concurrency limiter is what
+ * rejected the call — a playout that took a slot would defeat the feature it
+ * implements. See `lib/fallback-message/CONTRACT.md`.
+ *
+ * **This path runs when things are already broken**, and often when the host is
+ * loaded — load being one of the likelier reasons a session failed to start.
+ * So it stays cheap and it never throws: every failure here degrades to
+ * "caller does not get the announcement", handing control back to the fallback
+ * chain to try `fallback.number`, rather than turning one failure into two.
+ *
+ * Mirrors `agents/pipecat/pipecat_aplisay/fallback_message.py` — keep the
+ * resolution rules and playout semantics in step across stacks.
+ */
+
+import {
+  AudioFrame,
+  AudioSource,
+  LocalAudioTrack,
+  TrackPublishOptions,
+  TrackSource,
+  type Room,
+} from "@livekit/rtc-node";
+import { inference, type tts as ttsTypes } from "@livekit/agents";
+import logger from "./logger.js";
+import type { Agent } from "./api-client.js";
+import { resolveVoiceMode } from "./voice-mode.js";
+import {
+  decodeWav,
+  encodeWav,
+  fallbackMessageKey,
+  fetchCachedMessage,
+  resolveFallbackMessage,
+  storeCachedMessage,
+  type ResolvedFallbackMessage,
+} from "../agent-lib/fallback-message/index.js";
+
+/** Frame size pushed to the room. 20 ms is the LiveKit/SIP convention. */
+const FRAME_MS = 20;
+
+/** `AudioSource` queue depth; `captureFrame` blocks once it is full, which is
+ *  what paces the loop at realtime without a timer. Matches confidence-tone. */
+const QUEUE_MS = 200;
+
+/** Ceiling on synthesis. The caller is holding an already-failed call, so a
+ *  hung TTS vendor must not add to their wait — give up and let the chain move
+ *  on to `fallback.number`. */
+const SYNTHESIS_TIMEOUT_MS = 10_000;
+
+/** Hard ceiling on playout, so a pathological cached object cannot pin a room
+ *  open indefinitely. Well clear of any sane announcement. */
+const MAX_PLAYOUT_MS = 120_000;
+
+export interface FallbackMessageAudio {
+  pcm: Buffer;
+  sampleRate: number;
+  /** True when this came from GCS rather than a fresh vendor call. */
+  cached: boolean;
+}
+
+/**
+ * Resolve `options.fallback.message` for an agent, or `null` when the agent has
+ * not configured one.
+ *
+ * A realtime agent's `options.tts` describes the model's own voice, not a TTS,
+ * so its vendor/voice are not inherited — see `resolveFallbackMessage`. Keep
+ * this decision identical to Pipecat's `fixed_message_for`: it feeds the cache
+ * key, and disagreeing would split the shared cache in two.
+ */
+export function fallbackMessageFor(agent: Agent): ResolvedFallbackMessage | null {
+  const inheritAgentTts =
+    resolveVoiceMode(agent?.modelName ?? "", agent?.options) === "pipeline";
+  return resolveFallbackMessage(agent?.options?.fallback?.message, agent?.options, {
+    inheritAgentTts,
+  });
+}
+
+/**
+ * Build a TTS instance for the announcement.
+ *
+ * The message may name its own `vendor`/`voice`/`language` — the whole point
+ * being that it can be spoken by a stack known to work when the agent's own is
+ * what just failed. Rather than reimplement vendor selection, we hand
+ * `buildPipelineTts` a *synthetic agent* whose `options.tts` is the message's
+ * resolved settings. Every vendor the pipeline supports is therefore supported
+ * here for free, and stays supported as vendors are added, with no second
+ * catalogue to keep in step.
+ *
+ * `buildPipelineTts` returns either a configured TTS instance or a LiveKit
+ * Inference model string; only the former can synthesise on its own, so a
+ * string is turned into an `inference.TTS` here.
+ */
+async function buildMessageTts(
+  agent: Agent,
+  resolved: ResolvedFallbackMessage,
+): Promise<ttsTypes.TTS> {
+  // Imported lazily, as Pipecat's sibling does: the factory pulls in every
+  // vendor plugin, and this path only needs it on a cache miss. Deferring it
+  // keeps the cost off the common (cached) playout and off module load.
+  const { buildPipelineTts } = await import("./voice-session-factory.js");
+
+  const syntheticAgent = {
+    ...agent,
+    options: {
+      ...(agent.options || {}),
+      tts: {
+        ...(agent.options?.tts || {}),
+        ...(resolved.vendor ? { vendor: resolved.vendor } : {}),
+        ...(resolved.voice ? { voice: resolved.voice } : {}),
+        ...(resolved.language ? { language: resolved.language } : {}),
+      },
+    },
+  } as Agent;
+
+  const built = buildPipelineTts(syntheticAgent);
+  if (typeof built !== "string") {
+    return built as ttsTypes.TTS;
+  }
+  const [model, voice] = inference.parseTTSModelString(built);
+  return new inference.TTS({
+    model,
+    ...(voice ? { voice } : {}),
+    ...(resolved.language ? { language: resolved.language } : {}),
+  }) as unknown as ttsTypes.TTS;
+}
+
+/**
+ * Synthesise the announcement through the configured TTS.
+ *
+ * The usage this incurs is metered against the call that triggered it, through
+ * the runtime's normal TTS accounting — which is the honest place for it: this
+ * is the one call that actually paid a vendor for these characters. Every
+ * later playout is a cache hit and costs nothing, so the announcement is billed
+ * exactly once per distinct configuration rather than once per failed call.
+ */
+async function synthesise(
+  agent: Agent,
+  resolved: ResolvedFallbackMessage,
+): Promise<{ pcm: Buffer; sampleRate: number }> {
+  const tts = await buildMessageTts(agent, resolved);
+  const stream = tts.synthesize(resolved.text);
+  try {
+    const frame = (await Promise.race([
+      stream.collect(),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error(`fallback message synthesis timed out after ${SYNTHESIS_TIMEOUT_MS}ms`)),
+          SYNTHESIS_TIMEOUT_MS,
+        ).unref?.(),
+      ),
+    ])) as AudioFrame;
+    // `frame.data` is an Int16Array view; copy through its own byte range so a
+    // pooled or offset-backed buffer cannot smuggle neighbouring audio in.
+    const pcm = Buffer.from(frame.data.buffer, frame.data.byteOffset, frame.data.byteLength);
+    return { pcm: Buffer.from(pcm), sampleRate: frame.sampleRate };
+  } finally {
+    try {
+      stream.close();
+    } catch {
+      // Closing a finished stream is best-effort; nothing here is worth failing on.
+    }
+  }
+}
+
+/**
+ * Get the announcement audio: cache read, else synthesise and write through.
+ *
+ * Returns `null` if it could not be produced at all, which the caller should
+ * treat as "no announcement available" and continue down the fallback chain.
+ */
+export async function loadFallbackMessageAudio(
+  agent: Agent,
+  resolved: ResolvedFallbackMessage,
+): Promise<FallbackMessageAudio | null> {
+  const key = fallbackMessageKey(resolved);
+
+  const cached = await fetchCachedMessage({ key, logger });
+  if (cached) {
+    try {
+      const { pcm, sampleRate } = decodeWav(cached);
+      return { pcm, sampleRate, cached: true };
+    } catch (e) {
+      // A corrupt object should not condemn the caller to silence: fall through
+      // and re-synthesise. The bad object stays until something overwrites or
+      // expires it, which is fine — it is content-addressed, so the next writer
+      // produces byte-identical audio anyway.
+      logger.warn({ e, key }, "cached fallback message failed to decode; re-synthesising");
+    }
+  }
+
+  let fresh: { pcm: Buffer; sampleRate: number };
+  try {
+    fresh = await synthesise(agent, resolved);
+  } catch (e) {
+    logger.error({ e, key }, "fallback message synthesis failed; no announcement available");
+    return null;
+  }
+
+  if (!fresh.pcm.length) {
+    logger.error({ key }, "fallback message synthesis produced no audio");
+    return null;
+  }
+
+  // Write through, but do not make the caller wait for GCS — they are already
+  // holding a failed call. A lost write just means the next call re-synthesises.
+  void storeCachedMessage({ key, wav: encodeWav(fresh.pcm, fresh.sampleRate), logger }).catch(() => {});
+
+  return { ...fresh, cached: false };
+}
+
+/**
+ * Publish the announcement into the room and return once it has been played.
+ *
+ * Published as `SOURCE_MICROPHONE`, unlike the confidence tone, which must use
+ * `SOURCE_UNKNOWN` to avoid being hijacked by the running session's RoomIO.
+ * Here there is no session — that is the entire premise of this path — so
+ * nothing can contend for the microphone source, and using it means the
+ * announcement reaches the SIP bridge and any recording as ordinary agent
+ * audio rather than as a second track that per-participant recording drops.
+ *
+ * The source is created at the audio's own sample rate rather than resampling
+ * on the way in; LiveKit resamples to the transport's rate downstream, which
+ * keeps this path to a download and a write.
+ */
+export async function playFallbackMessage(
+  room: Room,
+  audio: FallbackMessageAudio,
+): Promise<boolean> {
+  const localParticipant = room?.localParticipant;
+  if (!localParticipant) {
+    logger.warn({}, "fallback message: no local participant to publish from");
+    return false;
+  }
+
+  const samplesPerFrame = Math.floor((audio.sampleRate * FRAME_MS) / 1000);
+  const bytesPerFrame = samplesPerFrame * 2; // 16-bit mono
+  let source: AudioSource | null = null;
+
+  try {
+    source = new AudioSource(audio.sampleRate, 1, QUEUE_MS);
+    const track = LocalAudioTrack.createAudioTrack("fallback-message", source);
+    await localParticipant.publishTrack(
+      track,
+      new TrackPublishOptions({ source: TrackSource.SOURCE_MICROPHONE }),
+    );
+
+    const deadline = Date.now() + MAX_PLAYOUT_MS;
+    for (let offset = 0; offset < audio.pcm.length; offset += bytesPerFrame) {
+      if (Date.now() > deadline) {
+        logger.warn({ offset, total: audio.pcm.length }, "fallback message playout exceeded its ceiling; stopping");
+        break;
+      }
+      const slice = audio.pcm.subarray(offset, offset + bytesPerFrame);
+      // Pad the final partial frame: AudioFrame wants a whole frame, and a
+      // short one would be interpreted as a rate change by the SIP resampler.
+      // (`new Int16Array(n)` is zero-filled, so the padding is silence.)
+      const data = new Int16Array(samplesPerFrame);
+      // Copied byte-wise rather than through an Int16Array view of `slice`.
+      // A view would require `slice.byteOffset` to be 2-byte aligned, and
+      // nothing guarantees that: `pcm` is a subarray of a downloaded buffer,
+      // and Node pools small allocations at arbitrary offsets. The view
+      // constructor throws on a misaligned offset, so that spelling would
+      // fail intermittently on cached audio depending on how the buffer
+      // happened to be allocated.
+      new Uint8Array(data.buffer).set(slice);
+      // `captureFrame` blocks once the queue is full, pacing this at realtime.
+      await source.captureFrame(new AudioFrame(data, audio.sampleRate, 1, samplesPerFrame));
+    }
+
+    // The loop returns as soon as the last frame is *queued*; wait for the
+    // queue itself to drain or the caller loses the tail of the announcement.
+    await source.waitForPlayout();
+    logger.info(
+      { bytes: audio.pcm.length, sampleRate: audio.sampleRate, cached: audio.cached },
+      "fallback message played",
+    );
+    return true;
+  } catch (e) {
+    logger.error({ e }, "fallback message playout failed");
+    return false;
+  } finally {
+    try {
+      source?.close();
+    } catch {
+      // Best effort; the room teardown that follows will reclaim it anyway.
+    }
+  }
+}
+
+/**
+ * Full fixed-message step: resolve, fetch-or-synthesise, play.
+ *
+ * @returns true when the caller heard the announcement. False means the chain
+ *   should carry on to `fallback.number` exactly as if no message were set.
+ */
+export async function runFallbackMessage(room: Room, agent: Agent): Promise<boolean> {
+  const resolved = fallbackMessageFor(agent);
+  if (!resolved) return false;
+
+  logger.info(
+    { voice: resolved.voice, vendor: resolved.vendor, chars: resolved.text.length },
+    "playing fixed fallback message",
+  );
+
+  const audio = await loadFallbackMessageAudio(agent, resolved);
+  if (!audio) return false;
+
+  return playFallbackMessage(room, audio);
+}

--- a/agents/livekit/lib/voice-session-factory.ts
+++ b/agents/livekit/lib/voice-session-factory.ts
@@ -115,7 +115,7 @@ function inferenceTtsForDeepgramAura2(ttsStr: string, agent: Agent) {
 }
 
 /** LiveKit Inference TTS model string, Deepgram `inference.TTS`, or Google Gemini TTS plugin. */
-function buildPipelineTts(agent: Agent) {
+export function buildPipelineTts(agent: Agent) {
   const useKeys = pipelineUsesProviderApiKeys();
 
   const t = agent.options?.tts;

--- a/agents/livekit/lib/worker.ts
+++ b/agents/livekit/lib/worker.ts
@@ -49,6 +49,7 @@ import {
 import { DISCONNECT_REASONS, getRoomService } from "./livekit-constants.js";
 import { deleteRoomWithRetry } from "./livekit-helpers.js";
 import { runAgentWorker } from "./voice-agent-runtime.js";
+import { runFallbackMessage } from "./fallback-message.js";
 import { userOwnsRow } from "./scope.js";
 
 // Types
@@ -401,12 +402,17 @@ export default defineAgent({
        *  - First attempt runs with the primary modelName from the agent.
        *  - On setup/timeout error from runAgentWorker (i.e. before call.start),
        *    we consult the current agent's options.fallback with precedence:
-       *      1. fallback.agent  – fetch and substitute a different agent, then retry.
-       *      2. fallback.model  – retry the same agent with a different modelName.
-       *      3. fallback.number – perform a blind transfer to this number and exit.
+       *      1. fallback.agent   – fetch and substitute a different agent, then retry.
+       *      2. fallback.model   – retry the same agent with a different modelName.
+       *      3. fallback.message – play a fixed TTS announcement at the caller.
+       *      4. fallback.number  – perform a blind transfer to this number and exit.
        *
        * Once we have switched to a fallback agent, any further fallback decisions are
        * controlled by that agent's own options.fallback.
+       *
+       * Concurrency rejections enter this chain at step 3 (see the catch block):
+       * retrying a different agent or model cannot help, but an announcement is
+       * exactly what a caller who arrived at a full system should hear.
        */
       let activeAgent = agent;
       let activeModelName = modelName;
@@ -455,13 +461,19 @@ export default defineAgent({
           break fallbackLoop;
         } catch (e) {
           const error = e instanceof Error ? e : new Error(String(e));
-          // Concurrency limit failures should not trigger fallback attempts.
-          // We want to fail fast so LiveKit can reject with a "busy" cause.
-          if ((error as any)?.code === "AGENT_CONCURRENCY_LIMIT_EXCEEDED") {
-            throw error;
-          }
+          // A concurrency rejection is not a fault we can retry around: the limit
+          // is enforced in Call.start() regardless of which agent or model is
+          // behind it, so fallback.agent and fallback.model would spend setup
+          // time only to be refused identically, and fallback.number's
+          // transfer-only path calls Call.start() too. Only the fixed message
+          // can actually serve a caller who arrived at a full system, because it
+          // plays from cache without starting a call at all — so `busy` skips
+          // straight to step 3 and, failing that, rethrows so LiveKit still
+          // signals busy rather than answering and dropping.
+          const busy =
+            (error as any)?.code === "AGENT_CONCURRENCY_LIMIT_EXCEEDED";
           logger.error(
-            { error, message: error.message, fallbackConfig },
+            { error, message: error.message, busy, fallbackConfig },
             "runAgentWorker failed, evaluating fallback options",
           );
 
@@ -472,6 +484,7 @@ export default defineAgent({
 
           // 1. Agent-level fallback: fetch and substitute a different agent
           if (
+            !busy &&
             !usedFallbackAgent &&
             fallbackConfig.agent &&
             fallbackConfig.agent !== activeAgent.id
@@ -532,6 +545,7 @@ export default defineAgent({
 
           // 2. Model-level fallback (restart with a different modelName)
           if (
+            !busy &&
             !usedFallbackModel &&
             fallbackConfig.model &&
             activeModelName !== fallbackConfig.model
@@ -549,7 +563,33 @@ export default defineAgent({
             continue fallbackLoop;
           }
 
-          // 3. Number-level fallback (transfer to a phone number / endpoint)
+          // 3. Fixed-message fallback: play the operator's announcement.
+          //
+          // Terminal on success — the chain stops at the first step that works,
+          // and the caller having heard the announcement *is* the outcome. The
+          // original error is then rethrown so the outer handler performs its
+          // usual setup-failure teardown: the call keeps its real failure reason
+          // and stays diagnosable, with the announcement having been a courtesy
+          // played on the way out rather than a different result.
+          if (fallbackConfig.message) {
+            const played = await playFixedFallbackMessage(ctx, activeAgent);
+            if (played) {
+              throw error;
+            }
+            logger.warn(
+              {},
+              "fixed fallback message unavailable; continuing down the fallback chain",
+            );
+          }
+
+          // A busy call has no route left: the number fallback would reserve
+          // concurrency it cannot get. Rethrow so the SIP leg is refused rather
+          // than answered and dropped.
+          if (busy) {
+            throw error;
+          }
+
+          // 4. Number-level fallback (transfer to a phone number / endpoint)
           if (fallbackConfig.number) {
             try {
               logger.info(
@@ -1199,6 +1239,39 @@ async function getCallInfo(ctx: JobContext, room: Room): Promise<CallScenario> {
  * It is not a perfect solution, but it is a better experience for the customer.
  *
  */
+/**
+ * Play an agent's fixed fallback announcement (`options.fallback.message`).
+ *
+ * Never throws: this runs when setup has already failed, so a problem here must
+ * cost the caller the announcement and nothing more, leaving the fallback chain
+ * free to try `fallback.number`.
+ *
+ * Connects to the room if we are not already in it. The main flow reserves
+ * concurrency in `Call.start()` *before* `ctx.connect()` precisely so a refused
+ * call is never answered — which means the busy path arrives here having never
+ * joined, and audio cannot be published from outside the room. Connecting
+ * answers the SIP leg, and that is the intended trade: an operator who
+ * configured an announcement has asked for the caller to hear it instead of
+ * getting a busy tone.
+ *
+ * Publishes from `ctx.room` rather than the worker's `room`, which is the job
+ * assignment's room info and has no local participant to publish from.
+ */
+async function playFixedFallbackMessage(
+  ctx: JobContext,
+  agent: Agent,
+): Promise<boolean> {
+  try {
+    if (!ctx.room?.isConnected) {
+      await ctx.connect();
+    }
+    return await runFallbackMessage(ctx.room, agent);
+  } catch (e) {
+    logger.error({ e }, "fixed fallback message failed");
+    return false;
+  }
+}
+
 async function waitForExistingBridgedParticipant(
   ctx: JobContext,
   room: Room,

--- a/agents/livekit/test/fallback-message.test.ts
+++ b/agents/livekit/test/fallback-message.test.ts
@@ -1,0 +1,124 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { fallbackMessageFor } from "../lib/fallback-message.js";
+
+// Unit tests for the LiveKit side of the fixed fallback message
+// (`options.fallback.message`). Run with:
+//   node --import tsx --test test/fallback-message.test.ts
+//
+// These pin the agent-options -> resolved-message mapping, which must stay in
+// step with Pipecat's `fixed_message_for` (agents/pipecat/tests/
+// test_fallback_message.py) — the two runtimes share one GCS cache, so a
+// divergence here silently splits it rather than raising anything.
+
+const agent = (options: unknown, modelName = "livekit:openai/gpt-4o-mini") =>
+  ({ options, modelName }) as never;
+
+/** A realtime speech-to-speech model — no discrete TTS of its own. */
+const REALTIME = "livekit:ultravox/ultravox-v0.7";
+
+test("returns null when no message is configured", () => {
+  assert.equal(fallbackMessageFor(agent({})), null);
+  assert.equal(fallbackMessageFor(agent({ fallback: {} })), null);
+  assert.equal(fallbackMessageFor(agent({ fallback: { number: "+441234" } })), null);
+});
+
+test("text alone is the minimal form", () => {
+  const resolved = fallbackMessageFor(
+    agent({ fallback: { message: { text: "we are busy" } } }),
+  );
+  assert.equal(resolved?.text, "we are busy");
+});
+
+test("a bare string is rejected, not treated as shorthand", () => {
+  // One shape to document, validate, and read. The write-time validation in
+  // lib/database.js refuses a string outright, so this can only be reached by
+  // data that bypassed it.
+  assert.equal(fallbackMessageFor(agent({ fallback: { message: "we are busy" } })), null);
+});
+
+test("blank text resolves to null rather than an empty announcement", () => {
+  assert.equal(fallbackMessageFor(agent({ fallback: { message: { text: "  " } } })), null);
+  assert.equal(fallbackMessageFor(agent({ fallback: { message: {} } })), null);
+});
+
+test("unstated tts settings inherit from the agent's own voice", () => {
+  const resolved = fallbackMessageFor(
+    agent({
+      tts: { vendor: "elevenlabs", voice: "Dominus", language: "en-GB" },
+      fallback: { message: { text: "hi" } },
+    }),
+  );
+  assert.deepEqual(resolved, {
+    text: "hi",
+    vendor: "elevenlabs",
+    voice: "Dominus",
+    language: "en-GB",
+  });
+});
+
+test("stated tts settings win, so the announcement can name a healthy vendor", () => {
+  // The point of the override: the agent's own TTS may be what just failed.
+  const resolved = fallbackMessageFor(
+    agent({
+      tts: { vendor: "elevenlabs", voice: "Dominus", language: "en-GB" },
+      fallback: { message: { text: "hi", vendor: "deepgram/aura-2", voice: "thalia" } },
+    }),
+  );
+  assert.equal(resolved?.vendor, "deepgram/aura-2");
+  assert.equal(resolved?.voice, "thalia");
+  // Unstated fields still inherit.
+  assert.equal(resolved?.language, "en-GB");
+});
+
+test("a realtime agent does not inherit the model's own voice", () => {
+  // options.tts here names an Ultravox timbre, not a TTS voice. Inheriting it
+  // would hand buildPipelineTts a vendor of "ultravox", which throws rather
+  // than degrading — so the announcement covering Ultravox's failure would
+  // itself fail. Language still comes through: it is portable.
+  const resolved = fallbackMessageFor(
+    agent(
+      {
+        tts: { vendor: "ultravox", voice: "Svetlana", language: "en-GB" },
+        fallback: { message: { text: "we are busy" } },
+      },
+      REALTIME,
+    ),
+  );
+  assert.equal(resolved?.vendor, undefined);
+  assert.equal(resolved?.voice, undefined);
+  assert.equal(resolved?.language, "en-GB");
+});
+
+test("a realtime agent keeps an explicit TTS override", () => {
+  // The configuration that makes the feature usable at all for Ultravox.
+  const resolved = fallbackMessageFor(
+    agent(
+      {
+        tts: { vendor: "ultravox", voice: "Svetlana", language: "en-GB" },
+        fallback: {
+          message: { text: "we are busy", vendor: "elevenlabs", voice: "Rachel" },
+        },
+      },
+      REALTIME,
+    ),
+  );
+  assert.equal(resolved?.vendor, "elevenlabs");
+  assert.equal(resolved?.voice, "Rachel");
+});
+
+test("options.voiceMode override is honoured when deciding inheritance", () => {
+  // Forcing pipeline mode means options.tts really does describe a TTS.
+  const resolved = fallbackMessageFor(
+    agent(
+      {
+        voiceMode: "pipeline",
+        tts: { vendor: "elevenlabs", voice: "Rachel" },
+        fallback: { message: { text: "we are busy" } },
+      },
+      REALTIME,
+    ),
+  );
+  assert.equal(resolved?.vendor, "elevenlabs");
+  assert.equal(resolved?.voice, "Rachel");
+});

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -8,8 +8,9 @@ contract:
 - Run the Pipecat ``PipelineTask``.
 - On any disconnect / error, end the call with the right reason from the
   taxonomy in section 7.3 and flush invocation logs.
-- Fallback loop per section 9.1: try ``modelName`` → ``fallback.model`` →
-  ``fallback.agent`` → ``fallback.number`` (last-resort blind transfer).
+- Fallback loop per section 9.1: try ``modelName`` → ``fallback.agent`` →
+  ``fallback.model`` → ``fallback.message`` (fixed TTS announcement) →
+  ``fallback.number`` (last-resort blind transfer).
 
 The :class:`SipGateway` indirection means this module does not know whether the
 SIP leg is a Daily room, a FreeSWITCH bridge, or anything else.
@@ -191,6 +192,13 @@ class CallSession:
     # threaded the same way so a transfer leg offers what the trunk can
     # actually do. None = unchanged. See ``OutboundCallParams.srtp``.
     srtp: Optional[bool] = None
+    # Set by ``setup_inbound_call`` when the agent concurrency limit refused
+    # this call and the agent has an ``options.fallback.message`` to play
+    # instead of a busy tone. Such a session exists ONLY to play that
+    # announcement: ``run`` plays it and returns without ever building a
+    # pipeline, and ``self.call`` was deliberately never started, so no
+    # concurrency slot is held while it plays. See ``fixed_message.py``.
+    fixed_message_only: bool = False
     # Resolved REFER-vs-bridge decision for the in-flight consultative
     # transfer, recorded when ``_on_transfer`` starts the consult leg so the
     # accept tool finalises via the same mode (attended REFER vs media bridge).
@@ -295,6 +303,19 @@ class CallSession:
         transport + child call record and runs the incoming agent's pipeline
         on the same live media connection.
         """
+        if self.fixed_message_only:
+            # Refused by the concurrency limiter before this session was even
+            # constructed. There is no agent to run and nothing to fall back
+            # through: play the announcement and let the caller go. Crucially
+            # this holds no concurrency slot — ``self.call`` was never started,
+            # and a cached announcement calls no vendor, so there is nothing to
+            # meter and nothing to reserve. Were it otherwise, playing "we are
+            # busy" would itself consume the capacity it is apologising for.
+            from .fixed_message import run_fixed_message
+
+            await run_fixed_message(self.gateway_session.transport, self.agent)
+            return
+
         active_agent = self.agent
         active_model = active_agent["modelName"]
         active_prompt = system_prompt
@@ -310,7 +331,15 @@ class CallSession:
                 await self._run_once(active_agent, active_model, active_prompt)
                 return
             except api_client.AgentConcurrencyLimitExceededBusyError:
-                # Map upstream — caller signals SIP busy / 429 to its caller.
+                # A concurrency rejection reaching *here* comes from a child
+                # call started mid-session (an agent handover, a consult leg),
+                # not from the caller's own arrival — that one is refused in
+                # ``setup_inbound_call`` before this loop exists, and is where
+                # the fixed message gets its chance (see ``fixed_message_only``).
+                # Retrying a model or agent cannot help either way, and a
+                # mid-call announcement to someone already talking to an agent
+                # would be worse than the failure. Map upstream — the caller
+                # signals SIP busy / 429 to its own caller.
                 raise
             except Exception as e:  # noqa: BLE001
                 logger.error(f"voice session failed: {e}; evaluating fallback")
@@ -343,7 +372,24 @@ class CallSession:
                     active_model = fallback_cfg["model"]
                     continue
 
-                # 3. Number-level fallback (blind transfer). Configured on the agent
+                # 3. Fixed-message fallback: play the operator's announcement.
+                #
+                #    Terminal on success — the chain stops at the first step that
+                #    works, and the caller having heard the announcement *is* the
+                #    outcome. The original error is then re-raised so the caller's
+                #    usual setup-failure teardown runs and the call keeps its real
+                #    failure reason, with the announcement having been a courtesy
+                #    played on the way out rather than a different result.
+                if fallback_cfg.get("message"):
+                    from .fixed_message import run_fixed_message
+
+                    if await run_fixed_message(self.gateway_session.transport, active_agent):
+                        raise
+                    logger.warning(
+                        "fixed fallback message unavailable; continuing down the fallback chain"
+                    )
+
+                # 4. Number-level fallback (blind transfer). Configured on the agent
                 #    rather than chosen by the model, but it still puts a leg out on
                 #    (possibly) our carrier, so it clears the same gate as a tool-call
                 #    transfer — see _on_transfer / outbound_filter.py.
@@ -2546,7 +2592,26 @@ async def setup_inbound_call(
             },
         }
     )
-    await api_client.start_call(call)
+    # A concurrency rejection is raised by ``start_call``. When the agent has a
+    # fixed announcement configured, answer and play it instead of refusing the
+    # call: that is precisely the case the feature exists for. The call stays
+    # unstarted — the server has already marked it failed with the limit as the
+    # reason — so no slot is reserved, which is what makes it safe to do this at
+    # the very moment we are out of slots. Without a message, behaviour is
+    # unchanged and the caller gets the busy signal.
+    fixed_message_only = False
+    try:
+        await api_client.start_call(call)
+    except api_client.AgentConcurrencyLimitExceededBusyError:
+        from .fixed_message import fixed_message_for
+
+        if not fixed_message_for(agent):
+            raise
+        logger.bind(call_id=call.id, agent_id=agent.get("id")).warning(
+            "agent concurrency limit reached; playing fixed fallback message instead of busy"
+        )
+        fixed_message_only = True
+
     return CallSession(
         session_id=inbound.session_id,
         agent=agent,
@@ -2554,6 +2619,7 @@ async def setup_inbound_call(
         sip_gateway=sip_gateway,
         gateway_session=gw_session,
         call=call,
+        fixed_message_only=fixed_message_only,
         registration_originated=inbound.registration_originated,
         force_refer_transfer=inbound.force_refer_transfer,
         force_bridged_transfer=inbound.force_bridged_transfer,

--- a/agents/pipecat/pipecat_aplisay/fallback_message/__init__.py
+++ b/agents/pipecat/pipecat_aplisay/fallback_message/__init__.py
@@ -1,0 +1,31 @@
+"""Fixed fallback-message support — see ``lib/fallback-message/CONTRACT.md``."""
+
+from .cache_key import (
+    KEY_LENGTH,
+    ResolvedFallbackMessage,
+    fallback_message_key,
+    resolve_fallback_message,
+)
+from .gcs_path import (
+    default_fallback_message_base_url,
+    object_name_for_key,
+    parse_gcs_path,
+)
+from .store import DEFAULT_TIMEOUT_SECS, fetch_cached_message, store_cached_message
+from .wav import DecodedWav, decode_wav, encode_wav
+
+__all__ = [
+    "KEY_LENGTH",
+    "ResolvedFallbackMessage",
+    "fallback_message_key",
+    "resolve_fallback_message",
+    "default_fallback_message_base_url",
+    "object_name_for_key",
+    "parse_gcs_path",
+    "DEFAULT_TIMEOUT_SECS",
+    "fetch_cached_message",
+    "store_cached_message",
+    "DecodedWav",
+    "decode_wav",
+    "encode_wav",
+]

--- a/agents/pipecat/pipecat_aplisay/fallback_message/cache_key.py
+++ b/agents/pipecat/pipecat_aplisay/fallback_message/cache_key.py
@@ -1,0 +1,114 @@
+"""Cache-key derivation for synthesised fallback messages.
+
+Sibling of ``lib/fallback-message/cache-key.js``. The digest formula is a
+cross-runtime contract — see ``lib/fallback-message/CONTRACT.md``. A change
+here that is not mirrored on the JS side does not corrupt anything, it just
+splits the cache so each runtime re-synthesises what the other already paid
+for.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+#: Digest length in hex characters. 32 hex chars = 128 bits.
+KEY_LENGTH = 32
+
+
+@dataclass(frozen=True)
+class ResolvedFallbackMessage:
+    """A fallback message with its TTS settings resolved against the agent."""
+
+    text: str
+    vendor: Optional[str] = None
+    voice: Optional[str] = None
+    language: Optional[str] = None
+
+
+def _clean(value: Any) -> Optional[str]:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def resolve_fallback_message(
+    message: Any,
+    agent_options: Optional[dict] = None,
+    *,
+    inherit_agent_tts: bool = True,
+) -> Optional[ResolvedFallbackMessage]:
+    """Resolve ``options.fallback.message`` against the agent's ``options.tts``.
+
+    The message may name its own vendor/voice/language: the point of the
+    feature is that the announcement can be spoken by a TTS known to work even
+    when the agent's own stack is what just failed. Anything it does not state
+    falls back to the agent's normal TTS settings, so the common case ("say
+    this, in my usual voice") needs only ``text``.
+
+    ``inherit_agent_tts`` is the exception, and it matters: a realtime
+    speech-to-speech agent (Ultravox, OpenAI Realtime, Gemini Live) has no
+    discrete TTS, and its ``options.tts.voice`` names a timbre of the *model*.
+    The announcement is always spoken by a real TTS — it plays because the
+    model could not be started, so the model cannot be what speaks it — and
+    handing ``build_tts_service`` a vendor of ``ultravox`` does not degrade, it
+    raises ``Unsupported TTS vendor``. So for those agents the vendor and voice
+    are NOT inherited, leaving the worker's default TTS unless the message
+    names one explicitly.
+
+    ``language`` is inherited either way: it is a portable BCP-47 tag meaning
+    the same thing to a model and to a TTS, and an announcement in the wrong
+    language would be worse than one in an unfamiliar voice.
+
+    Callers must agree with the LiveKit side on ``inherit_agent_tts``: it feeds
+    the cache key, so deciding differently would split the shared cache.
+
+    The option always takes an object: a bare string is NOT accepted as
+    shorthand for ``{"text": ...}``, so there is one shape to document, one to
+    validate, and one to read. Returns ``None`` for anything else, though the
+    write-time validation in ``lib/database.js`` rejects a bad shape outright,
+    so it is a save error rather than an announcement that never plays.
+    """
+    if not isinstance(message, dict):
+        return None
+    raw = message
+    text = raw.get("text")
+    text = text.strip() if isinstance(text, str) else ""
+    if not text:
+        return None
+    tts = (agent_options or {}).get("tts") or {}
+    inherited = tts if inherit_agent_tts else {}
+    return ResolvedFallbackMessage(
+        text=text,
+        vendor=_clean(raw.get("vendor")) or _clean(inherited.get("vendor")),
+        voice=_clean(raw.get("voice")) or _clean(inherited.get("voice")),
+        # Always inherited — a language tag is portable across model and TTS.
+        language=_clean(raw.get("language")) or _clean(tts.get("language")),
+    )
+
+
+def fallback_message_key(resolved: ResolvedFallbackMessage) -> str:
+    """Derive the content-addressed cache key for a resolved message.
+
+    Fields are hashed as a canonical JSON array rather than a concatenated
+    string so a value containing the separator cannot collide with a different
+    field split. ``separators`` is pinned because Python's default JSON encoder
+    inserts a space after ``,`` where JavaScript's ``JSON.stringify`` does not
+    — without it the two runtimes would derive different keys for identical
+    input, which is exactly the split this contract exists to prevent.
+    """
+    if not resolved or not resolved.text:
+        raise ValueError("fallback_message_key: resolved message must have text")
+    canonical = json.dumps(
+        [
+            resolved.text,
+            resolved.vendor or "",
+            resolved.voice or "",
+            resolved.language or "",
+        ],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:KEY_LENGTH]

--- a/agents/pipecat/pipecat_aplisay/fallback_message/gcs_path.py
+++ b/agents/pipecat/pipecat_aplisay/fallback_message/gcs_path.py
@@ -1,0 +1,63 @@
+"""GCS path helpers for the fallback-message cache.
+
+Sibling of ``lib/fallback-message/gcs-path.js``; the resolution order is a
+cross-runtime contract (see ``lib/fallback-message/CONTRACT.md``).
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = ["parse_gcs_path", "default_fallback_message_base_url", "object_name_for_key"]
+
+
+def parse_gcs_path(base_url: str) -> tuple[str, str]:
+    """Split a ``gs://bucket[/prefix]`` URL into ``(bucket, prefix)``.
+
+    ``prefix`` is either empty or ends with a single ``/`` so callers can
+    string-concat the object name without further normalisation.
+
+    Deliberately a local copy of ``recording/gcs_path.py``'s function rather
+    than an import of it: importing that module executes ``recording/__init__``,
+    which pulls in the encryption stack. This path exists to work when other
+    things are already failing, so it does not take a dependency on machinery
+    it has no use for. The ``gs://`` convention itself is shared and documented
+    in ``lib/fallback-message/CONTRACT.md``.
+    """
+    if not base_url.startswith("gs://"):
+        raise ValueError("Fallback message storage path must be a gs:// URL")
+
+    without_scheme = base_url[len("gs://") :]
+    first_slash = without_scheme.find("/")
+    if first_slash == -1:
+        return without_scheme, ""
+
+    bucket = without_scheme[:first_slash]
+    prefix = without_scheme[first_slash + 1 :]
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    return bucket, prefix
+
+
+def default_fallback_message_base_url() -> str:
+    """Default GCS base URL for cached announcements.
+
+    Derived from ``RECORDING_STORAGE_PATH``'s bucket when set, so a deployment
+    that has already pointed recordings at its own bucket does not silently
+    keep writing announcements to the default one.
+    """
+    explicit = os.environ.get("FALLBACK_MESSAGE_STORAGE_PATH")
+    if explicit:
+        return explicit
+    env = os.environ.get("NODE_ENV", "development")
+    recording_path = os.environ.get("RECORDING_STORAGE_PATH")
+    if recording_path:
+        # Reuse the configured bucket, but never the recordings prefix itself.
+        bucket = recording_path[len("gs://") :].split("/")[0]
+        return f"gs://{bucket}/{env}-fallback-messages"
+    return f"gs://llm-voice/{env}-fallback-messages"
+
+
+def object_name_for_key(prefix: str, key: str) -> str:
+    """Build the GCS object name for a cache key. Always ``.wav``."""
+    return f"{prefix}{key}.wav"

--- a/agents/pipecat/pipecat_aplisay/fallback_message/store.py
+++ b/agents/pipecat/pipecat_aplisay/fallback_message/store.py
@@ -1,0 +1,118 @@
+"""GCS read/write for the fallback-message cache.
+
+Sibling of ``lib/fallback-message/store.js``.
+
+Every function here is **never-throw**. This code runs only when agent setup
+has already failed and the caller's remaining options are the announcement or
+``fallback.number``; a bucket outage must degrade to "synthesise it again this
+call", never to an exception that costs the caller the announcement too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from google.cloud import storage  # type: ignore[import-untyped]
+from loguru import logger
+
+from .gcs_path import (
+    default_fallback_message_base_url,
+    object_name_for_key,
+    parse_gcs_path,
+)
+
+#: Default deadline for either direction. Short: the caller is on the line.
+DEFAULT_TIMEOUT_SECS = 5.0
+
+_shared_client: Optional[storage.Client] = None
+
+
+def _client() -> storage.Client:
+    """Lazily constructed so importing this module never touches credentials."""
+    global _shared_client
+    if _shared_client is None:
+        _shared_client = storage.Client()
+    return _shared_client
+
+
+async def fetch_cached_message(
+    key: str,
+    *,
+    base_url: Optional[str] = None,
+    timeout_secs: float = DEFAULT_TIMEOUT_SECS,
+) -> Optional[bytes]:
+    """Read a cached announcement. Returns ``None`` on a miss or any failure."""
+    bucket_name, prefix = parse_gcs_path(base_url or default_fallback_message_base_url())
+    gcs_object = object_name_for_key(prefix, key)
+
+    def _download() -> bytes:
+        # The GCS SDK is blocking; keep it off the event loop.
+        return _client().bucket(bucket_name).blob(gcs_object).download_as_bytes()
+
+    try:
+        contents = await asyncio.wait_for(asyncio.to_thread(_download), timeout=timeout_secs)
+    except Exception as e:  # noqa: BLE001
+        from google.cloud.exceptions import NotFound  # type: ignore[import-untyped]
+
+        # A 404 is the ordinary first-use miss and is not worth a warning;
+        # anything else is, but is still only a miss as far as the caller goes.
+        if isinstance(e, NotFound):
+            logger.bind(key=key, bucket=bucket_name, gcs_object=gcs_object).debug(
+                "fallback message cache miss"
+            )
+        else:
+            logger.bind(key=key, bucket=bucket_name, gcs_object=gcs_object).warning(
+                f"fallback message cache read failed; will synthesise: {e}"
+            )
+        return None
+
+    logger.bind(key=key, bucket=bucket_name, gcs_object=gcs_object, size=len(contents)).debug(
+        "fallback message cache hit"
+    )
+    return contents
+
+
+async def store_cached_message(
+    key: str,
+    wav: bytes,
+    *,
+    base_url: Optional[str] = None,
+    timeout_secs: float = DEFAULT_TIMEOUT_SECS,
+) -> bool:
+    """Write a freshly synthesised announcement into the cache.
+
+    Uploaded with ``if_generation_match=0`` (create-only). When an outage fails
+    many calls at once every worker misses and synthesises concurrently; the
+    first to finish publishes and the rest get a precondition failure, reported
+    here as success because the cache does now hold the object. The losers play
+    the copy they synthesised for their own call.
+
+    Returns True when the cache holds the object afterwards.
+    """
+    bucket_name, prefix = parse_gcs_path(base_url or default_fallback_message_base_url())
+    gcs_object = object_name_for_key(prefix, key)
+
+    def _upload() -> None:
+        blob = _client().bucket(bucket_name).blob(gcs_object)
+        blob.upload_from_string(wav, content_type="audio/wav", if_generation_match=0)
+
+    try:
+        await asyncio.wait_for(asyncio.to_thread(_upload), timeout=timeout_secs)
+    except Exception as e:  # noqa: BLE001
+        from google.api_core.exceptions import PreconditionFailed  # type: ignore[import-untyped]
+
+        if isinstance(e, PreconditionFailed):
+            logger.bind(key=key, bucket=bucket_name, gcs_object=gcs_object).debug(
+                "fallback message already cached by a concurrent writer"
+            )
+            return True
+        logger.bind(key=key, bucket=bucket_name, gcs_object=gcs_object).warning(
+            f"failed to cache fallback message; will re-synthesise next time: {e}"
+        )
+        return False
+
+    logger.bind(key=key, bucket=bucket_name, gcs_object=gcs_object, size=len(wav)).info(
+        "cached synthesised fallback message"
+    )
+    return True

--- a/agents/pipecat/pipecat_aplisay/fallback_message/wav.py
+++ b/agents/pipecat/pipecat_aplisay/fallback_message/wav.py
@@ -1,0 +1,93 @@
+"""Minimal mono PCM WAV reader/writer for the fallback-message cache.
+
+Sibling of ``lib/fallback-message/wav.js``. Only the subset needed here is
+implemented: PCM (format 1), mono, 16-bit little-endian. See
+``lib/fallback-message/CONTRACT.md`` for why the sample rate travels in the
+container rather than being pinned.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+
+_HEADER_BYTES = 44
+_PCM_FORMAT = 1
+_BITS_PER_SAMPLE = 16
+_CHANNELS = 1
+
+
+@dataclass(frozen=True)
+class DecodedWav:
+    pcm: bytes
+    sample_rate: int
+
+
+def encode_wav(pcm: bytes, sample_rate: int) -> bytes:
+    """Wrap mono 16-bit little-endian PCM in a WAV container."""
+    if not isinstance(pcm, (bytes, bytearray, memoryview)):
+        raise TypeError("encode_wav: pcm must be bytes-like")
+    if not isinstance(sample_rate, int) or sample_rate <= 0:
+        raise ValueError(f"encode_wav: invalid sample_rate {sample_rate}")
+    pcm = bytes(pcm)
+    byte_rate = sample_rate * _CHANNELS * (_BITS_PER_SAMPLE // 8)
+    block_align = _CHANNELS * (_BITS_PER_SAMPLE // 8)
+    return (
+        b"RIFF"
+        + struct.pack("<I", _HEADER_BYTES - 8 + len(pcm))
+        + b"WAVE"
+        + b"fmt "
+        + struct.pack(
+            "<IHHIIHH",
+            16,
+            _PCM_FORMAT,
+            _CHANNELS,
+            sample_rate,
+            byte_rate,
+            block_align,
+            _BITS_PER_SAMPLE,
+        )
+        + b"data"
+        + struct.pack("<I", len(pcm))
+        + pcm
+    )
+
+
+def decode_wav(buffer: bytes) -> DecodedWav:
+    """Read a mono 16-bit PCM WAV produced by :func:`encode_wav`.
+
+    Chunks are walked rather than assumed at fixed offsets: some TTS vendors
+    return WAV with a ``LIST``/``fact`` chunk ahead of ``data``, and a cached
+    object written from such a payload would otherwise decode as noise.
+    """
+    if not buffer or len(buffer) < 12:
+        raise ValueError("decode_wav: buffer too short to be a WAV")
+    if buffer[0:4] != b"RIFF" or buffer[8:12] != b"WAVE":
+        raise ValueError("decode_wav: not a RIFF/WAVE payload")
+
+    sample_rate = 0
+    offset = 12
+    while offset + 8 <= len(buffer):
+        chunk_id = buffer[offset : offset + 4]
+        (chunk_size,) = struct.unpack_from("<I", buffer, offset + 4)
+        body = offset + 8
+        if chunk_id == b"fmt ":
+            fmt, channels = struct.unpack_from("<HH", buffer, body)
+            (bits,) = struct.unpack_from("<H", buffer, body + 14)
+            if fmt != _PCM_FORMAT or channels != _CHANNELS or bits != _BITS_PER_SAMPLE:
+                raise ValueError(
+                    f"decode_wav: expected mono 16-bit PCM, got "
+                    f"format={fmt} channels={channels} bits={bits}"
+                )
+            (sample_rate,) = struct.unpack_from("<I", buffer, body + 4)
+        elif chunk_id == b"data":
+            if not sample_rate:
+                raise ValueError("decode_wav: data chunk before fmt chunk")
+            # Trust the buffer over the declared size: a truncated upload would
+            # otherwise hand callers fewer bytes than the header promises.
+            end = min(body + chunk_size, len(buffer))
+            return DecodedWav(pcm=buffer[body:end], sample_rate=sample_rate)
+        # Chunks are word-aligned: an odd size carries a trailing pad byte.
+        offset = body + chunk_size + (chunk_size % 2)
+
+    raise ValueError("decode_wav: no data chunk found")

--- a/agents/pipecat/pipecat_aplisay/fixed_message.py
+++ b/agents/pipecat/pipecat_aplisay/fixed_message.py
@@ -1,0 +1,267 @@
+"""Fixed-message failover for Pipecat — ``options.fallback.message``.
+
+Sits between ``fallback.model`` and ``fallback.number`` in the failover chain
+(see ``docs/agent-failover.md``): when the agent could not be brought up, play
+the operator's announcement at the caller rather than leaving them in dead air
+or sending them straight to a transfer.
+
+Two properties shape everything here.
+
+**The audio is cached, so playout makes no vendor call.** The announcement
+cannot vary for a given configuration, so it is synthesised once, stored in GCS
+keyed by a digest of its own content, and replayed from then on. That is not
+just a latency win: a cache hit calls no TTS vendor, so it meters no usage, so
+it needs no ``Call`` record, so it never reserves an agent concurrency slot.
+Which matters enormously, because the single most useful moment to play a fixed
+message is when the concurrency limiter is what rejected the call — a playout
+that took a slot would defeat the feature it implements. See
+``lib/fallback-message/CONTRACT.md``.
+
+**This path runs when things are already broken**, and often when the host is
+loaded — load being one of the likelier reasons a session failed to start. So
+it stays cheap and it never raises: every failure degrades to "the caller does
+not get the announcement", leaving the chain free to try ``fallback.number``,
+rather than turning one failure into two.
+
+Mirrors ``agents/livekit/lib/fallback-message.ts`` — keep the resolution rules
+and playout semantics in step across stacks. The one deliberate difference is
+on a cache miss: LiveKit collects the whole utterance and then plays it, while
+here the TTS is spliced into the playout pipeline and the caller hears it as it
+renders, with a tap capturing the audio for the write-back. Pipecat's streaming
+TTS services deliver audio out of band (``run_tts`` yields ``None`` and the
+frames arrive on a separate receive loop), so a pipeline is required to capture
+them at all; getting the lower latency for free is why this shape is kept.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from loguru import logger
+from pipecat.frames.frames import (
+    EndFrame,
+    Frame,
+    OutputAudioRawFrame,
+    TTSAudioRawFrame,
+    TTSSpeakFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineTask
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from .fallback_message import (
+    ResolvedFallbackMessage,
+    decode_wav,
+    encode_wav,
+    fallback_message_key,
+    fetch_cached_message,
+    resolve_fallback_message,
+    store_cached_message,
+)
+from .output_rate_guard import OutputRateGuard
+
+#: Chunk size for replaying cached audio. 20 ms is the SIP convention.
+_FRAME_MS = 20
+
+#: Hard ceiling on the whole step, so a hung vendor or a stalled transport
+#: cannot pin a failed call open. The caller is already waiting on a call that
+#: did not work; give up and let the chain move on to ``fallback.number``.
+_PLAYOUT_TIMEOUT_SECS = 45.0
+
+
+@dataclass(frozen=True)
+class FixedMessageAudio:
+    pcm: bytes
+    sample_rate: int
+    #: True when this came from GCS rather than a fresh vendor call.
+    cached: bool
+
+
+class _AudioTap(FrameProcessor):
+    """Pass-through processor that copies rendered TTS audio into a buffer.
+
+    Placed immediately after the TTS service and *before* the rate guard, so it
+    captures the vendor's native sample rate rather than the transport's. The
+    contract stores whatever the TTS emitted (see CONTRACT.md), which keeps the
+    cached object independent of the transport that happened to render it first
+    — a 16 kHz SIP leg and a 24 kHz WebRTC session share one cache entry.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._chunks: list[bytes] = []
+        self._sample_rate: Optional[int] = None
+
+    @property
+    def audio(self) -> Optional[FixedMessageAudio]:
+        if not self._chunks or not self._sample_rate:
+            return None
+        return FixedMessageAudio(
+            pcm=b"".join(self._chunks), sample_rate=self._sample_rate, cached=False
+        )
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, (TTSAudioRawFrame, OutputAudioRawFrame)) and frame.audio:
+            # Mono is assumed throughout; a stereo TTS would be captured wrong,
+            # but no supported vendor renders stereo speech.
+            if self._sample_rate is None:
+                self._sample_rate = frame.sample_rate
+            if frame.sample_rate == self._sample_rate:
+                self._chunks.append(bytes(frame.audio))
+        await self.push_frame(frame, direction)
+
+
+def fixed_message_for(agent: dict) -> Optional[ResolvedFallbackMessage]:
+    """Resolve ``options.fallback.message``, or ``None`` when unconfigured.
+
+    A realtime agent's ``options.tts`` describes the model's own voice, not a
+    TTS, so its vendor/voice are not inherited — see
+    :func:`resolve_fallback_message`. Keep this decision identical to LiveKit's
+    ``fallbackMessageFor``: it feeds the cache key, and disagreeing would split
+    the shared cache in two.
+    """
+    from .voice_mode import resolve_voice_mode
+
+    options = agent.get("options") or {}
+    fallback = options.get("fallback") or {}
+    inherit = resolve_voice_mode(agent.get("modelName") or "", options) == "pipeline"
+    return resolve_fallback_message(
+        fallback.get("message"), options, inherit_agent_tts=inherit
+    )
+
+
+def _build_message_tts(agent: dict, resolved: ResolvedFallbackMessage) -> Any:
+    """Build a TTS service for the announcement.
+
+    The message may name its own ``vendor``/``voice``/``language`` — the whole
+    point being that it can be spoken by a stack known to work when the agent's
+    own is what just failed. Rather than reimplement vendor selection, we hand
+    ``build_tts_service`` a *synthetic agent* whose ``options.tts`` carries the
+    message's resolved settings. Every vendor the pipeline supports is therefore
+    supported here for free, and stays supported as vendors are added, with no
+    second catalogue to keep in step.
+    """
+    from .voice_session import build_tts_service
+
+    options = dict(agent.get("options") or {})
+    tts_opts = dict(options.get("tts") or {})
+    if resolved.vendor:
+        tts_opts["vendor"] = resolved.vendor
+    if resolved.voice:
+        tts_opts["voice"] = resolved.voice
+    if resolved.language:
+        tts_opts["language"] = resolved.language
+    options["tts"] = tts_opts
+
+    synthetic = dict(agent)
+    synthetic["options"] = options
+    return build_tts_service(synthetic)
+
+
+def _audio_frames(audio: FixedMessageAudio) -> list[OutputAudioRawFrame]:
+    """Slice cached PCM into transport-sized frames."""
+    bytes_per_frame = int(audio.sample_rate * _FRAME_MS / 1000) * 2  # 16-bit mono
+    return [
+        OutputAudioRawFrame(
+            audio=audio.pcm[offset : offset + bytes_per_frame],
+            sample_rate=audio.sample_rate,
+            num_channels=1,
+        )
+        for offset in range(0, len(audio.pcm), bytes_per_frame)
+    ]
+
+
+async def run_fixed_message(transport: Any, agent: dict) -> bool:
+    """Play the agent's fixed announcement on ``transport``.
+
+    Returns True when the caller heard it. False means the chain should carry
+    on to ``fallback.number`` exactly as if no message were configured.
+
+    Never raises.
+    """
+    resolved = fixed_message_for(agent)
+    if not resolved:
+        return False
+
+    logger.bind(
+        vendor=resolved.vendor, voice=resolved.voice, chars=len(resolved.text)
+    ).info("playing fixed fallback message")
+
+    try:
+        return await asyncio.wait_for(
+            _play(transport, agent, resolved), timeout=_PLAYOUT_TIMEOUT_SECS
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"fixed fallback message timed out after {_PLAYOUT_TIMEOUT_SECS}s"
+        )
+        return False
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"fixed fallback message failed: {e}")
+        return False
+
+
+async def _play(transport: Any, agent: dict, resolved: ResolvedFallbackMessage) -> bool:
+    key = fallback_message_key(resolved)
+    cached_bytes = await fetch_cached_message(key)
+
+    audio: Optional[FixedMessageAudio] = None
+    if cached_bytes:
+        try:
+            decoded = decode_wav(cached_bytes)
+            audio = FixedMessageAudio(
+                pcm=decoded.pcm, sample_rate=decoded.sample_rate, cached=True
+            )
+        except Exception as e:  # noqa: BLE001
+            # A corrupt object must not condemn the caller to silence: fall
+            # through and re-synthesise. The bad object stays until something
+            # overwrites or expires it, which is harmless — the store is
+            # content-addressed, so the next writer produces identical audio.
+            logger.warning(f"cached fallback message failed to decode; re-synthesising: {e}")
+
+    # Defence in depth against the transport's latching resampler: every frame
+    # reaching output() carries the transport's own rate, so a cached object at
+    # some other rate cannot silence the leg. See output_rate_guard.py, which
+    # names this exact case ("a fallback TTS voice").
+    rate_guard = OutputRateGuard(output_transport=transport.output())
+
+    tap: Optional[_AudioTap] = None
+    if audio is not None:
+        processors: list = [rate_guard, transport.output()]
+        frames: list = _audio_frames(audio)
+    else:
+        tap = _AudioTap()
+        processors = [_build_message_tts(agent, resolved), tap, rate_guard, transport.output()]
+        frames = [TTSSpeakFrame(resolved.text)]
+
+    task = PipelineTask(Pipeline(processors))
+    # EndFrame is queued behind the audio, so it reaches the output transport
+    # only after everything ahead of it has been rendered — the graceful
+    # termination pattern, which is what stops the announcement being cut off.
+    await task.queue_frames([*frames, EndFrame()])
+    await PipelineRunner(handle_sigint=False).run(task)
+
+    if tap is not None:
+        fresh = tap.audio
+        if fresh is None or not fresh.pcm:
+            logger.error("fixed fallback message synthesis produced no audio")
+            return False
+        # Write back after the caller has been served, never before: they are
+        # already holding a failed call and must not wait on GCS. A lost write
+        # just means the next call re-synthesises.
+        await store_cached_message(key, encode_wav(fresh.pcm, fresh.sample_rate))
+        logger.bind(size=len(fresh.pcm), sample_rate=fresh.sample_rate).info(
+            "fixed fallback message synthesised and played"
+        )
+        return True
+
+    logger.bind(
+        size=len(audio.pcm) if audio else 0,
+        sample_rate=audio.sample_rate if audio else 0,
+        cached=True,
+    ).info("fixed fallback message played")
+    return True

--- a/agents/pipecat/tests/test_fallback_message.py
+++ b/agents/pipecat/tests/test_fallback_message.py
@@ -1,0 +1,263 @@
+"""Tests for the fixed fallback message (``options.fallback.message``).
+
+Two things are covered:
+
+- The shared cache layer (``pipecat_aplisay.fallback_message``): resolution
+  rules, key derivation, and the WAV codec. The JS side of this contract is
+  pinned in ``tests/fallback-message-cross-language.test.mjs``.
+- The routing that matters most: an agent concurrency rejection must reach the
+  fixed-message path rather than refusing the call, and must do so *without*
+  starting a call — a playout that reserved a slot would consume the capacity
+  it exists to apologise for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pipecat_aplisay.fallback_message import (
+    decode_wav,
+    encode_wav,
+    fallback_message_key,
+    resolve_fallback_message,
+)
+
+
+# ---- Resolution ----------------------------------------------------------
+
+
+def test_text_alone_is_the_minimal_form():
+    assert resolve_fallback_message({"text": "we are busy"}, {}).text == "we are busy"
+
+
+def test_bare_string_is_rejected_not_treated_as_shorthand():
+    """One shape to document, validate, and read.
+
+    The write-time validation in ``lib/database.js`` refuses a string outright,
+    so this can only be reached by data that bypassed it.
+    """
+    assert resolve_fallback_message("we are busy", {}) is None
+
+
+def test_text_is_trimmed_and_blank_resolves_to_none():
+    assert resolve_fallback_message({"text": "  hi  "}, {}).text == "hi"
+    assert resolve_fallback_message({"text": "   "}, {}) is None
+    assert resolve_fallback_message({}, {}) is None
+    assert resolve_fallback_message(None, {}) is None
+
+
+def test_unstated_tts_settings_inherit_from_the_agent():
+    resolved = resolve_fallback_message(
+        {"text": "hi"},
+        {"tts": {"vendor": "elevenlabs", "voice": "Dominus", "language": "en-GB"}},
+    )
+    assert (resolved.vendor, resolved.voice, resolved.language) == (
+        "elevenlabs",
+        "Dominus",
+        "en-GB",
+    )
+
+
+def test_stated_tts_settings_win_so_a_healthy_vendor_can_be_named():
+    resolved = resolve_fallback_message(
+        {"text": "hi", "vendor": "deepgram/aura-2", "voice": "thalia"},
+        {"tts": {"vendor": "elevenlabs", "voice": "Dominus", "language": "en-GB"}},
+    )
+    assert resolved.vendor == "deepgram/aura-2"
+    assert resolved.voice == "thalia"
+    # Unstated fields still inherit.
+    assert resolved.language == "en-GB"
+
+
+# ---- Realtime agents -----------------------------------------------------
+
+_REALTIME_OPTS = {"tts": {"vendor": "ultravox", "voice": "Svetlana", "language": "en-GB"}}
+
+
+def test_realtime_agent_does_not_inherit_the_model_voice():
+    """A realtime model's ``options.tts`` names a timbre of the MODEL, not a TTS.
+
+    Inheriting it would hand ``build_tts_service`` a vendor of ``ultravox``,
+    which does not degrade — it raises ``Unsupported TTS vendor`` — so the
+    announcement covering the model's failure would itself fail.
+    """
+    resolved = resolve_fallback_message({"text": "busy"}, _REALTIME_OPTS, inherit_agent_tts=False)
+    assert resolved.vendor is None
+    assert resolved.voice is None
+
+
+def test_realtime_agent_still_inherits_language():
+    resolved = resolve_fallback_message({"text": "busy"}, _REALTIME_OPTS, inherit_agent_tts=False)
+    assert resolved.language == "en-GB"
+
+
+def test_realtime_agent_keeps_an_explicit_tts_override():
+    """The configuration that makes the feature usable for speech-to-speech."""
+    resolved = resolve_fallback_message(
+        {"text": "busy", "vendor": "elevenlabs", "voice": "Rachel"},
+        _REALTIME_OPTS,
+        inherit_agent_tts=False,
+    )
+    assert (resolved.vendor, resolved.voice, resolved.language) == (
+        "elevenlabs",
+        "Rachel",
+        "en-GB",
+    )
+
+
+def test_realtime_and_pipeline_do_not_share_a_cache_entry():
+    """Different audio, so they must key differently."""
+    realtime = resolve_fallback_message({"text": "busy"}, _REALTIME_OPTS, inherit_agent_tts=False)
+    pipeline = resolve_fallback_message({"text": "busy"}, _REALTIME_OPTS, inherit_agent_tts=True)
+    assert fallback_message_key(realtime) != fallback_message_key(pipeline)
+
+
+def test_fixed_message_for_derives_inheritance_from_the_model():
+    """End-to-end: an Ultravox agent must not carry its model voice through."""
+    from pipecat_aplisay.fixed_message import fixed_message_for
+
+    realtime_agent = {
+        "modelName": "pipecat:ultravox/ultravox-v0.7",
+        "options": {**_REALTIME_OPTS, "fallback": {"message": {"text": "busy"}}},
+    }
+    resolved = fixed_message_for(realtime_agent)
+    assert resolved.vendor is None and resolved.voice is None
+    assert resolved.language == "en-GB"
+
+
+# ---- Cache key -----------------------------------------------------------
+
+
+def test_key_is_stable_and_well_formed():
+    a = resolve_fallback_message({"text": "hi"}, {})
+    b = resolve_fallback_message({"text": "hi"}, {})
+    key = fallback_message_key(a)
+    assert key == fallback_message_key(b)
+    assert len(key) == 32
+    assert all(c in "0123456789abcdef" for c in key)
+
+
+@pytest.mark.parametrize("field", ["text", "vendor", "voice", "language"])
+def test_key_changes_when_any_hashed_input_changes(field):
+    """This *is* the invalidation: an edit misses the cache and re-synthesises."""
+    base = resolve_fallback_message(
+        {"text": "hi", "vendor": "v", "voice": "x", "language": "en"}, {}
+    )
+    changed = resolve_fallback_message(
+        {**{"text": "hi", "vendor": "v", "voice": "x", "language": "en"}, field: "different"}, {}
+    )
+    assert fallback_message_key(base) != fallback_message_key(changed)
+
+
+def test_separator_in_a_value_cannot_collide_with_a_field_split():
+    a = resolve_fallback_message({"text": "t", "voice": "a|b"}, {})
+    b = resolve_fallback_message({"text": "t", "voice": "a", "language": "b"}, {})
+    assert fallback_message_key(a) != fallback_message_key(b)
+
+
+def test_key_requires_text():
+    with pytest.raises(ValueError):
+        fallback_message_key(resolve_fallback_message({"text": "x"}, {}).__class__(text=""))
+
+
+# ---- WAV codec -----------------------------------------------------------
+
+
+def _pcm() -> bytes:
+    return (12345).to_bytes(2, "little", signed=True) + bytes(636) + (
+        -12345
+    ).to_bytes(2, "little", signed=True)
+
+
+def test_wav_round_trips_samples_and_rate():
+    decoded = decode_wav(encode_wav(_pcm(), 24000))
+    assert decoded.sample_rate == 24000
+    assert decoded.pcm == _pcm()
+
+
+def test_wav_reads_a_chunk_ahead_of_data_as_some_vendors_emit():
+    wav = encode_wav(_pcm(), 16000)
+    # Odd-length LIST chunk plus its pad byte, spliced before `data`.
+    chunk = b"LIST" + (5).to_bytes(4, "little") + bytes(5) + bytes(1)
+    spliced = wav[:36] + chunk + wav[36:]
+    assert decode_wav(spliced).pcm == _pcm()
+
+
+def test_wav_truncation_yields_bytes_present_not_a_phantom_length():
+    wav = encode_wav(_pcm(), 16000)
+    assert len(decode_wav(wav[:-100]).pcm) == len(_pcm()) - 100
+
+
+def test_wav_rejects_payloads_it_cannot_honestly_decode():
+    with pytest.raises(ValueError):
+        decode_wav(bytes(64))
+    with pytest.raises(ValueError):
+        decode_wav(bytes(4))
+
+
+# ---- Concurrency routing -------------------------------------------------
+
+
+class _Recorder:
+    """Stands in for the fixed-message playout so the test observes routing."""
+
+    def __init__(self) -> None:
+        self.played: list = []
+
+    async def __call__(self, transport, agent) -> bool:
+        self.played.append(agent)
+        return True
+
+
+def test_concurrency_rejection_plays_the_message_without_starting_a_call(monkeypatch):
+    """The premise of the feature: refusing on capacity must still announce.
+
+    The call is deliberately never started, so no concurrency slot is reserved
+    while the announcement plays — otherwise "we are busy" would itself consume
+    the capacity it is apologising for.
+    """
+    from pipecat_aplisay import call_session as cs
+
+    recorder = _Recorder()
+    monkeypatch.setattr("pipecat_aplisay.fixed_message.run_fixed_message", recorder)
+
+    session = cs.CallSession.__new__(cs.CallSession)
+    session.fixed_message_only = True
+    session.agent = {
+        "id": "a1",
+        "modelName": "m",
+        "options": {"fallback": {"message": {"text": "busy"}}},
+    }
+    session.gateway_session = type("GW", (), {"transport": object()})()
+
+    asyncio.run(cs.CallSession.run(session, system_prompt="unused"))
+
+    assert recorder.played == [session.agent], "the announcement should have played"
+
+
+def test_concurrency_rejection_without_a_message_still_refuses(monkeypatch):
+    """No message configured means unchanged behaviour: the caller gets busy."""
+    from pipecat_aplisay import api_client, call_session as cs
+
+    async def _busy(_call):
+        raise api_client.AgentConcurrencyLimitExceededBusyError(scope="organisation")
+
+    async def _create_call(_body):
+        return type("Call", (), {"id": "c1"})()
+
+    class _Gateway:
+        async def setup_inbound(self, *_a, **_k):
+            return type("GW", (), {"transport": object()})()
+
+    monkeypatch.setattr(api_client, "start_call", _busy)
+    monkeypatch.setattr(api_client, "create_call", _create_call)
+
+    ctx = cs.InboundCallContext(session_id="s1", called_id="+441", caller_id="+442")
+    agent = {"id": "a1", "userId": "u", "organisationId": "o", "modelName": "m", "options": {}}
+
+    with pytest.raises(api_client.AgentConcurrencyLimitExceededBusyError):
+        asyncio.run(
+            cs.setup_inbound_call(_Gateway(), ctx, instance={"id": "i1"}, agent=agent)
+        )

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -504,8 +504,15 @@ components:
              1. `agent` – if specified, the current call/room will be torn down and restarted using the given fallback agent.
              2. `model` – if specified and no `agent` fallback is configured, the session will be restarted using this fallback model name,
                 keeping all other agent configuration the same.
-             3. `number` – if neither an `agent` nor `model` fallback is available (or the configured fallback model also fails),
-                the call will be transferred to this number using the builtin `transfer` platform function.
+             3. `message` – if no agent or model fallback is available (or those also failed), a fixed announcement is spoken
+                to the caller and the call then ends. The chain stops here when the announcement plays.
+             4. `number` – if none of the above is available or succeeded, the call will be transferred to this number using
+                the builtin `transfer` platform function.
+
+            An agent concurrency limit rejection is a special case: `agent` and `model` are skipped (the limit applies whichever
+            agent or model is behind it) and `number` is unreachable (its transfer would need the same slot), so `message` is the
+            only fallback that can serve such a caller. It can do so because a cached announcement calls no TTS vendor, records no
+            usage, and therefore holds no concurrency slot of its own.
           properties:
             agent:
               description: |-
@@ -523,6 +530,58 @@ components:
                 definition (prompt, tools, options, etc).
               type: string
               example: "gpt-4.1-mini"
+            message:
+              type: object
+              required: [text]
+              description: |-
+                A fixed announcement spoken to the caller when no agent could be started — for example
+                "Sorry, we are unusually busy right now; please call back shortly."
+
+                Set `text` alone to speak it in the agent's own voice, or add `vendor` / `voice` to have it
+                spoken by a different TTS from the agent's own. That matters when the agent's configured TTS
+                stack is itself what failed: pointing the announcement at a vendor known to be healthy keeps
+                it playable in exactly the circumstances it exists for.
+
+                The rendered audio is synthesised once, on the first call that needs it, and cached; every
+                later playout replays that recording. Editing the text (or the voice, vendor, or language)
+                changes the cache key, so the next call re-synthesises automatically — there is nothing to
+                invalidate by hand. TTS characters are therefore billed once per distinct announcement, not
+                once per failed call.
+
+                Playing the announcement does not start a call or reserve an agent concurrency slot, which is
+                what allows it to be the fallback for a concurrency rejection.
+
+                Voice and vendor are validated against the catalogue of voices a TTS can render, NOT against the
+                agent model's own voices. For a realtime speech-to-speech model (Ultravox, OpenAI Realtime, Gemini
+                Live) those are different sets: the model has no TTS, and `tts.voice` names a timbre of the model
+                itself. Since the announcement plays precisely when that model could not be started, a discrete TTS
+                always speaks it — so an ElevenLabs voice on an Ultravox agent is valid here, and is the
+                configuration that works.
+
+                For the same reason, a realtime agent does NOT inherit `tts.vendor` / `tts.voice` as defaults:
+                without an explicit override the worker's default TTS voice is used. `language` is inherited either
+                way. Pipeline agents inherit all three as you would expect.
+              properties:
+                text:
+                  type: string
+                  maxLength: 1000
+                  description: The words to speak.
+                  example: "Sorry, we are unusually busy right now. Please call back shortly."
+                vendor:
+                  type: string
+                  description: |-
+                    TTS provider for the announcement. Same form and constraints as `tts.vendor`.
+                    Defaults to `tts.vendor` for a pipeline agent; for a realtime agent there is no
+                    default and the worker's own default TTS is used.
+                  example: elevenlabs
+                voice:
+                  type: string
+                  description: |-
+                    TTS voice for the announcement. Defaults to `tts.voice` for a pipeline agent;
+                    for a realtime agent there is no default.
+                  example: en-GB-Wavenet-A
+                language:
+                  $ref: "#/components/schemas/Language"
             number:
               description: |-
                 A phone number or endpoint ID to transfer the call to if the LLM is unavailable or not responding (telephone agents only).

--- a/docs/agent-failover.md
+++ b/docs/agent-failover.md
@@ -1,16 +1,19 @@
 # Agent Failover
 
-This document describes how to configure and use agent failover, a feature that allows automatic fallback to alternative agents, models, or phone numbers when the primary agent or model fails to start or connect.
+This document describes how to configure and use agent failover, a feature that allows automatic fallback to alternative agents, models, a spoken announcement, or phone numbers when the primary agent or model fails to start or connect.
 
 ## Overview
 
-Agent failover provides resilience by automatically switching to backup options when the primary agent encounters setup failures (such as model connection timeouts, unsupported models, or initialization errors). The failover system supports three levels of fallback, applied in a strict precedence order:
+Agent failover provides resilience by automatically switching to backup options when the primary agent encounters setup failures (such as model connection timeouts, unsupported models, or initialization errors). The failover system supports four levels of fallback, applied in a strict precedence order:
 
 1. **Agent-level fallback**: Switch to a completely different agent configuration
 2. **Model-level fallback**: Retry with a different model using the same agent configuration
-3. **Number-level fallback**: Transfer the call to a phone number or endpoint
+3. **Message-level fallback**: Speak a fixed announcement to the caller, then end the call
+4. **Number-level fallback**: Transfer the call to a phone number or endpoint
 
 Failover is only triggered for **setup-time failures** (before the call starts). Runtime errors during an active call do not trigger failover, as the agent is already running and handling the conversation.
+
+The chain stops at the first level that works. A level that is not configured, or that fails, falls through to the next.
 
 ## How Failover Works
 
@@ -32,8 +35,14 @@ When an agent fails to start (e.g., model connection timeout, unsupported model,
    - The session is restarted with the fallback model
    - This is the second priority fallback
 
-3. **Number Fallback** (`options.fallback.number`)
-   - If neither agent nor model fallback is configured (or they fail), the call is transferred
+3. **Message Fallback** (`options.fallback.message`)
+   - If no agent or model fallback is configured (or they have failed), a fixed announcement is spoken to the caller
+   - The audio is synthesised once and cached, so repeat playouts make no TTS vendor call — see [Fixed message fallback](#fixed-message-fallback)
+   - Terminal on success: once the caller has heard the announcement the call ends, and `number` is not attempted
+   - Reached directly, skipping `agent` and `model`, when the failure is an agent concurrency limit
+
+4. **Number Fallback** (`options.fallback.number`)
+   - If none of the above is configured (or they fail), the call is transferred
    - The system performs a blind transfer to the specified phone number or endpoint ID
    - The transfer uses the same mechanisms as the builtin `transfer` function, this is a bridged transfer by default.
    - This is the final fallback option
@@ -61,7 +70,7 @@ this is only useful to recover from failure of a single LLM vendor to accept a c
 
 If the Aplisay platform itself is degraded by e.g. a Livekit failure then it is likely that the failover option will be of limited use.
 
-Failover only operates on Livekit agents, it does not operate on legacy Jambonz agents, nor does it work on platform specific (e.g. Ultravox) WebRTC agents.
+Failover operates on the LiveKit and Pipecat agent runtimes. It does not operate on legacy Jambonz agents, nor on platform-specific (e.g. native Ultravox) WebRTC agents — those stacks own their own session lifecycle and never enter the fallback chain.
 
 #### Voices
 
@@ -126,6 +135,53 @@ When the primary model fails, the system will:
 - Keep all other agent properties unchanged (prompt, functions, options, etc.)
 - Only the `modelName` is substituted
 
+#### Message Fallback
+
+To configure a spoken announcement, set `options.fallback.message`. It always takes an object; `text` is the only required field, and on its own means "say this in the agent's own voice":
+
+```json
+{
+  "modelName": "livekit:openai/gpt-4o",
+  "prompt": "You are a helpful assistant.",
+  "options": {
+    "tts": { "vendor": "elevenlabs", "voice": "Dominus" },
+    "fallback": {
+      "message": {
+        "text": "Sorry, we are unusually busy right now. Please call back shortly."
+      }
+    }
+  }
+}
+```
+
+There is deliberately no bare-string shorthand. `message: "..."` is rejected rather than accepted as `{ text }`: one shape to document, validate, and read is worth a few extra characters.
+
+Adding `vendor` / `voice` has the announcement spoken by a different TTS from the agent's own:
+
+```json
+{
+  "modelName": "livekit:openai/gpt-4o",
+  "prompt": "You are a helpful assistant.",
+  "options": {
+    "tts": { "vendor": "elevenlabs", "voice": "Dominus" },
+    "fallback": {
+      "message": {
+        "text": "Sorry, we are unusually busy right now. Please call back shortly.",
+        "vendor": "deepgram/aura-2",
+        "voice": "thalia",
+        "language": "en-GB"
+      }
+    }
+  }
+}
+```
+
+For a **pipeline** agent (STT–LLM–TTS), `vendor`, `voice`, and `language` each default to the corresponding `options.tts` value, so you only state what you want to differ. Overriding them is worth doing when the agent's own TTS stack is a plausible cause of the failure you are protecting against — pointing the announcement at a vendor you have no dependency on elsewhere keeps it playable in precisely the circumstances it exists for.
+
+For a **realtime** agent the defaults work differently — see [Realtime agents](#realtime-agents-ultravox-openai-realtime-gemini-live) below.
+
+`text` is required and limited to 1000 characters. `voice` and `vendor` are validated when the agent is saved, against the catalogue of voices and vendors a *TTS* can render — not against the agent model's own voices, which for a realtime model are timbres of the model rather than anything a TTS could produce. Validating at write time is deliberate: a typo that only surfaced during an outage would be a fallback that isn't one.
+
 #### Number Fallback
 
 To configure a number-level fallback (transfer), specify a phone number or endpoint ID:
@@ -159,11 +215,14 @@ You can configure multiple fallback levels:
     "fallback": {
       "agent": "550e8400-e29b-41d4-a716-446655440000",
       "model": "livekit:openai/gpt-realtime",
+      "message": { "text": "Sorry, we cannot take your call right now. Please try again shortly." },
       "number": "+441234567890"
     }
   }
 }
 ```
+
+Note that with both `message` and `number` set, the announcement wins: it is higher precedence, and it is terminal on success, so `number` is only reached if the announcement could not be played at all. If what you want is "announce, then transfer", that is not this option — configure `number` alone and use the transfer's own prompting.
 
 In this example:
 1. If the primary agent fails, try the fallback agent
@@ -205,6 +264,82 @@ curl -X PUT https://llm-agent.aplisay.com/api/agents/{agentId} \
     }
   }'
 ```
+
+## Fixed message fallback
+
+The message fallback exists for the case where every other option is either unavailable or inappropriate: there is no spare agent, no alternative model, and nobody to transfer to — but the caller is on the line and deserves better than dead air or a busy tone.
+
+### The audio is synthesised once, then cached
+
+An announcement cannot vary for a given configuration, so it is rendered once and stored in Google Cloud Storage under a key derived from its own content. Every later playout replays that recording.
+
+- **The first call that needs a given announcement pays for it.** That call synthesises through the configured TTS and is metered for the characters in the normal way.
+- **Every later call is free.** A cache hit calls no vendor, so it meters nothing. An announcement is therefore billed once per distinct configuration, not once per failed call — which matters, because failures arrive in bursts.
+- **Editing the message re-synthesises automatically.** The cache key is a digest of the text, vendor, voice, and language. Change any of them and the next call misses, re-renders, and stores the new audio. There is nothing to invalidate by hand and no way to serve stale audio for edited text.
+- **Identical announcements are shared.** Two agents configured with the same words in the same voice resolve to the same object. The content is fully determined by the key, so this leaks nothing between tenants, and the bucket is platform-private.
+
+Storage lives alongside call recordings — the same bucket, its own prefix — so it inherits the credentials and lifecycle management already in place. Unlike recordings, the cached audio is **not** encrypted. There would be nothing to protect (it is a rendering of `options.fallback.message.text`, which sits in clear in the agent record) and decrypting it would burn CPU at the worst possible moment, since heavy load is one of the likelier reasons an agent session failed in the first place. The playout path is deliberately kept to a download, a resample, and a write. The full storage contract is in `lib/fallback-message/CONTRACT.md`.
+
+### Realtime agents (Ultravox, OpenAI Realtime, Gemini Live)
+
+A realtime speech-to-speech agent has no TTS. The model speaks for itself, and `options.tts.voice` names one of *its* voices — `"Svetlana"` on Ultravox, say — which no TTS service can render.
+
+That matters here more than anywhere else, because the announcement plays precisely when the model could not be started. The model cannot be what speaks it, so a discrete TTS always does. Two consequences follow:
+
+- **The model's voice and vendor are not inherited.** With no explicit override, the announcement is spoken by the worker's default TTS voice. (Inheriting would hand the TTS builder a vendor of `ultravox`, which does not fall back to anything — it raises `Unsupported TTS vendor` — so the announcement covering the outage would fail with it.)
+- **`language` is still inherited**, because a BCP-47 tag means the same thing to a model and to a TTS, and an announcement in the wrong language is worse than one in an unfamiliar voice.
+
+So if you care which voice a realtime agent's announcement uses — and you probably do, since it is the only voice the caller will hear — **state it explicitly**:
+
+```json
+{
+  "modelName": "livekit:ultravox/ultravox-v0.7",
+  "options": {
+    "tts": { "voice": "Svetlana" },
+    "fallback": {
+      "message": {
+        "text": "Sorry, we cannot take your call right now. Please try again shortly.",
+        "vendor": "elevenlabs",
+        "voice": "Rachel"
+      }
+    }
+  }
+}
+```
+
+This is also the sturdiest configuration available, and worth considering even for pipeline agents: the announcement's vendor is then chosen independently of everything the agent depends on, so an outage at the agent's own provider cannot take the announcement with it.
+
+Voice and vendor here are validated against the TTS catalogue, so an ElevenLabs voice on an Ultravox agent is accepted — it is the configuration that works.
+
+### Concurrency limits
+
+This is the case the message fallback is most useful for, and it behaves differently from the other failure modes.
+
+When a call is refused because it would exceed an agent concurrency limit (on the instance, user, or organisation), the chain **skips `agent` and `model` and goes straight to `message`**:
+
+- Retrying with a different agent or a different model cannot help. The limit is enforced when the call is started, whichever agent or model is behind it, so those attempts would spend setup time only to be refused identically.
+- `number` cannot help either. Its transfer needs a started call, and starting one is exactly what the limiter refused.
+
+Playing the announcement works where those do not, because **it never starts a call**. A cached announcement makes no vendor call, so there is no usage to record, so there is no call record to create, so no concurrency slot is reserved. This is essential rather than incidental: an announcement that consumed a slot would be spending the very capacity it is apologising for, and under sustained load would compete with the real calls it is meant to protect.
+
+The consequence to be aware of is that **the call is answered**. Without a message configured, a concurrency rejection is signalled back as busy and the caller never connects. With one configured, the platform answers the leg in order to play the announcement, which means the caller is connected for those few seconds and any per-minute carrier cost for them is incurred. That is the trade an operator is asking for by configuring the option, and it is small — but it is a real change in behaviour, not merely an added courtesy.
+
+If the announcement cannot be played (synthesis fails and there is no cached copy, or the media path is unavailable), the concurrency rejection is re-raised and the caller gets the busy signal exactly as before.
+
+### What is recorded
+
+The message fallback does not change how the underlying failure is recorded. The call keeps its real failure reason and remains diagnosable; the announcement is a courtesy played on the way out, not a different outcome. The seconds spent playing it are not recorded as call duration, because the call was never started.
+
+### Failure behaviour
+
+Every step of this path is non-fatal by design, because it only ever runs when something else has already broken:
+
+| Failure | Result |
+| --- | --- |
+| Cache read fails or the object is corrupt | Re-synthesise for this call |
+| Cache write fails | Announcement still plays; next call re-synthesises |
+| Synthesis fails | Fall through to `fallback.number` (or, for a concurrency rejection, busy) |
+| Playout fails | Fall through to `fallback.number` (or busy) |
 
 ## Failover Scenarios
 
@@ -249,12 +384,29 @@ curl -X PUT https://llm-agent.aplisay.com/api/agents/{agentId} \
 3. If fallback agent fails, system tries fallback model (livekit:ultravox/ultravox-v0.6-gemma3-27b) configured in fallback agent
 4. If fallback model fails, call is transferred to `+441234567890`
 
+### Scenario 4: All Agents Busy (Concurrency Limit)
+
+**Setup:**
+
+- Organisation `agentLimit` is 10, and 10 calls are already in progress
+- Fallback message: `"Sorry, we are unusually busy right now. Please call back shortly."`
+- Fallback model and number are also configured
+
+**What happens:**
+1. An eleventh call arrives and is refused by the concurrency limiter
+2. Agent and model fallback are **skipped** — the limit applies whichever model would run
+3. The announcement is played from cache; no call is started and no concurrency slot is taken
+4. The call ends. The number fallback is not attempted, because its transfer would need the slot that was just refused
+
+Without `message` configured, step 2 onwards is replaced by an immediate busy rejection, which remains the behaviour if the announcement cannot be played.
+
 ## Best Practices
 
 1. **Test Your Fallback Chain**: Ensure your fallback agents/models are properly configured and tested
 2. **Use Appropriate Fallbacks**: 
    - Agent fallback for completely different agents, where each agent definition (prompt) is tuned to the model provider
    - Model fallback where a single agent definition is known to work well with two different providers/models
+   - Message fallback to say something useful when there is no agent and no human to hand to — and as the only fallback that can serve a caller refused on a concurrency limit
    - Number fallback as a last resort to human operators
 3. **Avoid Circular References**: Don't create fallback chains that reference each other
 4. **Consider Costs**: Each fallback attempt may incur LLM costs, different models have different token or per minute costs
@@ -269,6 +421,7 @@ The `options.fallback` object supports the following properties:
 
 - `agent` (string, optional): UUID of a fallback agent
 - `model` (string, optional): Model name for fallback (e.g., `"livekit:openai/gpt-4.1-mini"`)
+- `message` (object, optional): Fixed announcement spoken to the caller. Takes `text` (required, max 1000 characters) plus optional `vendor`, `voice`, and `language`. There is no bare-string form. For a pipeline agent these default to the matching `options.tts` value; for a realtime agent only `language` is inherited, and the worker's default TTS voice is used unless `vendor`/`voice` are stated — see [Realtime agents](#realtime-agents-ultravox-openai-realtime-gemini-live)
 - `number` (string, optional): Phone number or endpoint ID for fallback transfer (E.164 format or endpoint UUID)
 
 All properties are optional, but at least one should be specified for failover to be useful.
@@ -291,6 +444,18 @@ All properties are optional, but at least one should be specified for failover t
 
 - **Verify agent exists**: The fallback agent ID must reference an existing agent
 - **Check permissions**: Ensure the fallback agent is accessible to the same user/organization
+
+### Message Fallback Not Playing
+
+- **Check the agent saved cleanly**: `voice` and `vendor` are validated against the model's TTS catalogue at write time; a rejected save means no message is configured at all
+- **Check the text is non-empty**: whitespace-only `text` is treated as no message
+- **Look for `playing fixed fallback message` in the logs**: its absence means the chain never reached this step (an `agent` or `model` fallback succeeded, or none was configured)
+- **Check for `fixed fallback message unavailable`**: the step was reached but synthesis or playout failed, and the chain moved on
+- **Check worker credentials for the storage bucket**: a cache read failure is logged and degrades to re-synthesis, so persistent re-synthesis of the same message points at the bucket rather than the TTS
+
+### Message Fallback Plays But The Caller Was Expecting Busy
+
+Configuring `options.fallback.message` deliberately answers calls that would otherwise be refused with a busy signal, including those refused on a concurrency limit. Remove the message to restore busy rejection. See [Concurrency limits](#concurrency-limits).
 
 ### Transfer Fallback Not Working
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -71,6 +71,13 @@ const schemaVersion = 59;  // 59: billing — DROP the rate_cards period-overlap
                            //     RateCard.sync to create rate_cards. Idempotent on DBs already fully on v44.
                            // 44: billing — RateCard table + organisations.{rate_history,balance,billing_config,billing_blocked} + usage_records billing/cost columns
 
+/**
+ * Cap on `options.fallback.message.text`. Generous for an announcement, but
+ * bounded: the rendered audio is cached as uncompressed PCM and held on a
+ * caller who is already waiting on a call that failed.
+ */
+const FALLBACK_MESSAGE_MAX_CHARS = 1000;
+
 /** Set after concurrency models + store are initialised (end of model definitions). */
 let agentConcurrencyLimits;
 
@@ -442,6 +449,68 @@ Agent.init({
             }
             if (tone.enabled !== undefined && typeof tone.enabled !== 'boolean') {
               throw new Error('options.transferTone.enabled must be a boolean');
+            }
+          }
+        }
+        if (this.options?.fallback?.message !== undefined && this.options?.fallback?.message !== null) {
+          // Fixed announcement played when the agent cannot be started at all
+          //  (options.fallback.message) — see docs/agent-failover.md. Validated
+          //  here rather than at call time because the whole point of this option
+          //  is to work when everything else has failed: a typo'd voice that only
+          //  surfaces mid-outage is a fallback that isn't one.
+          const message = this.options.fallback.message;
+          if (typeof message !== 'object' || Array.isArray(message)) {
+            throw new Error(
+              'options.fallback.message must be an object with a "text" property'
+              + (typeof message === 'string' ? ' (a bare string is not accepted)' : ''));
+          }
+          if (typeof message.text !== 'string' || !message.text.trim()) {
+            throw new Error('options.fallback.message.text is required and must be a non-empty string');
+          }
+          if (message.text.length > FALLBACK_MESSAGE_MAX_CHARS) {
+            throw new Error(
+              `options.fallback.message.text must be ${FALLBACK_MESSAGE_MAX_CHARS} characters or fewer`);
+          }
+          for (const field of ['vendor', 'voice', 'language']) {
+            if (message[field] !== undefined && typeof message[field] !== 'string') {
+              throw new Error(`options.fallback.message.${field} must be a string`);
+            }
+          }
+          // The announcement is ALWAYS rendered by a discrete TTS, even when the
+          //  agent itself is a realtime speech-to-speech model with no TTS of its
+          //  own — a fixed message plays precisely because that model could not be
+          //  started, so there is nothing else left to speak it. Hence discreteTts:
+          //  validating an Ultravox agent's announcement against Ultravox's own
+          //  voices would reject the one configuration that works (say it with
+          //  ElevenLabs) and accept ones no TTS can render.
+          if (message.voice || message.vendor) {
+            const voicesInstance = new Voices();
+            if (message.voice) {
+              const allowedNames = await getVoiceNamesForAgentValidation({
+                modelName: this.modelName,
+                Handler,
+                voicesInstance,
+                discreteTts: true,
+              });
+              if (!allowedNames.has(message.voice)) {
+                throw new Error(
+                  `options.fallback.message.voice ${message.voice} is not a usable TTS voice `
+                  + `(the announcement is spoken by a TTS, not by ${this.modelName})`);
+              }
+            }
+            if (message.vendor) {
+              const allowedVendors = await getTtsVendorsForAgentValidation({
+                modelName: this.modelName,
+                Handler,
+                voicesInstance,
+                discreteTts: true,
+              });
+              const vendor = String(message.vendor).toLowerCase();
+              if (allowedVendors.size && !allowedVendors.has(vendor)) {
+                throw new Error(
+                  `options.fallback.message.vendor "${message.vendor}" is not a usable TTS vendor `
+                  + `(supported: ${[...allowedVendors].sort().join(', ')})`);
+              }
             }
           }
         }

--- a/lib/fallback-message/CONTRACT.md
+++ b/lib/fallback-message/CONTRACT.md
@@ -1,0 +1,140 @@
+# Fixed fallback message — shared contract
+
+This document is the single source of truth for the cache layout and audio
+format used by the fixed-message failover path (`options.fallback.message`).
+Two implementations follow it:
+
+- **JS** — this directory (`lib/fallback-message/`), consumed by the LiveKit
+  agent via the `agent-lib/` symlink.
+- **Python** — `agents/pipecat/pipecat_aplisay/fallback_message/`, a sibling
+  implementation. Different language, same contract.
+
+Both runtimes read and write the *same* objects. A change made on one side and
+not the other does not corrupt anything — it splits the cache in two, so each
+runtime silently re-synthesises what the other already paid for. If you change
+anything here, change both sides and update
+`tests/lib/fallback-message.test.mjs` and
+`agents/pipecat/tests/test_fallback_message.py`.
+
+## Why there is a cache at all
+
+The announcement never varies for a given configuration, so it is synthesised
+once and replayed thereafter. That is not only a latency and cost win: it is
+what keeps the playout path free of any billing interaction. A cache hit makes
+no vendor call, so it meters nothing, so it needs no `Call` record, so it never
+touches the concurrency limiter — which matters because the single most useful
+time to play a fixed message is when that limiter is the thing rejecting the
+call. See `docs/agent-failover.md` for the full argument.
+
+## Cache key
+
+Content-addressed. The key is the first 32 hex characters (128 bits) of
+`sha256(canonical)` where `canonical` is the UTF-8 JSON encoding of exactly:
+
+```json
+["<text>", "<vendor>", "<voice>", "<language>"]
+```
+
+Absent fields are the empty string, never `null` or omitted. Fields are hashed
+as a JSON array rather than a delimited string so a value containing the
+delimiter cannot collide with a different field split.
+
+`options.fallback.message` is always an object — there is no bare-string
+shorthand, and both runtimes resolve a string to `null` rather than treating it
+as `{ text }`.
+
+`text` is whitespace-trimmed. `vendor`, `voice`, and `language` are resolved
+against the agent's own `options.tts` before hashing, so an agent that states
+only `text` hashes with its normal TTS settings filled in.
+
+### Inheritance is conditional, and both runtimes must agree
+
+`vendor` and `voice` are inherited from `options.tts` **only when the agent has
+a discrete TTS** — that is, when its voice mode is `pipeline`. A realtime
+speech-to-speech agent's `options.tts.voice` names a timbre of the *model*
+(`"Svetlana"` on Ultravox), which no TTS can render; inheriting it would hand
+the TTS builder a vendor of `ultravox`, which raises rather than degrading. So
+for realtime agents those two fields resolve to empty and the worker's default
+TTS is used unless the message states its own.
+
+`language` is inherited either way — a BCP-47 tag means the same thing to a
+model and to a TTS.
+
+Each runtime derives this from its own voice-mode resolver
+(`resolveVoiceMode` / `resolve_voice_mode`, both of which honour
+`options.voiceMode`). **This decision feeds the key**, so a runtime that decided
+it differently would split the cache exactly as a hashing difference would. The
+cross-language test pins realtime cases for this reason.
+
+Consequences, both intended:
+
+- Editing any of the four inputs changes the key, so invalidation is automatic.
+  There is no cache to bust and no way to serve stale audio for edited text.
+- Two agents with an identical announcement in an identical voice share one
+  object. Safe: the content is fully determined by the key, so computing the
+  key requires already holding the plaintext, and the bucket is platform-private.
+
+## Storage layout
+
+Base URL resolution, in order:
+
+1. `FALLBACK_MESSAGE_STORAGE_PATH` if set.
+2. The bucket from `RECORDING_STORAGE_PATH` (if set) with prefix
+   `<NODE_ENV>-fallback-messages` — so a deployment that has already moved
+   recordings to its own bucket does not keep writing announcements to the
+   default one.
+3. `gs://llm-voice/<NODE_ENV>-fallback-messages`.
+
+Object name: `<prefix><key>.wav`.
+
+Objects are stored **unencrypted**, unlike recordings, and deliberately so.
+
+There is nothing to protect: a recording is customer conversation audio, held
+under a key the platform sometimes does not have, whereas an announcement is
+rendered from an agent's own `options.fallback.message.text`, which sits in
+clear in the database. Encrypting a rendering of plaintext we already hold
+buys no confidentiality.
+
+More importantly it would cost CPU in the worst possible place. This path runs
+when an agent session has failed, and one of the likelier reasons for that is
+that the system is under load — so the playout path is disproportionately
+likely to execute exactly when there are no cycles to spare. It must be as
+cheap as we can make it. That is the same reasoning behind storing PCM rather
+than a compressed codec: playing a cached announcement should be a download, a
+resample, and a write to the transport, with no decrypt and no decode in the
+way.
+
+The bucket is platform-private and is never exposed to tenants.
+
+## Audio format
+
+- Container: **WAV** (RIFF/WAVE), codec **PCM**, signed 16-bit little-endian.
+- Channels: **mono**.
+- Sample rate: **whatever the synthesising TTS emitted** — readers must take
+  the rate from the WAV header and resample to their transport's rate. It is
+  deliberately not pinned: the two runtimes synthesise through different vendor
+  stacks, and forcing a rate would mean an extra resample on the write path for
+  no benefit.
+
+WAV rather than raw PCM so the rate travels with the samples, and so a cached
+object can be pulled from the bucket and played in any audio tool during
+diagnosis.
+
+Readers must walk the RIFF chunks rather than assuming `data` at offset 36:
+some vendors emit a `LIST` or `fact` chunk first, and a fixed-offset reader
+turns such a payload into noise.
+
+## Write concurrency
+
+Uploads use `ifGenerationMatch: 0` (create-only). When an outage fails many
+calls at once, every worker misses and synthesises concurrently; the first to
+finish publishes and the rest receive a precondition failure, which both
+implementations report to their caller as success — the cache does now hold the
+object. The losers play the copy they synthesised for their own call.
+
+## Failure behaviour
+
+Every cache operation is never-throw in both implementations. A read failure is
+a miss (synthesise it again this call); a write failure is a no-op (re-synthesise
+next time). This path only ever runs when something else has already broken, so
+it must not add a second failure of its own.

--- a/lib/fallback-message/cache-key.js
+++ b/lib/fallback-message/cache-key.js
@@ -1,0 +1,124 @@
+/**
+ * Cache-key derivation for synthesised fallback messages.
+ *
+ * The fixed-message failover path (`options.fallback.message`) plays a
+ * pre-synthesised announcement at the caller when agent setup has failed. The
+ * audio never varies for a given configuration, so it is synthesised once and
+ * cached in GCS; every later playout is a byte-for-byte replay.
+ *
+ * The cache is **content-addressed**: the object name is a digest of exactly
+ * those inputs that change the audio. Two consequences follow, and both are
+ * deliberate:
+ *
+ *   - Editing the message text (or the voice, vendor, or language) yields a
+ *     different key, so the next playout misses, re-synthesises, and writes a
+ *     new object. Invalidation is therefore automatic — there is no cache to
+ *     explicitly bust and no way to serve stale audio for edited text.
+ *   - Two agents configured with the same announcement in the same voice share
+ *     one object. That is a dedupe win rather than a leak: the object's content
+ *     is fully determined by the key, so a reader who can compute the key
+ *     already holds the plaintext that produced it, and the bucket itself is
+ *     platform-private (workers read it with platform credentials; it is never
+ *     exposed to tenants).
+ *
+ * Mirrored by `agents/pipecat/pipecat_aplisay/fallback_message/cache_key.py`.
+ * The digest formula is a cross-runtime contract: a change on one side that is
+ * not made on the other silently splits the cache in two (correct audio, wasted
+ * synthesis). See CONTRACT.md.
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Digest length in hex characters. 32 hex chars = 128 bits, ample for a CAS. */
+export const KEY_LENGTH = 32;
+
+/**
+ * @typedef {Object} ResolvedFallbackMessage
+ * @property {string} text The words to speak.
+ * @property {string=} vendor TTS provider, e.g. `elevenlabs` or `deepgram/aura-2`.
+ * @property {string=} voice Voice specifier as understood by `vendor`.
+ * @property {string=} language BCP-47 language tag.
+ */
+
+/**
+ * Resolve `options.fallback.message` against the agent's own `options.tts`.
+ *
+ * The message may name its own vendor/voice/language — the point of the feature
+ * is that the announcement can be spoken by a TTS that is known-good even when
+ * the agent's configured stack is what just failed. Anything the message does
+ * not state falls back to the agent's normal TTS settings, so the common case
+ * ("say this, in my usual voice") needs only `text`.
+ *
+ * `inheritAgentTts` is the exception, and it matters: a realtime
+ * speech-to-speech agent (Ultravox, OpenAI Realtime, Gemini Live) has no
+ * discrete TTS, and its `options.tts.voice` names a timbre of the *model*.
+ * The announcement is always spoken by a real TTS — it plays because the model
+ * could not be started, so the model cannot be what speaks it — and handing a
+ * TTS service a vendor of `ultravox` does not degrade, it throws. So for those
+ * agents the vendor and voice are NOT inherited, leaving the worker to use its
+ * default TTS unless the message names one explicitly.
+ *
+ * `language` is inherited either way: it is a portable BCP-47 tag that means
+ * the same thing to a model and to a TTS, and an announcement in the wrong
+ * language would be worse than one in an unfamiliar voice.
+ *
+ * @param {unknown} message Raw `options.fallback.message`. Must be an object
+ *   with `text`; a bare string is not accepted (see below).
+ * @param {{ tts?: { vendor?: string, voice?: string, language?: string } }=} agentOptions
+ * @param {{ inheritAgentTts?: boolean }=} opts `inheritAgentTts` defaults to
+ *   true (a pipeline agent, whose `options.tts` describes a real TTS). Pass
+ *   false for a realtime agent. Callers must agree on this: it feeds the cache
+ *   key, so the two runtimes deciding differently would split the cache.
+ * @returns {ResolvedFallbackMessage | null} `null` when no usable text is configured.
+ */
+export function resolveFallbackMessage(message, agentOptions = {}, { inheritAgentTts = true } = {}) {
+  // Deliberately NOT accepting a bare string as shorthand for `{ text }`. The
+  // option always takes an object, so there is one shape to document, one to
+  // validate, and one to read — worth a few extra characters in the common
+  // case. Anything else resolves to null here, but the write-time validation in
+  // lib/database.js rejects it outright, so a bad shape is a save error rather
+  // than an announcement that silently never plays.
+  const raw = message;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+  const text = typeof raw.text === 'string' ? raw.text.trim() : '';
+  if (!text) {
+    return null;
+  }
+  const tts = agentOptions?.tts || {};
+  const pick = (a, b) => {
+    const v = typeof a === 'string' && a.trim() ? a : b;
+    return typeof v === 'string' && v.trim() ? v.trim() : undefined;
+  };
+  return {
+    text,
+    vendor: pick(raw.vendor, inheritAgentTts ? tts.vendor : undefined),
+    voice: pick(raw.voice, inheritAgentTts ? tts.voice : undefined),
+    // Always inherited — a language tag is portable across model and TTS.
+    language: pick(raw.language, tts.language),
+  };
+}
+
+/**
+ * Derive the content-addressed cache key for a resolved message.
+ *
+ * Fields are hashed as a canonical JSON array rather than a concatenated string
+ * so that a value containing the separator cannot collide with a different
+ * field split (`{voice: 'a|b'}` vs `{voice: 'a', language: 'b'}`).
+ *
+ * @param {ResolvedFallbackMessage} resolved Output of {@link resolveFallbackMessage}.
+ * @returns {string} Lowercase hex digest, {@link KEY_LENGTH} characters.
+ */
+export function fallbackMessageKey(resolved) {
+  if (!resolved?.text) {
+    throw new Error('fallbackMessageKey: resolved message must have text');
+  }
+  const canonical = JSON.stringify([
+    resolved.text,
+    resolved.vendor || '',
+    resolved.voice || '',
+    resolved.language || '',
+  ]);
+  return createHash('sha256').update(canonical, 'utf8').digest('hex').slice(0, KEY_LENGTH);
+}

--- a/lib/fallback-message/gcs-path.js
+++ b/lib/fallback-message/gcs-path.js
@@ -1,0 +1,66 @@
+/**
+ * GCS path helpers for the fallback-message cache.
+ *
+ * Sibling of `lib/recording/gcs-path.js` and deliberately shaped the same way:
+ * exactly one formula for where a cached announcement lands, shared by every
+ * runtime that reads or writes one.
+ *
+ * The cache lives in the same platform-owned bucket as call recordings, under
+ * its own prefix. That bucket is already provisioned, credentialed, and
+ * lifecycle-managed on every deployment, so the cache inherits all of it
+ * without new infrastructure.
+ *
+ * Unlike recordings, cached announcements are stored unencrypted. A recording
+ * is customer conversation audio, sometimes under a key we do not hold; an
+ * announcement is a rendering of `options.fallback.message.text`, which sits
+ * in clear in the database, so encrypting it would protect nothing. It would
+ * also cost CPU precisely where we can least afford it — this path runs after
+ * an agent session has failed, and heavy load is one of the likelier reasons
+ * for that, so playout is disproportionately likely to happen when the machine
+ * is already struggling. Keep it a download, a resample, and a write.
+ */
+
+/**
+ * @typedef {Object} GcsPath
+ * @property {string} bucket
+ * @property {string} prefix Always empty or ending with a single trailing slash.
+ */
+
+export { parseGcsPath } from '../recording/gcs-path.js';
+
+/**
+ * Default base URL for the fallback-message cache.
+ *
+ * Derived from `RECORDING_STORAGE_PATH`'s bucket when set so that a deployment
+ * which has already pointed recordings at its own bucket does not silently
+ * keep writing announcements to the default one. Falls back to the same
+ * `gs://llm-voice` default the recording path uses.
+ *
+ * @returns {string}
+ */
+export function defaultFallbackMessageBaseUrl() {
+  const { FALLBACK_MESSAGE_STORAGE_PATH, RECORDING_STORAGE_PATH, NODE_ENV } = process.env;
+  if (FALLBACK_MESSAGE_STORAGE_PATH) {
+    return FALLBACK_MESSAGE_STORAGE_PATH;
+  }
+  const env = NODE_ENV || 'development';
+  if (RECORDING_STORAGE_PATH) {
+    // Reuse the configured bucket, but never the recordings prefix itself.
+    const withoutScheme = RECORDING_STORAGE_PATH.slice('gs://'.length);
+    const bucket = withoutScheme.split('/')[0];
+    return `gs://${bucket}/${env}-fallback-messages`;
+  }
+  return `gs://llm-voice/${env}-fallback-messages`;
+}
+
+/**
+ * Build the GCS object name for a cache key. Cached announcements are always
+ * mono 16 kHz PCM in a WAV container — see `wav.js`.
+ *
+ * @param {string} prefix Empty string or trailing-slash prefix from `parseGcsPath`.
+ * @param {string} key Digest from `fallbackMessageKey`.
+ * @returns {string}
+ */
+export function objectNameForKey(prefix, key) {
+  return `${prefix}${key}.wav`;
+}

--- a/lib/fallback-message/index.d.ts
+++ b/lib/fallback-message/index.d.ts
@@ -1,0 +1,64 @@
+/**
+ * Type declarations for the shared fallback-message cache, consumed by the
+ * LiveKit agent through the `agent-lib/` symlink. The implementation is plain
+ * JS (see `index.js`); this file exists so the TypeScript side gets real types
+ * instead of `any`. Keep it in step with the JSDoc on the modules themselves.
+ */
+
+export const KEY_LENGTH: number;
+export const DEFAULT_TIMEOUT_MS: number;
+
+export interface ResolvedFallbackMessage {
+  text: string;
+  vendor?: string;
+  voice?: string;
+  language?: string;
+}
+
+export interface GcsPath {
+  bucket: string;
+  prefix: string;
+}
+
+export interface CacheLogger {
+  debug?: (meta: unknown, message: string) => void;
+  info?: (meta: unknown, message: string) => void;
+  warn?: (meta: unknown, message: string) => void;
+}
+
+export function resolveFallbackMessage(
+  message: unknown,
+  agentOptions?: { tts?: { vendor?: string; voice?: string; language?: string } },
+  opts?: {
+    /**
+     * Whether the agent's `options.tts` describes a real TTS whose vendor/voice
+     * may be inherited. False for realtime speech-to-speech agents, whose
+     * `options.tts` names a timbre of the model. Defaults to true.
+     */
+    inheritAgentTts?: boolean;
+  },
+): ResolvedFallbackMessage | null;
+
+export function fallbackMessageKey(resolved: ResolvedFallbackMessage): string;
+
+export function parseGcsPath(baseUrl: string): GcsPath;
+export function defaultFallbackMessageBaseUrl(): string;
+export function objectNameForKey(prefix: string, key: string): string;
+
+export function encodeWav(pcm: Buffer, sampleRate: number): Buffer;
+export function decodeWav(buffer: Buffer): { pcm: Buffer; sampleRate: number };
+
+export function fetchCachedMessage(options: {
+  key: string;
+  baseUrl?: string;
+  timeoutMs?: number;
+  logger?: CacheLogger;
+}): Promise<Buffer | null>;
+
+export function storeCachedMessage(options: {
+  key: string;
+  wav: Buffer;
+  baseUrl?: string;
+  timeoutMs?: number;
+  logger?: CacheLogger;
+}): Promise<boolean>;

--- a/lib/fallback-message/index.js
+++ b/lib/fallback-message/index.js
@@ -1,0 +1,16 @@
+export {
+  KEY_LENGTH,
+  resolveFallbackMessage,
+  fallbackMessageKey,
+} from './cache-key.js';
+export {
+  parseGcsPath,
+  defaultFallbackMessageBaseUrl,
+  objectNameForKey,
+} from './gcs-path.js';
+export { encodeWav, decodeWav } from './wav.js';
+export {
+  DEFAULT_TIMEOUT_MS,
+  fetchCachedMessage,
+  storeCachedMessage,
+} from './store.js';

--- a/lib/fallback-message/store.js
+++ b/lib/fallback-message/store.js
@@ -1,0 +1,118 @@
+/**
+ * GCS read/write for the fallback-message cache.
+ *
+ * Every function here is **never-throw**. This code runs only when agent setup
+ * has already failed, and the caller's remaining options are to play the
+ * announcement or drop to `fallback.number`; a bucket outage must degrade to
+ * "synthesise it again this call", never to an exception that costs the caller
+ * the announcement as well as the agent.
+ *
+ * Mirrored by `agents/pipecat/pipecat_aplisay/fallback_message/store.py`.
+ */
+
+import { Storage } from '@google-cloud/storage';
+import { parseGcsPath, defaultFallbackMessageBaseUrl, objectNameForKey } from './gcs-path.js';
+
+const NOOP_LOGGER = { debug() {}, info() {}, warn() {} };
+
+/** Default deadline for either direction. Short: the caller is on the line. */
+export const DEFAULT_TIMEOUT_MS = 5000;
+
+let sharedStorage;
+/** Lazily constructed so importing this module never touches credentials. */
+function storage() {
+  if (!sharedStorage) {
+    sharedStorage = new Storage();
+  }
+  return sharedStorage;
+}
+
+/** @param {Promise<any>} promise @param {number} ms @param {string} what */
+function withTimeout(promise, ms, what) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`${what} timed out after ${ms}ms`)), ms).unref?.(),
+    ),
+  ]);
+}
+
+/**
+ * Read a cached announcement.
+ *
+ * @param {Object} options
+ * @param {string} options.key Digest from `fallbackMessageKey`.
+ * @param {string=} options.baseUrl Defaults to {@link defaultFallbackMessageBaseUrl}.
+ * @param {number=} options.timeoutMs
+ * @param {{debug?:Function,info?:Function,warn?:Function}=} options.logger
+ * @returns {Promise<Buffer|null>} WAV bytes, or `null` on a miss or any failure.
+ */
+export async function fetchCachedMessage({ key, baseUrl, timeoutMs = DEFAULT_TIMEOUT_MS, logger = NOOP_LOGGER }) {
+  const { bucket, prefix } = parseGcsPath(baseUrl || defaultFallbackMessageBaseUrl());
+  const gcsObject = objectNameForKey(prefix, key);
+  try {
+    const [contents] = await withTimeout(
+      storage().bucket(bucket).file(gcsObject).download(),
+      timeoutMs,
+      'fallback message download',
+    );
+    logger.debug?.({ key, bucket, gcsObject, bytes: contents.length }, 'fallback message cache hit');
+    return contents;
+  } catch (e) {
+    // 404 is the ordinary first-use miss and is not worth a warning; anything
+    // else is worth seeing, but is still only a miss as far as the caller goes.
+    if (e?.code === 404) {
+      logger.debug?.({ key, bucket, gcsObject }, 'fallback message cache miss');
+    } else {
+      logger.warn?.({ e, key, bucket, gcsObject }, 'fallback message cache read failed; will synthesise');
+    }
+    return null;
+  }
+}
+
+/**
+ * Write a freshly synthesised announcement into the cache.
+ *
+ * Written with `ifGenerationMatch: 0`, which makes the upload succeed only if
+ * the object does not yet exist. When a model outage fails many calls at once
+ * every worker misses the cache and synthesises concurrently; this way the
+ * first to finish publishes and the rest get a precondition failure, which is
+ * reported here as success because the cache does now hold the object. Without
+ * it the losers would overwrite a perfectly good object with an identical one,
+ * burning writes and briefly exposing readers to a partial overwrite.
+ *
+ * @param {Object} options
+ * @param {string} options.key
+ * @param {Buffer} options.wav Complete WAV payload from `encodeWav`.
+ * @param {string=} options.baseUrl
+ * @param {number=} options.timeoutMs
+ * @param {{debug?:Function,info?:Function,warn?:Function}=} options.logger
+ * @returns {Promise<boolean>} True when the cache holds the object afterwards.
+ */
+export async function storeCachedMessage({ key, wav, baseUrl, timeoutMs = DEFAULT_TIMEOUT_MS, logger = NOOP_LOGGER }) {
+  const { bucket, prefix } = parseGcsPath(baseUrl || defaultFallbackMessageBaseUrl());
+  const gcsObject = objectNameForKey(prefix, key);
+  try {
+    await withTimeout(
+      storage()
+        .bucket(bucket)
+        .file(gcsObject)
+        .save(wav, {
+          resumable: false,
+          contentType: 'audio/wav',
+          preconditionOpts: { ifGenerationMatch: 0 },
+        }),
+      timeoutMs,
+      'fallback message upload',
+    );
+    logger.info?.({ key, bucket, gcsObject, bytes: wav.length }, 'cached synthesised fallback message');
+    return true;
+  } catch (e) {
+    if (e?.code === 412) {
+      logger.debug?.({ key, bucket, gcsObject }, 'fallback message already cached by a concurrent writer');
+      return true;
+    }
+    logger.warn?.({ e, key, bucket, gcsObject }, 'failed to cache fallback message; will re-synthesise next time');
+    return false;
+  }
+}

--- a/lib/fallback-message/wav.js
+++ b/lib/fallback-message/wav.js
@@ -1,0 +1,111 @@
+/**
+ * Minimal mono PCM WAV reader/writer for the fallback-message cache.
+ *
+ * Cached announcements are stored as 16-bit signed little-endian PCM in a WAV
+ * container. WAV rather than raw PCM because the container carries the sample
+ * rate with the samples: the two runtimes synthesise through different TTS
+ * stacks at whatever rate the vendor emits, and the reader must resample to
+ * the transport's rate without being told out of band what it started from. It
+ * also means a cached object can be pulled out of the bucket and played in any
+ * audio tool when someone is working out why an announcement sounds wrong.
+ *
+ * Only the subset needed here is implemented: PCM (format 1), mono, 16-bit.
+ * Mirrored by `agents/pipecat/pipecat_aplisay/fallback_message/wav.py`.
+ */
+
+const RIFF = 0x46464952; // 'RIFF' little-endian
+const WAVE = 0x45564157; // 'WAVE'
+const FMT_ = 0x20746d66; // 'fmt '
+const DATA = 0x61746164; // 'data'
+
+const HEADER_BYTES = 44;
+const PCM_FORMAT = 1;
+const BITS_PER_SAMPLE = 16;
+const CHANNELS = 1;
+
+/**
+ * @typedef {Object} DecodedWav
+ * @property {Buffer} pcm Raw 16-bit little-endian mono samples.
+ * @property {number} sampleRate
+ */
+
+/**
+ * Wrap mono 16-bit PCM in a WAV container.
+ *
+ * @param {Buffer} pcm Raw 16-bit little-endian mono samples.
+ * @param {number} sampleRate
+ * @returns {Buffer}
+ */
+export function encodeWav(pcm, sampleRate) {
+  if (!Buffer.isBuffer(pcm)) {
+    throw new Error('encodeWav: pcm must be a Buffer');
+  }
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+    throw new Error(`encodeWav: invalid sampleRate ${sampleRate}`);
+  }
+  const byteRate = sampleRate * CHANNELS * (BITS_PER_SAMPLE / 8);
+  const blockAlign = CHANNELS * (BITS_PER_SAMPLE / 8);
+  const header = Buffer.alloc(HEADER_BYTES);
+  header.writeUInt32LE(RIFF, 0);
+  header.writeUInt32LE(HEADER_BYTES - 8 + pcm.length, 4); // RIFF chunk size
+  header.writeUInt32LE(WAVE, 8);
+  header.writeUInt32LE(FMT_, 12);
+  header.writeUInt32LE(16, 16); // fmt chunk size
+  header.writeUInt16LE(PCM_FORMAT, 20);
+  header.writeUInt16LE(CHANNELS, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(BITS_PER_SAMPLE, 34);
+  header.writeUInt32LE(DATA, 36);
+  header.writeUInt32LE(pcm.length, 40);
+  return Buffer.concat([header, pcm]);
+}
+
+/**
+ * Read a mono 16-bit PCM WAV produced by {@link encodeWav}.
+ *
+ * Chunks are walked rather than assumed at fixed offsets: some TTS vendors
+ * return WAV with a `LIST`/`fact` chunk ahead of `data`, and a cached object
+ * written from such a payload would otherwise decode as noise.
+ *
+ * @param {Buffer} buffer
+ * @returns {DecodedWav}
+ */
+export function decodeWav(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 12) {
+    throw new Error('decodeWav: buffer too short to be a WAV');
+  }
+  if (buffer.readUInt32LE(0) !== RIFF || buffer.readUInt32LE(8) !== WAVE) {
+    throw new Error('decodeWav: not a RIFF/WAVE payload');
+  }
+  let sampleRate = 0;
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.readUInt32LE(offset);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    const body = offset + 8;
+    if (chunkId === FMT_) {
+      const format = buffer.readUInt16LE(body);
+      const channels = buffer.readUInt16LE(body + 2);
+      const bits = buffer.readUInt16LE(body + 14);
+      if (format !== PCM_FORMAT || channels !== CHANNELS || bits !== BITS_PER_SAMPLE) {
+        throw new Error(
+          `decodeWav: expected mono 16-bit PCM, got format=${format} channels=${channels} bits=${bits}`,
+        );
+      }
+      sampleRate = buffer.readUInt32LE(body + 4);
+    } else if (chunkId === DATA) {
+      if (!sampleRate) {
+        throw new Error('decodeWav: data chunk before fmt chunk');
+      }
+      // Trust the buffer over the declared size: a truncated upload would
+      // otherwise hand callers a Buffer slice shorter than they expect.
+      const end = Math.min(body + chunkSize, buffer.length);
+      return { pcm: buffer.subarray(body, end), sampleRate };
+    }
+    // Chunks are word-aligned: an odd size carries a trailing pad byte.
+    offset = body + chunkSize + (chunkSize % 2);
+  }
+  throw new Error('decodeWav: no data chunk found');
+}

--- a/lib/model-voices.js
+++ b/lib/model-voices.js
@@ -247,12 +247,15 @@ export function collectVendorNamesFromTree(voiceTree) {
  * @param {string} p.modelName
  * @param {object} p.Handler
  * @param {import('./voices/index.js').default} p.voicesInstance
+ * @param {boolean} [p.discreteTts] Validate against the discrete-TTS catalogue
+ *   even when `modelName` is a realtime model. See the note on
+ *   {@link getVoiceNamesForAgentValidation}.
  * @returns {Promise<Set<string>>}
  */
-export async function getTtsVendorsForAgentValidation({ modelName, Handler, voicesInstance }) {
+export async function getTtsVendorsForAgentValidation({ modelName, Handler, voicesInstance, discreteTts = false }) {
   const { handler, rest } = splitHandlerModel(modelName);
   if (!handler || !rest) return new Set();
-  if (handler === 'livekit' && isLivekitPipelineModelId(rest)) {
+  if (handler === 'livekit' && (discreteTts || isLivekitPipelineModelId(rest))) {
     const rawTree = await pipelineVendorTrees(voicesInstance);
     return new Set([
       ...collectVendorNamesFromTree(transformVoiceTreeForLiveKitPipeline(rawTree)),
@@ -264,7 +267,7 @@ export async function getTtsVendorsForAgentValidation({ modelName, Handler, voic
     return collectVendorNamesFromTree(
       filterVoiceTreeVendors(await Handler.voices, livekitRealtimeVoiceVendorsForRestModelId(rest)));
   }
-  if (handler === 'pipecat' && isPipecatPipelineModelId(rest)) {
+  if (handler === 'pipecat' && (discreteTts || isPipecatPipelineModelId(rest))) {
     return new Set([
       ...collectVendorNamesFromTree(pipecatPipelineTtsTree(await pipelineVendorTrees(voicesInstance))),
       ...PIPELINE_TTS_VENDORS,
@@ -282,16 +285,29 @@ export async function getTtsVendorsForAgentValidation({ modelName, Handler, voic
  * LiveKit **pipeline** models use Inference TTS (`voicesInstance.listVoices()`);
  * realtime LiveKit and other handlers use `Handler.voices`.
  *
+ * `discreteTts` forces the pipeline (discrete-TTS) catalogue even for a realtime
+ * model. That is not a hack for the sake of it: a realtime model such as Ultravox
+ * speaks for itself and has no TTS service, so its `Handler.voices` are timbres of
+ * the model rather than voices any TTS could render. Anything that must be spoken
+ * *outside* such a session — today, `options.fallback.message`, which plays when the
+ * model could not be started at all — necessarily goes through a discrete TTS, and
+ * so must be validated against that catalogue instead. Validating it against the
+ * model's own voices would reject exactly the configuration that works (an
+ * ElevenLabs voice announcing an Ultravox outage) and accept ones that cannot be
+ * rendered.
+ *
  * @param {object} p
  * @param {string} p.modelName
  * @param {object} p.Handler handler class (with `.voices`)
  * @param {import('./voices/index.js').default} p.voicesInstance
+ * @param {boolean} [p.discreteTts] Validate against the discrete-TTS catalogue
+ *   even when `modelName` is a realtime model.
  * @returns {Promise<Set<string>>}
  */
-export async function getVoiceNamesForAgentValidation({ modelName, Handler, voicesInstance }) {
+export async function getVoiceNamesForAgentValidation({ modelName, Handler, voicesInstance, discreteTts = false }) {
   const { handler, rest } = splitHandlerModel(modelName);
   if (!handler || !rest) return new Set();
-  if (handler === 'livekit' && isLivekitPipelineModelId(rest)) {
+  if (handler === 'livekit' && (discreteTts || isLivekitPipelineModelId(rest))) {
     const rawTree = await pipelineVendorTrees(voicesInstance);
     const mappedTree = transformVoiceTreeForLiveKitPipeline(rawTree);
     return new Set([
@@ -304,7 +320,7 @@ export async function getVoiceNamesForAgentValidation({ modelName, Handler, voic
     const allowed = livekitRealtimeVoiceVendorsForRestModelId(rest);
     return collectVoiceNamesFromTree(filterVoiceTreeVendors(fullTree, allowed));
   }
-  if (handler === 'pipecat' && isPipecatPipelineModelId(rest)) {
+  if (handler === 'pipecat' && (discreteTts || isPipecatPipelineModelId(rest))) {
     // Pipeline mode: voice names come from the platform's TTS catalogue,
     // filtered to vendors the worker can actually instantiate.
     // Unlike LiveKit pipeline mode, Pipecat hits each TTS provider's native

--- a/tests/fallback-message-cross-language.test.mjs
+++ b/tests/fallback-message-cross-language.test.mjs
@@ -1,0 +1,169 @@
+/**
+ * Cross-language contract test for the fallback-message cache.
+ *
+ * Both runtimes read and write the *same* GCS objects, so two things must agree
+ * exactly or the cache silently splits in two — each stack re-synthesising what
+ * the other already paid for, with no error to notice:
+ *
+ *   1. the cache key derived from a given message, and
+ *   2. the WAV encoding of a given PCM buffer.
+ *
+ * These are cheap to get subtly wrong (JSON separator spacing, non-ASCII
+ * escaping, RIFF field widths), which is exactly why they are pinned here
+ * rather than left to inspection. See lib/fallback-message/CONTRACT.md.
+ *
+ * Skips automatically when the pipecat venv is absent (e.g. CI without the
+ * Python toolchain); `fallback-message-shared-lib.test.mjs` is the always-on
+ * safety net for the JS half.
+ */
+import { describe, expect, test } from '@jest/globals';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import {
+  decodeWav,
+  encodeWav,
+  fallbackMessageKey,
+  resolveFallbackMessage,
+} from '../lib/fallback-message/index.js';
+
+function findPipecatPython() {
+  const candidates = [
+    process.env.PIPECAT_VENV_PYTHON,
+    path.resolve(process.cwd(), 'agents/pipecat/.venv/bin/python'),
+    // Repo-relative fallback for when tests run from a worktree.
+    path.resolve(process.cwd(), '..', '..', 'agents/pipecat/.venv/bin/python'),
+  ].filter(Boolean);
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+const PYTHON = findPipecatPython();
+const describeOrSkip = PYTHON ? describe : describe.skip;
+const PIPECAT_ROOT = path.resolve(process.cwd(), 'agents/pipecat');
+
+/**
+ * Message shapes chosen to exercise the encodings most likely to diverge, plus
+ * the realtime-agent inheritance rule — a disagreement there would split the
+ * cache just as silently as a hashing difference.
+ *
+ * Each case is `[message, agentOptions, inheritAgentTts]`.
+ */
+const CASES = [
+  [{ text: 'Sorry, we are busy.' }, {}, true],
+  // Non-ASCII: Python's json defaults to \u-escaping where JS does not.
+  [
+    { text: 'Désolé, nous sommes occupés — rappelez plus tard.', vendor: 'elevenlabs', voice: 'Rachel' },
+    {},
+    true,
+  ],
+  // Astral-plane codepoint (surrogate pair in JS, single codepoint in Python).
+  [{ text: 'busy 🙂' }, { tts: { vendor: 'deepgram/aura-2', voice: 'thalia', language: 'en-US' } }, true],
+  // Minimal form (text only) plus inheritance from agent options.
+  [{ text: 'text only, inherits the agent voice' }, { tts: { voice: 'Dominus' } }, true],
+  // Empty-vs-absent fields must hash the same way on both sides.
+  [{ text: 'no voice configured' }, {}, true],
+  // Realtime agent: the model's own voice must be dropped on both sides, and
+  // the surviving language must still be hashed identically.
+  [
+    { text: 'realtime, no override' },
+    { tts: { vendor: 'ultravox', voice: 'Svetlana', language: 'en-GB' } },
+    false,
+  ],
+  // Realtime agent with an explicit TTS — the configuration that makes the
+  // feature usable at all for a speech-to-speech model.
+  [
+    { text: 'realtime, elevenlabs override', vendor: 'elevenlabs', voice: 'Rachel' },
+    { tts: { vendor: 'ultravox', voice: 'Svetlana', language: 'en-GB' } },
+    false,
+  ],
+];
+
+function runPython(script) {
+  const result = spawnSync(PYTHON, ['-c', script], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`python failed: ${result.stderr || result.stdout}`);
+  }
+  return result.stdout.trim();
+}
+
+describeOrSkip('lib/fallback-message — JS / Python cross-language contract', () => {
+  test('both runtimes derive the same cache key for every message shape', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fallback-msg-xlang-'));
+    const casesPath = path.join(tmpDir, 'cases.json');
+    try {
+      fs.writeFileSync(casesPath, JSON.stringify(CASES));
+      const pythonKeys = JSON.parse(
+        runPython(
+          [
+            'import json, sys',
+            `sys.path.insert(0, ${JSON.stringify(PIPECAT_ROOT)})`,
+            'from pipecat_aplisay.fallback_message import resolve_fallback_message, fallback_message_key',
+            `cases = json.load(open(${JSON.stringify(casesPath)}))`,
+            'print(json.dumps([fallback_message_key(resolve_fallback_message(m, o, inherit_agent_tts=i)) for m, o, i in cases]))',
+          ].join('\n'),
+        ).split('\n').pop(),
+      );
+      const jsKeys = CASES.map(([m, o, i]) =>
+        fallbackMessageKey(resolveFallbackMessage(m, o, { inheritAgentTts: i })),
+      );
+      expect(pythonKeys).toEqual(jsKeys);
+      // Guard against the degenerate pass where both sides return the same
+      // constant for everything.
+      expect(new Set(jsKeys).size).toBe(CASES.length);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('a WAV written in Python decodes in JS, and re-encodes byte-identically', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fallback-msg-wav-'));
+    const wavPath = path.join(tmpDir, 'fixture.wav');
+    try {
+      runPython(
+        [
+          'import sys',
+          `sys.path.insert(0, ${JSON.stringify(PIPECAT_ROOT)})`,
+          'from pipecat_aplisay.fallback_message import encode_wav',
+          "pcm = b'\\xd2\\x04' + bytes(316) + b'\\xbf\\xef'",
+          `open(${JSON.stringify(wavPath)}, 'wb').write(encode_wav(pcm, 24000))`,
+        ].join('\n'),
+      );
+      const raw = fs.readFileSync(wavPath);
+      const decoded = decodeWav(raw);
+      expect(decoded.sampleRate).toBe(24000);
+      expect(decoded.pcm.length).toBe(320);
+      // Byte-identical re-encode proves the header layout matches, not merely
+      // that each side can read its own output.
+      expect(encodeWav(decoded.pcm, decoded.sampleRate).equals(raw)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('a WAV written in JS decodes in Python with the same samples and rate', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fallback-msg-wav-js-'));
+    const wavPath = path.join(tmpDir, 'fixture.wav');
+    try {
+      const pcm = Buffer.alloc(480);
+      pcm.writeInt16LE(999, 0);
+      pcm.writeInt16LE(-999, 478);
+      fs.writeFileSync(wavPath, encodeWav(pcm, 16000));
+      const out = runPython(
+        [
+          'import sys',
+          `sys.path.insert(0, ${JSON.stringify(PIPECAT_ROOT)})`,
+          'from pipecat_aplisay.fallback_message import decode_wav',
+          `d = decode_wav(open(${JSON.stringify(wavPath)}, 'rb').read())`,
+          'print(d.sample_rate, len(d.pcm), int.from_bytes(d.pcm[0:2], "little", signed=True))',
+        ].join('\n'),
+      ).split('\n').pop();
+      expect(out).toBe('16000 480 999');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/fallback-message-shared-lib.test.mjs
+++ b/tests/fallback-message-shared-lib.test.mjs
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for the shared fallback-message cache layer
+ * (`lib/fallback-message/`). The cross-runtime half of the contract is proved
+ * in `fallback-message-cross-language.test.mjs`; this file is the always-on
+ * safety net for the JS side.
+ */
+import { describe, expect, test } from '@jest/globals';
+import {
+  decodeWav,
+  defaultFallbackMessageBaseUrl,
+  encodeWav,
+  fallbackMessageKey,
+  objectNameForKey,
+  parseGcsPath,
+  resolveFallbackMessage,
+} from '../lib/fallback-message/index.js';
+
+describe('resolveFallbackMessage', () => {
+  test('text alone is the minimal form', () => {
+    expect(resolveFallbackMessage({ text: 'we are busy' }, {})).toMatchObject({
+      text: 'we are busy',
+    });
+  });
+
+  test('a bare string is rejected, not treated as shorthand', () => {
+    // One shape to document, validate, and read. The write-time validation in
+    // lib/database.js refuses a string outright.
+    expect(resolveFallbackMessage('we are busy', {})).toBeNull();
+  });
+
+  test('an array is rejected too', () => {
+    expect(resolveFallbackMessage(['we are busy'], {})).toBeNull();
+  });
+
+  test('text is trimmed and blank text resolves to null', () => {
+    expect(resolveFallbackMessage({ text: '  hi  ' }, {}).text).toBe('hi');
+    expect(resolveFallbackMessage({ text: '   ' }, {})).toBeNull();
+    expect(resolveFallbackMessage({}, {})).toBeNull();
+    expect(resolveFallbackMessage(null, {})).toBeNull();
+    expect(resolveFallbackMessage(undefined, {})).toBeNull();
+  });
+
+  test('unstated tts settings fall back to the agent options', () => {
+    const resolved = resolveFallbackMessage(
+      { text: 'hi' },
+      { tts: { vendor: 'elevenlabs', voice: 'Dominus', language: 'en-GB' } },
+    );
+    expect(resolved).toEqual({
+      text: 'hi',
+      vendor: 'elevenlabs',
+      voice: 'Dominus',
+      language: 'en-GB',
+    });
+  });
+
+  test('stated tts settings win, so the announcement can use a healthy vendor', () => {
+    const resolved = resolveFallbackMessage(
+      { text: 'hi', vendor: 'deepgram/aura-2', voice: 'thalia' },
+      { tts: { vendor: 'elevenlabs', voice: 'Dominus', language: 'en-GB' } },
+    );
+    expect(resolved).toMatchObject({
+      vendor: 'deepgram/aura-2',
+      voice: 'thalia',
+      // Unstated fields still inherit.
+      language: 'en-GB',
+    });
+  });
+});
+
+describe('resolveFallbackMessage — realtime agents', () => {
+  // A realtime speech-to-speech agent's options.tts names a timbre of the
+  // MODEL, not a TTS. Inheriting it would hand the TTS builder a vendor of
+  // "ultravox", which does not degrade — it throws — so the announcement that
+  // exists to cover the model failing would itself fail.
+  const realtimeOptions = {
+    tts: { vendor: 'ultravox', voice: 'Svetlana', language: 'en-GB' },
+  };
+
+  test('does not inherit the model voice or vendor', () => {
+    const resolved = resolveFallbackMessage({ text: 'busy' }, realtimeOptions, {
+      inheritAgentTts: false,
+    });
+    expect(resolved.vendor).toBeUndefined();
+    expect(resolved.voice).toBeUndefined();
+  });
+
+  test('still inherits language, which is portable across model and TTS', () => {
+    const resolved = resolveFallbackMessage({ text: 'busy' }, realtimeOptions, {
+      inheritAgentTts: false,
+    });
+    expect(resolved.language).toBe('en-GB');
+  });
+
+  test('an explicit TTS override is kept — the whole point for a realtime agent', () => {
+    const resolved = resolveFallbackMessage(
+      { text: 'busy', vendor: 'elevenlabs', voice: 'Rachel' },
+      realtimeOptions,
+      { inheritAgentTts: false },
+    );
+    expect(resolved).toMatchObject({ vendor: 'elevenlabs', voice: 'Rachel', language: 'en-GB' });
+  });
+
+  test('the same words resolve differently for a realtime and a pipeline agent', () => {
+    // Different audio, so they must not share a cache entry.
+    const realtime = resolveFallbackMessage({ text: 'busy' }, realtimeOptions, {
+      inheritAgentTts: false,
+    });
+    const pipeline = resolveFallbackMessage({ text: 'busy' }, realtimeOptions, {
+      inheritAgentTts: true,
+    });
+    expect(fallbackMessageKey(realtime)).not.toBe(fallbackMessageKey(pipeline));
+  });
+});
+
+describe('fallbackMessageKey', () => {
+  test('is stable for identical input', () => {
+    const a = resolveFallbackMessage({ text: 'hi' }, {});
+    const b = resolveFallbackMessage({ text: 'hi' }, {});
+    expect(fallbackMessageKey(a)).toBe(fallbackMessageKey(b));
+  });
+
+  test('changes when any hashed input changes — this is the invalidation', () => {
+    const base = { text: 'hi', vendor: 'v', voice: 'x', language: 'en' };
+    const key = fallbackMessageKey(base);
+    for (const field of ['text', 'vendor', 'voice', 'language']) {
+      expect(fallbackMessageKey({ ...base, [field]: 'different' })).not.toBe(key);
+    }
+  });
+
+  test('a value containing the field separator cannot collide with a field split', () => {
+    expect(fallbackMessageKey({ text: 't', voice: 'a|b' })).not.toBe(
+      fallbackMessageKey({ text: 't', voice: 'a', language: 'b' }),
+    );
+  });
+
+  test('is 32 lowercase hex characters', () => {
+    expect(fallbackMessageKey({ text: 'hi' })).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test('refuses a message with no text', () => {
+    expect(() => fallbackMessageKey({ text: '' })).toThrow(/must have text/);
+  });
+});
+
+describe('storage paths', () => {
+  const withEnv = (env, fn) => {
+    const saved = { ...process.env };
+    Object.assign(process.env, env);
+    for (const [k, v] of Object.entries(env)) if (v === undefined) delete process.env[k];
+    try {
+      return fn();
+    } finally {
+      process.env = saved;
+    }
+  };
+
+  test('defaults to the llm-voice bucket under a per-environment prefix', () => {
+    withEnv(
+      { NODE_ENV: 'production', RECORDING_STORAGE_PATH: undefined, FALLBACK_MESSAGE_STORAGE_PATH: undefined },
+      () => {
+        expect(defaultFallbackMessageBaseUrl()).toBe('gs://llm-voice/production-fallback-messages');
+      },
+    );
+  });
+
+  test('follows the recordings bucket when one is configured', () => {
+    withEnv(
+      { NODE_ENV: 'staging', RECORDING_STORAGE_PATH: 'gs://acme-media/staging-recordings', FALLBACK_MESSAGE_STORAGE_PATH: undefined },
+      () => {
+        // Same bucket, never the recordings prefix.
+        expect(defaultFallbackMessageBaseUrl()).toBe('gs://acme-media/staging-fallback-messages');
+      },
+    );
+  });
+
+  test('an explicit override wins over both', () => {
+    withEnv(
+      { RECORDING_STORAGE_PATH: 'gs://acme-media/prod-recordings', FALLBACK_MESSAGE_STORAGE_PATH: 'gs://elsewhere/msgs' },
+      () => {
+        expect(defaultFallbackMessageBaseUrl()).toBe('gs://elsewhere/msgs');
+      },
+    );
+  });
+
+  test('object names are <prefix><key>.wav', () => {
+    const { bucket, prefix } = parseGcsPath('gs://llm-voice/development-fallback-messages');
+    expect(bucket).toBe('llm-voice');
+    expect(objectNameForKey(prefix, 'deadbeef')).toBe('development-fallback-messages/deadbeef.wav');
+  });
+});
+
+describe('wav', () => {
+  const pcm = Buffer.alloc(640);
+  pcm.writeInt16LE(12345, 0);
+  pcm.writeInt16LE(-12345, 638);
+
+  test('round-trips samples and rate', () => {
+    const decoded = decodeWav(encodeWav(pcm, 24000));
+    expect(decoded.sampleRate).toBe(24000);
+    expect(decoded.pcm.equals(pcm)).toBe(true);
+  });
+
+  test('reads a payload with a chunk ahead of data, as some vendors emit', () => {
+    const wav = encodeWav(pcm, 16000);
+    // Splice an odd-length LIST chunk (plus its pad byte) before `data`.
+    const list = Buffer.alloc(8 + 5);
+    list.write('LIST', 0, 'ascii');
+    list.writeUInt32LE(5, 4);
+    const spliced = Buffer.concat([
+      wav.subarray(0, 36),
+      list,
+      Buffer.alloc(1),
+      wav.subarray(36),
+    ]);
+    expect(decodeWav(spliced).pcm.equals(pcm)).toBe(true);
+  });
+
+  test('a truncated payload yields the bytes present, not a phantom length', () => {
+    const wav = encodeWav(pcm, 16000);
+    const truncated = wav.subarray(0, wav.length - 100);
+    expect(decodeWav(truncated).pcm.length).toBe(pcm.length - 100);
+  });
+
+  test('rejects payloads it cannot honestly decode', () => {
+    expect(() => decodeWav(Buffer.alloc(64))).toThrow(/not a RIFF/);
+    expect(() => decodeWav(Buffer.alloc(4))).toThrow(/too short/);
+  });
+});


### PR DESCRIPTION
Adds `options.fallback.message` — a TTS announcement played to the caller when agent setup has failed. Implemented on the LiveKit and Pipecat runtimes, not native Ultravox or Jambonz, which own their own session lifecycle and never enter the fallback chain.

## Precedence

`agent` → `model` → **`message`** → `number`. Terminal on success: a caller who hears the announcement is not then transferred, so `number` is only reached if it could not be played.

## Why it's cached

The audio is synthesised once and stored in GCS, keyed on a digest of its own text, vendor, voice and language. That's what makes the rest work: a cache hit calls no TTS vendor → meters no usage → needs no `Call` record → **reserves no agent concurrency slot**.

TTS characters are therefore billed once per distinct announcement rather than once per failed call, and editing the text changes the key, so invalidation is automatic.

## Concurrency behaviour changed

Both runtimes previously short-circuited `AGENT_CONCURRENCY_LIMIT_EXCEEDED` *past* the whole fallback chain. A busy failure now enters at the message step:

- `agent` and `model` are skipped — the limit is enforced in `Call.start()` whichever is behind it
- `number` stays unreachable — its transfer needs the slot that was just refused
- With no message configured, busy rejection is **unchanged**

**Behaviour change to be aware of:** with a message configured, the leg is *answered* in order to play it, where previously it would have been refused with busy. That is the trade the option asks for, and it's documented.

## Realtime agents

A speech-to-speech model has no TTS, and its `options.tts.voice` names a timbre of the model. Inheriting that would hand the TTS builder a vendor of `ultravox`, which raises rather than degrading — so the announcement covering an Ultravox outage would fail with it. Those agents inherit `language` only, and the message voice validates against the TTS catalogue rather than the model's own, so an ElevenLabs voice on an Ultravox agent is accepted. That's the configuration that works, and it's the recommended one.

## Storage

Lives in the recordings bucket under its own prefix, inheriting existing credentials and lifecycle management. Stored **unencrypted**, deliberately: it renders text already held in clear in the agent record, so there is nothing to protect, and a decrypt would cost CPU exactly when the host is loaded — one of the likelier reasons the session failed in the first place.

## API shape

`message` is always an object: `{ text, vendor?, voice?, language? }`. No bare-string shorthand — one shape to document, validate and read.

## Cross-runtime contract

The cache layer is a JS/Python mirror pair. Key derivation, WAV encoding and the inheritance rule must agree exactly: a disagreement splits the cache silently rather than raising. Documented in `lib/fallback-message/CONTRACT.md` and pinned by a cross-language test that runs both implementations against shared fixtures.

## Testing

- Pipecat: 373 passed
- JS `fallback-message` + `recording-` suites: 38 passed
- LiveKit typecheck clean; its 9 assertions verified via esbuild, since `tsx` isn't installed in the repo and the existing LiveKit tests don't run locally either
- Validation predicate exercised against 12 input shapes separately, as the Sequelize validator needs a live DB

Not live-verified — no call has yet been placed against this.
