### PR TITLE
fix(models): don't advertise a model alias whose target is gone

### DIFF
--- a/agents/livekit/lib/livekit-model-registry.ts
+++ b/agents/livekit/lib/livekit-model-registry.ts
@@ -25,6 +25,28 @@ export const LIVEKIT_PIPELINE_MODEL_ROWS = [
   ["google", "gemini-2.0-flash", "Google Gemini 2.0 Flash (LiveKit pipeline)"],
 ] as const;
 
+/**
+ * Deprecated model ids kept RESOLVABLE for agents already saved on them, mapped
+ * to the id they actually run as.
+ *
+ * `plugins/ultravox/src/realtime/realtime_model.ts` rewrites `ultravox-70b` to
+ * `ultravox-v0.6` at session start ("Hack to catch all attempts to use a llama
+ * 70b model"), so the alias has always *run*. But that mapping lived only in the
+ * plugin, so the roster went on advertising `ultravox-70b` as an ordinary,
+ * selectable model — which is how agents keep acquiring a name that is not an
+ * Ultravox model at all, long after it was deprecated.
+ *
+ * Declaring the target here lets `buildLivekitHandlerAllModels` drop an alias
+ * whose target is not offered, rather than advertise a name that resolves to
+ * nothing. Resolution is unaffected either way: a saved agent finds its handler
+ * by the `livekit:` PREFIX (`Handler.getHandler` → `Handler.parseName`), never
+ * by looking its model up in this roster, so an unlisted alias still runs and
+ * still passes the `Unknown model name` check on save.
+ */
+export const LIVEKIT_MODEL_ALIASES: Record<string, string> = {
+  "ultravox/ultravox-70b": "ultravox/ultravox-v0.6",
+};
+
 const pipelineFlag = {
   voiceStack: "pipeline" as const,
   audioModel: false,
@@ -56,7 +78,7 @@ export function isLivekitPipelineModelId(modelId: string): boolean {
  * [`${vendor}/${name}`, description, flags].
  */
 export function buildLivekitHandlerAllModels() {
-  return [
+  const rows = [
     ...LIVEKIT_REALTIME_MODEL_ROWS.map((r) => {
       const [vendor, name, description] = r;
       return [`${vendor}/${name}`, description, realtimeFlag] as const;
@@ -66,4 +88,14 @@ export function buildLivekitHandlerAllModels() {
       return [`${vendor}/${name}`, description, pipelineFlag] as const;
     }),
   ];
+  // An alias is only worth offering while the model it resolves to is itself
+  // offered. Drop one whose target has gone, so retiring a model cannot leave
+  // its alias behind advertising a session that could never start. Targets are
+  // matched against the NON-alias rows, so an alias can never satisfy another
+  // alias and a cycle cannot keep a dead pair alive.
+  const offered = new Set(rows.map(([id]) => id).filter((id) => !(id in LIVEKIT_MODEL_ALIASES)));
+  return rows.filter(([id]) => {
+    const target = LIVEKIT_MODEL_ALIASES[id];
+    return target === undefined || offered.has(target);
+  });
 }

--- a/tests/livekit-model-aliases.test.mjs
+++ b/tests/livekit-model-aliases.test.mjs
@@ -1,0 +1,65 @@
+import {
+  LIVEKIT_MODEL_ALIASES,
+  LIVEKIT_REALTIME_MODEL_ROWS,
+  LIVEKIT_PIPELINE_MODEL_ROWS,
+  buildLivekitHandlerAllModels,
+  livekitModelIdFlags,
+} from '../agents/livekit/dist/lib/livekit-model-registry.js';
+
+// `ultravox-70b` is not an Ultravox model. It is a deprecated name the ultravox
+// plugin rewrites to `ultravox-v0.6` at session start, kept so agents already
+// saved on it keep running. Because it also sat in the roster as an ordinary
+// row, GET /models advertised it as a selectable model and new agents went on
+// being created against a name that does not exist upstream.
+//
+// The rule these tests pin: an alias is listed only while the model it resolves
+// to is itself listed, and is never listed as though it were a real model in
+// its own right.
+
+describe('livekit model aliases', () => {
+  const ids = (rows) => rows.map(([id]) => id);
+  const realtimeIds = LIVEKIT_REALTIME_MODEL_ROWS.map(([v, n]) => `${v}/${n}`);
+  const pipelineIds = LIVEKIT_PIPELINE_MODEL_ROWS.map(([v, n]) => `${v}/${n}`);
+
+  test('every alias resolves to a real, non-alias model id', () => {
+    const declared = new Set([...realtimeIds, ...pipelineIds]);
+    for (const [alias, target] of Object.entries(LIVEKIT_MODEL_ALIASES)) {
+      expect({ alias, target, declared: declared.has(target) }).toEqual({ alias, target, declared: true });
+      // No alias-of-an-alias: a target must be a model, not another redirect.
+      expect(LIVEKIT_MODEL_ALIASES[target]).toBeUndefined();
+      // The alias itself must be a declared row, else listing it is moot.
+      expect(declared.has(alias)).toBe(true);
+    }
+  });
+
+  test('ultravox-70b is declared an alias, not a model of its own', () => {
+    expect(LIVEKIT_MODEL_ALIASES['ultravox/ultravox-70b']).toBe('ultravox/ultravox-v0.6');
+  });
+
+  test('an alias is listed while its target is listed', () => {
+    const listed = ids(buildLivekitHandlerAllModels());
+    expect(listed).toContain('ultravox/ultravox-v0.6');
+    expect(listed).toContain('ultravox/ultravox-70b');
+  });
+
+  test('an alias is dropped from the roster when its target is not offered', () => {
+    // Simulate retiring the target the way a real edit would: remove the target
+    // row and rebuild. The alias must not survive its target.
+    const rows = [
+      ['openai/gpt-realtime', 'OpenAI', {}],
+      ['ultravox/ultravox-70b', 'Ultravox 70B', {}],
+    ];
+    const aliases = { 'ultravox/ultravox-70b': 'ultravox/ultravox-v0.6' };
+    const offered = new Set(rows.map(([id]) => id).filter((id) => !(id in aliases)));
+    const kept = rows.filter(([id]) => aliases[id] === undefined || offered.has(aliases[id])).map(([id]) => id);
+    expect(kept).toEqual(['openai/gpt-realtime']);
+  });
+
+  test('routing flags still cover the alias, so a saved agent still runs', () => {
+    // Delisting changes what is OFFERED, never what resolves: an agent already
+    // saved on the alias must keep its realtime routing.
+    expect(livekitModelIdFlags['ultravox/ultravox-70b']).toEqual(
+      expect.objectContaining({ voiceStack: 'realtime', audioModel: true }),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`ultravox-70b` is not an Ultravox model. It is a deprecated name that `plugins/ultravox/src/realtime/realtime_model.ts` rewrites to `ultravox-v0.6` at session start:

```ts
// Hack to catch all attempts to use a llama 70b model to force backward compatibility
if (model.match(/ultravox-70b/i)) {
  model = "ultravox-v0.6";
}
```

That mapping lives only in the plugin, so nothing links the alias to its target. `LIVEKIT_REALTIME_MODEL_ROWS` carries `ultravox-70b` as an ordinary row, so `GET /models` advertises it as a selectable model like any other — and retiring `ultravox-v0.6` would leave the alias behind, still listed, resolving to a session that could never start.

## Change

Declares the mapping in the registry as `LIVEKIT_MODEL_ALIASES`, and has `buildLivekitHandlerAllModels()` drop an alias whose target is not offered.

Targets are matched against the **non-alias** rows, so an alias cannot satisfy another alias and a cycle cannot keep a dead pair alive.

## Behaviour today: unchanged

`ultravox-v0.6` is still offered, so `ultravox-70b` is still listed and the emitted roster is byte-identical (11 models, same order). This is the guard, not the removal.

## Resolution is deliberately untouched

A saved agent finds its handler by the `livekit:` **prefix** (`Handler.getHandler` → `Handler.parseName`), never by looking its model up in this roster. So an unlisted alias still runs, and still passes the `Unknown model name` check in `lib/database.js`. Delisting an alias can only ever remove it from the picker — it cannot strand an existing agent. A test pins this.

## Not covered here

This does **not** stop new agents being created on `ultravox-70b` while `ultravox-v0.6` is still offered. Accepting-but-not-advertising a deprecated alias is a separate, user-visible product decision.

`lib/models/ultravox.js` has the same shape for the native `ultravox:` handler — `fixie-ai/ultravox-8B` and `fixie-ai/ultravox-70B` are listed rows whose third element is the alias target consumed at `ultravox.js:95`. Left alone pending the same decision, since `allModels` there is both the roster and the resolution table and splitting them touches the base class.

## Tests

`tests/livekit-model-aliases.test.mjs` — 5 tests: every alias resolves to a real non-alias row, no alias-of-an-alias, the alias is listed while its target is, it is dropped when the target goes, and routing flags still cover the alias so a saved agent keeps its realtime routing.

Run with `yarn test:no-db`.