### PR TITLE
feat(api): accept agentLimit on the organisation billing seam

### DIFF
--- a/api/paths/organisations/{organisationId}/billing.js
+++ b/api/paths/organisations/{organisationId}/billing.js
@@ -4,7 +4,8 @@ import { isSafeCallbackUrl } from '../../../../lib/balance-callback.js';
 
 /**
  * /api/organisations/{id}/billing — the org's billing CONTROLS (not money):
- *   GET    read `billingBlocked` + `billingConfig` + `chargeableNumberLimit`.
+ *   GET    read `billingBlocked` + `billingConfig` + `chargeableNumberLimit` +
+ *          `agentLimit`.
  *   PATCH  set any of them. `billingConfig` is validated whole (callbackUrl must
  *          pass the SSRF guard, hashKey ≥ 16 chars, balanceLowPennies ≥ 0) or
  *          cleared with null; `billingBlocked` is the hard call-refusal lever
@@ -13,6 +14,12 @@ import { isSafeCallbackUrl } from '../../../../lib/balance-callback.js';
  *          (null = unlimited) that a client billing service sets alongside the
  *          rest of the billing config — the direct org-PATCH route keeps its
  *          own stricter `organisation:setRate` gate for this field.
+ *          `agentLimit` is the generic per-organisation concurrency cap already
+ *          enforced by lib/concurrency (null = unlimited, 0 = no concurrent
+ *          calls); it is exposed here for the same reason as
+ *          `chargeableNumberLimit` — a client billing service sets it from
+ *          whatever package the customer is on, and the direct org-PATCH route
+ *          keeps its stricter `organisation:setLimits` gate.
  *
  * Gated on `organisation:billing` — held by superAdmin and the least-privilege
  * `billingService` role (the client billing system's server-side seam, like
@@ -25,6 +32,7 @@ export default function (logger) {
     billingBlocked: !!org.billingBlocked,
     billingConfig: org.billingConfig ?? null,
     chargeableNumberLimit: org.chargeableNumberLimit ?? null,
+    agentLimit: org.agentLimit ?? null,
   });
 
   const get = async (req, res) => {
@@ -51,8 +59,23 @@ export default function (logger) {
     if (!org) return res.status(404).send({ message: `Organisation ${req.params.organisationId} not found` });
 
     const body = req.body || {};
-    if (!('billingBlocked' in body) && !('billingConfig' in body) && !('chargeableNumberLimit' in body)) {
-      return res.status(400).send({ message: 'Provide billingBlocked, billingConfig and/or chargeableNumberLimit' });
+    if (
+      !('billingBlocked' in body) &&
+      !('billingConfig' in body) &&
+      !('chargeableNumberLimit' in body) &&
+      !('agentLimit' in body)
+    ) {
+      return res
+        .status(400)
+        .send({ message: 'Provide billingBlocked, billingConfig, chargeableNumberLimit and/or agentLimit' });
+    }
+
+    if ('agentLimit' in body) {
+      const limit = body.agentLimit;
+      if (limit !== null && (!Number.isInteger(limit) || limit < 0)) {
+        return res.status(400).send({ message: 'agentLimit must be a non-negative integer or null (unlimited)' });
+      }
+      org.agentLimit = limit;
     }
 
     if ('chargeableNumberLimit' in body) {
@@ -102,7 +125,7 @@ export default function (logger) {
     return res.send(shape(org));
   };
   update.apiDoc = {
-    summary: 'Set an organisation’s billing controls (billingBlocked / billingConfig / chargeableNumberLimit).',
+    summary: 'Set an organisation’s billing controls (billingBlocked / billingConfig / chargeableNumberLimit / agentLimit).',
     operationId: 'updateOrganisationBilling',
     tags: ['Organisations', 'Billing'],
     parameters: [{ in: 'path', name: 'organisationId', required: true, schema: { type: 'string' } }],
@@ -129,6 +152,12 @@ export default function (logger) {
                 nullable: true,
                 minimum: 0,
                 description: 'Spend-policy cap: max numbers the org may hold on chargeable (non-owned) trunks; null = unlimited. A client billing service sets this alongside the other billing controls.',
+              },
+              agentLimit: {
+                type: 'integer',
+                nullable: true,
+                minimum: 0,
+                description: 'Concurrency cap: max simultaneous calls for the organisation, enforced at call start; null = unlimited, 0 = none allowed. A client billing service sets this alongside the other billing controls.',
               },
             },
           },

--- a/tests/balance-api.test.mjs
+++ b/tests/balance-api.test.mjs
@@ -216,7 +216,7 @@ describe('Phase 3: rate-history + balance + balance/credit', () => {
 
     const read = mockReqRes({ role: 'billingService', params: { organisationId: orgId } });
     await billingGET(read.req, read.res);
-    expect(read.res.body).toEqual({ billingBlocked: true, billingConfig: cfg, chargeableNumberLimit: 3 });
+    expect(read.res.body).toEqual({ billingBlocked: true, billingConfig: cfg, chargeableNumberLimit: 3, agentLimit: null });
 
     // balance read (own-org member) surfaces the block flag
     const bal = mockReqRes({ role: 'owner', organisationId: orgId, params: { organisationId: orgId } });
@@ -224,7 +224,7 @@ describe('Phase 3: rate-history + balance + balance/credit', () => {
     expect(bal.res.body.blocked).toBe(true);
 
     const cleared = await patch({ billingBlocked: false, billingConfig: null });
-    expect(cleared.body).toEqual({ billingBlocked: false, billingConfig: null, chargeableNumberLimit: 3 });
+    expect(cleared.body).toEqual({ billingBlocked: false, billingConfig: null, chargeableNumberLimit: 3, agentLimit: null });
   });
 
   it('billing PATCH sets chargeableNumberLimit (integer >= 0, null = unlimited) and validates it', async () => {
@@ -262,6 +262,46 @@ describe('Phase 3: rate-history + balance + balance/credit', () => {
     expect((await patch({ chargeableNumberLimit: 99 }, 'owner')).statusCode).toBe(403);
   });
 
+  it('billing PATCH sets agentLimit (the concurrency cap lib/concurrency already enforces)', async () => {
+    // Exposed on the billing seam for the same reason as chargeableNumberLimit:
+    // a client billing service sets it from whatever package the customer is
+    // on, without holding the stricter organisation:setLimits the direct
+    // org-PATCH route requires. The CAP is generic here; what number goes in it
+    // is the billing system's policy, not ours.
+    const patch = (body, role = 'billingService') => {
+      const { req, res } = mockReqRes({ role, params: { organisationId: orgId }, body });
+      return billingPATCH(req, res).then(() => res);
+    };
+
+    const capped = await patch({ agentLimit: 2 });
+    expect(capped.statusCode).toBe(200);
+    expect(capped.body.agentLimit).toBe(2);
+    expect((await Organisation.findByPk(orgId)).agentLimit).toBe(2);
+
+    // 0 is meaningful and distinct from null: no concurrent calls at all.
+    const none = await patch({ agentLimit: 0 });
+    expect(none.statusCode).toBe(200);
+    expect((await Organisation.findByPk(orgId)).agentLimit).toBe(0);
+
+    const unlimited = await patch({ agentLimit: null });
+    expect(unlimited.statusCode).toBe(200);
+    expect(unlimited.body.agentLimit).toBeNull();
+    expect((await Organisation.findByPk(orgId)).agentLimit).toBeNull();
+
+    // Settable alongside the other controls in one PATCH.
+    const combined = await patch({ agentLimit: 6, chargeableNumberLimit: 10 });
+    expect(combined.body).toMatchObject({ agentLimit: 6, chargeableNumberLimit: 10 });
+
+    // Invalid values reject without persisting anything.
+    expect((await patch({ agentLimit: -1 })).statusCode).toBe(400);
+    expect((await patch({ agentLimit: 1.5 })).statusCode).toBe(400);
+    expect((await patch({ agentLimit: '2' })).statusCode).toBe(400);
+    expect((await Organisation.findByPk(orgId)).agentLimit).toBe(6);
+
+    // Same gate as the rest of the billing controls.
+    expect((await patch({ agentLimit: 99 }, 'owner')).statusCode).toBe(403);
+  });
+
   it('billing PATCH validates: unsafe URL, short hashKey, bad types, empty body, owner 403', async () => {
     const patch = (body, role = 'billingService') => {
       const { req, res } = mockReqRes({ role, params: { organisationId: orgId }, body });
@@ -271,7 +311,7 @@ describe('Phase 3: rate-history + balance + balance/credit', () => {
     expect((await patch({ billingConfig: { callbackUrl: 'https://ok.example.com/x', hashKey: 'short' } })).statusCode).toBe(400);
     expect((await patch({ billingConfig: { callbackUrl: 'https://ok.example.com/x', hashKey: 'k'.repeat(32), balanceLowPennies: -5 } })).statusCode).toBe(400);
     expect((await patch({ billingBlocked: 'yes' })).statusCode).toBe(400);
-    expect((await patch({})).statusCode).toBe(400);
+    expect((await patch({})).statusCode).toBe(400); // still 400 with agentLimit added to the accepted set
     expect((await patch({ billingBlocked: true }, 'owner')).statusCode).toBe(403);
     // nothing stuck from the failed attempts
     const org = await Organisation.findByPk(orgId);


### PR DESCRIPTION
`PATCH`/`GET /organisations/{id}/billing` now carries `agentLimit` alongside `chargeableNumberLimit` — same validation (non-negative integer, or `null` for unlimited) and the same `organisation:billing` gate.

The cap already exists and is already enforced: `lib/concurrency` reserves against `Organisation.agentLimit` at call start and fails the call with `organisation concurrency limit` on breach. What was missing was a way for a client billing service to **set** it — the direct org PATCH route requires `organisation:setLimits`, which the least-privilege `billingService` role does not hold. Same shape as `chargeableNumberLimit` before it.

The endpoint stays generic: it accepts a cap and has no opinion about what number belongs in it.

Tests: new coverage for set / 0 / null / combined-PATCH / validation / role gate, plus the two existing GET-shape assertions updated for the added field. Full DB suite green — 75 suites, 797 tests.