### PR TITLE
Expose finalised per-call cost (costMicros) on call endpoints

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1525,6 +1525,15 @@ components:
             When present, a recording is available for this call. Use `GET /calls/{callId}/recording`
             to stream or download it. Omit or null when the call has no recording.
           example: "development-recordings/648aa45d-204a-4c0c-a1e1-419406254134.enc"
+        costMicros:
+          type: number
+          nullable: true
+          description: |-
+            Finalised cost of this call in micro-pounds (1e-6 GBP): the sum of the call's costed,
+            finalised usage records. Costs are stamped at call end, so a completed call either
+            carries its figure or was not costed; `null` means "not costed", which is distinct
+            from a zero-cost call.
+          example: 777000
     CallId:
       type: string
       description: The Call ID the event relates to

--- a/api/paths/agents/{agentId}/calls.js
+++ b/api/paths/agents/{agentId}/calls.js
@@ -1,7 +1,13 @@
 import { Call, Op } from '../../../../lib/database.js';
+import { Sequelize } from 'sequelize';
 import { scopeWhereForUser } from '../../../../lib/scope.js';
 import { requirePermission } from '../../../../lib/auth/permissions.js';
 let appParameters, log;
+
+/** Finalised per-call cost in micro-pounds — see api/paths/calls.js. */
+const COST_MICROS_LITERAL =
+  '(SELECT SUM(ur.cost_micros)::float8 FROM usage_records ur WHERE ur.call_id = "Call"."id" AND ur.finalised AND ur.cost_micros IS NOT NULL)';
+
 
 export default function (logger) {
 
@@ -29,7 +35,7 @@ export default function (logger) {
         };
       }
       let { count, rows: calls } = await Call.findAndCountAll({
-        attributes: ['id', 'parentId', 'instanceId', 'callerId', 'calledId', 'startedAt', 'endedAt', 'recordingId', 'status'],
+        attributes: ['id', 'parentId', 'instanceId', 'callerId', 'calledId', 'startedAt', 'endedAt', 'recordingId', 'status', [Sequelize.literal(COST_MICROS_LITERAL), 'costMicros']],
         where,
         order: [['createdAt', 'DESC']],
         limit: parseInt(limit),

--- a/api/paths/calls.js
+++ b/api/paths/calls.js
@@ -1,7 +1,19 @@
 import { Call, Op } from '../../lib/database.js';
+import { Sequelize } from 'sequelize';
 import { scopeWhereForUser } from '../../lib/scope.js';
 import { requirePermission } from '../../lib/auth/permissions.js';
 let appParameters, log;
+
+/**
+ * Finalised cost of a call in micro-pounds (1e-6 GBP): the sum of its costed,
+ * finalised usage records, as a correlated aggregate so list pages stay one
+ * query. NULL when nothing has been costed yet — distinct from a zero-cost
+ * call. float8 keeps the JSON value numeric (a bigint SUM would serialise as a
+ * string).
+ */
+const COST_MICROS_LITERAL =
+  '(SELECT SUM(ur.cost_micros)::float8 FROM usage_records ur WHERE ur.call_id = "Call"."id" AND ur.finalised AND ur.cost_micros IS NOT NULL)';
+
 
 export default function (logger) {
 
@@ -26,7 +38,7 @@ export default function (logger) {
         };
       }
       let { count, rows: calls } = await Call.findAndCountAll({
-        attributes: ['id', 'index', 'agentId', 'parentId', 'modelName', 'callerId', 'calledId', 'startedAt', 'endedAt', 'status', 'recordingId'],
+        attributes: ['id', 'index', 'agentId', 'parentId', 'modelName', 'callerId', 'calledId', 'startedAt', 'endedAt', 'status', 'recordingId', [Sequelize.literal(COST_MICROS_LITERAL), 'costMicros']],
         where,
         order: [['index', 'ASC']],
         limit: parseInt(limit),

--- a/api/paths/calls/{callId}.js
+++ b/api/paths/calls/{callId}.js
@@ -1,5 +1,10 @@
 import { Call } from '../../../lib/database.js';
+import { Sequelize } from 'sequelize';
 import { requirePermission } from '../../../lib/auth/permissions.js';
+
+/** Finalised per-call cost in micro-pounds — see api/paths/calls.js. */
+const COST_MICROS_LITERAL =
+  '(SELECT SUM(ur.cost_micros)::float8 FROM usage_records ur WHERE ur.call_id = "Call"."id" AND ur.finalised AND ur.cost_micros IS NOT NULL)';
 
 export default function (logger) {
 
@@ -13,7 +18,7 @@ export default function (logger) {
     try {
       const call = await Call.findOne({
         where,
-        attributes: ['id', 'index', 'agentId', 'parentId', 'modelName', 'callerId', 'calledId', 'startedAt', 'endedAt', 'status', 'recordingId'],
+        attributes: ['id', 'index', 'agentId', 'parentId', 'modelName', 'callerId', 'calledId', 'startedAt', 'endedAt', 'status', 'recordingId', [Sequelize.literal(COST_MICROS_LITERAL), 'costMicros']],
       });
 
       if (!call) {

--- a/tests/calls-get-endpoint.test.mjs
+++ b/tests/calls-get-endpoint.test.mjs
@@ -117,7 +117,8 @@ describe('GET /calls/{callId} Endpoint Test', () => {
     // Exactly the attributes the handler selects (matches the OpenAPI Call schema).
     const expectedKeys = [
       'id', 'index', 'agentId', 'parentId', 'modelName',
-      'callerId', 'calledId', 'startedAt', 'endedAt', 'status', 'recordingId'
+      'callerId', 'calledId', 'startedAt', 'endedAt', 'status', 'recordingId',
+      'costMicros'
     ].sort();
     expect(Object.keys(res._body).sort()).toEqual(expectedKeys);
 


### PR DESCRIPTION
Call list/detail responses carry no cost information, so API consumers showing per-call cost have to join usage records themselves. This adds a read-only `costMicros` field to `GET /calls`, `GET /agents/{agentId}/calls` and `GET /calls/{callId}`:

- Sum of the call's **finalised, costed** usage records, in micro-pounds (1e-6 GBP).
- Correlated aggregate (`usage_records.call_id` is already indexed), cast `::float8` so the JSON value is numeric rather than a bigint string.
- `null` = not costed — deliberately distinct from a zero-cost call.
- OpenAPI `Call` schema updated; the exact-attribute-list contract test extended.

Verified the aggregate against live data (three known calls return their exact finalised figures). No schema/migration changes.
