### PR TITLE
pipecat worker: re-key peer registry on restart_pc; /healthz with thread-spawn canary

### DIFF
--- a/agents/pipecat/deploy/k8s/base/daemonset.yaml
+++ b/agents/pipecat/deploy/k8s/base/daemonset.yaml
@@ -117,16 +117,27 @@ spec:
             - name: worker-http
               containerPort: 8082
               protocol: TCP
+          # /healthz, not a bare TCP probe: the worker's proven silent-failure
+          # mode (thread-spawn exhaustion — new calls connect with outbound
+          # audio but the per-track decoder thread can't start, so inbound RTP
+          # is dropped without a single error line) keeps accepting TCP and
+          # serving HTTP throughout. /healthz runs a thread-spawn canary plus
+          # session/thread watermarks and returns 503 in that state, so the
+          # kubelet restarts the container instead of a human deleting the pod.
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /healthz
               port: 8082
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /healthz
               port: 8082
             initialDelaySeconds: 15
             periodSeconds: 20
+            failureThreshold: 3
+            timeoutSeconds: 3
           resources:
             requests:
               cpu: 250m

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import threading
 import uuid
 
 # The ``websockets`` library logs every frame it sends/receives as a hex dump
@@ -503,6 +504,63 @@ app.add_middleware(
 )
 
 
+# Watermarks for /healthz, env-overridable. The canary below is the decisive
+# check; these catch runaway accumulation before it starves the process (the
+# healthy baseline on a SIP node is ~1-2 concurrent sessions and ~25 threads).
+HEALTHZ_MAX_SESSIONS = int(os.environ.get("HEALTHZ_MAX_SESSIONS", "64"))
+HEALTHZ_MAX_THREADS = int(os.environ.get("HEALTHZ_MAX_THREADS", "400"))
+
+
+@app.get("/healthz")
+async def healthz(request: Request) -> JSONResponse:
+    """Liveness/readiness that actually detects a worker unable to run calls.
+
+    The decisive check is the THREAD-SPAWN CANARY. aiortc starts one decoder
+    thread per received track inside RTCPeerConnection's connect sequence —
+    AFTER the sender side is already up. When ``Thread.start()`` raises under
+    process resource exhaustion, every new call connects with working outbound
+    audio and no inbound audio at all: the receiver never registers with the
+    RTP router, inbound RTP is silently dropped, and the only in-log trace is a
+    deferred "Task exception was never retrieved". A bare TCP probe stays green
+    through all of that (HTTP keeps serving); this endpoint goes 503 the moment
+    the process can no longer start a thread.
+
+    Session/peer-registry and thread-count watermarks ride along as early
+    warning for the accumulation that produces the exhaustion.
+    """
+    problems: list[str] = []
+    try:
+        canary = threading.Thread(target=lambda: None, name="healthz-canary", daemon=True)
+        canary.start()
+        canary.join(1.0)
+        if canary.is_alive():
+            problems.append("thread canary did not complete within 1s")
+    except Exception as e:  # noqa: BLE001 — this is precisely the failure probed for
+        problems.append(f"cannot start threads: {type(e).__name__}: {e}")
+    live_calls = len(getattr(request.app.state, "live_calls", {}) or {})
+    peers = len(getattr(request.app.state, "webrtc_connections", {}) or {})
+    try:
+        threads = len(os.listdir("/proc/self/task"))
+    except OSError:  # non-Linux dev hosts
+        threads = threading.active_count()
+    if live_calls > HEALTHZ_MAX_SESSIONS:
+        problems.append(f"live_calls={live_calls} above {HEALTHZ_MAX_SESSIONS}")
+    if peers > HEALTHZ_MAX_SESSIONS:
+        problems.append(f"webrtc_connections={peers} above {HEALTHZ_MAX_SESSIONS}")
+    if threads > HEALTHZ_MAX_THREADS:
+        problems.append(f"threads={threads} above {HEALTHZ_MAX_THREADS}")
+    return JSONResponse(
+        {
+            "ok": not problems,
+            "live_calls": live_calls,
+            "webrtc_connections": peers,
+            "threads": threads,
+            "problems": problems,
+        },
+        status_code=200 if not problems else 503,
+    )
+
+
 @app.post("/dispatch")
 async def dispatch(request: Request, authorization: Optional[str] = Header(default=None)):
     require_dispatch_token(authorization)
@@ -684,6 +742,18 @@ async def webrtc_offer(request: Request) -> JSONResponse:
         await existing.renegotiate(
             sdp=sdp, type=sdp_type, restart_pc=bool(body.get("restart_pc"))
         )
+        # A restart_pc renegotiation mints a FRESH pc_id: the upstream wrapper
+        # strips the old aiortc peer's listeners before closing it (so no
+        # "closed" event ever fires for the old identity) and _initialize()
+        # assigns a new id, which the answer below hands to the browser. Re-key
+        # the registry to the current id, or (a) the browser's follow-up
+        # trickle PATCH — sent with the NEW id — 404s on the very pod that owns
+        # the peer, forcing reconnects to limp through peer-reflexive ICE, and
+        # (b) the entry under the old id can never be popped and leaks for the
+        # life of the process (one leaked entry per reconnect attempt).
+        if existing.pc_id != pc_id:
+            request.app.state.webrtc_connections.pop(pc_id, None)
+            request.app.state.webrtc_connections[existing.pc_id] = existing
         answer = existing.get_answer()
         if not answer:
             raise HTTPException(

--- a/agents/pipecat/tests/test_worker_healthz.py
+++ b/agents/pipecat/tests/test_worker_healthz.py
@@ -1,0 +1,90 @@
+"""Tests for the worker's /healthz handler.
+
+A bare TCP probe cannot see the worker's proven silent-failure mode: under
+thread-spawn exhaustion, aiortc's per-received-track decoder thread fails to
+start AFTER the sender is already up, so every new call carries outbound audio
+while all inbound RTP is silently discarded (the receiver never registers with
+the RTP router) — and HTTP keeps serving throughout. What is pinned here is
+that /healthz goes 503 the moment threads cannot start, that runaway
+session/peer-registry growth trips the watermarks, and that a healthy idle
+process reports 200 with its counts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from pipecat_aplisay import worker
+
+
+class _State:
+    def __init__(self, live=None, peers=None):
+        self.live_calls = live or {}
+        self.webrtc_connections = peers or {}
+
+
+class _App:
+    def __init__(self, state):
+        self.state = state
+
+
+class _Request:
+    def __init__(self, state):
+        self.app = _App(state)
+
+
+def _run(state):
+    resp = asyncio.get_event_loop().run_until_complete(worker.healthz(_Request(state)))
+    return resp.status_code, json.loads(resp.body)
+
+
+@pytest.fixture()
+def loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    loop.close()
+
+
+def test_healthy_idle_process_reports_ok(loop):
+    status, body = _run(_State())
+    assert status == 200
+    assert body["ok"] is True
+    assert body["problems"] == []
+    assert body["live_calls"] == 0
+    assert body["webrtc_connections"] == 0
+    assert body["threads"] >= 1
+
+
+def test_peer_registry_runaway_trips_the_watermark(loop):
+    peers = {f"pc-{i}": object() for i in range(worker.HEALTHZ_MAX_SESSIONS + 1)}
+    status, body = _run(_State(peers=peers))
+    assert status == 503
+    assert body["ok"] is False
+    assert any("webrtc_connections" in p for p in body["problems"])
+
+
+def test_live_calls_runaway_trips_the_watermark(loop):
+    live = {f"call-{i}": object() for i in range(worker.HEALTHZ_MAX_SESSIONS + 1)}
+    status, body = _run(_State(live=live))
+    assert status == 503
+    assert any("live_calls" in p for p in body["problems"])
+
+
+def test_thread_spawn_failure_is_a_hard_503(loop, monkeypatch):
+    """The decisive canary: ``can't start new thread`` must flip the probe."""
+
+    class _DeadThread:
+        def __init__(self, *a, **k):
+            pass
+
+        def start(self):
+            raise RuntimeError("can't start new thread")
+
+    monkeypatch.setattr(worker.threading, "Thread", _DeadThread)
+    status, body = _run(_State())
+    assert status == 503
+    assert any("cannot start threads" in p for p in body["problems"])


### PR DESCRIPTION
Two worker fixes for failure modes observed on a live 2-node deployment.

## 1. `restart_pc` renegotiation leaves the peer registry keyed by a dead id
`SmallWebRTCConnection.renegotiate(restart_pc=True)` strips the old aiortc peer's listeners before closing it (so no `closed` event fires for the old identity) and `_initialize()` mints a fresh `pc_id`, which the SDP answer returns to the browser. The worker's `app.state.webrtc_connections` map, however, stayed keyed by the old id — so after any client reconnect attempt:

- the browser's follow-up trickle `PATCH` (sent with the new id) 404s **on the very pod that owns the peer**, leaving reconnects to limp through peer-reflexive ICE, and
- the old entry can never be popped (the runner's `finally` and the `closed` handler both pop the *current* `pc_id`), leaking one registry entry per reconnect attempt for the life of the process.

The offer handler now re-keys the registry to the connection's current `pc_id` after renegotiation.

## 2. `GET /healthz` + `httpGet` probes (base DaemonSet)
The worker has a proven silent-failure mode that a `tcpSocket` probe cannot see: under **thread-spawn exhaustion**, `RTCPeerConnection`'s connect sequence has already started the sender when `receiver.receive()` tries to spawn the per-received-track decoder thread; when `Thread.start()` raises, the receiver never registers with the RTP router, so every **new** call connects with working outbound audio and silently discards all inbound RTP — the only in-log trace is a deferred `Task exception was never retrieved`, HTTP keeps serving, and the state persists until the process restarts.

Reproduced end-to-end against the pinned dependency stack (pipecat-ai 1.6.0 / aiortc 1.15.0): with `Thread.start` failing for decoder threads only, a loopback session connects, sends 350+ RTP packets, receives zero frames, and logs `read_audio_frame … Timeout: No audio frame received` every ~2 s indefinitely — while a TCP probe stays green throughout.

`/healthz` returns 503 on:
- a **thread-spawn canary** failing (the decisive check for the above),
- session / peer-registry / OS-thread watermarks (env-overridable `HEALTHZ_MAX_SESSIONS`, `HEALTHZ_MAX_THREADS`) as early warning for the accumulation that produces the exhaustion (fix 1 removes one known accumulator).

The base DaemonSet's worker readiness+liveness probes switch from `tcpSocket:8082` to `httpGet /healthz:8082`, so the kubelet restarts a wedged container instead of an operator deleting the pod. (The sipbridge/voiceblender containers' probes are unchanged.)

Tests: new `tests/test_worker_healthz.py` (healthy 200 with counts; watermark 503s; canary 503 on `can't start new thread`); full worker suite passes (366).

Possible follow-up, deliberately out of scope here: a per-session "connected but zero inbound frames ever" staleness report on `/healthz`, which would also catch non-thread variants of receive-deafness.
