### PR TITLE
Default Ultravox vadSettings: minimumInterruptionDuration 0.48s on every path

### DIFF
--- a/agents/livekit/lib/voice-session-factory.ts
+++ b/agents/livekit/lib/voice-session-factory.ts
@@ -32,6 +32,19 @@ import {
  */
 export const INACTIVITY_PROMPT_COUNT = 3;
 
+// Default Ultravox vadSettings, applied when the agent supplies no explicit
+// `vendorSpecific.ultravox.vadSettings`. Ultravox's stock
+// minimumInterruptionDuration is 0.09s — any ~90ms sound (a breath, a
+// backchannel "mm-hm", handset rustle) cancels agent speech mid-turn and the
+// truncated text is finalised, with nothing re-offering the lost answer. 0.48s
+// (15 × the VAD's 32ms frames) requires deliberate speech to barge in, at the
+// cost of ~0.4s extra latency on a deliberate interruption. Must stay in step
+// with DEFAULT_VAD_SETTINGS in lib/models/ultravox.js and
+// ULTRAVOX_DEFAULT_VAD_SETTINGS in the pipecat worker's voice_session.py.
+export const ULTRAVOX_DEFAULT_VAD_SETTINGS = Object.freeze({
+  minimumInterruptionDuration: "0.48s",
+});
+
 /**
  * Whether `options.inactivity.hangup` opts this agent into ending the call once the
  * inactivity prompt has gone unanswered {@link INACTIVITY_PROMPT_COUNT} times.
@@ -304,6 +317,26 @@ export function buildRealtimeLlmOptions(
         ultravox: {
           ...((base && base.ultravox) || {}),
           inactivityMessages: messages,
+        },
+      };
+    }
+  }
+
+  // Ultravox realtime: default vadSettings unless the caller supplied their
+  // own (which wins wholesale, same contract as the other native blocks) —
+  // see ULTRAVOX_DEFAULT_VAD_SETTINGS for why the stock 0.09s interruption
+  // threshold is unusable on live calls.
+  if (modelName.includes("livekit:ultravox/")) {
+    const base =
+      (llmOptions.vendorSpecific as Record<string, any> | undefined) ||
+      vendorSpecific ||
+      undefined;
+    if (!(base as any)?.ultravox?.vadSettings) {
+      llmOptions.vendorSpecific = {
+        ...(base || {}),
+        ultravox: {
+          ...((base && (base as any).ultravox) || {}),
+          vadSettings: { ...ULTRAVOX_DEFAULT_VAD_SETTINGS },
         },
       };
     }

--- a/agents/livekit/test/ultravox-vad-default.test.ts
+++ b/agents/livekit/test/ultravox-vad-default.test.ts
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildRealtimeLlmOptions,
+  ULTRAVOX_DEFAULT_VAD_SETTINGS,
+} from "../lib/voice-session-factory.js";
+
+// Covers the platform default for Ultravox vadSettings. Ultravox's stock
+// minimumInterruptionDuration is 0.09s, which lets any ~90ms sound (a breath,
+// a backchannel "mm-hm") cancel agent speech mid-turn; the cancelled turn is
+// finalised truncated and nothing re-offers the lost answer. What is pinned:
+// every Ultravox session carries the 0.48s default unless the agent supplies
+// an explicit vendorSpecific.ultravox.vadSettings, an explicit value replaces
+// the default WHOLESALE (documented contract — never merged), the default
+// composes with the greeting/inactivity vendorSpecific mappings, and
+// non-Ultravox models are untouched.
+// run: npx tsx --test test/ultravox-vad-default.test.ts
+
+const ULTRAVOX = "livekit:ultravox/ultravox-v0.7";
+const OPENAI = "livekit:openai/gpt-4o-realtime";
+
+const makeAgent = (options: Record<string, unknown> = {}) =>
+  ({ prompt: "You are a test agent.", options }) as any;
+
+const uv = (modelName: string, agent: any) =>
+  (buildRealtimeLlmOptions(modelName, agent, "call-1").vendorSpecific as any)?.ultravox;
+
+test("ultravox sessions get the default vadSettings out of the box", () => {
+  assert.deepEqual(uv(ULTRAVOX, makeAgent()).vadSettings, {
+    minimumInterruptionDuration: "0.48s",
+  });
+  assert.equal(
+    ULTRAVOX_DEFAULT_VAD_SETTINGS.minimumInterruptionDuration,
+    "0.48s",
+  );
+});
+
+test("an explicit vendorSpecific vadSettings replaces the default wholesale", () => {
+  const agent = makeAgent({
+    vendorSpecific: { ultravox: { vadSettings: { turnEndpointDelay: "0.5s" } } },
+  });
+  const settings = uv(ULTRAVOX, agent).vadSettings;
+  assert.deepEqual(settings, { turnEndpointDelay: "0.5s" });
+  assert.equal(settings.minimumInterruptionDuration, undefined);
+});
+
+test("the default preserves other vendorSpecific keys", () => {
+  const agent = makeAgent({
+    vendorSpecific: {
+      google: { geminiVoiceName: "Kore" },
+      ultravox: { experimentalSettings: { transcriptionProvider: "deepgram-nova-3" } },
+    },
+  });
+  const opts = buildRealtimeLlmOptions(ULTRAVOX, agent, "call-1");
+  const vendor = opts.vendorSpecific as any;
+  assert.deepEqual(vendor.ultravox.vadSettings, ULTRAVOX_DEFAULT_VAD_SETTINGS);
+  assert.deepEqual(vendor.ultravox.experimentalSettings, {
+    transcriptionProvider: "deepgram-nova-3",
+  });
+  assert.deepEqual(vendor.google, { geminiVoiceName: "Kore" });
+});
+
+test("the default composes with the greeting and inactivity mappings", () => {
+  const agent = makeAgent({
+    greeting: { text: "Hello there" },
+    inactivity: { timeout: "6s", message: "Are you still there?" },
+  });
+  const ultravox = uv(ULTRAVOX, agent);
+  assert.deepEqual(ultravox.vadSettings, ULTRAVOX_DEFAULT_VAD_SETTINGS);
+  assert.equal(ultravox.firstSpeakerSettings.agent.text, "Hello there");
+  assert.equal(ultravox.inactivityMessages.length, 3);
+});
+
+test("the default object is copied per session, so callers cannot mutate the constant", () => {
+  const settings = uv(ULTRAVOX, makeAgent()).vadSettings;
+  settings.minimumInterruptionDuration = "9s";
+  assert.equal(
+    uv(ULTRAVOX, makeAgent()).vadSettings.minimumInterruptionDuration,
+    "0.48s",
+  );
+});
+
+test("non-ultravox realtime models are untouched", () => {
+  assert.equal(buildRealtimeLlmOptions(OPENAI, makeAgent(), "call-1").vendorSpecific, undefined);
+  const agent = makeAgent({ vendorSpecific: { openai: { foo: 1 } } });
+  assert.deepEqual(buildRealtimeLlmOptions(OPENAI, agent, "call-1").vendorSpecific, {
+    openai: { foo: 1 },
+  });
+});

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -175,6 +175,35 @@ def _language_setting(agent: dict, prefer: str) -> Language | str | None:
     return _language_enum(tag) or tag
 
 
+#: Default Ultravox ``vadSettings`` for the /calls request body, applied when
+#: the agent supplies no explicit ``options.vendorSpecific.ultravox.vadSettings``.
+#: Ultravox's stock ``minimumInterruptionDuration`` is 0.09s — any ~90ms sound
+#: (a breath, a backchannel "mm-hm", handset rustle) cancels agent speech
+#: mid-turn and the truncated text is finalised, with nothing re-offering the
+#: lost answer. 0.48s (15 × the VAD's 32ms frames) requires deliberate speech
+#: to barge in, at the cost of ~0.4s extra latency on a deliberate
+#: interruption. Must stay in step with DEFAULT_VAD_SETTINGS in
+#: lib/models/ultravox.js and ULTRAVOX_DEFAULT_VAD_SETTINGS in the LiveKit
+#: worker's voice-session-factory.ts.
+ULTRAVOX_DEFAULT_VAD_SETTINGS = {"minimumInterruptionDuration": "0.48s"}
+
+
+def _ultravox_vad_extra(agent: dict) -> dict:
+    """Native Ultravox ``vadSettings`` for the /calls request body.
+
+    An explicit ``options.vendorSpecific.ultravox.vadSettings`` dict passes
+    through verbatim — caller wins wholesale, the same contract as the native
+    driver and the LiveKit plugin (this is also the first vendorSpecific field
+    this worker honours at all). Otherwise the platform default applies; see
+    :data:`ULTRAVOX_DEFAULT_VAD_SETTINGS`.
+    """
+    vendor = ((agent.get("options") or {}).get("vendorSpecific") or {})
+    supplied = (vendor.get("ultravox") or {}).get("vadSettings") if isinstance(vendor, dict) else None
+    if isinstance(supplied, dict) and supplied:
+        return {"vadSettings": supplied}
+    return {"vadSettings": dict(ULTRAVOX_DEFAULT_VAD_SETTINGS)}
+
+
 def _ultravox_language_extra(agent: dict) -> dict:
     """Native Ultravox ``languageHint`` derived from ``options.tts.language``.
 
@@ -1120,6 +1149,9 @@ async def _build_realtime(
                 # Same reason: no separate TTS stage to carry the language, so
                 # this single hint drives both recognition and synthesis.
                 **_ultravox_language_extra(agent),
+                # Interruption sensitivity: platform default unless the agent
+                # carries an explicit vendorSpecific override.
+                **_ultravox_vad_extra(agent),
             },
         )
         if voice:

--- a/agents/pipecat/tests/test_ultravox_vad_settings.py
+++ b/agents/pipecat/tests/test_ultravox_vad_settings.py
@@ -1,0 +1,57 @@
+"""Tests for the worker's Ultravox ``vadSettings`` mapping.
+
+Ultravox's stock ``minimumInterruptionDuration`` is 0.09s, which lets any
+~90ms sound — a breath, a backchannel "mm-hm", handset rustle — cancel agent
+speech mid-turn; the cancelled turn is finalised truncated and nothing
+re-offers the lost answer (2026-08-24: a gas-safety answer finalised as
+"If you ever smell"). What is pinned here: every Ultravox call body carries a
+platform default of 0.48s unless the agent supplies an explicit
+``vendorSpecific.ultravox.vadSettings``, an explicit override replaces the
+default WHOLESALE (documented contract — never merged), and malformed
+vendorSpecific shapes fall back to the default rather than raising.
+"""
+
+from __future__ import annotations
+
+from pipecat_aplisay.voice_session import (
+    ULTRAVOX_DEFAULT_VAD_SETTINGS,
+    _ultravox_vad_extra,
+)
+
+
+def test_default_applied_when_agent_has_no_vendor_settings():
+    assert _ultravox_vad_extra({}) == {
+        "vadSettings": {"minimumInterruptionDuration": "0.48s"}
+    }
+    assert _ultravox_vad_extra({"options": {}}) == {
+        "vadSettings": {"minimumInterruptionDuration": "0.48s"}
+    }
+
+
+def test_default_is_a_fresh_dict_per_call():
+    a = _ultravox_vad_extra({})["vadSettings"]
+    a["minimumInterruptionDuration"] = "9s"
+    assert _ultravox_vad_extra({})["vadSettings"]["minimumInterruptionDuration"] == "0.48s"
+    assert ULTRAVOX_DEFAULT_VAD_SETTINGS["minimumInterruptionDuration"] == "0.48s"
+
+
+def test_explicit_vendor_settings_replace_the_default_wholesale():
+    agent = {
+        "options": {
+            "vendorSpecific": {"ultravox": {"vadSettings": {"turnEndpointDelay": "0.5s"}}}
+        }
+    }
+    out = _ultravox_vad_extra(agent)["vadSettings"]
+    assert out == {"turnEndpointDelay": "0.5s"}
+    assert "minimumInterruptionDuration" not in out
+
+
+def test_malformed_vendor_shapes_fall_back_to_the_default():
+    for bad in (
+        {"options": {"vendorSpecific": None}},
+        {"options": {"vendorSpecific": "nope"}},
+        {"options": {"vendorSpecific": {"ultravox": None}}},
+        {"options": {"vendorSpecific": {"ultravox": {"vadSettings": "0.2s"}}}},
+        {"options": {"vendorSpecific": {"ultravox": {"vadSettings": {}}}}},
+    ):
+        assert _ultravox_vad_extra(bad)["vadSettings"] == ULTRAVOX_DEFAULT_VAD_SETTINGS

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -938,6 +938,13 @@ components:
             
             Each vendor can have its own set of options under a vendor-specific key (e.g., `ultravox`).
             These options are passed through to the vendor's implementation without validation at the API level.
+
+            `ultravox.vadSettings`: when omitted, the platform applies a default of
+            `{ "minimumInterruptionDuration": "0.48s" }` on every Ultravox-backed path (native driver,
+            LiveKit worker, Pipecat worker) — Ultravox's own 0.09s default lets any ~90ms sound cancel
+            agent speech mid-turn. Supplying an explicit `vadSettings` object replaces the default
+            wholesale (it is not merged), so include `minimumInterruptionDuration` in any override
+            where you still want it raised.
             
             Example for Ultravox:
               ```json

--- a/lib/models/ultravox.js
+++ b/lib/models/ultravox.js
@@ -310,6 +310,10 @@ class Ultravox extends Llm {
     return raw;
   }
 
+  /** Default /calls vadSettings when no vendorSpecific override is given —
+   *  see the assignment in `modelData` for the rationale. */
+  static DEFAULT_VAD_SETTINGS = Object.freeze({ minimumInterruptionDuration: '0.48s' });
+
   static inactivityTimeoutSecs(inactivity) {
     if (!inactivity || typeof inactivity !== 'object') return undefined;
     let { timeout, message } = inactivity;
@@ -349,7 +353,19 @@ class Ultravox extends Llm {
     // Provider-native pass-through: same whitelist as the LiveKit Ultravox plugin.
     let uv = vendorSpecific?.ultravox || {};
     uv.experimentalSettings && (data.experimentalSettings = uv.experimentalSettings);
-    uv.vadSettings && (data.vadSettings = uv.vadSettings);
+    // Explicit vendor vadSettings win wholesale; otherwise the platform default
+    // applies. Ultravox's stock minimumInterruptionDuration is 0.09s — any
+    // ~90ms sound (a breath, a backchannel "mm-hm") cancels agent speech
+    // mid-turn and finalises the truncated text, with nothing re-offering the
+    // lost answer. 0.48s (15 × the VAD's 32ms frames) requires deliberate
+    // speech to barge in, costing a deliberate interruption ~0.4s of latency.
+    // Must stay in step with ULTRAVOX_DEFAULT_VAD_SETTINGS in
+    // agents/livekit/lib/voice-session-factory.ts and the pipecat worker's
+    // voice_session.py.
+    data.vadSettings =
+      (uv.vadSettings && typeof uv.vadSettings === 'object')
+        ? uv.vadSettings
+        : { ...Ultravox.DEFAULT_VAD_SETTINGS };
     // Portable `options.tts.language` (falling back to `options.stt.language`) →
     // provider-native `languageHint`, a BCP-47 tag guiding Ultravox's own ASR and
     // TTS. Ultravox is speech-to-speech, so there is no separate TTS to carry the

--- a/tests/ultravox-native-options.test.mjs
+++ b/tests/ultravox-native-options.test.mjs
@@ -34,7 +34,11 @@ describe('Ultravox native driver option mapping', () => {
       expect(data.timeExceededMessage).toMatch(/great chatting/);
       expect(data.firstSpeakerSettings).toBeUndefined();
       expect(data.inactivityMessages).toBeUndefined();
-      expect(data.vadSettings).toBeUndefined();
+      // Interruption sensitivity is a platform default, not an opt-in:
+      // Ultravox's stock 0.09s minimumInterruptionDuration lets any ~90ms
+      // sound cancel agent speech mid-turn (2026-08-24: gas-safety answer
+      // finalised as "If you ever smell" by a caller's overlapping speech).
+      expect(data.vadSettings).toEqual({ minimumInterruptionDuration: '0.48s' });
       expect(data.experimentalSettings).toBeUndefined();
     });
 
@@ -163,6 +167,23 @@ describe('Ultravox native driver option mapping', () => {
       }).modelData;
       expect(data.vadSettings).toBe(vadSettings);
       expect(data.experimentalSettings).toBe(experimentalSettings);
+    });
+
+    test('explicit vadSettings replace the default wholesale, never merged', () => {
+      // Documented contract (api-doc.yaml vendorSpecific): an override that
+      // wants a raised interruption threshold must carry it itself.
+      const data = makeModel({
+        vendorSpecific: { ultravox: { vadSettings: { turnEndpointDelay: '0.5s' } } },
+      }).modelData;
+      expect(data.vadSettings).toEqual({ turnEndpointDelay: '0.5s' });
+      expect(data.vadSettings.minimumInterruptionDuration).toBeUndefined();
+    });
+
+    test('the default object is fresh per call, so callers cannot mutate the constant', () => {
+      const a = makeModel().modelData.vadSettings;
+      a.minimumInterruptionDuration = '9s';
+      expect(makeModel().modelData.vadSettings.minimumInterruptionDuration).toBe('0.48s');
+      expect(Ultravox.DEFAULT_VAD_SETTINGS.minimumInterruptionDuration).toBe('0.48s');
     });
 
     test('unlisted vendorSpecific keys are not forwarded', () => {


### PR DESCRIPTION
Ultravox's stock `vadSettings.minimumInterruptionDuration` is **0.09s**, so any ~90ms sound — a breath, a backchannel "mm-hm", handset rustle — cancels agent speech mid-turn: the provider sends `playback_clear_buffer`, the truncated text is finalised as the turn's transcript, and nothing re-offers the lost answer (observed live: a safety answer finalised as literally "If you ever smell"). No path set `vadSettings` unless the agent carried an explicit `vendorSpecific` block, so every default agent ran at the 90ms hair-trigger.

This applies a platform default of `{ "minimumInterruptionDuration": "0.48s" }` — 15 × the VAD's 32ms frames; deliberate speech still barges in, at ~0.4s extra latency on a deliberate interruption — at **all three Ultravox call-creation sites**:

- native driver: `lib/models/ultravox.js` `modelData` (new `Ultravox.DEFAULT_VAD_SETTINGS`),
- LiveKit worker: `buildRealtimeLlmOptions` injects it into `vendorSpecific.ultravox`, consumed by the plugin's existing pass-through,
- Pipecat worker: new `_ultravox_vad_extra` merged into the `/calls` `extra` body — also the first `vendorSpecific` field that worker honours at all.

**Override contract (documented on the AgentOptions `vendorSpecific` description):** an explicit `vendorSpecific.ultravox.vadSettings` object replaces the default *wholesale*, never merged — same caller-wins semantics as `firstSpeakerSettings` and `inactivityMessages` — so an override that still wants the raised threshold must carry it itself. Each site hands out a fresh copy per call, so callers can't mutate the shared constant.

**Tests:** native-driver baseline updated (vadSettings is now a default, not undefined) plus wholesale-replacement and no-mutation cases; new LiveKit factory suite (default, wholesale override, other-key preservation, composition with the greeting/inactivity mappings, non-Ultravox models untouched); new Pipecat worker suite (default, wholesale override, malformed `vendorSpecific` shapes fall back to the default). Full JS no-db suite (701), Pipecat suite (377) and the LiveKit factory tests pass. The `livekit-model-registry.ts` typecheck error is pre-existing on `next` (verified against a clean tree).
