### PR TITLE
do-staging: refresh stale DO LB certificate ID; document LE renewal rotation

### DIFF
--- a/agents/pipecat/deploy/k8s/do-staging/kustomization.yaml
+++ b/agents/pipecat/deploy/k8s/do-staging/kustomization.yaml
@@ -38,6 +38,14 @@ patches:
       # Paste its ID below. MUST be a real cert ID before `kubectl apply` — a
       # placeholder makes the DO LB reject the 443 listener. (Remove this op + the
       # webrtc-do component to deploy SIP-only.)
+      #
+      # GOTCHA: DO mints a NEW certificate ID on every Let's Encrypt auto-renewal
+      # (~90 days). The CCM keeps the LIVE Service annotation current, but this
+      # pinned copy goes stale — and the DO admission webhook then rejects the
+      # whole apply (even --dry-run=server) with "certificate not found". Before
+      # applying, refresh the value from the live object:
+      #   kubectl -n pipecat get svc pipecat-sip -o jsonpath=\
+      #     '{.metadata.annotations.service\.beta\.kubernetes\.io/do-loadbalancer-certificate-id}'
       - op: add
         path: /metadata/annotations/service.beta.kubernetes.io~1do-loadbalancer-certificate-id
-        value: b0d6588d-fd3e-4280-8e98-4b6da8b3cb8b
+        value: 4ca3a6bb-3516-4b7c-901d-7648c42916c3


### PR DESCRIPTION
DigitalOcean mints a new certificate ID on every Let's Encrypt auto-renewal. The CCM keeps the **live** Service annotation current, but the ID pinned in `do-staging/kustomization.yaml` went stale — and the DO admission webhook then rejects the entire `kubectl apply -k do-staging` (including `kubectl diff` / server dry-run) with `certificate with ID b0d6588d-… not found`, blocking the documented deploy path for the whole overlay. This was hit today while rolling out the DaemonSet probe change (which had to be applied as an extracted, DaemonSet-only manifest instead).

- Updated the pinned ID to the one currently on the live Service (`4ca3a6bb-…`).
- Documented the rotation gotcha and the one-liner to read the live value before an apply.

`kubectl kustomize do-staging` renders clean. Worth checking whether do-beta/do-production pin cert IDs the same way.