### PR TITLE
do-production/do-beta: refresh stale DO LB certificate ID (unblocks beta applies)

### DIFF
--- a/agents/pipecat/deploy/k8s/do-production/kustomization.yaml
+++ b/agents/pipecat/deploy/k8s/do-production/kustomization.yaml
@@ -37,6 +37,14 @@ patches:
       #     --name pipecat-production --dns-names production.pipecat.aplisay.net
       # Paste its ID below. MUST be a real cert ID before `kubectl apply`.
       # (Remove this op + the webrtc-do component to deploy SIP-only.)
+      #
+      # GOTCHA: DO mints a NEW certificate ID on every Let's Encrypt auto-renewal
+      # (~90 days). The CCM keeps the LIVE Service annotation current, but this
+      # pinned copy goes stale — and the DO admission webhook then rejects the
+      # whole apply (even --dry-run=server) with "certificate not found". Before
+      # applying, refresh the value from the live object:
+      #   kubectl -n pipecat get svc pipecat-sip -o jsonpath=\
+      #     '{.metadata.annotations.service\.beta\.kubernetes\.io/do-loadbalancer-certificate-id}'
       - op: add
         path: /metadata/annotations/service.beta.kubernetes.io~1do-loadbalancer-certificate-id
-        value: 00e0dbb7-ccbc-4ec6-925e-c418c7c679db
+        value: 2119c655-7cdd-4b5b-84a1-d9be184323a1


### PR DESCRIPTION
The overlay pinned certificate ID `00e0dbb7-…`, which no longer exists — DigitalOcean mints a new ID on every Let's Encrypt renewal, and once the pin is stale the DO admission webhook rejects the **entire** `kubectl apply -k` (including server dry-runs) with `certificate not found`.

**This is the live beta deployment path, not a hypothetical production one.** `do-beta` is `resources: [../do-production]` plus `:beta` image tags — it inherits this overlay's LB name and certificate pin. So the stale ID here was blocking `kubectl apply -k do-beta`, which is what the live LON1 cluster is deployed from:

| | do-beta renders | live LON1 |
|---|---|---|
| LB name | `pipecat-sip-production` | `pipecat-sip-production` |
| cert ID | `2119c655-…` (after this PR) | `2119c655-…` |
| images | `:beta` | `:beta` |

- Updated the pin to the ID currently on the live `pipecat-sip` Service.
- Added the same rotation-gotcha comment as #245 (do-staging), with the one-liner to read the live value before an apply.

Validated with a server dry-run against the live cluster before DO's API started 503-ing: the webhook **accepts** the refreshed manifest, where the stale pin was rejected outright. `kubectl kustomize do-production` and `do-beta` both render clean.

Note on the overlay's name: it is the shared base for beta rather than a separately-deployed environment (there is no separate live production pipecat — beta is the production candidate), and the LB it names is `pipecat-sip-production` while serving beta. Renaming is out of scope here; flagging it as a trap for the next person diffing an overlay against a cluster.
