### PR TITLE
fix(pipecat): route trickle ICE to the node that owns the peer

### DIFF
--- a/agents/pipecat/deploy/k8s/README.md
+++ b/agents/pipecat/deploy/k8s/README.md
@@ -410,6 +410,16 @@ The flow: the browser calls the llm-agent server's `…/join`, gets back
 answering node** directly. The offer is self-contained from the join token, so
 any worker node can answer any offer (no session affinity).
 
+Everything *after* that offer is a different matter: the aiortc peer lives on
+the node that answered, keyed by `pc_id`, and the browser's trickle-ICE
+`PATCH`es and any renegotiation `POST` are load-balanced independently. They
+therefore reach the owning node only by chance — measured at 1 in 6 on the
+two-node staging pool. A node that does not hold the `pc_id` now **forwards to
+its siblings**, discovered through the headless `pipecat-worker-peers` Service
+(`pipecat_aplisay/webrtc_peers.py`); the request carries a marker header so a
+forward is never forwarded again. Set `WEBRTC_PEER_HOST=""` to switch it off on
+single-replica deploys.
+
 **1. Public TLS endpoint — on the EXISTING SIP LB.** The base `pipecat-worker`
 Service is ClusterIP (in-cluster only). Rather than a second LB, the
 **`components/webrtc-do`** component (already wired into `do-staging` /

--- a/agents/pipecat/deploy/k8s/base/daemonset.yaml
+++ b/agents/pipecat/deploy/k8s/base/daemonset.yaml
@@ -113,6 +113,15 @@ spec:
                 name: pipecat-secretenv
                 optional: true
           # SIP_GATEWAY is set by each overlay (sipbridge / freeswitch / ...).
+          # Our own address, so the WebRTC signalling forwarder can exclude
+          # itself from the peer list resolved out of pipecat-worker-peers.
+          # These pods are hostNetwork, so podIP is the node IP — the same
+          # value that Service's DNS returns for us.
+          env:
+            - name: PIPECAT_SELF_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           ports:
             - name: worker-http
               containerPort: 8082

--- a/agents/pipecat/deploy/k8s/base/kustomization.yaml
+++ b/agents/pipecat/deploy/k8s/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - daemonset.yaml
   - service-sip.yaml
   - service-worker.yaml
+  - service-worker-peers.yaml
   # NOTE: secret.example.yaml / sip-tls-secret.example.yaml are intentionally
   # NOT listed — create the real Secrets out-of-band (see README) so pods fail
   # closed until secrets exist rather than running with placeholders.

--- a/agents/pipecat/deploy/k8s/base/service-worker-peers.yaml
+++ b/agents/pipecat/deploy/k8s/base/service-worker-peers.yaml
@@ -1,0 +1,41 @@
+# Peer discovery for WebRTC signalling — a HEADLESS sibling of pipecat-worker.
+#
+# A browser's SDP offer is stateless and any node can answer it, but the aiortc
+# peer that answering creates lives on ONE node. The trickle-ICE PATCHes and
+# renegotiation POSTs that follow are load-balanced independently, so they reach
+# the owning node only by chance (measured: 5 of 6 sessions landed wrong on a
+# two-node staging pool). The worker fixes that by asking its siblings, and this
+# is how it finds them: clusterIP None means DNS returns an A record per READY
+# pod, so `getaddrinfo("pipecat-worker-peers")` IS the peer list — no Kubernetes
+# API, no RBAC, no service account.
+#
+# Why not the existing pipecat-worker Service: it has a cluster IP, so resolving
+# it yields one virtual address that load-balances to a random pod — useless for
+# enumerating peers.
+#
+# The pods are hostNetwork, so the addresses here are node IPs, which is also
+# what the downward-API PIPECAT_SELF_IP reports — that is what lets a pod
+# exclude itself. `dnsPolicy: ClusterFirstWithHostNet` on the DaemonSet is what
+# makes cluster DNS resolvable from a host-network pod at all; without it this
+# Service exists but cannot be looked up.
+#
+# Not published to not-ready addresses on purpose: a pod that is failing its
+# health check should not be handed signalling traffic.
+apiVersion: v1
+kind: Service
+metadata:
+  name: pipecat-worker-peers
+  namespace: pipecat
+  labels:
+    app.kubernetes.io/name: pipecat-agent
+    app.kubernetes.io/component: sip-node
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: pipecat-agent
+    app.kubernetes.io/component: sip-node
+  ports:
+    - name: worker-http
+      port: 8082
+      targetPort: 8082
+      protocol: TCP

--- a/agents/pipecat/deploy/k8s/components/webrtc-do/kustomization.yaml
+++ b/agents/pipecat/deploy/k8s/components/webrtc-do/kustomization.yaml
@@ -7,14 +7,24 @@
 # LB keeps its IP (it's the same Service / do-loadbalancer-name).
 #
 # Browsers POST /webrtc/offer to https://<fqdn>/ ; an off-cluster llm-agent POSTs
-# /dispatch there too. Sessions are pod-local: the offer and its follow-up PATCH
-# /webrtc/offer (trickle ICE) must reach the pod that owns the session — any
-# other pod 404s them. With 2 SIP nodes and no affinity we observed exactly
-# that: intermittent 404s on offer/PATCH, browser connects wedging, and one-way
-# media. sessionAffinity: ClientIP restored reliable connects (verified
-# empirically; SIP on 5061 is unaffected — each TLS dialog is one connection).
-# A durable fix is routing by the session token (or shared session state) so
-# any pod can serve any client; until then this narrows the failure window.
+# /dispatch there too. Sessions are pod-local: the first offer is stateless and
+# any pod can answer it, but everything after it (trickle-ICE PATCH,
+# renegotiation POST carrying a pc_id) must reach the pod that owns the session.
+#
+# sessionAffinity: ClientIP below is kept as a cheap first-hit optimisation, but
+# it is NOT what makes this correct, and on its own it does not work: with
+# externalTrafficPolicy: Local and one pod per node, the pod is decided by which
+# NODE the DO LB picked, and kube-proxy's affinity table is per-node — it can
+# never move a request between nodes. Measured on staging over 20 hours with
+# this setting live: 6 of 6 offer POSTs succeeded (they are stateless, so that
+# proves nothing about pinning) while 5 of 6 trickle PATCHes 404'd on the wrong
+# node.
+#
+# The correctness now comes from the worker: a pod that does not hold the pc_id
+# forwards to its siblings, found via the headless pipecat-worker-peers Service
+# (see pipecat_aplisay/webrtc_peers.py). That is the "route by session" fix this
+# comment used to call for. SIP on 5061 is unaffected either way — each TLS
+# dialog is one connection.
 #
 # Layer AFTER cloud-digitalocean (which creates the annotations object), then set
 # the per-env cert ID + LB name in the overlay:

--- a/agents/pipecat/pipecat_aplisay/webrtc_peers.py
+++ b/agents/pipecat/pipecat_aplisay/webrtc_peers.py
@@ -1,0 +1,167 @@
+"""Deliver a WebRTC signalling request to whichever node owns the peer.
+
+WHY THIS EXISTS (measured on staging, 2026-08-25)
+-------------------------------------------------
+A browser's SDP offer is stateless — any node can answer it — but the aiortc
+peer that answering creates lives on ONE node, in that process's
+``app.state.webrtc_connections`` under its ``pc_id``. Everything the browser
+sends afterwards (trickle candidates via ``PATCH``, renegotiation and ICE
+restart via ``POST`` with a ``pc_id``) is load-balanced independently of the
+original ``POST``, so it reaches the owning node only by luck. Over a 20-hour
+sample on staging, **five of six browser sessions had every trickle candidate
+404'd on the wrong node** — the client logs it and limps on with peer-reflexive
+discovery, which happens to work because the nodes have public IPs, and which
+leaves ICE restart dead.
+
+``sessionAffinity: ClientIP`` on the Service cannot fix that. With
+``externalTrafficPolicy: Local`` and one pod per node, the pod is decided by
+which NODE the cloud load balancer picked, and kube-proxy's affinity table is
+per-node — it can never move a request between nodes. DigitalOcean's only
+stickiness mode is a cookie, and this is a cross-origin ``fetch`` that neither
+asks for credentials nor should be allowed to send them: the offer endpoint is
+deliberately credential-free, gated by an HMAC-signed time-limited token, which
+is exactly why it can safely allow a wildcard origin.
+
+So the routing is fixed here, where the state actually is: a node that does not
+hold ``pc_id`` asks its siblings and returns the first real answer. Peers come
+from the HEADLESS Service ``pipecat-worker-peers``, whose DNS A records are
+precisely the ready pods — no Kubernetes API, no RBAC, no service account.
+(``dnsPolicy: ClusterFirstWithHostNet`` on the DaemonSet is what makes cluster
+DNS reachable at all from these host-network pods.)
+
+Every forwarded request carries ``x-aplisay-trickle-forwarded``, and a request
+arriving with that header is never forwarded again. One hop, no loops, whatever
+the cluster does with the next packet.
+
+Set ``WEBRTC_PEER_HOST=""`` to disable forwarding entirely (single-replica
+deploys, or local dev where there are no siblings to ask).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+import time
+from typing import Any, Optional
+
+import httpx
+from loguru import logger
+
+#: Marks a request we generated. Its presence means "do not forward again".
+FORWARDED_HEADER = "x-aplisay-trickle-forwarded"
+
+_DEFAULT_HOST = "pipecat-worker-peers"
+
+# (resolved_at_monotonic, ips). Module-level so a burst of candidates from one
+# browser costs one DNS lookup rather than one per candidate.
+_peer_cache: tuple[float, list[str]] = (0.0, [])
+
+
+def _env(name: str, default: str) -> str:
+    return os.environ.get(name, default).strip()
+
+
+def reset_peer_cache() -> None:
+    """Drop the resolved-peer cache (tests, and after a known topology change)."""
+    global _peer_cache
+    _peer_cache = (0.0, [])
+
+
+async def peer_addresses() -> list[str]:
+    """Ready sibling nodes, by IP, excluding ourselves.
+
+    Resolution is cached for ``WEBRTC_PEER_DNS_TTL_S`` because a single browser
+    emits a burst of candidates and each one would otherwise re-resolve.
+    """
+    global _peer_cache
+    host = _env("WEBRTC_PEER_HOST", _DEFAULT_HOST)
+    if not host:
+        return []
+
+    ttl = float(_env("WEBRTC_PEER_DNS_TTL_S", "10"))
+    resolved_at, cached = _peer_cache
+    now = time.monotonic()
+    if cached and now - resolved_at < ttl:
+        return cached
+
+    port = int(_env("WEBRTC_PEER_PORT", "8082"))
+    try:
+        loop = asyncio.get_running_loop()
+        infos = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except (OSError, ValueError) as e:
+        # No siblings reachable is a degraded state, not a broken one: the
+        # request still 404s exactly as it did before this module existed.
+        logger.warning(f"trickle forward: cannot resolve peer service {host!r}: {e}")
+        _peer_cache = (now, [])
+        return []
+
+    # hostNetwork pods advertise the node IP, which is also what podIP reports,
+    # so this is a like-for-like comparison.
+    mine = _env("PIPECAT_SELF_IP", "")
+    ips = sorted({info[4][0] for info in infos} - {mine})
+    _peer_cache = (now, ips)
+    return ips
+
+
+async def forward_to_owner(
+    *,
+    method: str,
+    token: str,
+    body: dict[str, Any],
+    headers: Any,
+) -> Optional[dict[str, Any]]:
+    """Ask the siblings to service this request; return the owner's reply.
+
+    ``None`` means nobody owned it (or there was nobody to ask), and the caller
+    should raise its own 404 exactly as before.
+
+    All peers are asked concurrently. Only the owner can act on the ``pc_id``;
+    the rest 404 harmlessly, so a broadcast is idempotent and costs one small
+    request per node.
+    """
+    if headers is not None and headers.get(FORWARDED_HEADER):
+        return None                       # already a forward — never loop
+
+    peers = await peer_addresses()
+    if not peers:
+        return None
+
+    port = int(_env("WEBRTC_PEER_PORT", "8082"))
+    timeout = float(_env("WEBRTC_PEER_TIMEOUT_S", "1.5"))
+
+    async def ask(client: httpx.AsyncClient, ip: str) -> Optional[dict[str, Any]]:
+        try:
+            r = await client.request(
+                method,
+                f"http://{ip}:{port}/webrtc/offer",
+                params={"token": token},
+                json=body,
+                headers={FORWARDED_HEADER: "1"},
+            )
+        except httpx.HTTPError as e:
+            logger.warning(f"trickle forward to {ip} failed: {e}")
+            return None
+        if r.status_code == 404:
+            return None                   # this node simply isn't the owner
+        if r.status_code >= 400:
+            logger.warning(f"trickle forward to {ip}: {r.status_code} {r.text[:200]}")
+            return None
+        try:
+            return r.json()
+        except ValueError:
+            return {"status": "success"}
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        results = await asyncio.gather(
+            *(ask(client, ip) for ip in peers), return_exceptions=True
+        )
+
+    for ip, result in zip(peers, results):
+        if isinstance(result, BaseException):
+            logger.warning(f"trickle forward to {ip} raised: {result}")
+            continue
+        if result is not None:
+            logger.info(f"{method} /webrtc/offer forwarded to the owning node {ip}")
+            return result
+    return None

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -85,6 +85,7 @@ from .sip_gateway import (
     VoiceblenderSipGateway,
     collect_sip_headers,
 )
+from .webrtc_peers import forward_to_owner
 from pipecat.serializers.protobuf import ProtobufFrameSerializer
 
 
@@ -732,12 +733,17 @@ async def webrtc_offer(request: Request) -> JSONResponse:
     # SmallWebRTC client re-POSTs to the same endpoint carrying the pc_id we
     # handed back in the original answer (restart_pc=true for an ICE restart).
     # Reuse the live connection and its running pipeline rather than standing up
-    # a whole new session. Affinity caveat as on the PATCH handler: this must
-    # reach the worker that owns the pc_id.
+    # a whole new session. Like the PATCH handler, this must reach the worker
+    # that owns the pc_id, so hand it on if that is not us.
     pc_id = body.get("pc_id")
     if pc_id:
         existing = request.app.state.webrtc_connections.get(pc_id)
         if existing is None:
+            owner = await forward_to_owner(
+                method="POST", token=token, body=body, headers=request.headers
+            )
+            if owner is not None:
+                return JSONResponse(owner)
             raise HTTPException(status_code=404, detail="unknown pc_id")
         await existing.renegotiate(
             sdp=sdp, type=sdp_type, restart_pc=bool(body.get("restart_pc"))
@@ -1052,11 +1058,12 @@ async def webrtc_ice_candidate(request: Request) -> JSONResponse:
     leaves ICE restart / reconnect (restart_pc) dead.
 
     SESSION AFFINITY: the offer is stateless (self-contained token, any node
-    answers — see deploy/k8s README), but a peer lives on ONE node once created.
-    In a multi-node pool with no LB affinity a PATCH can land on a different node
-    and 404 here; the client logs and ignores that, falling back to
-    peer-reflexive discovery. Reliable trickle needs signalling affinity (a
-    single WebRTC replica, or LB sticky sessions).
+    answers — see deploy/k8s README), but a peer lives on ONE node once created,
+    and a PATCH is load-balanced independently of the POST that created it. On a
+    two-node staging pool that put five of six sessions' candidates on the wrong
+    node. Rather than depend on load-balancer stickiness — which cannot work
+    here; see webrtc_peers for why — a node that does not hold this pc_id asks
+    its siblings and returns their answer.
     """
     body = await request.json()
     token = request.query_params.get("token") or body.get("token")
@@ -1068,6 +1075,11 @@ async def webrtc_ice_candidate(request: Request) -> JSONResponse:
     pc_id = body.get("pc_id")
     pc = request.app.state.webrtc_connections.get(pc_id) if pc_id else None
     if pc is None:
+        owner = await forward_to_owner(
+            method="PATCH", token=token, body=body, headers=request.headers
+        )
+        if owner is not None:
+            return JSONResponse(owner)
         raise HTTPException(status_code=404, detail="unknown pc_id")
 
     for c in body.get("candidates") or []:

--- a/agents/pipecat/tests/test_webrtc_peers.py
+++ b/agents/pipecat/tests/test_webrtc_peers.py
@@ -1,0 +1,243 @@
+"""A WebRTC signalling request finds the node that owns the peer.
+
+Background: the SDP offer is stateless and any node answers it, but the aiortc
+peer it creates lives on ONE node. Trickle candidates and renegotiation are
+load-balanced independently of that offer, so on staging five of six sessions
+had every candidate 404'd on the wrong node. Load-balancer stickiness cannot fix
+it (see the module docstring), so the worker asks its siblings instead.
+
+What these tests pin is the part that can go badly wrong: exactly one hop, never
+a loop; a peer that is down or slow must not take the batch with it; and a
+request that nobody owns must still 404 exactly as it did before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from pipecat_aplisay import webrtc_peers
+from pipecat_aplisay.webrtc_peers import (
+    FORWARDED_HEADER,
+    forward_to_owner,
+    peer_addresses,
+    reset_peer_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch: pytest.MonkeyPatch) -> None:
+    reset_peer_cache()
+    monkeypatch.setenv("WEBRTC_PEER_HOST", "peers.test")
+    monkeypatch.delenv("PIPECAT_SELF_IP", raising=False)
+    yield
+    reset_peer_cache()
+
+
+class _Resolver:
+    """Stands in for the event loop's getaddrinfo, and counts lookups."""
+
+    def __init__(self, ips: list[str]) -> None:
+        self.ips = ips
+        self.calls = 0
+
+    def install(self) -> None:
+        loop = asyncio.get_running_loop()
+
+        async def getaddrinfo(host, port, **kw):  # noqa: ANN001, ANN003
+            self.calls += 1
+            return [(None, None, None, "", (ip, port)) for ip in self.ips]
+
+        loop.getaddrinfo = getaddrinfo  # type: ignore[method-assign]
+
+
+def _fake_httpx(handler) -> SimpleNamespace:  # noqa: ANN001
+    """webrtc_peers.httpx, with AsyncClient wired to a MockTransport."""
+
+    def AsyncClient(**kw):  # noqa: ANN003, N802
+        kw.pop("transport", None)
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler), **kw)
+
+    return SimpleNamespace(AsyncClient=AsyncClient, HTTPError=httpx.HTTPError)
+
+
+class TestPeerDiscovery:
+    def test_self_is_excluded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PIPECAT_SELF_IP", "10.0.0.1")
+
+        async def run() -> None:
+            _Resolver(["10.0.0.1", "10.0.0.2", "10.0.0.3"]).install()
+            assert await peer_addresses() == ["10.0.0.2", "10.0.0.3"]
+
+        asyncio.run(run())
+
+    def test_disabled_by_an_empty_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Single-replica deploys and local dev have no siblings to ask."""
+        monkeypatch.setenv("WEBRTC_PEER_HOST", "")
+
+        async def run() -> None:
+            r = _Resolver(["10.0.0.2"])
+            r.install()
+            assert await peer_addresses() == []
+            assert r.calls == 0
+
+        asyncio.run(run())
+
+    def test_dns_is_cached_for_the_ttl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """One browser emits a burst of candidates; that must not be a burst of
+        DNS lookups."""
+        monkeypatch.setenv("WEBRTC_PEER_DNS_TTL_S", "60")
+
+        async def run() -> None:
+            r = _Resolver(["10.0.0.2"])
+            r.install()
+            for _ in range(5):
+                assert await peer_addresses() == ["10.0.0.2"]
+            assert r.calls == 1
+
+        asyncio.run(run())
+
+    def test_an_unresolvable_service_is_degraded_not_fatal(self) -> None:
+        async def run() -> None:
+            loop = asyncio.get_running_loop()
+
+            async def boom(*a, **kw):  # noqa: ANN002, ANN003
+                raise OSError("Name or service not known")
+
+            loop.getaddrinfo = boom  # type: ignore[method-assign]
+            assert await peer_addresses() == []
+
+        asyncio.run(run())
+
+
+class TestForwarding:
+    def test_a_forwarded_request_is_never_forwarded_again(self) -> None:
+        """The loop guard. Without it, two nodes that both lack the pc_id would
+        bounce the same candidate between them until something gave out."""
+
+        async def run() -> None:
+            r = _Resolver(["10.0.0.2"])
+            r.install()
+            got = await forward_to_owner(
+                method="PATCH",
+                token="t",
+                body={"pc_id": "x"},
+                headers={FORWARDED_HEADER: "1"},
+            )
+            assert got is None
+            assert r.calls == 0, "a forwarded request must not even look for peers"
+
+        asyncio.run(run())
+
+    def test_the_owner_answers_and_its_reply_is_returned(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[tuple[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append((str(request.url.host), request.headers.get(FORWARDED_HEADER, "")))
+            if request.url.host == "10.0.0.3":
+                return httpx.Response(200, json={"status": "success"})
+            return httpx.Response(404, json={"detail": "unknown pc_id"})
+
+        monkeypatch.setattr(webrtc_peers, "httpx", _fake_httpx(handler))
+
+        async def run() -> None:
+            _Resolver(["10.0.0.2", "10.0.0.3"]).install()
+            got = await forward_to_owner(
+                method="PATCH", token="t", body={"pc_id": "x"}, headers={}
+            )
+            assert got == {"status": "success"}
+            # every hop must carry the marker, or the guard above is unreachable
+            assert {h for _, h in seen} == {"1"}
+            assert {host for host, _ in seen} == {"10.0.0.2", "10.0.0.3"}
+
+        asyncio.run(run())
+
+    def test_nobody_owns_it_means_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The caller then raises its own 404 — behaviour unchanged from before
+        this module existed."""
+        monkeypatch.setattr(
+            webrtc_peers,
+            "httpx",
+            _fake_httpx(lambda request: httpx.Response(404, json={"detail": "unknown pc_id"})),
+        )
+
+        async def run() -> None:
+            _Resolver(["10.0.0.2", "10.0.0.3"]).install()
+            assert (
+                await forward_to_owner(
+                    method="PATCH", token="t", body={"pc_id": "x"}, headers={}
+                )
+                is None
+            )
+
+        asyncio.run(run())
+
+    def test_a_dead_peer_does_not_sink_the_batch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A node mid-restart is exactly when this matters most."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.host == "10.0.0.2":
+                raise httpx.ConnectError("connection refused", request=request)
+            return httpx.Response(200, json={"status": "success"})
+
+        monkeypatch.setattr(webrtc_peers, "httpx", _fake_httpx(handler))
+
+        async def run() -> None:
+            _Resolver(["10.0.0.2", "10.0.0.3"]).install()
+            got = await forward_to_owner(
+                method="PATCH", token="t", body={"pc_id": "x"}, headers={}
+            )
+            assert got == {"status": "success"}
+
+        asyncio.run(run())
+
+    def test_renegotiation_forwards_the_post_and_returns_the_sdp(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The POST path carries an SDP answer back, not just a status."""
+        answer = {"sdp": "v=0\\r\\n", "type": "answer", "pc_id": "abc"}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            return httpx.Response(200, json=answer)
+
+        monkeypatch.setattr(webrtc_peers, "httpx", _fake_httpx(handler))
+
+        async def run() -> None:
+            _Resolver(["10.0.0.2"]).install()
+            got = await forward_to_owner(
+                method="POST",
+                token="t",
+                body={"pc_id": "abc", "sdp": "...", "type": "offer"},
+                headers={},
+            )
+            assert got == answer
+
+        asyncio.run(run())
+
+    def test_a_peer_error_response_is_not_mistaken_for_an_answer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            webrtc_peers,
+            "httpx",
+            _fake_httpx(lambda request: httpx.Response(500, text="boom")),
+        )
+
+        async def run() -> None:
+            _Resolver(["10.0.0.2"]).install()
+            assert (
+                await forward_to_owner(
+                    method="PATCH", token="t", body={"pc_id": "x"}, headers={}
+                )
+                is None
+            )
+
+        asyncio.run(run())


### PR DESCRIPTION
## The problem

A browser's SDP offer is stateless — any node answers it — but the aiortc peer that answering creates lives on **one** node, keyed by `pc_id` in that process's `app.state.webrtc_connections`. Everything the browser sends afterwards is load-balanced independently of that offer:

- trickle-ICE candidates (`PATCH /webrtc/offer`)
- renegotiation and ICE restart (`POST /webrtc/offer` carrying a `pc_id`)

so they reach the owning node only by chance. Measured on staging over 20 hours, with `sessionAffinity: ClientIP` already in place:

| | 200 | 404 |
|---|---|---|
| `POST /webrtc/offer` | 6 | 0 |
| `PATCH /webrtc/offer` | **1** | **5** |

The POSTs prove nothing about pinning — they are stateless, so any node can serve them. The PATCHes are the real measurement: five of six sessions had every candidate thrown away. The client logs that and carries on with peer-reflexive discovery, which happens to work only because the nodes have public IPs, and which leaves ICE restart dead.

## Why load-balancer stickiness cannot fix it

`sessionAffinity: ClientIP` is on the Service and is inert here. With `externalTrafficPolicy: Local` and one pod per node, the pod is decided entirely by **which node the DO load balancer picked**, and kube-proxy's affinity table is per-node — it can never move a request between nodes.

DigitalOcean's only other stickiness mode is a cookie. That cannot work either: the transport's request is cross-origin and never asks for credentials (`credentials` does not appear anywhere in `@pipecat-ai/small-webrtc-transport`, so it inherits the `same-origin` default), and making the endpoint credentialed would cost the property that lets it safely allow a wildcard origin — it is deliberately credential-free, gated by an HMAC-signed time-limited token.

## The fix

Route where the state is. A node that does not hold the `pc_id` asks its siblings and returns the first real answer.

- Peers come from a new **headless** Service, `pipecat-worker-peers`, whose DNS A records are exactly the ready pods. No Kubernetes API, no RBAC, no service account. (`dnsPolicy: ClusterFirstWithHostNet` on the DaemonSet is what makes cluster DNS resolvable from these host-network pods at all.)
- Self-exclusion uses `PIPECAT_SELF_IP` from the downward API; `hostNetwork` means `podIP` is the node IP, the same value the Service's DNS returns.
- Every forwarded request carries `x-aplisay-trickle-forwarded`, and a request bearing it is never forwarded again. One hop, no loops.
- Peers are asked concurrently; only the owner can act on the `pc_id`, so the broadcast is idempotent. A peer that is down or slow does not take the batch with it.
- Nobody owns it → the caller raises the same 404 as before. Behaviour is unchanged when there are no siblings.

`sessionAffinity: ClientIP` stays as a cheap first-hit optimisation — when it does land right there is no forward hop — but it is no longer load-bearing. `WEBRTC_PEER_HOST=""` disables forwarding entirely for single-replica deploys and local dev.

This is the "route by session token / shared session state" fix that `components/webrtc-do` has been asking for in a comment.

## Testing

- `tests/test_webrtc_peers.py` — 10 cases covering the loop guard, self-exclusion, DNS caching, an unresolvable service, a dead peer mid-batch, the POST renegotiation path returning SDP, and an error response not being mistaken for an answer.
- Full pipecat suite: **391 passed**.
- `kubectl kustomize do-staging` builds and includes the new Service.

Not yet verified on a live multi-node call — that is the next step, and the reason for the change is a rig that can now measure it.