### PR TITLE
feat(pipecat): measure how long the WebRTC output track starves, and by how much

### DIFF
--- a/agents/pipecat/pipecat_aplisay/output_underrun.py
+++ b/agents/pipecat/pipecat_aplisay/output_underrun.py
@@ -1,0 +1,189 @@
+"""Measure how badly the WebRTC output track starves, and by how long.
+
+WHY THIS EXISTS (measured on staging, 2026-08-25)
+-------------------------------------------------
+A closed-loop rig that captures the agent's audio both at the platform's own
+recording tap (which sits after ``transport.output()``, so it holds the bytes
+handed to the track) and at the browser's decoder found gaps that exist ONLY in
+the browser copy: 50 ms, 80 ms and 100 ms of **arithmetic zero** across two
+calls, each with packets still flowing, nothing lost and nothing concealed.
+NetEq's concealment extrapolates waveform and never emits zeroes, so those
+samples were transmitted as zeroes — which is ``RawAudioTrack.recv()`` finding
+its queue empty and emitting ``bytes(self._bytes_per_10ms)``.
+
+That much is settled. What is NOT settled is the only thing that decides
+whether it can be fixed at the transport at all:
+
+  * if the audio **arrives late** — a few tens of milliseconds — then a modest
+    output cushion absorbs it and the gap disappears;
+  * if the audio **never arrives** — the model or the pipeline simply produced
+    nothing for that span — then there is nothing to buffer and no amount of
+    pre-roll helps. The gap is real and the fix belongs upstream.
+
+So the number that matters is ``late_by_ms``: the interval from the first
+starved ``recv()`` to the moment real audio was next queued. Everything else
+here is context for it.
+
+The second measurement is the **queue-depth histogram**, sampled at every
+``recv()``. If the queue normally sits at 0 or 1 chunks then there is no
+cushion at all and any hiccup at all underruns — which would make a pre-roll
+the obvious fix. If it normally sits several chunks deep, a starve means
+something upstream stopped for longer than that cushion, and the depth tells
+you how much longer would have been needed.
+
+Mechanism: ``RawAudioTrack`` is constructed inside pipecat's
+``SmallWebRTCClient._handle_client_connected`` by module-global lookup, so
+swapping that global for a subclass instruments it without touching the
+transport or duplicating its logic. We observe around ``super()`` rather than
+reimplementing ``recv()``, so an upstream change to the pacing cannot silently
+diverge from what we measure.
+
+Off with ``WEBRTC_UNDERRUN_STATS=0``.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Optional
+
+from loguru import logger
+
+# Depth buckets, sampled every recv(). The first two are the interesting ones:
+# time spent at 0 or 1 is time with no cushion.
+_BUCKETS = ((0, "0"), (1, "1"), (2, "2"), (5, "3-5"), (10, "6-10"))
+
+
+def _bucket(depth: int) -> str:
+    for limit, label in _BUCKETS:
+        if depth <= limit:
+            return label
+    return ">10"
+
+
+class UnderrunStats:
+    """Counters for one output track."""
+
+    def __init__(self, chunk_ms: float) -> None:
+        self.chunk_ms = chunk_ms
+        self.events = 0
+        self.chunks_filled = 0            # 10 ms slots filled with zeroes
+        self.max_gap_ms = 0.0
+        self.late_ms: list[float] = []    # one per event that was refilled
+        self.never_refilled = 0           # starved and the track ended first
+        self.depth = {label: 0 for _, label in _BUCKETS}
+        self.depth[">10"] = 0
+        self.recvs = 0
+
+    @property
+    def silence_ms(self) -> float:
+        return self.chunks_filled * self.chunk_ms
+
+    def summary(self) -> str:
+        if not self.events:
+            return f"no output underruns in {self.recvs} slots"
+        late = sorted(self.late_ms)
+        p50 = late[len(late) // 2] if late else float("nan")
+        p90 = late[int(len(late) * 0.9)] if late else float("nan")
+        worst = late[-1] if late else float("nan")
+        depth = " ".join(
+            f"{k}:{100.0 * v / max(1, self.recvs):.0f}%" for k, v in self.depth.items() if v
+        )
+        return (
+            f"output underruns: {self.events} events, {self.silence_ms:.0f} ms of inserted "
+            f"silence over {self.recvs * self.chunk_ms / 1000:.0f} s, worst gap "
+            f"{self.max_gap_ms:.0f} ms; refill lateness p50 {p50:.0f} ms / p90 {p90:.0f} ms / "
+            f"max {worst:.0f} ms ({self.never_refilled} never refilled); queue depth {depth}"
+        )
+
+
+def instrumented(base: type) -> type:
+    """Build a subclass of pipecat's RawAudioTrack that counts its own starvation."""
+
+    class _InstrumentedRawAudioTrack(base):  # type: ignore[misc, valid-type]
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            super().__init__(*a, **kw)
+            chunk_ms = 1000.0 * self._samples_per_10ms / max(1, self._sample_rate)
+            self.underrun = UnderrunStats(chunk_ms)
+            self._starved_at: Optional[float] = None
+            self._starved_slots = 0
+            self._last_summary = time.monotonic()
+            self._event_log_ms = float(os.environ.get("WEBRTC_UNDERRUN_LOG_MS", "20"))
+            self._summary_s = float(os.environ.get("WEBRTC_UNDERRUN_SUMMARY_S", "30"))
+
+        # --- observation points ------------------------------------------
+        def add_audio_bytes(self, audio_bytes: bytes):  # noqa: ANN201
+            # The instant real audio comes back is what makes lateness
+            # measurable at all; close the open event here rather than waiting
+            # for the next recv(), which would add up to one slot of error.
+            if self._starved_at is not None and audio_bytes:
+                self._close(time.monotonic())
+            return super().add_audio_bytes(audio_bytes)
+
+        async def recv(self):  # noqa: ANN201
+            st = self.underrun
+            depth = len(self._chunk_queue)
+            st.recvs += 1
+            st.depth[_bucket(depth)] += 1
+            starving = depth == 0 and getattr(self, "_auto_silence", True)
+            if starving:
+                if self._starved_at is None:
+                    self._starved_at = time.monotonic()
+                    self._starved_slots = 0
+                self._starved_slots += 1
+                st.chunks_filled += 1
+            frame = await super().recv()
+            self._maybe_summarise()
+            return frame
+
+        # --- bookkeeping --------------------------------------------------
+        def _close(self, now: float) -> None:
+            st = self.underrun
+            gap_ms = self._starved_slots * st.chunk_ms
+            late_ms = (now - (self._starved_at or now)) * 1000.0
+            st.events += 1
+            st.max_gap_ms = max(st.max_gap_ms, gap_ms)
+            st.late_ms.append(late_ms)
+            if gap_ms >= self._event_log_ms:
+                # The verdict this line exists to support: a lateness of a few
+                # tens of ms means a cushion would have covered it; a lateness
+                # far larger than the gap means the audio was never coming.
+                logger.info(
+                    f"output underrun: {gap_ms:.0f} ms of silence sent, real audio arrived "
+                    f"{late_ms:.0f} ms after the queue ran dry"
+                )
+            self._starved_at = None
+            self._starved_slots = 0
+
+        def _maybe_summarise(self) -> None:
+            now = time.monotonic()
+            if now - self._last_summary < self._summary_s:
+                return
+            self._last_summary = now
+            if self.underrun.events:
+                logger.info(self.underrun.summary())
+
+        def stop(self) -> None:  # noqa: ANN201
+            if self._starved_at is not None:
+                self.underrun.never_refilled += 1
+                self._starved_at = None
+            if self.underrun.events:
+                logger.info(f"track finished — {self.underrun.summary()}")
+            return super().stop()
+
+    _InstrumentedRawAudioTrack.__name__ = "InstrumentedRawAudioTrack"
+    return _InstrumentedRawAudioTrack
+
+
+def install() -> bool:
+    """Swap pipecat's RawAudioTrack for the instrumented subclass. Idempotent."""
+    if os.environ.get("WEBRTC_UNDERRUN_STATS", "1").strip() in ("0", "false", "no"):
+        return False
+    from pipecat.transports.smallwebrtc import transport as _t
+
+    current = getattr(_t, "RawAudioTrack", None)
+    if current is None or getattr(current, "__name__", "") == "InstrumentedRawAudioTrack":
+        return False
+    _t.RawAudioTrack = instrumented(current)
+    logger.info("output underrun stats installed on RawAudioTrack")
+    return True

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -74,6 +74,7 @@ from .call_session import (
 )
 from .constants import DISCONNECT_REASONS, PLATFORM
 from .invocation_log import flush_invocation_logs, install_capture
+from .output_underrun import install as install_underrun_stats
 from .serializers import DtmfProtobufFrameSerializer, FreeSwitchAudioStreamSerializer
 from .serializers.freeswitch_audio_stream import FreeSwitchAudioStreamStart
 from .sip_gateway import (
@@ -112,6 +113,12 @@ async def lifespan(app: FastAPI):
     # Capture call-scoped logs into the InvocationLog buffer. Installed here (at
     # runtime, after all imports) so nothing resets loguru's handlers on us.
     install_capture()
+
+    # Count how often the WebRTC output track runs dry and, crucially, how LATE
+    # the audio was when it came back — the number that says whether an output
+    # cushion could have covered the gap or whether the audio was never coming.
+    # See output_underrun for the measurements this exists to settle.
+    install_underrun_stats()
 
     # SIP gateway is selected at startup. SIP_GATEWAY=daily|freeswitch|voiceblender.
     gateway_name = os.environ.get("SIP_GATEWAY", "freeswitch").lower()

--- a/agents/pipecat/tests/test_output_underrun.py
+++ b/agents/pipecat/tests/test_output_underrun.py
@@ -1,0 +1,177 @@
+"""The output track reports how long it starved for, and how late the audio was.
+
+A rig comparing the platform's own recording tap against the browser's decoder
+found gaps that exist only in the browser copy — arithmetic zero, with packets
+flowing and nothing lost or concealed. That is ``RawAudioTrack.recv()`` finding
+an empty queue and sending ``bytes(bytes_per_10ms)``.
+
+These tests pin the measurement that decides what to do about it: **lateness**.
+Audio that turns up a few tens of milliseconds after the queue ran dry could
+have been covered by a cushion. Audio that never turns up could not have been,
+by anything, and the fix would belong upstream. A counter that only said "an
+underrun happened" would not tell those two apart, and that is the whole point.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from pipecat.transports.smallwebrtc.transport import RawAudioTrack
+
+from pipecat_aplisay.output_underrun import install, instrumented
+
+RATE = 16000
+CHUNK = RATE * 10 // 1000 * 2  # bytes in 10 ms of s16 mono
+
+
+def _track(**kw):
+    return instrumented(RawAudioTrack)(sample_rate=RATE, **kw)
+
+
+def _audio(chunks: int = 1) -> bytes:
+    return b"\x01\x00" * (RATE * 10 // 1000) * chunks
+
+
+class TestStarvationIsCounted:
+    def test_a_full_queue_never_reports_an_underrun(self) -> None:
+        async def run() -> None:
+            t = _track()
+            t.add_audio_bytes(_audio(3))
+            for _ in range(3):
+                await t.recv()
+            assert t.underrun.events == 0
+            assert t.underrun.chunks_filled == 0
+            assert "no output underruns" in t.underrun.summary()
+
+        asyncio.run(run())
+
+    def test_an_empty_queue_is_counted_as_inserted_silence(self) -> None:
+        async def run() -> None:
+            t = _track()
+            for _ in range(4):
+                await t.recv()
+            assert t.underrun.chunks_filled == 4
+            assert t.underrun.silence_ms == pytest.approx(40.0)
+            # still open — nothing has come back yet, so there is no lateness
+            assert t.underrun.events == 0
+
+        asyncio.run(run())
+
+    def test_the_event_closes_when_real_audio_returns(self) -> None:
+        async def run() -> None:
+            t = _track()
+            for _ in range(3):
+                await t.recv()
+            t.add_audio_bytes(_audio())
+            assert t.underrun.events == 1
+            assert t.underrun.max_gap_ms == pytest.approx(30.0)
+
+        asyncio.run(run())
+
+
+class TestLatenessIsTheAnswer:
+    """The distinction the whole module exists for."""
+
+    def test_late_audio_reports_a_lateness_a_cushion_could_cover(self) -> None:
+        async def run() -> None:
+            t = _track()
+            await t.recv()                      # queue dry
+            await asyncio.sleep(0.05)           # ...audio is 50 ms late
+            t.add_audio_bytes(_audio())
+            assert t.underrun.events == 1
+            (late,) = t.underrun.late_ms
+            assert 40 <= late <= 200, late
+            summary = t.underrun.summary()
+            assert "refill lateness" in summary, summary
+            assert "0 never refilled" in summary, summary
+
+        asyncio.run(run())
+
+    def test_audio_that_never_returns_is_reported_separately(self) -> None:
+        """The case no amount of buffering can fix: the track ends still starved."""
+
+        async def run() -> None:
+            t = _track()
+            for _ in range(5):
+                await t.recv()
+            t.stop()
+            assert t.underrun.never_refilled == 1
+            assert t.underrun.late_ms == [], "nothing arrived, so nothing can be late"
+
+        asyncio.run(run())
+
+    def test_lateness_is_measured_from_the_starve_not_the_refill_slot(self) -> None:
+        """Closing on add_audio_bytes rather than the next recv() keeps up to one
+        slot of error out of the number the decision rests on."""
+
+        async def run() -> None:
+            t = _track()
+            await t.recv()
+            t0 = time.monotonic()
+            await asyncio.sleep(0.03)
+            t.add_audio_bytes(_audio())
+            measured = t.underrun.late_ms[0]
+            elapsed = (time.monotonic() - t0) * 1000.0
+            assert measured >= elapsed - 5, (measured, elapsed)
+
+        asyncio.run(run())
+
+
+class TestQueueDepth:
+    def test_depth_is_sampled_every_slot(self) -> None:
+        """If the queue normally sits at 0 or 1 there is no cushion at all, and
+        that is what would justify adding one."""
+
+        async def run() -> None:
+            t = _track()
+            t.add_audio_bytes(_audio(3))
+            for _ in range(3):
+                await t.recv()
+            assert t.underrun.recvs == 3
+            assert sum(t.underrun.depth.values()) == 3
+            assert t.underrun.depth["3-5"] == 1     # first recv saw 3 queued
+            assert t.underrun.depth["2"] == 1
+            assert t.underrun.depth["1"] == 1
+
+        asyncio.run(run())
+
+
+class TestInstall:
+    def test_install_is_idempotent_and_reversible_by_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pipecat.transports.smallwebrtc import transport as t
+
+        original = t.RawAudioTrack
+        try:
+            monkeypatch.setenv("WEBRTC_UNDERRUN_STATS", "1")
+            assert install() is True
+            assert t.RawAudioTrack.__name__ == "InstrumentedRawAudioTrack"
+            assert install() is False, "must not wrap the wrapper"
+        finally:
+            t.RawAudioTrack = original
+
+    def test_disabled_by_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from pipecat.transports.smallwebrtc import transport as t
+
+        original = t.RawAudioTrack
+        monkeypatch.setenv("WEBRTC_UNDERRUN_STATS", "0")
+        assert install() is False
+        assert t.RawAudioTrack is original
+
+    def test_the_subclass_still_paces_and_emits_like_the_original(self) -> None:
+        """Observation only — the parent's pacing and frame shape must survive."""
+
+        async def run() -> None:
+            plain = RawAudioTrack(sample_rate=RATE)
+            inst = _track()
+            plain.add_audio_bytes(_audio())
+            inst.add_audio_bytes(_audio())
+            a, b = await plain.recv(), await inst.recv()
+            assert a.sample_rate == b.sample_rate
+            assert a.samples == b.samples
+            assert bytes(a.planes[0]) == bytes(b.planes[0])
+
+        asyncio.run(run())


### PR DESCRIPTION
## What we know, and what we don't

A rig capturing the agent's audio at two points that bracket the transport — the platform's own recording tap (which sits after `transport.output()`, so it holds the bytes handed to the track) and the browser's decoder — found gaps present **only** in the browser copy:

| call | gap | wire across it |
|---|---|---|
| run 1 @ 192.80 s | 50 ms | packets +54, lost 0, concealed 0 |
| run 2 @ 215.15 s | 80 ms | packets +55, lost 0, concealed 0 |
| run 2 @ 337.20 s | 100 ms | packets +55, lost 0, concealed 0 |

All three are **arithmetic zero** (-180 dBFS). NetEq's concealment extrapolates waveform and never emits zeroes, so those samples were transmitted as zeroes — `RawAudioTrack.recv()` finding an empty queue and sending `bytes(self._bytes_per_10ms)`. They sit 0.3 s, 9.7 s and 39.2 s into their turns, so it is not a turn-onset effect, and run 2 had ten turns over 15 s of which only two carried a gap.

That much is settled. **What is not settled is the only thing that decides what to do about it**, and it cannot be inferred from the audio:

- if the audio **arrives late** — a few tens of ms — an output cushion absorbs it and the gap disappears;
- if the audio **never arrives** — the model or pipeline produced nothing for that span — then there is nothing to buffer, no pre-roll helps, and the fix belongs upstream.

A counter that only said "an underrun happened" would not tell those two apart, which is why this PR measures something more specific.

## What it measures

**`late_by_ms`** — the interval from the first starved `recv()` to the moment real audio is next queued. This is the number the decision rests on. It is closed on `add_audio_bytes` rather than the next `recv()`, keeping up to one slot of error out of it.

**Queue depth, sampled every slot**, bucketed 0 / 1 / 2 / 3-5 / 6-10 / >10. If the queue normally sits at 0 or 1 there is no cushion at all and any hiccup underruns — which would itself justify adding one. If it normally sits several deep, a starve means something stopped for longer than that, and the depth says how much longer would have been needed.

Plus event count, total inserted silence, worst gap, lateness p50/p90/max, and a `never_refilled` count for the case where the track ends still starved — the one no amount of buffering can fix.

Per-event log above `WEBRTC_UNDERRUN_LOG_MS` (default 20 ms):

```
output underrun: 80 ms of silence sent, real audio arrived 91 ms after the queue ran dry
```

and a rolled-up line every `WEBRTC_UNDERRUN_SUMMARY_S` (default 30 s) and at track teardown.

## How

`RawAudioTrack` is constructed inside pipecat's `SmallWebRTCClient._handle_client_connected` by module-global lookup, so a subclass swapped into that global instruments it without touching the transport. It observes **around** `super()` rather than reimplementing `recv()`, so an upstream change to the pacing cannot silently diverge from what we measure — a test pins that the instrumented track still emits a byte-identical frame.

Off with `WEBRTC_UNDERRUN_STATS=0`. `install()` is idempotent and refuses to wrap the wrapper.

## Testing

- `tests/test_output_underrun.py` — 10 cases. The load-bearing ones are `test_late_audio_reports_a_lateness_a_cushion_could_cover` and `test_audio_that_never_returns_is_reported_separately`: those two are the distinction the module exists for.
- Full pipecat suite: **401 passed**.

## After this deploys

One more five-minute run on the same script tells us which case we are in, and therefore whether an output cushion is the fix or whether this belongs upstream of the transport entirely.
