### PR TITLE
feat(pipecat): give the WebRTC output queue a 60 ms cushion

### DIFF
--- a/agents/pipecat/pipecat_aplisay/output_cushion.py
+++ b/agents/pipecat/pipecat_aplisay/output_cushion.py
@@ -1,0 +1,118 @@
+"""Let the WebRTC output queue run a little ahead of the playhead.
+
+WHY THIS EXISTS (measured on staging, 2026-08-25/26)
+---------------------------------------------------
+``RawAudioTrack.recv()`` emits one 10 ms chunk per 10 ms of media time and, when
+its queue is empty, emits ``bytes(self._bytes_per_10ms)`` — arithmetic zero, on
+the wire, in real packets. A rig capturing the agent's audio at both the
+platform's recording tap and the browser's decoder found exactly that: holes of
+digital zero present only in the browser copy, with nothing lost and nothing
+concealed. Instrumenting the track (see ``output_underrun``) confirmed it from
+the other end and measured the shape of it, gated on the bot's own speaking
+window so that the silence between turns is not miscounted as starvation:
+
+  39 starves inside speech over a 6-minute call, 1.79 s of inserted silence.
+  Gap ladder: 20 ms x20, 30 x9, 40 x2, 50 x1, 60 x2, then 140, 150, 160, 210, 210.
+
+Two things follow. The distribution is bimodal with **nothing at all between
+60 ms and 140 ms**, so 60 ms covers the whole small-jitter cluster — 34 of 39
+events — and anything up to 140 ms buys not one extra event. And the audio was
+always merely late: ``never_refilled`` was zero, so there is something to
+buffer.
+
+WHY THERE IS NO CUSHION TODAY — and why this costs no latency
+--------------------------------------------------------------
+``write_audio_frame`` awaits the future ``add_audio_bytes`` returns, and the
+parent attaches that future to the LAST chunk of the batch. So the producer is
+released only once the track has drained everything it just handed over: the
+queue is held near empty by design, and the measured depth bears that out (0 or
+1 chunk for ~44 % of slots, never more than 5). Any upstream hiccup longer than
+that lands as a hole.
+
+This does not add a pre-roll and does not delay playout. The pacer still emits
+chunk N at ``start + N * 10 ms``; the first chunk of a turn still goes out at
+the very next slot. All that changes is WHEN backpressure is released — at a
+queue depth of ``cushion`` rather than at zero — so a burst from the model can
+sit in the queue instead of being refused, and the next stall drains the queue
+instead of the wire. The cushion only ever forms out of audio the model has
+already produced.
+
+The one real cost: the track has no ``clear()``, so whatever is queued plays out
+even after a barge-in. That is true today at up to 5 chunks; this raises the
+ceiling to ``cushion``, so an interrupted bot may talk over the caller for a few
+tens of milliseconds longer than it does now.
+
+``WEBRTC_OUTPUT_CUSHION_MS=0`` restores the stock lock-step behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+from loguru import logger
+
+DEFAULT_CUSHION_MS = 60
+
+
+def cushioned(base: type) -> type:
+    """Subclass of RawAudioTrack that releases backpressure at a queue depth."""
+
+    class _CushionedRawAudioTrack(base):  # type: ignore[misc, valid-type]
+        def __init__(self, *a: Any, **kw: Any) -> None:
+            super().__init__(*a, **kw)
+            ms = float(os.environ.get("WEBRTC_OUTPUT_CUSHION_MS", DEFAULT_CUSHION_MS))
+            chunk_ms = 1000.0 * self._samples_per_10ms / max(1, self._sample_rate)
+            self._cushion_chunks = max(0, int(round(ms / chunk_ms)))
+
+        def add_audio_bytes(self, audio_bytes: bytes):  # noqa: ANN201
+            cushion = self._cushion_chunks
+            if cushion <= 0:
+                return super().add_audio_bytes(audio_bytes)
+            if len(audio_bytes) % self._bytes_per_10ms != 0:
+                # Same contract as the parent — an odd-sized write is a bug
+                # upstream and must not be silently repacked.
+                raise ValueError("Audio bytes must be a multiple of 10ms size.")
+
+            future = asyncio.get_running_loop().create_future()
+            step = self._bytes_per_10ms
+            chunks = [audio_bytes[i : i + step] for i in range(0, len(audio_bytes), step)]
+            if not chunks:
+                future.set_result(True)
+                return future
+
+            # Hand the future to the chunk that leaves `cushion` behind it, so
+            # the producer wakes while the queue still has that much to play.
+            release = max(0, len(chunks) - 1 - cushion)
+            for i, chunk in enumerate(chunks):
+                self._chunk_queue.append((chunk, future if i == release else None))
+
+            # While the queue is still shallower than the cushion, do not hold
+            # the producer at all: this is what lets the cushion form at the
+            # start of a turn, when it is most needed and least available.
+            if len(self._chunk_queue) <= cushion and not future.done():
+                future.set_result(True)
+            return future
+
+    _CushionedRawAudioTrack.__name__ = "CushionedRawAudioTrack"
+    return _CushionedRawAudioTrack
+
+
+def install() -> bool:
+    """Swap pipecat's RawAudioTrack for the cushioned subclass. Idempotent.
+
+    Layer this AFTER output_underrun.install() so the cushioned class inherits
+    the instrumented one and both measurements survive.
+    """
+    ms = float(os.environ.get("WEBRTC_OUTPUT_CUSHION_MS", DEFAULT_CUSHION_MS))
+    if ms <= 0:
+        return False
+    from pipecat.transports.smallwebrtc import transport as _t
+
+    current = getattr(_t, "RawAudioTrack", None)
+    if current is None or getattr(current, "__name__", "") == "CushionedRawAudioTrack":
+        return False
+    _t.RawAudioTrack = cushioned(current)
+    logger.info(f"output cushion installed on RawAudioTrack: {ms:.0f} ms")
+    return True

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -74,6 +74,7 @@ from .call_session import (
 )
 from .constants import DISCONNECT_REASONS, PLATFORM
 from .invocation_log import flush_invocation_logs, install_capture
+from .output_cushion import install as install_output_cushion
 from .output_underrun import install as install_underrun_stats
 from .serializers import DtmfProtobufFrameSerializer, FreeSwitchAudioStreamSerializer
 from .serializers.freeswitch_audio_stream import FreeSwitchAudioStreamStart
@@ -119,6 +120,9 @@ async def lifespan(app: FastAPI):
     # cushion could have covered the gap or whether the audio was never coming.
     # See output_underrun for the measurements this exists to settle.
     install_underrun_stats()
+    # ...and let the queue those stats measure actually hold something. Layered
+    # after the instrumentation so the cushioned class inherits it.
+    install_output_cushion()
 
     # SIP gateway is selected at startup. SIP_GATEWAY=daily|freeswitch|voiceblender.
     gateway_name = os.environ.get("SIP_GATEWAY", "freeswitch").lower()

--- a/agents/pipecat/tests/test_output_cushion.py
+++ b/agents/pipecat/tests/test_output_cushion.py
@@ -1,0 +1,193 @@
+"""The output queue is allowed to run ahead, so a short stall drains it not the wire.
+
+Measured cause (see output_cushion's docstring): `write_audio_frame` awaits the
+future `add_audio_bytes` returns, and the stock track hands that future to the
+LAST chunk of the batch — so the producer is released only once the track has
+drained everything. The queue is pinned near empty by design, and a stall of
+more than a few tens of milliseconds becomes arithmetic zero on the wire.
+
+These tests pin the two properties that make the fix a fix: the producer is
+released while audio remains queued, and a stall the cushion is sized for is
+absorbed without a single silent frame. Plus the shape of the parent's queue,
+because we append to it directly and an upstream change there would break us
+quietly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pipecat.transports.smallwebrtc.transport import RawAudioTrack
+
+from pipecat_aplisay.output_cushion import cushioned, install
+
+RATE = 16000
+PER_CHUNK = RATE * 10 // 1000            # samples in 10 ms
+
+
+def _track(monkeypatch: pytest.MonkeyPatch, ms: int):
+    monkeypatch.setenv("WEBRTC_OUTPUT_CUSHION_MS", str(ms))
+    return cushioned(RawAudioTrack)(sample_rate=RATE)
+
+
+def _audio(chunks: int) -> bytes:
+    return b"\x11\x11" * PER_CHUNK * chunks
+
+
+def _is_silence(frame) -> bool:
+    return not any(bytes(frame.planes[0]))
+
+
+class TestBackpressure:
+    def test_stock_behaviour_holds_the_producer_until_the_queue_drains(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The thing being fixed: nothing may accumulate."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 0)
+            fut = t.add_audio_bytes(_audio(3))
+            assert not fut.done(), "stock track releases only after the last chunk"
+            for _ in range(3):
+                await t.recv()
+            assert fut.done()
+
+        asyncio.run(run())
+
+    def test_a_cushion_releases_the_producer_while_audio_is_still_queued(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def run() -> None:
+            t = _track(monkeypatch, 60)          # 6 chunks
+            fut = t.add_audio_bytes(_audio(3))
+            assert fut.done(), "below the cushion the producer must not be held"
+            assert len(t._chunk_queue) == 3, "and the audio stays queued"
+
+        asyncio.run(run())
+
+    def test_the_producer_is_held_once_the_cushion_is_full(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """It is a cushion, not an unbounded buffer — flow control still applies."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            for _ in range(3):
+                t.add_audio_bytes(_audio(3))     # 9 chunks queued, over the cushion
+            fut = t.add_audio_bytes(_audio(3))
+            assert not fut.done(), "past the cushion the producer waits again"
+
+        asyncio.run(run())
+
+
+class TestStallsAreAbsorbed:
+    def test_sixty_ms_of_stall_produces_no_silence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The measured cluster is 20-60 ms. None of it should reach the wire."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            # producer runs until the cushion holds it
+            while True:
+                fut = t.add_audio_bytes(_audio(3))
+                if not fut.done():
+                    break
+            # ...then stalls completely for six slots
+            frames = [await t.recv() for _ in range(6)]
+            assert not any(_is_silence(f) for f in frames), "a stall reached the wire"
+
+        asyncio.run(run())
+
+    def test_without_the_cushion_the_same_stall_reaches_the_wire(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The control: same stall, stock track, silence goes out."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 0)
+            t.add_audio_bytes(_audio(3))         # all a held producer could deliver
+            frames = [await t.recv() for _ in range(6)]
+            assert sum(_is_silence(f) for f in frames) == 3
+
+        asyncio.run(run())
+
+
+class TestContract:
+    def test_an_odd_sized_write_still_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            with pytest.raises(ValueError, match="multiple of 10ms"):
+                t.add_audio_bytes(b"\x00" * 7)
+
+        asyncio.run(run())
+
+    def test_the_parent_queue_is_still_chunk_future_pairs(self) -> None:
+        """We append to _chunk_queue directly; if upstream changes its shape this
+        breaks quietly, so fail loudly here instead."""
+
+        async def run() -> None:
+            stock = RawAudioTrack(sample_rate=RATE)
+            stock.add_audio_bytes(_audio(2))
+            assert len(stock._chunk_queue) == 2
+            for entry in stock._chunk_queue:
+                assert isinstance(entry, tuple) and len(entry) == 2
+                chunk, fut = entry
+                assert isinstance(chunk, (bytes, bytearray))
+                assert fut is None or isinstance(fut, asyncio.Future)
+
+        asyncio.run(run())
+
+    def test_frames_are_identical_to_the_stock_track(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def run() -> None:
+            a = RawAudioTrack(sample_rate=RATE)
+            b = _track(monkeypatch, 60)
+            a.add_audio_bytes(_audio(1))
+            b.add_audio_bytes(_audio(1))
+            fa, fb = await a.recv(), await b.recv()
+            assert fa.sample_rate == fb.sample_rate and fa.samples == fb.samples
+            assert bytes(fa.planes[0]) == bytes(fb.planes[0])
+
+        asyncio.run(run())
+
+
+class TestInstall:
+    def test_install_is_idempotent_and_disabled_by_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pipecat.transports.smallwebrtc import transport as t
+
+        original = t.RawAudioTrack
+        try:
+            monkeypatch.setenv("WEBRTC_OUTPUT_CUSHION_MS", "60")
+            assert install() is True
+            assert t.RawAudioTrack.__name__ == "CushionedRawAudioTrack"
+            assert install() is False
+        finally:
+            t.RawAudioTrack = original
+        monkeypatch.setenv("WEBRTC_OUTPUT_CUSHION_MS", "0")
+        assert install() is False
+        assert t.RawAudioTrack is original
+
+    def test_it_layers_over_the_instrumented_track(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both must survive: we still want to measure what the cushion changed."""
+        from pipecat.transports.smallwebrtc import transport as t
+
+        from pipecat_aplisay.output_underrun import install as install_stats
+
+        original = t.RawAudioTrack
+        try:
+            monkeypatch.setenv("WEBRTC_UNDERRUN_STATS", "1")
+            monkeypatch.setenv("WEBRTC_OUTPUT_CUSHION_MS", "60")
+            assert install_stats() is True
+            assert install() is True
+            made = t.RawAudioTrack(sample_rate=RATE)
+            assert hasattr(made, "underrun"), "lost the instrumentation"
+            assert made._cushion_chunks == 6
+        finally:
+            t.RawAudioTrack = original


### PR DESCRIPTION
## Why 60 ms

Instrumenting the output track (#248) and gating the counter on the bot's own speaking window — otherwise the silence *between* turns is counted as starvation and the raw figure is 50x too high — gives this over a 6-minute call:

**39 starves inside speech, 1.79 s of inserted silence.** Gap ladder:

```
20 x20   30 x9   40 x2   50 x1   60 x2   ‖   140  150  160  210  210
```

The distribution is bimodal with **nothing at all between 60 ms and 140 ms**:

| cushion | events covered | ms still lost |
|---|---|---|
| 40 ms | 31/39 = 79% | 720 ms |
| **60 ms** | **34/39 = 87%** | 570 ms |
| 80 ms | 34/39 = 87% | 470 ms |
| 100 ms | 34/39 = 87% | 370 ms |
| 250 ms | 39/39 = 100% | 0 ms |

60 ms covers the entire small-jitter cluster. Anything between 60 and 140 ms is spent for zero additional events. The 140-210 ms tail is five events and looks like a different phenomenon; sizing for it is a separate decision, and one worth more data first.

`never_refilled` was **0** — the audio was always merely late, so there is something to buffer.

## Why there is no cushion today

`write_audio_frame` awaits the future `add_audio_bytes` returns, and the stock track hands that future to the **last** chunk of the batch. The producer is therefore released only once the track has drained everything it just handed over — the queue is pinned near empty by design. Measured depth: **0 or 1 chunk for ~44% of slots, never more than 5.** Any hiccup longer than that becomes zeroes on the wire.

## Why this costs no latency

This is **not** a pre-roll and does not delay playout. The pacer still emits chunk N at `start + N * 10 ms`, and the first chunk of a turn still goes out at the very next slot. The only change is *when* backpressure is released — at a queue depth of `cushion` rather than at zero — so a burst from the model can sit in the queue instead of being refused, and the next stall drains the queue instead of the wire. The cushion only ever forms out of audio the model has already produced.

## The one real cost

`RawAudioTrack` has no `clear()`, so queued audio plays out even after a barge-in. That is already true today at up to 5 chunks; this raises the ceiling to 6, so an interrupted bot may talk over the caller for a few tens of milliseconds longer than it does now. Worth knowing, small in absolute terms, and `WEBRTC_OUTPUT_CUSHION_MS=0` restores the stock behaviour.

## Testing

`tests/test_output_cushion.py` — 10 cases. The load-bearing pair is a direct before/after on the actual symptom:

- `test_sixty_ms_of_stall_produces_no_silence` — cushion on, producer stalls six slots, **no silent frame reaches the wire**
- `test_without_the_cushion_the_same_stall_reaches_the_wire` — same stall, stock track, **3 silent frames**

Plus: the producer is still held once the cushion is full (it is a cushion, not an unbounded buffer), odd-sized writes still raise, frames are byte-identical to the stock track, it layers correctly over #248's instrumentation, and a test pins the parent's `_chunk_queue` entry shape since we append to it directly.

Full pipecat suite: **411 passed**.

## After deploy

The instrumentation from #248 stays on, so the same gated analysis on the next run measures directly what this bought — the expectation is the 20-60 ms cluster disappears from the mid-speech counts and only the 140-210 ms tail remains.
