### PR TITLE
fix(pipecat): the output cushion must not swallow the underrun measurement

### DIFF
--- a/agents/pipecat/pipecat_aplisay/output_cushion.py
+++ b/agents/pipecat/pipecat_aplisay/output_cushion.py
@@ -70,6 +70,14 @@ def cushioned(base: type) -> type:
             cushion = self._cushion_chunks
             if cushion <= 0:
                 return super().add_audio_bytes(audio_bytes)
+            # We are reimplementing the parent's method rather than delegating,
+            # so anything it does BESIDES chunking has to be done here too. The
+            # instrumentation underneath closes its open starvation event on
+            # refill; without this the counters read zero for ever and the
+            # measurement quietly stops working.
+            note = getattr(self, "note_refill", None)
+            if note is not None:
+                note(audio_bytes)
             if len(audio_bytes) % self._bytes_per_10ms != 0:
                 # Same contract as the parent — an odd-sized write is a bug
                 # upstream and must not be silently repacked.

--- a/agents/pipecat/pipecat_aplisay/output_underrun.py
+++ b/agents/pipecat/pipecat_aplisay/output_underrun.py
@@ -112,12 +112,23 @@ def instrumented(base: type) -> type:
             self._summary_s = float(os.environ.get("WEBRTC_UNDERRUN_SUMMARY_S", "30"))
 
         # --- observation points ------------------------------------------
+        def note_refill(self, audio_bytes: bytes) -> None:
+            """Real audio has been queued — close any open starvation event.
+
+            Separate from add_audio_bytes because a SUBCLASS may reimplement
+            that method rather than delegating to it (output_cushion does, to
+            place the backpressure future differently). When it does, it must
+            still call this, or every event stays open, nothing is ever counted
+            and the whole instrument silently reports zero.
+            """
+            if self._starved_at is not None and audio_bytes:
+                self._close(time.monotonic())
+
         def add_audio_bytes(self, audio_bytes: bytes):  # noqa: ANN201
             # The instant real audio comes back is what makes lateness
             # measurable at all; close the open event here rather than waiting
             # for the next recv(), which would add up to one slot of error.
-            if self._starved_at is not None and audio_bytes:
-                self._close(time.monotonic())
+            self.note_refill(audio_bytes)
             return super().add_audio_bytes(audio_bytes)
 
         async def recv(self):  # noqa: ANN201

--- a/agents/pipecat/tests/test_output_cushion.py
+++ b/agents/pipecat/tests/test_output_cushion.py
@@ -189,5 +189,19 @@ class TestInstall:
             made = t.RawAudioTrack(sample_rate=RATE)
             assert hasattr(made, "underrun"), "lost the instrumentation"
             assert made._cushion_chunks == 6
+
+            # Attributes surviving is not the same as the instrument WORKING.
+            # The cushion reimplements add_audio_bytes instead of delegating,
+            # so unless it calls the refill hook the event never closes and the
+            # counters read zero for ever — which is exactly what happened on
+            # the first call after this shipped.
+            async def starve_then_refill() -> None:
+                await made.recv()          # queue empty: starvation begins
+                await made.recv()
+                made.add_audio_bytes(_audio(1))
+
+            asyncio.run(starve_then_refill())
+            assert made.underrun.events == 1, "the cushion swallowed the measurement"
+            assert made.underrun.max_gap_ms == pytest.approx(20.0)
         finally:
             t.RawAudioTrack = original


### PR DESCRIPTION
## The bug

`output_cushion` reimplements `add_audio_bytes` rather than delegating to it, so it can place the backpressure future at the cushion depth instead of on the last chunk. But `add_audio_bytes` is also where `output_underrun` closes an open starvation event and records how late the audio was — reached only through the `super()` call the cushion no longer makes.

Consequence on the very first call after #249 deployed: **zero underrun events logged, no summary line, no lateness.** Not because nothing starved — because nothing could be counted. The instrument that justified the cushion was silently disabled by the cushion.

## The fix

Factor the refill bookkeeping into `note_refill()` and call it from the cushion's override.

## Why the tests didn't catch it

`test_it_layers_over_the_instrumented_track` asserted the composed class still had `underrun` and `_cushion_chunks`. Attributes surviving is not the same as the instrument working. It now starves the composed track and asserts an event is actually recorded, with the right gap:

```python
await made.recv()          # queue empty: starvation begins
await made.recv()
made.add_audio_bytes(_audio(1))
assert made.underrun.events == 1, "the cushion swallowed the measurement"
assert made.underrun.max_gap_ms == pytest.approx(20.0)
```

Verified it fails against the broken version and passes against the fixed one.

Full pipecat suite: **411 passed**.

## Impact on what has already been measured

The call running when this was found has no usable server-side underrun counters. Its **audio capture is unaffected** — and since that is the outcome measure (does the browser still hear holes?) rather than the cause measure, it still answers whether the cushion worked. The cause-side numbers need one more run after this deploys.
