### PR TITLE
feat(pipecat): build the output cushion from the agent's own pauses, and clear it on interruption

### DIFF
--- a/agents/pipecat/pipecat_aplisay/output_cushion.py
+++ b/agents/pipecat/pipecat_aplisay/output_cushion.py
@@ -49,11 +49,19 @@ from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any
+from typing import Any, Optional
 
+import numpy as np
 from loguru import logger
+from pipecat.frames.frames import Frame, InterruptionFrame
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 DEFAULT_CUSHION_MS = 60
+DEFAULT_TARGET_MS = 300
+DEFAULT_STRETCH_QUIET_DBFS = -50.0
+#: Duplicate one quiet chunk in every N — a ~33% stretch of pause regions, which
+#: is what the measurement below is sized against.
+DEFAULT_STRETCH_EVERY = 3
 
 
 def cushioned(base: type) -> type:
@@ -65,6 +73,13 @@ def cushioned(base: type) -> type:
             ms = float(os.environ.get("WEBRTC_OUTPUT_CUSHION_MS", DEFAULT_CUSHION_MS))
             chunk_ms = 1000.0 * self._samples_per_10ms / max(1, self._sample_rate)
             self._cushion_chunks = max(0, int(round(ms / chunk_ms)))
+            target = float(os.environ.get("WEBRTC_OUTPUT_TARGET_MS", DEFAULT_TARGET_MS))
+            self._target_chunks = max(self._cushion_chunks, int(round(target / chunk_ms)))
+            db = float(os.environ.get("WEBRTC_STRETCH_QUIET_DBFS", DEFAULT_STRETCH_QUIET_DBFS))
+            self._quiet_peak = 32767.0 * (10.0 ** (db / 20.0))
+            self._stretch_every = max(0, int(os.environ.get("WEBRTC_STRETCH_EVERY", DEFAULT_STRETCH_EVERY)))
+            self._quiet_seen = 0
+            self.stretched_chunks = 0
 
         def add_audio_bytes(self, audio_bytes: bytes):  # noqa: ANN201
             cushion = self._cushion_chunks
@@ -95,6 +110,17 @@ def cushioned(base: type) -> type:
             release = max(0, len(chunks) - 1 - cushion)
             for i, chunk in enumerate(chunks):
                 self._chunk_queue.append((chunk, future if i == release else None))
+                # Build the cushion out of the agent's own pauses. A quarter of
+                # in-turn agent audio is pause (measured: 60 s in 240 s, ~360
+                # runs of >=40 ms), so repeating one quiet chunk in three banks
+                # ~67 ms of cushion per second of audio — 13x what a flat 95%
+                # playout rate would yield, and inaudible, because a repeated
+                # near-silent frame has no pitch to shift and no transient to
+                # smear. Voiced audio is never touched: that would need WSOLA,
+                # and these pods have little CPU to spare.
+                if self._should_stretch(chunk):
+                    self._chunk_queue.append((chunk, None))
+                    self.stretched_chunks += 1
 
             # While the queue is still shallower than the cushion, do not hold
             # the producer at all: this is what lets the cushion form at the
@@ -103,8 +129,72 @@ def cushioned(base: type) -> type:
                 future.set_result(True)
             return future
 
+        def _should_stretch(self, chunk: bytes) -> bool:
+            """May this chunk be repeated to lengthen a pause?"""
+            if self._stretch_every <= 0 or len(self._chunk_queue) >= self._target_chunks:
+                return False
+            samples = np.frombuffer(chunk, dtype=np.int16)
+            if samples.size == 0 or np.abs(samples).max() > self._quiet_peak:
+                self._quiet_seen = 0          # voiced: never stretch, and reset
+                return False
+            self._quiet_seen += 1
+            return self._quiet_seen % self._stretch_every == 0
+
+        def clear(self) -> int:
+            """Drop everything queued — the caller has interrupted.
+
+            Without this the cushion is a liability: the track plays out whatever
+            it holds no matter what the pipeline decides, so a deeper queue means
+            the agent talks over the caller for longer. Any future still riding a
+            dropped chunk MUST be resolved here or write_audio_frame waits on it
+            for ever and the leg goes silent.
+            """
+            n = len(self._chunk_queue)
+            for _chunk, fut in self._chunk_queue:
+                if fut is not None and not fut.done():
+                    fut.set_result(True)
+            self._chunk_queue.clear()
+            self._quiet_seen = 0
+            return n
+
     _CushionedRawAudioTrack.__name__ = "CushionedRawAudioTrack"
     return _CushionedRawAudioTrack
+
+
+class OutputCushionInterrupt(FrameProcessor):
+    """Empty the output track's queue the moment the caller interrupts.
+
+    The track sits below the transport and nothing upstream can reach it, so
+    clearing the transport's own buffers is not enough: whatever the track holds
+    still goes on the wire. That is tolerable at the 60 ms hard cushion and not
+    at a 300 ms stretched one, which is why this ships with the stretcher rather
+    than after it.
+
+    Place it immediately before ``transport.output()`` so it sees the
+    InterruptionFrame on its way down.
+    """
+
+    def __init__(self, *, output_transport: Any, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._output = output_transport
+
+    def _track(self) -> Optional[Any]:
+        # transport.output() -> SmallWebRTCClient -> the live RawAudioTrack.
+        # Both hops are private, so a test pins this path: if pipecat renames
+        # either, that test fails instead of barge-in quietly regressing.
+        client = getattr(self._output, "_client", None)
+        return getattr(client, "_audio_output_track", None) if client else None
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+        if isinstance(frame, InterruptionFrame):
+            track = self._track()
+            clear = getattr(track, "clear", None)
+            if callable(clear):
+                dropped = clear()
+                if dropped:
+                    logger.debug(f"interruption: dropped {dropped} queued output chunks")
+        await self.push_frame(frame, direction)
 
 
 def install() -> bool:

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -38,6 +38,7 @@ from pipecat.turns.user_mute.mute_until_first_bot_complete_user_mute_strategy im
     MuteUntilFirstBotCompleteUserMuteStrategy,
 )
 
+from .output_cushion import OutputCushionInterrupt
 from .output_rate_guard import OutputRateGuard
 from .tool_log import log_tool_call, log_tool_result
 
@@ -1244,6 +1245,11 @@ async def _build_realtime(
     # stream resampler at the wrong ratio and mute the call. See
     # output_rate_guard for the incident this prevents recurring.
     rate_guard = OutputRateGuard(output_transport=transport.output())
+    # Barge-in has to reach BELOW the transport: the output track plays out
+    # whatever it holds regardless of what the pipeline decides, so the cushion
+    # that protects against starvation would otherwise become tail-talk over an
+    # interrupting caller. Inert unless the cushioned track is installed.
+    cushion_interrupt = OutputCushionInterrupt(output_transport=transport.output())
     # Buffer DTMF keypresses into a single user turn before the context
     # aggregator (see _dtmf_aggregator_for). Without this, InputDTMFFrames are
     # never consumed and digits are dropped.
@@ -1257,6 +1263,7 @@ async def _build_realtime(
         *tone,
         *relay_inject,
         rate_guard,
+        cushion_interrupt,
         transport.output(),
     ]
     # The recording docs require ``AudioBufferProcessor`` to sit AFTER

--- a/agents/pipecat/tests/test_output_cushion.py
+++ b/agents/pipecat/tests/test_output_cushion.py
@@ -205,3 +205,147 @@ class TestInstall:
             assert made.underrun.max_gap_ms == pytest.approx(20.0)
         finally:
             t.RawAudioTrack = original
+
+
+class TestPauseStretching:
+    """Build the cushion out of the agent's own pauses.
+
+    Measured on two calls: ~25% of in-turn agent audio is pause (60 s in 240 s),
+    across ~360 runs of >=40 ms. Repeating one quiet chunk in three banks ~67 ms
+    of cushion per second of audio — against 5 ms/s for a flat 95% playout rate,
+    and with no pitch shift to hear, because a repeated near-silent frame has
+    neither pitch nor transient.
+    """
+
+    def _quiet(self, chunks: int) -> bytes:
+        return b"\x05\x00" * PER_CHUNK * chunks      # ~-76 dBFS
+
+    def test_quiet_chunks_are_repeated_to_lengthen_a_pause(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.add_audio_bytes(self._quiet(9))
+            # one in three repeated => 9 in, 12 queued
+            assert len(t._chunk_queue) == 12
+            assert t.stretched_chunks == 3
+
+        asyncio.run(run())
+
+    def test_voiced_audio_is_never_stretched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stretching speech would need WSOLA and would be audible; this must
+        only ever touch pauses."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.add_audio_bytes(_audio(9))          # loud
+            assert len(t._chunk_queue) == 9
+            assert t.stretched_chunks == 0
+
+        asyncio.run(run())
+
+    def test_stretching_stops_at_the_target(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def run() -> None:
+            monkeypatch.setenv("WEBRTC_OUTPUT_TARGET_MS", "100")   # 10 chunks
+            t = _track(monkeypatch, 60)
+            for _ in range(6):
+                t.add_audio_bytes(self._quiet(3))
+            assert len(t._chunk_queue) >= 10
+            # once at target, no further repeats
+            before = t.stretched_chunks
+            t.add_audio_bytes(self._quiet(3))
+            assert t.stretched_chunks == before
+
+        asyncio.run(run())
+
+    def test_a_voiced_chunk_resets_the_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two pauses of two quiet chunks each must not add up to a repeat that
+        lands in the middle of the speech between them."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.add_audio_bytes(self._quiet(2) + _audio(1) + self._quiet(2))
+            assert t.stretched_chunks == 0
+
+        asyncio.run(run())
+
+    def test_disabled_by_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def run() -> None:
+            monkeypatch.setenv("WEBRTC_STRETCH_EVERY", "0")
+            t = _track(monkeypatch, 60)
+            t.add_audio_bytes(self._quiet(9))
+            assert t.stretched_chunks == 0
+            assert len(t._chunk_queue) == 9
+
+        asyncio.run(run())
+
+
+class TestClearOnInterruption:
+    def test_clear_drops_the_queue(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.add_audio_bytes(_audio(5))
+            assert t.clear() == 5
+            assert len(t._chunk_queue) == 0
+
+        asyncio.run(run())
+
+    def test_clear_resolves_a_future_riding_a_dropped_chunk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Otherwise write_audio_frame waits on it for ever and the leg dies."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            for _ in range(4):
+                fut = t.add_audio_bytes(_audio(3))
+                if not fut.done():
+                    break
+            assert not fut.done(), "expected a held producer to set the test up"
+            t.clear()
+            assert fut.done(), "clear() stranded the producer"
+
+        asyncio.run(run())
+
+    def test_the_processor_clears_the_live_track(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from types import SimpleNamespace
+
+        from pipecat.frames.frames import InterruptionFrame
+
+        from pipecat_aplisay.output_cushion import OutputCushionInterrupt
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.add_audio_bytes(_audio(4))
+            transport = SimpleNamespace(_client=SimpleNamespace(_audio_output_track=t))
+            proc = OutputCushionInterrupt(output_transport=transport)
+            assert proc._track() is t
+            proc._track().clear()
+            assert len(t._chunk_queue) == 0
+
+        asyncio.run(run())
+
+    def test_the_private_path_to_the_track_still_exists(self) -> None:
+        """We reach the track through two private attributes. If pipecat renames
+        either, fail here rather than let barge-in quietly regress."""
+        import inspect
+
+        from pipecat.transports.smallwebrtc.transport import (
+            SmallWebRTCClient,
+            SmallWebRTCOutputTransport,
+        )
+
+        # transport.output() -> _client
+        init = inspect.getsource(SmallWebRTCOutputTransport.__init__)
+        assert "self._client = client" in init, (
+            "SmallWebRTCOutputTransport no longer stores the client as _client — "
+            "OutputCushionInterrupt._track() cannot reach the track"
+        )
+        # _client -> _audio_output_track
+        client_src = inspect.getsource(SmallWebRTCClient)
+        assert "self._audio_output_track = RawAudioTrack(" in client_src, (
+            "SmallWebRTCClient no longer holds the output track as _audio_output_track — "
+            "barge-in will not clear the queue"
+        )


### PR DESCRIPTION
## The idea

The 60 ms cushion from #249 reduces the *severity* of output starvation but not its *frequency* — measured across two calls, event rate was unchanged while inserted silence fell 32% and the >100 ms tail all but vanished. The reason it can't do better: the queue sits at zero for ~29% of slots because Ultravox delivers at roughly realtime, so there is often nothing spare to buffer. **A cushion cannot prevent a stall that begins with an empty queue.**

So stop waiting for spare audio and *manufacture* it: play slightly slower than realtime while the cushion is below target, and the slack accumulates. Time-to-first-audio is unchanged — the first chunk still goes out at the next slot — and the total time added is bounded by the cushion size.

## Why pauses rather than a global rate change

A flat 95% playout banks 5% of elapsed time: **6 seconds of speech to build 300 ms**, and starves happen throughout turns, including early. Measured on two calls instead:

- **~25% of in-turn agent audio is pause** — 60 s in 240 s, across ~360 runs of ≥40 ms, median 60 ms. Consistent to within 1% across both calls.
- Repeating one quiet chunk in three is a ~33% stretch of pause regions and banks **~67 ms of cushion per second of audio — 13× a flat 95%**.

It is also the safe version:

- **No pitch artefact.** A 95% resample shifts pitch ~0.85 of a semitone, clearly audible on a sustained voice. Avoiding that needs WSOLA/PSOLA.
- **Near-zero CPU.** Repeating a near-silent frame is a copy plus one `np.abs().max()`. WSOLA is real per-frame DSP, and these pods run a 250m CPU request on 2-core nodes — where event-loop pressure is plausibly *causing* some of these stalls. Adding DSP could deepen the hole.
- **Inaudible by construction.** A repeated near-silent frame has no pitch to shift and no transient to smear. Voiced audio is never touched.

## clear() on interruption — shipped with it, not after

`RawAudioTrack` plays out whatever it holds regardless of what the pipeline decides. At the 60 ms hard cushion that tail is unnoticeable; **at a 300 ms target it is not** — the agent would talk over an interrupting caller for up to 300 ms. So this PR also adds `clear()` and an `OutputCushionInterrupt` processor that empties the queue on `InterruptionFrame`, placed immediately before `transport.output()`.

`clear()` resolves any future riding a dropped chunk. Without that, `write_audio_frame` waits on it for ever and the leg goes silent — there is a test for exactly that.

The processor reaches the track through two private attributes (`transport.output()._client._audio_output_track`). A test asserts both still exist in pipecat's source, so an upstream rename fails loudly rather than letting barge-in regress quietly.

## Knobs

| env | default | |
|---|---|---|
| `WEBRTC_OUTPUT_CUSHION_MS` | 60 | hard floor, where backpressure releases |
| `WEBRTC_OUTPUT_TARGET_MS` | 300 | stretch up to this, opportunistically |
| `WEBRTC_STRETCH_EVERY` | 3 | repeat one quiet chunk in N; 0 disables stretching |
| `WEBRTC_STRETCH_QUIET_DBFS` | -50 | what counts as a pause |

With `WEBRTC_STRETCH_EVERY=0` the behaviour degrades exactly to what is deployed today, so this is safe to roll back without a deploy.

## Testing

`tests/test_output_cushion.py` — 19 cases. New ones cover: quiet chunks repeated one in three, voiced audio never stretched, stretching stops at the target, a voiced chunk resets the run (so two short pauses either side of a word cannot combine into a repeat landing mid-speech), env disable, `clear()` dropping the queue, `clear()` resolving a stranded producer, and the private path to the track.

Full pipecat suite: **420 passed**.

## What to watch after deploy

The gated server-side measure (`ms of inserted silence per second of speech`) should fall below the current 4.39, and the depth histogram should spend much more time in 6-10 and above. The thing to listen for is barge-in: if `clear()` is working, interrupting the agent should cut it off no later than it does today.
