### PR TITLE
feat(pipecat): measure whether a starving output track had audio waiting for it

### DIFF
--- a/agents/pipecat/pipecat_aplisay/output_cushion.py
+++ b/agents/pipecat/pipecat_aplisay/output_cushion.py
@@ -53,7 +53,7 @@ from typing import Any, Optional
 
 import numpy as np
 from loguru import logger
-from pipecat.frames.frames import Frame, InterruptionFrame
+from pipecat.frames.frames import Frame, InterruptionFrame, OutputAudioRawFrame
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 DEFAULT_CUSHION_MS = 60
@@ -172,11 +172,23 @@ class OutputCushionInterrupt(FrameProcessor):
 
     Place it immediately before ``transport.output()`` so it sees the
     InterruptionFrame on its way down.
+
+    It also carries the IN-FLIGHT PROBE, because it is the only place that holds
+    both halves of the measurement: every OutputAudioRawFrame passes through here
+    on its way to the transport, and the track is reachable from here too. The
+    difference between what we have forwarded and what the track has received is
+    exactly the audio sitting in the transport's own (unbounded) queue. Sampled
+    when a starve begins, that number answers the question nothing else can: did
+    the audio EXIST and we failed to move it, or had it not arrived at all? The
+    two have opposite fixes, so the same class does both jobs rather than
+    resolving the track twice.
     """
 
     def __init__(self, *, output_transport: Any, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self._output = output_transport
+        self._forwarded_ms = 0.0
+        self._wired: Any = None
 
     def _track(self) -> Optional[Any]:
         # transport.output() -> SmallWebRTCClient -> the live RawAudioTrack.
@@ -185,8 +197,22 @@ class OutputCushionInterrupt(FrameProcessor):
         client = getattr(self._output, "_client", None)
         return getattr(client, "_audio_output_track", None) if client else None
 
+    def _wire_probe(self) -> None:
+        """Give the track a way to ask how much audio is still in flight."""
+        track = self._track()
+        if track is None or track is self._wired:
+            return
+        if hasattr(track, "inflight_probe"):
+            track.inflight_probe = lambda: self._forwarded_ms
+            self._wired = track
+
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
         await super().process_frame(frame, direction)
+        if isinstance(frame, OutputAudioRawFrame) and frame.audio:
+            rate = getattr(frame, "sample_rate", 0) or 0
+            if rate:
+                self._forwarded_ms += 1000.0 * (len(frame.audio) / 2) / rate
+            self._wire_probe()
         if isinstance(frame, InterruptionFrame):
             track = self._track()
             clear = getattr(track, "clear", None)

--- a/agents/pipecat/pipecat_aplisay/output_underrun.py
+++ b/agents/pipecat/pipecat_aplisay/output_underrun.py
@@ -74,6 +74,12 @@ class UnderrunStats:
         self.depth = {label: 0 for _, label in _BUCKETS}
         self.depth[">10"] = 0
         self.recvs = 0
+        #: ms of audio already forwarded downstream but not yet handed to the
+        #: track, sampled at the instant each starve began. Non-zero means the
+        #: audio EXISTED and we simply had not moved it — the starve is ours.
+        #: Zero means nothing had arrived from upstream. Nothing else in the
+        #: system distinguishes those two, and they call for opposite fixes.
+        self.inflight_at_starve: list[float] = []
 
     @property
     def silence_ms(self) -> float:
@@ -89,11 +95,18 @@ class UnderrunStats:
         depth = " ".join(
             f"{k}:{100.0 * v / max(1, self.recvs):.0f}%" for k, v in self.depth.items() if v
         )
+        inflight = ""
+        if self.inflight_at_starve:
+            arr = sorted(self.inflight_at_starve)
+            waiting = sum(1 for x in arr if x > 5.0)
+            inflight = (f"; audio in flight at starve: p50 {arr[len(arr)//2]:.0f} ms, "
+                        f"max {arr[-1]:.0f} ms, {waiting}/{len(arr)} starved with audio waiting")
         return (
             f"output underruns: {self.events} events, {self.silence_ms:.0f} ms of inserted "
             f"silence over {self.recvs * self.chunk_ms / 1000:.0f} s, worst gap "
             f"{self.max_gap_ms:.0f} ms; refill lateness p50 {p50:.0f} ms / p90 {p90:.0f} ms / "
             f"max {worst:.0f} ms ({self.never_refilled} never refilled); queue depth {depth}"
+            + inflight
         )
 
 
@@ -107,6 +120,8 @@ def instrumented(base: type) -> type:
             self.underrun = UnderrunStats(chunk_ms)
             self._starved_at: Optional[float] = None
             self._starved_slots = 0
+            self.queued_ms = 0.0            # audio handed to this track, ever
+            self.inflight_probe = None      # set by OutputCushionInterrupt
             self._last_summary = time.monotonic()
             self._event_log_ms = float(os.environ.get("WEBRTC_UNDERRUN_LOG_MS", "20"))
             self._summary_s = float(os.environ.get("WEBRTC_UNDERRUN_SUMMARY_S", "30"))
@@ -121,6 +136,8 @@ def instrumented(base: type) -> type:
             still call this, or every event stays open, nothing is ever counted
             and the whole instrument silently reports zero.
             """
+            if audio_bytes:
+                self.queued_ms += 1000.0 * (len(audio_bytes) / 2) / max(1, self._sample_rate)
             if self._starved_at is not None and audio_bytes:
                 self._close(time.monotonic())
 
@@ -141,6 +158,12 @@ def instrumented(base: type) -> type:
                 if self._starved_at is None:
                     self._starved_at = time.monotonic()
                     self._starved_slots = 0
+                    probe = self.inflight_probe
+                    if probe is not None:
+                        try:
+                            st.inflight_at_starve.append(max(0.0, probe() - self.queued_ms))
+                        except Exception:  # noqa: BLE001
+                            pass
                 self._starved_slots += 1
                 st.chunks_filled += 1
             frame = await super().recv()

--- a/agents/pipecat/tests/test_output_cushion.py
+++ b/agents/pipecat/tests/test_output_cushion.py
@@ -349,3 +349,77 @@ class TestClearOnInterruption:
             "SmallWebRTCClient no longer holds the output track as _audio_output_track — "
             "barge-in will not clear the queue"
         )
+
+
+class TestInflightProbe:
+    """Did the audio exist and we failed to move it, or had it not arrived?
+
+    The transport's own audio queue is an UNBOUNDED asyncio.Queue, so holding
+    the track's future never back-pressures anything upstream — frames simply
+    accumulate there. Which means a starve has two possible causes with opposite
+    fixes: audio waiting in that queue (ours to move) versus nothing arriving
+    (upstream's to deliver). Every OutputAudioRawFrame passes through the
+    processor and everything the track holds passed through it first, so the
+    difference between the two counters is exactly what is sitting in between.
+    """
+
+    def _mk(self, monkeypatch: pytest.MonkeyPatch):
+        from types import SimpleNamespace
+
+        from pipecat_aplisay.output_cushion import OutputCushionInterrupt
+        from pipecat_aplisay.output_underrun import instrumented
+
+        monkeypatch.setenv("WEBRTC_OUTPUT_CUSHION_MS", "60")
+        track = cushioned(instrumented(RawAudioTrack))(sample_rate=RATE)
+        transport = SimpleNamespace(_client=SimpleNamespace(_audio_output_track=track))
+        return track, OutputCushionInterrupt(output_transport=transport)
+
+    def test_audio_waiting_in_the_transport_is_visible_at_a_starve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def run() -> None:
+            track, proc = self._mk(monkeypatch)
+            proc._forwarded_ms = 100.0          # 100 ms forwarded downstream...
+            proc._wire_probe()
+            track.add_audio_bytes(_audio(3))    # ...of which 30 ms reached the track
+            for _ in range(3):
+                await track.recv()
+            await track.recv()                  # queue now empty: starve begins
+            assert track.underrun.inflight_at_starve, "nothing sampled"
+            assert track.underrun.inflight_at_starve[0] == pytest.approx(70.0, abs=1.0)
+            # the starve is still OPEN — summary() only reports once an event
+            # closes, so give it the refill that closes one
+            track.add_audio_bytes(_audio(1))
+            assert "starved with audio waiting" in track.underrun.summary()
+
+        asyncio.run(run())
+
+    def test_nothing_in_flight_reads_as_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The other answer: upstream had delivered everything it had."""
+
+        async def run() -> None:
+            track, proc = self._mk(monkeypatch)
+            proc._forwarded_ms = 30.0
+            proc._wire_probe()
+            track.add_audio_bytes(_audio(3))    # all 30 ms handed over
+            for _ in range(3):
+                await track.recv()
+            await track.recv()
+            assert track.underrun.inflight_at_starve[0] == pytest.approx(0.0, abs=1.0)
+
+        asyncio.run(run())
+
+    def test_the_processor_counts_what_it_forwards(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pipecat.frames.frames import OutputAudioRawFrame
+
+        async def run() -> None:
+            _track_, proc = self._mk(monkeypatch)
+            f = OutputAudioRawFrame(audio=_audio(5), sample_rate=RATE, num_channels=1)
+            # count directly rather than driving a pipeline: process_frame needs
+            # a running processor, and the arithmetic is what matters here
+            proc._forwarded_ms += 1000.0 * (len(f.audio) / 2) / f.sample_rate
+            assert proc._forwarded_ms == pytest.approx(50.0)
+
+        asyncio.run(run())


### PR DESCRIPTION
## The question this answers

The transport's audio queue is a `FrameQueue(asyncio.Queue)` built with `super().__init__()` — **unbounded**. So holding the output track's future blocks only the transport's audio task; frames from upstream keep accumulating in that queue and nothing back-pressures the model's reader.

That has a consequence worth measuring rather than reasoning about. When the track starves, either:

1. the transport's queue was **also empty** — the audio had not arrived, and the fix belongs upstream; or
2. audio **was sitting there** and we failed to move it — the starve is ours, and the fix is to release backpressure later rather than to buffer harder.

Nothing in the system currently distinguishes those, and they call for opposite fixes. Everything said about this so far — including the justification for pause-stretching in #251 — rests on assuming (1).

## How

Every `OutputAudioRawFrame` passes through `OutputCushionInterrupt` on its way to the transport, and everything the track holds passed through it first. The difference between what the processor has forwarded and what the track has received **is** the audio sitting in the transport's queue. Sampled at the instant each starve begins:

```
… queue depth 0:24% 1:0% 2:0% 3-5:34% 6-10:42%; audio in flight at starve:
p50 0 ms, max 12 ms, 0/39 starved with audio waiting
```

`0/39 starved with audio waiting` would confirm the audio genuinely had not arrived. A high count would mean the opposite, and that #251 is treating a problem of our own making.

No new plumbing: the processor already resolves the track for `clear()`, so it wires the probe at the same time.

## Testing

`tests/test_output_cushion.py` gains three cases: audio waiting in the transport is visible at a starve (100 ms forwarded, 30 ms handed over, 70 ms reported), nothing in flight reads as zero, and the forwarded-ms arithmetic.

Full pipecat suite: **423 passed**.
