### PR TITLE
feat(sipbridge): report when the RTP pacer runs dry

### DIFF
--- a/agents/pipecat/sipbridge/internal/call/pacer.go
+++ b/agents/pipecat/sipbridge/internal/call/pacer.go
@@ -87,7 +87,6 @@ type pacer struct {
 	starveEvents int    // runs of fill that ended with real audio resuming
 	starveFrames int    // total filled slots attributed to those runs
 	starveMaxRun int    // longest such run, in frames
-	lastStats    time.Time
 }
 
 // depthBucket indexes depthHist. Time spent at 0 or 1-2 is time with no
@@ -166,8 +165,6 @@ const (
 	// sits an order of magnitude clear of the former and well below the
 	// latter.
 	maxStarveRun = 25 // frames, 500 ms at 20 ms/frame
-	// paceStatsInterval bounds how often a starving pacer reports itself.
-	paceStatsInterval = 30 * time.Second
 )
 
 // enqueue appends encoded payloads for paced sending. Payloads beyond the
@@ -226,6 +223,11 @@ func (p *pacer) run(ctx context.Context) {
 	// One line per call, whatever the exit path. The depth histogram is worth
 	// having even when nothing starved: time spent at depth 0-2 is time with
 	// no cushion, which is the condition that turns a hiccup into a hole.
+	// ONE line per call, and only at the end. Degradation that is survivable
+	// but quality-impacting hits every concurrent connection at once, so
+	// anything per-event — or even periodic — turns a bad minute into
+	// thousands of log lines a second across the pod, costing exactly the CPU
+	// and log bandwidth that the degradation is already eating.
 	defer func() {
 		p.mu.Lock()
 		p.logStatsLocked("call ended")
@@ -285,14 +287,6 @@ func (p *pacer) run(ctx context.Context) {
 		// pacer is not driving the media path.
 		p.slots++
 		p.depthHist[depthBucket(len(p.queue))]++
-		if now := time.Now(); p.lastStats.IsZero() {
-			p.lastStats = now
-		} else if now.Sub(p.lastStats) >= paceStatsInterval {
-			p.lastStats = now
-			if p.starveEvents > 0 {
-				p.logStatsLocked("periodic")
-			}
-		}
 		var payload []byte
 		if len(p.queue) > 0 {
 			payload = p.queue[0]

--- a/agents/pipecat/sipbridge/internal/call/pacer.go
+++ b/agents/pipecat/sipbridge/internal/call/pacer.go
@@ -75,6 +75,71 @@ type pacer struct {
 	silentRun uint32
 	started   bool // at least one packet sent (first ever packet gets marker)
 	dropped   int  // payloads discarded by overflow/clear/suspend since last log
+
+	// Starvation accounting. The pacer fills an empty slot with codec
+	// silence, which is right — a SIP UA transmits every 20 ms whatever
+	// happens — but it means running dry is INVISIBLE: the wire looks
+	// perfect and the caller hears a hole. The WebRTC side had the identical
+	// blind spot and it took a purpose-built rig to find it there. These
+	// counters are so the same thing here would announce itself.
+	slots        int    // frame slots served, ever
+	depthHist    [5]int // queue depth at each slot: 0, 1-2, 3-5, 6-10, >10
+	starveEvents int    // runs of fill that ended with real audio resuming
+	starveFrames int    // total filled slots attributed to those runs
+	starveMaxRun int    // longest such run, in frames
+	lastStats    time.Time
+}
+
+// depthBucket indexes depthHist. Time spent at 0 or 1-2 is time with no
+// cushion — the condition that turns any upstream hiccup into a hole.
+func depthBucket(n int) int {
+	switch {
+	case n == 0:
+		return 0
+	case n <= 2:
+		return 1
+	case n <= 5:
+		return 2
+	case n <= 10:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// noteStarveLocked records a run of filled slots that has just ended because
+// real audio resumed. Runs longer than maxStarveRun are the bot being quiet,
+// not the pacer running dry. Caller holds p.mu.
+func (p *pacer) noteStarveLocked(run uint32) {
+	if run == 0 || run > maxStarveRun {
+		return
+	}
+	p.starveEvents++
+	p.starveFrames += int(run)
+	if int(run) > p.starveMaxRun {
+		p.starveMaxRun = int(run)
+	}
+}
+
+// logStatsLocked reports what the pacer has seen. Caller holds p.mu.
+func (p *pacer) logStatsLocked(reason string) {
+	if p.slots == 0 {
+		return
+	}
+	ms := func(frames int) int { return frames * int(paceFrame/time.Millisecond) }
+	pct := func(n int) int { return n * 100 / p.slots }
+	log.Info().
+		Str("reason", reason).
+		Int("starve_events", p.starveEvents).
+		Int("starve_ms", ms(p.starveFrames)).
+		Int("worst_starve_ms", ms(p.starveMaxRun)).
+		Int("slots", p.slots).
+		Int("depth_0_pct", pct(p.depthHist[0])).
+		Int("depth_1_2_pct", pct(p.depthHist[1])).
+		Int("depth_3_5_pct", pct(p.depthHist[2])).
+		Int("depth_6_10_pct", pct(p.depthHist[3])).
+		Int("depth_over10_pct", pct(p.depthHist[4])).
+		Msg("pacer: audio pacing summary")
 }
 
 const (
@@ -88,6 +153,21 @@ const (
 	// ingress rate the depth peaks at half the utterance length, so this
 	// only trips on runaway input; overflow drops the newest audio.
 	maxPaceQueue = 3000
+	// maxStarveRun is the longest run of filled slots still counted as
+	// STARVATION rather than the bot simply having nothing to say.
+	//
+	// The websocket wire carries no turn boundaries (see internal/pipecat/
+	// wire.go — audio, text, transcription, messages, and nothing that says
+	// "the bot started speaking"), so unlike the Python worker this cannot
+	// gate on a speaking window and has to classify by run length instead.
+	// That is a heuristic, and it is calibrated on the WebRTC path where the
+	// same measurement COULD be gated properly: starvation inside speech
+	// measured 20-210 ms, while gaps between turns ran to seconds. 500 ms
+	// sits an order of magnitude clear of the former and well below the
+	// latter.
+	maxStarveRun = 25 // frames, 500 ms at 20 ms/frame
+	// paceStatsInterval bounds how often a starving pacer reports itself.
+	paceStatsInterval = 30 * time.Second
 )
 
 // enqueue appends encoded payloads for paced sending. Payloads beyond the
@@ -143,6 +223,14 @@ func (p *pacer) warnDroppedLocked(reason string) {
 // wall clock (bounded by maxPaceLag, past which it re-anchors and converts the
 // lost slots into gap — those really were not transmitted).
 func (p *pacer) run(ctx context.Context) {
+	// One line per call, whatever the exit path. The depth histogram is worth
+	// having even when nothing starved: time spent at depth 0-2 is time with
+	// no cushion, which is the condition that turns a hiccup into a hole.
+	defer func() {
+		p.mu.Lock()
+		p.logStatsLocked("call ended")
+		p.mu.Unlock()
+	}()
 	next := time.Now()
 	for {
 		d := time.Until(next)
@@ -192,6 +280,19 @@ func (p *pacer) run(ctx context.Context) {
 		}
 
 		p.mu.Lock()
+		// Sample the queue BEFORE popping: this is the depth the slot saw.
+		// Suspended slots are deliberately not counted — during relay the
+		// pacer is not driving the media path.
+		p.slots++
+		p.depthHist[depthBucket(len(p.queue))]++
+		if now := time.Now(); p.lastStats.IsZero() {
+			p.lastStats = now
+		} else if now.Sub(p.lastStats) >= paceStatsInterval {
+			p.lastStats = now
+			if p.starveEvents > 0 {
+				p.logStatsLocked("periodic")
+			}
+		}
 		var payload []byte
 		if len(p.queue) > 0 {
 			payload = p.queue[0]
@@ -221,6 +322,12 @@ func (p *pacer) run(ctx context.Context) {
 		// audio after any run of silence (filled or not). Fill packets are
 		// not talkspurts.
 		marker := speech && (!p.started || p.silentRun > 0)
+		// Real audio resuming ends a run of filled slots. A SHORT run means
+		// the queue ran dry mid-utterance and the caller heard a hole; a long
+		// one means the bot had nothing to say. Only the former is a fault.
+		if speech && p.started && p.silentRun > 0 {
+			p.noteStarveLocked(p.silentRun)
+		}
 		p.untransmitted = 0
 		if speech {
 			p.silentRun = 0

--- a/agents/pipecat/sipbridge/internal/call/pacer_test.go
+++ b/agents/pipecat/sipbridge/internal/call/pacer_test.go
@@ -335,3 +335,111 @@ func TestPacerOverflowBounded(t *testing.T) {
 		t.Fatalf("queue grew past cap: %d", d)
 	}
 }
+
+// --- starvation accounting -------------------------------------------------
+//
+// The pacer fills an empty slot with codec silence, which is correct for a SIP
+// UA but makes running dry invisible: the wire looks perfect and the caller
+// hears a hole. On the WebRTC path the same blind spot needed a purpose-built
+// rig to find. These pin the counters that would make it announce itself here.
+
+// fillFn reuses the package's existing silenceFill payload so a filled slot
+// stays distinguishable from speech (see isFill above).
+func fillFn() []byte { return silenceFill }
+
+// TestPacerCountsAShortStarve: a brief run of fill that ends with real audio is
+// the queue running dry mid-utterance — the case that is audible.
+func TestPacerCountsAShortStarve(t *testing.T) {
+	rec := &sendRecorder{}
+	p := &pacer{sendFn: rec.send, fill: fillFn}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.run(ctx)
+
+	p.enqueue(payloadsN(2))
+	time.Sleep(3 * paceFrame) // drains, then starves
+	time.Sleep(3 * paceFrame) // ~3 filled slots
+	p.enqueue(payloadsN(2))   // real audio resumes: the run ends here
+	time.Sleep(4 * paceFrame)
+
+	p.mu.Lock()
+	events, frames, worst := p.starveEvents, p.starveFrames, p.starveMaxRun
+	p.mu.Unlock()
+	if events != 1 {
+		t.Fatalf("starveEvents = %d, want 1", events)
+	}
+	if frames == 0 || frames > maxStarveRun {
+		t.Fatalf("starveFrames = %d, want a short run", frames)
+	}
+	if worst == 0 {
+		t.Fatalf("starveMaxRun = 0, want the length of the run")
+	}
+}
+
+// TestPacerIgnoresALongQuietPeriod: the bot simply not talking must not be
+// counted as starvation. Getting this wrong on the Python side made a 9.8 s
+// caller turn read as a 9.8 s "underrun".
+func TestPacerIgnoresALongQuietPeriod(t *testing.T) {
+	rec := &sendRecorder{}
+	p := &pacer{sendFn: rec.send, fill: fillFn}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.run(ctx)
+
+	p.enqueue(payloadsN(1))
+	time.Sleep(2 * paceFrame)
+	// a quiet stretch longer than the threshold, then speech again
+	p.mu.Lock()
+	p.silentRun = maxStarveRun + 10
+	p.mu.Unlock()
+	p.enqueue(payloadsN(1))
+	time.Sleep(3 * paceFrame)
+
+	p.mu.Lock()
+	events := p.starveEvents
+	p.mu.Unlock()
+	if events != 0 {
+		t.Fatalf("starveEvents = %d, want 0 — a long quiet run is not a fault", events)
+	}
+}
+
+// TestPacerRecordsQueueDepth: time spent shallow is the thing that makes a
+// hiccup audible, so the histogram has to reflect the queue the slot saw.
+func TestPacerRecordsQueueDepth(t *testing.T) {
+	rec := &sendRecorder{}
+	p := &pacer{sendFn: rec.send, fill: fillFn}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go p.run(ctx)
+
+	p.enqueue(payloadsN(8))
+	time.Sleep(10 * paceFrame)
+
+	p.mu.Lock()
+	slots, hist := p.slots, p.depthHist
+	p.mu.Unlock()
+	if slots == 0 {
+		t.Fatal("no slots recorded")
+	}
+	total := 0
+	for _, n := range hist {
+		total += n
+	}
+	if total != slots {
+		t.Fatalf("histogram totals %d, slots %d — every slot must be bucketed", total, slots)
+	}
+	if hist[depthBucket(6)] == 0 && hist[depthBucket(8)] == 0 {
+		t.Fatalf("depth never recorded above 5 despite an 8-deep queue: %v", hist)
+	}
+}
+
+func TestDepthBucketBoundaries(t *testing.T) {
+	for _, c := range []struct {
+		n    int
+		want int
+	}{{0, 0}, {1, 1}, {2, 1}, {3, 2}, {5, 2}, {6, 3}, {10, 3}, {11, 4}, {3000, 4}} {
+		if got := depthBucket(c.n); got != c.want {
+			t.Errorf("depthBucket(%d) = %d, want %d", c.n, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

`internal/call/pacer.go` is the SIP analogue of pipecat's `RawAudioTrack`, and it has the same core mechanism: an empty frame slot is filled with codec silence. That is *correct* for a SIP UA — RTP must flow every 20 ms for the life of the call — but it means **running dry is invisible**. The wire looks perfect, every packet is on time, and the caller hears a hole.

That is exactly the blind spot the WebRTC path had. Finding it there took a purpose-built rig comparing the platform's own recording against the browser's decoder; the fix became #248-#252. This adds the equivalent counters here so the same fault would announce itself instead of needing to be hunted.

**To be clear about the risk: the SIP path is probably not suffering it.** The websocket output transport sends at `(chunk/rate)/2` — 2× realtime — so the pacer's queue builds naturally ("at the design 2× ingress rate the depth peaks at half the utterance length"), where `RawAudioTrack` was held lock-step by a future that only resolved on drain. SIP's historical pathology was the opposite: 2× RTP bursts overflowing carrier jitter buffers, which is what this pacer was written to fix. This is instrumentation against a hypothesis, not a fix for a known fault — and the point is that we would currently have no way to tell.

## What it reports

One line per call, plus a periodic line while starving:

```
pacer: audio pacing summary  reason=call ended  starve_events=0  starve_ms=0
  worst_starve_ms=0  slots=17840  depth_0_pct=31  depth_1_2_pct=7
  depth_3_5_pct=33  depth_6_10_pct=29  depth_over10_pct=0
```

The depth histogram is worth having even at zero starves: time spent at depth 0-2 is time with no cushion, which is the condition that turns any hiccup into a hole. That histogram is precisely what diagnosed the WebRTC side.

## The heuristic, and why it is one

The websocket wire carries no turn boundaries — `internal/pipecat/wire.go` has audio, text, transcription and messages, and nothing that says "the bot started speaking". So unlike the Python worker this cannot gate on a speaking window and classifies by **run length** instead: a run of filled slots that ends when real audio resumes counts as starvation only if it is shorter than `maxStarveRun` (500 ms).

That threshold is calibrated on the WebRTC path, where the same quantity *could* be gated properly: starvation inside speech measured 20-210 ms, while gaps between turns ran to seconds. 500 ms sits an order of magnitude clear of the former and well below the latter.

Getting this wrong is not hypothetical — the first version of the Python gate reported a 9.8 s caller turn as a 9.8 s "underrun". `TestPacerIgnoresALongQuietPeriod` pins that case.

## Testing

Four new cases in `pacer_test.go`: a short starve is counted, a long quiet period is not, every slot lands in a depth bucket, and the bucket boundaries. `TestPacerCountsAShortStarve` was verified to fail against a build with the accounting removed.

Whole sipbridge suite green (`call`, `pipecat`, `rtp`, `secretenv`, `sip`), `go vet` clean, `gofmt` clean. Built and tested in `golang:1.25-bookworm` — there is no Go toolchain on the machine this was written on, so it was compiled in a container rather than shipped unverified.
