### PR TITLE
fix(pipecat): one underrun summary per call, never per event

### DIFF
--- a/agents/pipecat/pipecat_aplisay/output_underrun.py
+++ b/agents/pipecat/pipecat_aplisay/output_underrun.py
@@ -70,6 +70,7 @@ class UnderrunStats:
         self.chunks_filled = 0            # 10 ms slots filled with zeroes
         self.max_gap_ms = 0.0
         self.late_ms: list[float] = []    # one per event that was refilled
+        self.gap_hist: dict[str, int] = {}  # gap size distribution, for the summary
         self.never_refilled = 0           # starved and the track ended first
         self.depth = {label: 0 for _, label in _BUCKETS}
         self.depth[">10"] = 0
@@ -85,6 +86,12 @@ class UnderrunStats:
     def silence_ms(self) -> float:
         return self.chunks_filled * self.chunk_ms
 
+    def note_gap(self, gap_ms: float) -> None:
+        b = ("<=20 ms" if gap_ms <= 20 else "21-50 ms" if gap_ms <= 50
+             else "51-100 ms" if gap_ms <= 100 else "101-250 ms" if gap_ms <= 250
+             else ">250 ms")
+        self.gap_hist[b] = self.gap_hist.get(b, 0) + 1
+
     def summary(self) -> str:
         if not self.events:
             return f"no output underruns in {self.recvs} slots"
@@ -95,6 +102,8 @@ class UnderrunStats:
         depth = " ".join(
             f"{k}:{100.0 * v / max(1, self.recvs):.0f}%" for k, v in self.depth.items() if v
         )
+        order = ("<=20 ms", "21-50 ms", "51-100 ms", "101-250 ms", ">250 ms")
+        gaps = " ".join(f"{k}:{self.gap_hist[k]}" for k in order if k in self.gap_hist)
         inflight = ""
         if self.inflight_at_starve:
             arr = sorted(self.inflight_at_starve)
@@ -105,8 +114,8 @@ class UnderrunStats:
             f"output underruns: {self.events} events, {self.silence_ms:.0f} ms of inserted "
             f"silence over {self.recvs * self.chunk_ms / 1000:.0f} s, worst gap "
             f"{self.max_gap_ms:.0f} ms; refill lateness p50 {p50:.0f} ms / p90 {p90:.0f} ms / "
-            f"max {worst:.0f} ms ({self.never_refilled} never refilled); queue depth {depth}"
-            + inflight
+            f"max {worst:.0f} ms ({self.never_refilled} never refilled); gaps {gaps}; "
+            f"queue depth {depth}" + inflight
         )
 
 
@@ -122,9 +131,14 @@ def instrumented(base: type) -> type:
             self._starved_slots = 0
             self.queued_ms = 0.0            # audio handed to this track, ever
             self.inflight_probe = None      # set by OutputCushionInterrupt
-            self._last_summary = time.monotonic()
-            self._event_log_ms = float(os.environ.get("WEBRTC_UNDERRUN_LOG_MS", "20"))
-            self._summary_s = float(os.environ.get("WEBRTC_UNDERRUN_SUMMARY_S", "30"))
+            # Per-event logging is OFF by default and exists only for a
+            # deliberate debugging session. Degradation that is survivable but
+            # quality-impacting hits every concurrent call at once: at ~50
+            # events per call, a pod carrying a few dozen calls through a bad
+            # minute would emit thousands of lines a second, burning the CPU
+            # and log bandwidth that the degradation is already eating. Set
+            # WEBRTC_UNDERRUN_LOG_MS to a gap size to turn it back on.
+            self._event_log_ms = float(os.environ.get("WEBRTC_UNDERRUN_LOG_MS", "0"))
 
         # --- observation points ------------------------------------------
         def note_refill(self, audio_bytes: bytes) -> None:
@@ -166,9 +180,7 @@ def instrumented(base: type) -> type:
                             pass
                 self._starved_slots += 1
                 st.chunks_filled += 1
-            frame = await super().recv()
-            self._maybe_summarise()
-            return frame
+            return await super().recv()
 
         # --- bookkeeping --------------------------------------------------
         def _close(self, now: float) -> None:
@@ -178,7 +190,8 @@ def instrumented(base: type) -> type:
             st.events += 1
             st.max_gap_ms = max(st.max_gap_ms, gap_ms)
             st.late_ms.append(late_ms)
-            if gap_ms >= self._event_log_ms:
+            st.note_gap(gap_ms)
+            if self._event_log_ms > 0 and gap_ms >= self._event_log_ms:
                 # The verdict this line exists to support: a lateness of a few
                 # tens of ms means a cushion would have covered it; a lateness
                 # far larger than the gap means the audio was never coming.
@@ -189,19 +202,11 @@ def instrumented(base: type) -> type:
             self._starved_at = None
             self._starved_slots = 0
 
-        def _maybe_summarise(self) -> None:
-            now = time.monotonic()
-            if now - self._last_summary < self._summary_s:
-                return
-            self._last_summary = now
-            if self.underrun.events:
-                logger.info(self.underrun.summary())
-
         def stop(self) -> None:  # noqa: ANN201
             if self._starved_at is not None:
                 self.underrun.never_refilled += 1
                 self._starved_at = None
-            if self.underrun.events:
+            if self.underrun.recvs:
                 logger.info(f"track finished — {self.underrun.summary()}")
             return super().stop()
 

--- a/agents/pipecat/tests/test_output_underrun.py
+++ b/agents/pipecat/tests/test_output_underrun.py
@@ -175,3 +175,78 @@ class TestInstall:
             assert bytes(a.planes[0]) == bytes(b.planes[0])
 
         asyncio.run(run())
+
+
+class TestItStaysQuiet:
+    """One line per call, and only at the end.
+
+    Degradation that is survivable but quality-impacting hits every concurrent
+    call at once. At ~50 events per call, a pod carrying a few dozen calls
+    through a bad minute would emit thousands of lines a second — burning the
+    CPU and log bandwidth that the degradation is already eating, which is the
+    last thing wanted at that moment.
+    """
+
+    def _capture(self):
+        from loguru import logger
+
+        lines: list[str] = []
+        sink = logger.add(lines.append, format="{message}", level="DEBUG")
+        return lines, (lambda: logger.remove(sink))
+
+    def _starve_and_refill(self, t) -> None:
+        async def run() -> None:
+            for _ in range(4):
+                await t.recv()
+            t.add_audio_bytes(_audio())
+
+        asyncio.run(run())
+
+    def test_no_per_event_line_by_default(self) -> None:
+        lines, stop = self._capture()
+        try:
+            t = _track()
+            self._starve_and_refill(t)
+            assert t.underrun.events == 1, "the event must still be COUNTED"
+            assert not [l for l in lines if "output underrun:" in l], lines
+        finally:
+            stop()
+
+    def test_per_event_logging_can_be_switched_back_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Kept for a deliberate debugging session, not for normal running."""
+        monkeypatch.setenv("WEBRTC_UNDERRUN_LOG_MS", "20")
+        lines, stop = self._capture()
+        try:
+            self._starve_and_refill(_track())
+            assert [l for l in lines if "output underrun:" in l], lines
+        finally:
+            stop()
+
+    def test_the_summary_carries_the_gap_distribution(self) -> None:
+        """Since the per-event lines are gone, the one summary has to say what
+        the gaps looked like or the detail is simply lost."""
+        t = _track()
+        self._starve_and_refill(t)
+        assert "gaps" in t.underrun.summary()
+        assert "<=20 ms" in t.underrun.summary() or "21-50 ms" in t.underrun.summary()
+
+    def test_the_summary_fires_even_with_nothing_to_report(self) -> None:
+        """The depth histogram is the diagnostic, and it is meaningful whether
+        or not anything starved."""
+
+        async def run() -> None:
+            t = _track()
+            t.add_audio_bytes(_audio(3))
+            for _ in range(3):
+                await t.recv()
+            assert t.underrun.events == 0
+            lines, stop = self._capture()
+            try:
+                t.stop()
+                assert [l for l in lines if "track finished" in l], lines
+            finally:
+                stop()
+
+        asyncio.run(run())


### PR DESCRIPTION
## The problem

`output_underrun` logs a line **per starvation event**. On a normal call that is ~50 lines. But the events are not independent: degradation that is survivable but quality-impacting — a bad upstream minute, a congested path — hits **every concurrent connection at once**. A pod carrying a few dozen calls through that would emit thousands of lines a second, burning the CPU and log bandwidth that the degradation is already eating. Exactly the wrong behaviour at exactly the wrong moment.

This is live on `next` today.

## The change

**One line per call, at track teardown. Nothing periodic, nothing per event.**

- per-event logging defaults **off** (`WEBRTC_UNDERRUN_LOG_MS=0`); set it to a gap size to turn it back on for a deliberate debugging session
- the 30-second periodic summary is removed entirely
- the summary now carries a **gap histogram**, so the detail the per-event lines used to provide is not simply lost
- it fires even with zero events, because the depth histogram is the diagnostic and is meaningful either way — time at depth 0-2 is time with no cushion

```
track finished — output underruns: 6 events, 80 ms of inserted silence over 315 s,
worst gap 30 ms; refill lateness p50 10 ms / p90 29 ms / max 29 ms (0 never refilled);
gaps <=20 ms:5 21-50 ms:1; queue depth 0:19% 1:14% 2:14% 3-5:40% 6-10:12%
```

Everything that mattered in the investigation is still in that one line: event count, total inserted silence, worst gap, the lateness distribution, the gap distribution, and the depth histogram.

The one thing genuinely lost is per-event **timestamps**, which were used to correlate individual starves against holes in a browser capture. That is a debugging activity, and `WEBRTC_UNDERRUN_LOG_MS=20` restores it for the duration.

## Testing

Four new cases in `TestItStaysQuiet`: no per-event line by default (while still *counting* the event), per-event logging can be switched back on, the summary carries the gap distribution, and the summary fires even with nothing to report.

Full pipecat suite: **427 passed**.

The sipbridge equivalent has the same treatment in #253 — its periodic summary is gone too, leaving only the end-of-call line.
