### PR TITLE
docs(pipecat): WEBRTC_OUTPUT_TARGET_MS is a ceiling, not a depth

### DIFF
--- a/agents/pipecat/pipecat_aplisay/output_cushion.py
+++ b/agents/pipecat/pipecat_aplisay/output_cushion.py
@@ -42,7 +42,48 @@ even after a barge-in. That is true today at up to 5 chunks; this raises the
 ceiling to ``cushion``, so an interrupted bot may talk over the caller for a few
 tens of milliseconds longer than it does now.
 
-``WEBRTC_OUTPUT_CUSHION_MS=0`` restores the stock lock-step behaviour.
+THE KNOBS, AND WHAT ``WEBRTC_OUTPUT_TARGET_MS`` ACTUALLY DOES
+------------------------------------------------------------
+``WEBRTC_OUTPUT_TARGET_MS`` (300) is a **ceiling on the stretcher, not a depth
+the queue reaches.** Measured on staging: with it at 300 the queue never
+exceeded 10 chunks — 100 ms — because backpressure still releases at
+``WEBRTC_OUTPUT_CUSHION_MS`` (60). The producer is held once the queue passes
+the hard cushion, so stretching can push depth to roughly cushion+4 and no
+further. The target only ever stops the stretcher going higher.
+
+That is deliberate as it stands, because the result was good: pause-stretching
+took mid-speech starvation from 39 events per call to 1, at an effective cushion
+of 60-100 ms. Raising the release point to the target instead would triple the
+audio queued behind an interrupting caller for no measured benefit — the
+experiment below says the depth was never the binding constraint.
+
+Do not "fix" this by keying the release point to the target without re-running
+that measurement. If the knob's name is the problem, rename the knob.
+
+WHAT THE RELEASE POINT IS *NOT* FOR
+-----------------------------------
+Tested directly (staging, 2026-08-26): ``WEBRTC_OUTPUT_CUSHION_MS=300`` with
+``WEBRTC_STRETCH_EVERY=0`` — release backpressure at 30 chunks, no stretching.
+The queue **still never exceeded 10 chunks** and mid-speech starvation was
+essentially unchanged (36 events, 5.38 ms/s against 6.46 stock). The producer
+was free to run 300 ms ahead and could not: there was no audio to buffer.
+
+So Ultravox really does deliver at about realtime with no surplus, and the
+transport's own audio queue is an UNBOUNDED ``asyncio.Queue`` — holding the
+track's future never back-pressures anything upstream. Releasing backpressure
+later achieves almost nothing; the stretcher works precisely because it
+MANUFACTURES slack that does not otherwise exist.
+
+  ================================  =========  ==============
+  configuration                     starves    ms/s of speech
+  ================================  =========  ==============
+  60 ms release, no stretch              39              6.46
+  300 ms release, no stretch             36              5.38
+  60 ms release + pause-stretch           1              0.06
+  ================================  =========  ==============
+
+``WEBRTC_OUTPUT_CUSHION_MS=0`` restores the stock lock-step behaviour;
+``WEBRTC_STRETCH_EVERY=0`` keeps the hard cushion but disables stretching.
 """
 
 from __future__ import annotations

--- a/agents/pipecat/pipecat_aplisay/output_underrun.py
+++ b/agents/pipecat/pipecat_aplisay/output_underrun.py
@@ -207,7 +207,16 @@ def instrumented(base: type) -> type:
                 self.underrun.never_refilled += 1
                 self._starved_at = None
             if self.underrun.recvs:
-                logger.info(f"track finished — {self.underrun.summary()}")
+                # The cushion counts its own pause-repeats but has nowhere to
+                # report them; ride the one per-call line rather than add a
+                # second. Without this there is no way to tell the stretcher
+                # fired at all, short of inferring it from the depth histogram.
+                banked = getattr(self, "stretched_chunks", 0)
+                extra = ""
+                if banked:
+                    extra = (f"; stretched {banked} chunks "
+                             f"({banked * self.underrun.chunk_ms:.0f} ms banked from pauses)")
+                logger.info(f"track finished — {self.underrun.summary()}{extra}")
             return super().stop()
 
     _InstrumentedRawAudioTrack.__name__ = "InstrumentedRawAudioTrack"

--- a/agents/pipecat/tests/test_output_cushion.py
+++ b/agents/pipecat/tests/test_output_cushion.py
@@ -423,3 +423,33 @@ class TestInflightProbe:
             assert proc._forwarded_ms == pytest.approx(50.0)
 
         asyncio.run(run())
+
+
+class TestStretcherIsVisible:
+    def test_the_per_call_line_reports_what_the_stretcher_banked(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Counted but never logged is the same as not measured — that gap cost
+        a run's worth of ambiguity about whether the stretcher had fired."""
+        from loguru import logger
+
+        from pipecat_aplisay.output_underrun import instrumented
+
+        monkeypatch.setenv("WEBRTC_OUTPUT_CUSHION_MS", "60")
+        lines: list[str] = []
+        sink = logger.add(lines.append, format="{message}", level="INFO")
+        try:
+            t = cushioned(instrumented(RawAudioTrack))(sample_rate=RATE)
+
+            async def run() -> None:
+                t.add_audio_bytes(b"\x05\x00" * PER_CHUNK * 9)   # quiet: stretchable
+                await t.recv()
+
+            asyncio.run(run())
+            assert t.stretched_chunks == 3
+            t.stop()
+            banked = [l for l in lines if "stretched 3 chunks" in l]
+            assert banked, lines
+            assert "banked from pauses" in banked[0]
+        finally:
+            logger.remove(sink)


### PR DESCRIPTION
## `WEBRTC_OUTPUT_TARGET_MS` does not do what its name says

It is a **ceiling on the stretcher, not a depth the queue reaches.** Measured on staging: with it at 300 the queue never exceeded 10 chunks — 100 ms — because backpressure still releases at `WEBRTC_OUTPUT_CUSHION_MS` (60). The producer is held once the queue passes the hard cushion, so stretching can push depth to roughly cushion+4 and no further. The target only ever stops the stretcher going *higher*.

**That is fine as it stands, and the docstring now says why**: pause-stretching took mid-speech starvation from 39 events per call to 1 at an effective cushion of 60-100 ms. Keying the release point to the target instead would triple the audio queued behind an interrupting caller for no measured benefit — because the depth was never the binding constraint. The measurement that establishes this is recorded alongside it:

| configuration | starves | ms/s of speech |
|---|---|---|
| 60 ms release, no stretch | 39 | 6.46 |
| **300 ms release, no stretch** | 36 | **5.38** |
| 60 ms release + pause-stretch | **1** | **0.06** |

The middle row is the one worth keeping: releasing backpressure at 30 chunks with stretching off left the queue **still never exceeding 10** and starvation essentially unchanged. The producer was free to run 300 ms ahead and could not — there was no audio to buffer. Combined with the transport's audio queue being an unbounded `asyncio.Queue` (so holding the track's future never back-pressures anything upstream), that rules out the theory that we were manufacturing the deficit ourselves by pacing too early.

The docstring carries an explicit "do not fix this by keying the release point to the target without re-running that measurement — if the name is the problem, rename the knob."

## Also: the stretcher is now visible

`stretched_chunks` was counted and never logged, so the only way to tell the stretcher had fired was to infer it from the depth histogram. It now rides the existing per-call summary line — **no new log volume**, consistent with #254:

```
track finished — output underruns: 1 events, 30 ms of inserted silence over 315 s, …
  ; stretched 214 chunks (2140 ms banked from pauses)
```

## Testing

One new case asserting the per-call line reports what was banked. Full pipecat suite: **428 passed**.

Documentation and one log field — no behaviour change.
