### PR TITLE
text-chat: a tool failure reaches the model without internal ids in it

### DIFF
--- a/lib/mask-ids.js
+++ b/lib/mask-ids.js
@@ -1,0 +1,71 @@
+/**
+ * Keep internal identifiers out of anything a builder model can quote at a user.
+ *
+ * Set/agent/draft ids are platform plumbing. The builder is told as much in its
+ * prompt, but a prompt is guidance and a tool result is evidence — asked to
+ * explain a failure, the model relays the string it was handed. A builder
+ * session whose placeholder set had been deleted mid-conversation told the
+ * user, verbatim:
+ *
+ *   I couldn't save the name because the supplied placeholder set could not be
+ *   found: "Agent set <uuid> not found."
+ *
+ * The model cannot leak what it never received, so the id is removed on the way
+ * IN, at the one seam every tool result crosses to reach the conversation. The
+ * unmasked message still reaches the server log, where the id is the whole
+ * point of having it.
+ *
+ * Errors themselves are never suppressed — the model must still read what went
+ * wrong to correct a payload, and the user must still be told plainly.
+ */
+
+/** 8-4-4-4-12 hex: every set, agent, draft and call id we mint. */
+const UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+/**
+ * The id means nothing to a reader, so it goes rather than becoming a
+ * placeholder that merely announces an id was here. Removal leaves debris —
+ * doubled spaces, a space before punctuation, the empty quotes or brackets it
+ * sat in — which this clears so the sentence still reads.
+ */
+function tidy(text) {
+  return text
+    .replace(/[([{"'`]\s*[)\]}"'`]/g, '')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/[ \t]+([,.;:!?)\]}])/g, '$1')
+    .replace(/([([{])[ \t]+/g, '$1')
+    .replace(/[ \t]+$/gm, '');
+}
+
+/** Remove every internal id from a string. Non-strings pass through. */
+export function maskInternalIds(text) {
+  if (typeof text !== 'string' || !text) return text;
+  let touched = false;
+  const masked = text.replace(UUID, () => {
+    touched = true;
+    return '';
+  });
+  return touched ? tidy(masked) : text;
+}
+
+/**
+ * Mask the `error` of a failed tool result, leaving everything else alone.
+ *
+ * Deliberately narrow. A SUCCESSFUL set save carries ids the model is meant to
+ * have — `slimResults` hands back the post-save set id and member ids so
+ * test_agent can resolve a label to an agent — and blanking those would break
+ * the build flow. Only the failure branch is a leak.
+ */
+export function maskToolResultIds(result) {
+  if (typeof result !== 'string' || !result.includes('error')) return result;
+  let parsed;
+  try {
+    parsed = JSON.parse(result);
+  } catch {
+    return result; // non-JSON result — not ours to rewrite
+  }
+  if (!parsed || typeof parsed !== 'object' || typeof parsed.error !== 'string') return result;
+  const error = maskInternalIds(parsed.error);
+  if (error === parsed.error) return result;
+  return JSON.stringify({ ...parsed, error });
+}

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -19,6 +19,7 @@ import handlers from './handlers/index.js';
 import { functionHandler } from './function-handler.js';
 import { llmFunctions, runSubagentById } from './subagent.js';
 import { createAgentSetForAgent, updateAgentSetForAgent, patchAgentSetForAgent } from './agent-set-service.js';
+import { maskToolResultIds } from './mask-ids.js';
 import { recordLlmTokens, recordSubagentUsage, finaliseSession } from './usage.js';
 import { ChatSession } from './database.js';
 
@@ -753,13 +754,18 @@ class TextChatSession {
    * identities (set id, member ids) that label resolution produced. Without
    * this, every save echo rides the conversation for the rest of the session —
    * an iterative build carries ~20-25k tokens of near-duplicate set snapshots.
-   * Save FAILURES (an `{ error }` result) pass through untouched — the model
-   * must read those verbatim to correct the payload.
+   * Save FAILURES (an `{ error }` result) still reach the model in full — it
+   * must read those to correct the payload — but with any internal id stripped
+   * out of the message first. This is the ONE seam every tool result crosses on
+   * its way into the conversation, so it is also where a raw uuid stops being
+   * something the model can go on to quote at the user (see lib/mask-ids.js).
    */
   static SET_PLATFORMS = new Set(['create_agent_set', 'update_agent_set', 'patch_agent_set']);
 
   slimResults(results) {
-    return (results || []).map((r) => {
+    return (results || []).map((raw) => {
+      const masked = maskToolResultIds(raw.result);
+      const r = masked === raw.result ? raw : { ...raw, result: masked };
       if (!TextChatSession.SET_PLATFORMS.has(this.platformOf(r.name))) return r;
       try {
         const parsed = JSON.parse(r.result);

--- a/tests/mask-ids.test.mjs
+++ b/tests/mask-ids.test.mjs
@@ -1,0 +1,88 @@
+import { maskInternalIds, maskToolResultIds } from '../lib/mask-ids.js';
+
+// Internal ids are platform plumbing and must never reach a user. The prompt
+// has said so since 0146c4e, but a prompt is guidance and a tool result is
+// evidence: a builder session whose placeholder set had been deleted
+// mid-conversation relayed the tool error word for word —
+//
+//   I couldn't save the name because the supplied placeholder set could not be
+//   found: "Agent set <uuid> not found." Please reopen or refresh the team,
+//   and I'll continue building into that same set.
+//
+// These pin the invariant that closes it at the source: the model never
+// RECEIVES the id, so it has nothing to quote. What it must still receive is
+// the failure itself, and a successful save's ids, which it needs to build.
+
+const ID = '00000000-0000-4000-8000-000000000001';
+const OTHER = '00000000-0000-4000-8000-000000000002';
+/** Nothing shaped like an id we mint may survive. */
+const ID_SHAPE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+describe('maskInternalIds', () => {
+  // One entry per shape a tool error has been seen to carry an id in. A new
+  // thrower that dodges these is still caught by the ID_SHAPE assertion.
+  const MESSAGES = [
+    ['the incident, from agent-set-service', `Agent set ${ID} not found`],
+    ['the sibling thrower', `Agent set ${ID} not found`],
+    ['uppercase', `Agent set ${ID.toUpperCase()} not found`],
+    ['parenthesised', `The team (${ID}) could not be updated`],
+    ['quoted', `The set "${ID}" is gone`],
+    ['two in one message', `Agent ${OTHER} does not belong to set ${ID}`],
+    ['a labelled field', `id: ${ID}`],
+  ];
+
+  test.each(MESSAGES)('removes the id from %s', (_name, message) => {
+    expect(maskInternalIds(message)).not.toMatch(ID_SHAPE);
+  });
+
+  test('leaves a readable sentence, not punctuation debris', () => {
+    // A mask that shredded the message would be worse than the leak: the model
+    // still has to understand the failure to act on it.
+    expect(maskInternalIds(`Agent set ${ID} not found`)).toBe('Agent set not found');
+    expect(maskInternalIds(`The team (${ID}) could not be updated`)).toBe(
+      'The team could not be updated',
+    );
+    expect(maskInternalIds(`The set "${ID}" is gone`)).toBe('The set is gone');
+  });
+
+  test('leaves text with no ids in it byte-identical', () => {
+    const clean = 'label "reception" is not a member of this set';
+    expect(maskInternalIds(clean)).toBe(clean);
+  });
+
+  test('passes non-strings through', () => {
+    expect(maskInternalIds(undefined)).toBeUndefined();
+    expect(maskInternalIds(null)).toBeNull();
+    expect(maskInternalIds('')).toBe('');
+  });
+});
+
+describe('maskToolResultIds', () => {
+  test('masks the error a failed save hands back to the model', () => {
+    const masked = maskToolResultIds(JSON.stringify({ error: `Agent set ${ID} not found` }));
+    expect(masked).not.toMatch(ID_SHAPE);
+    expect(JSON.parse(masked).error).toBe('Agent set not found');
+  });
+
+  test('keeps every other field of the failure', () => {
+    const masked = maskToolResultIds(JSON.stringify({ error: `Agent set ${ID} not found`, retryable: false }));
+    expect(JSON.parse(masked)).toEqual({ error: 'Agent set not found', retryable: false });
+  });
+
+  test('leaves a SUCCESSFUL save alone — those ids are the model\'s to use', () => {
+    // slimResults hands back the post-save set and member ids precisely so
+    // test_agent can resolve a label to an agent. Masking them breaks the build.
+    const saved = JSON.stringify({ id: ID, name: 'Reception', agents: [{ label: 'front', id: OTHER }] });
+    expect(maskToolResultIds(saved)).toBe(saved);
+  });
+
+  test('leaves a non-JSON result alone', () => {
+    const plain = `Agent set ${ID} not found`;
+    expect(maskToolResultIds(plain)).toBe(plain);
+  });
+
+  test('leaves a clean error untouched rather than reserialising it', () => {
+    const clean = JSON.stringify({ error: 'label "reception" is not a member of this set' });
+    expect(maskToolResultIds(clean)).toBe(clean);
+  });
+});

--- a/tests/text-chat-id-masking.test.mjs
+++ b/tests/text-chat-id-masking.test.mjs
@@ -1,0 +1,99 @@
+// database-test-wrapper sets the POSTGRES_* env for the standard test container
+// BEFORE lib/database.js is imported (text-chat.js pulls it in transitively),
+// and its teardown closes the import-time connections so jest can exit.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+
+const { createChatSession } = await import('../lib/text-chat.js');
+
+// slimResults is the ONE seam every tool result crosses to reach the LLM
+// conversation, and therefore where an internal id stops being something the
+// model can quote at a user. lib/mask-ids.js owns the rewriting and is pinned
+// on its own in mask-ids.test.mjs; these pin the WIRING — that a failed save is
+// masked in place, and that a successful one keeps the ids the builder needs.
+//
+// The regression: a builder session whose placeholder set had been deleted
+// mid-conversation told the user "Agent set <uuid> not found."
+
+const ID = '00000000-0000-4000-8000-000000000001';
+const ID_SHAPE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+const logger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const agent = {
+  id: 'agent-1',
+  organisationId: 'org-1',
+  userId: 'user-1',
+  modelName: 'text:anthropic/claude-sonnet-5',
+  functions: [],
+  keys: [],
+  options: {},
+  mcpServers: [],
+};
+
+beforeAll(async () => {
+  await setupRealDatabase();
+});
+
+afterAll(async () => {
+  await teardownRealDatabase();
+});
+
+/** A session whose function list names the set tools, so platformOf resolves. */
+function makeSession() {
+  const session = createChatSession({ agent, logger });
+  session.functions = [
+    { name: 'patch_agent_set', platform: 'patch_agent_set' },
+    { name: 'notify_email_team', platform: 'notify' },
+  ];
+  return session;
+}
+
+describe('slimResults keeps internal ids out of the conversation', () => {
+  test('a failed save reaches the model without the id', () => {
+    const session = makeSession();
+    const [out] = session.slimResults([
+      { name: 'patch_agent_set', result: JSON.stringify({ error: `Agent set ${ID} not found` }) },
+    ]);
+    expect(out.result).not.toMatch(ID_SHAPE);
+    // The failure itself still arrives — the model has to read it to recover.
+    expect(JSON.parse(out.result).error).toBe('Agent set not found');
+  });
+
+  test('a successful save keeps the ids label resolution produced', () => {
+    // test_agent resolves a label to an agent id from exactly this stub.
+    const session = makeSession();
+    const [out] = session.slimResults([
+      {
+        name: 'patch_agent_set',
+        result: JSON.stringify({
+          id: ID,
+          name: 'Reception',
+          agents: [{ label: 'front', id: '00000000-0000-4000-8000-000000000002', name: 'Front desk' }],
+        }),
+      },
+    ]);
+    const parsed = JSON.parse(out.result);
+    expect(parsed).toMatchObject({ saved: true, id: ID, name: 'Reception' });
+    expect(parsed.members[0]).toMatchObject({ label: 'front', id: '00000000-0000-4000-8000-000000000002' });
+  });
+
+  test('a failure from a NON-set tool is masked too', () => {
+    // The leak is not specific to set saves: any tool error the model reads is
+    // one it can relay. Masking runs before the set-platform branch.
+    const session = makeSession();
+    const [out] = session.slimResults([
+      { name: 'notify_email_team', result: JSON.stringify({ error: `agent ${ID} has no verified members` }) },
+    ]);
+    expect(out.result).not.toMatch(ID_SHAPE);
+  });
+
+  test('results with nothing to mask are passed through by identity', () => {
+    // Rebuilding every result would churn the array for no reason.
+    const session = makeSession();
+    const input = [{ name: 'notify_email_team', result: JSON.stringify({ ok: true }) }];
+    expect(session.slimResults(input)[0]).toBe(input[0]);
+  });
+});


### PR DESCRIPTION
## The problem

Set/agent/draft ids are platform plumbing, and the builder prompt has said so since `0146c4e`. But a prompt is guidance and a tool result is evidence — asked to explain a save that failed, the model relays the string it was handed. A builder session whose placeholder set had been deleted mid-conversation told the user, verbatim:

> I couldn't save the name because the supplied placeholder set could not be found: "Agent set &lt;uuid&gt; not found."

The message shape (`Agent set <id> not found`, no "with ID") identifies it precisely: `patchAgentSetForAgent` in `lib/agent-set-service.js`, thrown in-process, never an HTTP round trip. `function-handler` then hands `e.message` to the model as the tool result — raw uuid included — so the model had it in context and quoted it.

## The fix

Masked on the way **in**, not on the way out: the model cannot leak what it never received.

`slimResults` is the one seam every tool result crosses to reach the conversation. New `lib/mask-ids.js` strips ids from the `error` of a failed result there, applied **before** the set-platform branch — the leak is not specific to set saves, and any tool error is one the model can relay.

Deliberately narrow in two directions:

- **The failure still arrives in full**, minus the id. The model has to read it to correct a payload, and the existing "save failures reach the model verbatim" intent is preserved in substance — only the id, which is meaningless to it, is gone.
- **A successful save keeps its ids untouched.** `slimResults` hands back the post-save set id and member ids precisely so `test_agent` can resolve a label to an agent; masking those would break the build flow. Only the `{ error }` branch is a leak.

The unmasked message still reaches the server log via `function-handler`'s `logger.info`, where the id is the whole point of having it.

Removal rather than a placeholder: an id means nothing to a reader, and `[id hidden]` just announces that one was here. `tidy()` clears the debris removal leaves — doubled spaces, a space before punctuation, the empty quotes or brackets it sat in — so `Agent set <uuid> not found` reads back as `Agent set not found`.

## Tests

- `tests/mask-ids.test.mjs` — 15 cases, **no database needed** (the module imports nothing). Table-driven over every shape a tool error has been seen to carry an id in, plus the readability cases (a mask that shredded the message would be worse than the leak), a byte-identical no-op case, and non-string inputs.
- `tests/text-chat-id-masking.test.mjs` — 4 cases pinning the **wiring** through a real session: a failed save masked in place, a successful save keeping its ids, a non-set tool error masked too, and pass-through by identity when there is nothing to mask.

Verified non-vacuous: reverting the `slimResults` wiring fails 2 of the 4 wiring tests.

Full DB suite: **819 passed, 1 failed, 3 skipped**. The one failure is `phone-endpoints-comprehensive.test.mjs › should filter by outbound status`, which **fails identically on unmodified `next`** — pre-existing, unrelated to this change (it is also excluded from the no-db config).

## Scope

The other half of this is in the polite-ai client and lands separately: ids the model can name from the `CURRENT SET (JSON)` it was seeded with are scrubbed from chat text there, and the placeholder loss that raised the error in the first place is fixed there too. Neither change gates the other, and this one is safe to deploy first.