### PR TITLE
fix(tool-calls): better rate limit logic, exempt transfer-status

### DIFF
--- a/agents/livekit/lib/agent-tools.ts
+++ b/agents/livekit/lib/agent-tools.ts
@@ -7,6 +7,11 @@ import {
   logToolResult,
   type ToolKind,
 } from "./tool-log.js";
+import {
+  createToolLoopBreaker,
+  isLoopExempt,
+  TOOL_LOOP_WINDOW_MS,
+} from "./tool-loop-breaker.js";
 import { functionHandler } from "../agent-lib/function-handler.js";
 import { invokeSubagent } from "./api-client.js";
 import type { Agent, AgentFunction, Call, CallMetadata } from "./api-client.js";
@@ -25,22 +30,6 @@ export interface AgentTransferArgs {
   includeHistory?: boolean;
   summary?: string;
 }
-
-// ---- Runaway tool-call breaker -------------------------------------------
-// A realtime model that gets an unsatisfying tool result can re-issue the same
-// call as fast as it can generate — far faster than any human-paced turn. On a
-// live call that burns carrier minutes, model minutes and tokens silently, with
-// no error raised anywhere. These bounds are per tool name, per session.
-//
-// Sizing: a genuine voice turn needs speech in and speech out, so even an
-// impatient caller cannot legitimately drive one tool past a handful of calls
-// in 20s. REFUSE is set well above that; KILL is set where the loop is plainly
-// mechanical and the model has shown it will not stop on its own.
-const TOOL_LOOP_WINDOW_MS = 20_000;
-/** Stop executing the tool and hand the model an explicit error instead. */
-const TOOL_LOOP_REFUSE_CALLS = 10;
-/** Unrecoverable: tear the call down rather than keep billing it. */
-const TOOL_LOOP_KILL_CALLS = 25;
 
 /**
  * Creates tools for the agent based on the agent's functions configuration
@@ -114,32 +103,13 @@ export function createTools({
 }): llm.ToolContext {
   const { functions = [], keys = [] } = agent;
 
-  // Per-session sliding window of invocation times, keyed by tool name. The
-  // closure is created once per createTools() call — i.e. once per agent stack
-  // — so counts do not leak across calls or survive an agent handover.
-  const recentCalls = new Map<string, number[]>();
+  // Runaway-loop breaker, created once per createTools() call — i.e. once per
+  // agent stack — so counts do not leak across calls or survive an agent
+  // handover. Policy and thresholds live in ./tool-loop-breaker.ts.
+  const noteCallAndCheckLoop = createToolLoopBreaker();
   // Teardown is requested once; further refused calls in the window before the
   // session actually comes down must not re-fire it or spam the error log.
   let toolLoopKilled = false;
-
-  /**
-   * Records an invocation and reports whether this tool has breached either
-   * loop threshold within the trailing window.
-   */
-  const noteCallAndCheckLoop = (
-    tool: string,
-  ): { calls: number; refuse: boolean; kill: boolean } => {
-    const now = Date.now();
-    const cutoff = now - TOOL_LOOP_WINDOW_MS;
-    const times = (recentCalls.get(tool) ?? []).filter((t) => t > cutoff);
-    times.push(now);
-    recentCalls.set(tool, times);
-    return {
-      calls: times.length,
-      refuse: times.length > TOOL_LOOP_REFUSE_CALLS,
-      kill: times.length > TOOL_LOOP_KILL_CALLS,
-    };
-  };
 
   return (
     functions &&
@@ -207,7 +177,20 @@ export function createTools({
             // cannot keep re-entering the tool body, and after logToolCall so
             // the refused attempts still appear in the debug log rather than
             // vanishing from the record of what the model actually did.
-            const loop = noteCallAndCheckLoop(fnc.name);
+            // Poll-by-design builtins are counted but never refused or killed.
+            const loop = noteCallAndCheckLoop(fnc.name, isLoopExempt(fnc));
+            if (loop.hot) {
+              // Diagnostic only: the tool still runs. Emitted once per hot
+              // spell so a legitimate poll cannot flood the size-bounded
+              // InvocationLog, while an unexpectedly hot poll stays visible.
+              logToolLoop(logger, {
+                tool: fnc.name,
+                kind,
+                calls: loop.calls,
+                windowMs: TOOL_LOOP_WINDOW_MS,
+                action: "exempt",
+              });
+            }
             if (loop.refuse) {
               const kill = loop.kill && !toolLoopKilled;
               logToolLoop(logger, {

--- a/agents/livekit/lib/tool-log.ts
+++ b/agents/livekit/lib/tool-log.ts
@@ -12,7 +12,10 @@
  *   - `event: "tool_loop"`   — the same tool breached the runaway-loop rate
  *                              limit (ERROR; this is the alertable signal that
  *                              a model is spinning a tool on a live, billed
- *                              call — see the breaker in agent-tools.ts)
+ *                              call — see ./tool-loop-breaker.ts). The
+ *                              one exception is `action: "exempt"`, a WARN
+ *                              emitted for a poll-by-design builtin that ran
+ *                              hot but was allowed through unharmed.
  *
  * The field shape is kept deliberately identical to the Pipecat worker's
  * `pipecat_aplisay/tool_log.py` so tool activity reads and correlates the same
@@ -115,14 +118,19 @@ export function logToolResult(
 }
 
 /**
- * Log a runaway tool-call loop at ERROR with `event: "tool_loop"`.
+ * Log a runaway tool-call loop with `event: "tool_loop"`.
  *
  * This is the alertable signal for the class of failure where a realtime model
  * re-issues the same tool as fast as it can generate (observed at ~2.5 calls/s
  * against Ultravox): the call stays up and billed, no error is raised anywhere
  * else, and nothing in the transcript looks wrong. `action` says what the
  * breaker did — `"refused"` (tool not executed, hard error returned to the
- * model) or `"terminated"` (call torn down).
+ * model), `"terminated"` (call torn down), or `"exempt"` (poll-by-design
+ * builtin — counted and reported, but executed anyway; see the exemption set
+ * in ./tool-loop-breaker.ts).
+ *
+ * `"exempt"` logs at WARN, not ERROR: nothing is broken and no call is at
+ * risk, but a poll running this hot is still worth seeing in the debug log.
  */
 export function logToolLoop(
   log: ToolLogger,
@@ -137,11 +145,19 @@ export function logToolLoop(
     kind: ToolKind;
     calls: number;
     windowMs: number;
-    action: "refused" | "terminated";
+    action: "refused" | "terminated" | "exempt";
   },
 ): void {
+  const fields = { event: "tool_loop", tool, kind, calls, windowMs, action };
+  if (action === "exempt") {
+    log.warn(
+      fields,
+      `hot tool poll: ${tool} called ${calls} times in ${windowMs}ms (exempt from the loop breaker)`,
+    );
+    return;
+  }
   log.error(
-    { event: "tool_loop", tool, kind, calls, windowMs, action },
+    fields,
     `runaway tool loop: ${tool} called ${calls} times in ${windowMs}ms (${action})`,
   );
 }

--- a/agents/livekit/lib/tool-loop-breaker.ts
+++ b/agents/livekit/lib/tool-loop-breaker.ts
@@ -1,0 +1,115 @@
+/**
+ * Runaway tool-call breaker.
+ *
+ * A realtime model that gets an unsatisfying tool result can re-issue the same
+ * call as fast as it can generate — far faster than any human-paced turn. On a
+ * live call that burns carrier minutes, model minutes and tokens silently, with
+ * no error raised anywhere. These bounds are per tool name, per session.
+ *
+ * Sizing: a genuine voice turn needs speech in and speech out, so even an
+ * impatient caller cannot legitimately drive one tool past a handful of calls
+ * in 20s. REFUSE is set well above that; KILL is set where the loop is plainly
+ * mechanical and the model has shown it will not stop on its own.
+ *
+ * Lives in its own module (rather than inline in agent-tools.ts) so the policy
+ * is testable without standing up the LiveKit SDK — see
+ * test/tool-loop-breaker.test.ts.
+ */
+
+export const TOOL_LOOP_WINDOW_MS = 20_000;
+/** Stop executing the tool and hand the model an explicit error instead. */
+export const TOOL_LOOP_REFUSE_CALLS = 10;
+/** Unrecoverable: tear the call down rather than keep billing it. */
+export const TOOL_LOOP_KILL_CALLS = 25;
+
+/**
+ * Builtins that are polls BY DESIGN and so must never trip the breaker.
+ *
+ * The sizing above assumes one tool call per conversational turn, which holds
+ * for every tool the model calls in order to *do* something. It does not hold
+ * for a poll: `transfer_status` exists precisely so the model can watch a
+ * transfer that is still in flight, and the platform's own transfer result
+ * tells it to ("Consultation started. Use transfer_status to check progress."
+ * — see transfer-handler.ts). A dialling window routinely runs 20-30s, so a
+ * model polling even twice a second crosses REFUSE within the first few
+ * seconds and KILL a few seconds after that — at which point the breaker tears
+ * down a live, correctly behaving call in the middle of its transfer. That is
+ * strictly worse than the failure it guards against: the caller is dropped
+ * rather than merely charged.
+ *
+ * The exemption is safe for this shape of tool and only this shape. Membership
+ * requires ALL of:
+ *   - the tool only reads in-process state (no network I/O, no vendor spend,
+ *     no side effect a loop could amplify);
+ *   - repeat calls are the documented, intended usage, not a symptom;
+ *   - the state it reports is expected to change without the model acting.
+ *
+ * `transfer_status` returns `getTransferState()` — a synchronous read of a
+ * local field — and meets all three. `metadata` also reads locally, but fails
+ * the second test: nothing asks the model to poll it, so a model spinning on
+ * `metadata` IS a runaway and must still be caught.
+ *
+ * Keyed on `platform` (the builtin's stable identity), NOT on `name`: the
+ * function name is author-supplied in the agent definition and can be anything.
+ */
+export const TOOL_LOOP_EXEMPT_PLATFORMS: ReadonlySet<string> = new Set([
+  "transfer_status",
+]);
+
+/** True when this tool is a poll-by-design builtin, so the breaker stands down. */
+export function isLoopExempt(fnc: {
+  implementation?: string;
+  platform?: string;
+}): boolean {
+  return (
+    fnc.implementation === "builtin" &&
+    !!fnc.platform &&
+    TOOL_LOOP_EXEMPT_PLATFORMS.has(fnc.platform)
+  );
+}
+
+export interface LoopVerdict {
+  /** Calls to this tool inside the trailing window, including this one. */
+  calls: number;
+  /** Do not execute; hand the model a hard error instead. */
+  refuse: boolean;
+  /** Tear the call down. */
+  kill: boolean;
+  /**
+   * An exempt tool just crossed the refuse threshold. Diagnostic only — the
+   * tool still runs. True on the crossing call alone so a legitimate poll logs
+   * once per hot spell rather than on every call for as long as it lasts.
+   */
+  hot: boolean;
+}
+
+/**
+ * Creates a per-session breaker. The returned function records an invocation
+ * and reports what should happen to it.
+ *
+ * State is per instance, so counts neither leak across calls nor survive an
+ * agent handover — agent-tools.ts creates one per createTools() call.
+ */
+export function createToolLoopBreaker(now: () => number = Date.now): (
+  tool: string,
+  exempt: boolean,
+) => LoopVerdict {
+  // Sliding window of invocation times, keyed by tool name.
+  const recentCalls = new Map<string, number[]>();
+
+  return (tool, exempt) => {
+    const at = now();
+    const cutoff = at - TOOL_LOOP_WINDOW_MS;
+    const times = (recentCalls.get(tool) ?? []).filter((t) => t > cutoff);
+    times.push(at);
+    recentCalls.set(tool, times);
+    return {
+      calls: times.length,
+      refuse: !exempt && times.length > TOOL_LOOP_REFUSE_CALLS,
+      kill: !exempt && times.length > TOOL_LOOP_KILL_CALLS,
+      // Exactly the crossing call. Under a sustained loop the window stays
+      // saturated, so this does not recur until the tool has actually cooled.
+      hot: exempt && times.length === TOOL_LOOP_REFUSE_CALLS + 1,
+    };
+  };
+}

--- a/agents/livekit/test/tool-loop-breaker.test.ts
+++ b/agents/livekit/test/tool-loop-breaker.test.ts
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createToolLoopBreaker,
+  isLoopExempt,
+  TOOL_LOOP_KILL_CALLS,
+  TOOL_LOOP_REFUSE_CALLS,
+  TOOL_LOOP_WINDOW_MS,
+} from "../lib/tool-loop-breaker.js";
+
+// The runaway tool-call breaker refuses, and ultimately tears down, a call
+// where the model spins one tool. `transfer_status` is the exception: it is a
+// poll by design (the transfer result literally tells the model to poll it),
+// so a normal 20-30s dialling window drove it past both thresholds and the
+// breaker dropped live, correctly behaving calls mid-transfer.
+// run: npx tsx --test test/tool-loop-breaker.test.ts
+
+/** A breaker driven by a clock we control, so no test sleeps. */
+function breakerAt() {
+  let clock = 1_000_000;
+  const note = createToolLoopBreaker(() => clock);
+  return {
+    note,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+  };
+}
+
+test("a spinning non-exempt tool is refused, then killed", () => {
+  const { note } = breakerAt();
+  let refusedAt = 0;
+  let killedAt = 0;
+  for (let i = 1; i <= TOOL_LOOP_KILL_CALLS + 5; i++) {
+    const v = note("lookup_order", false);
+    if (v.refuse && !refusedAt) refusedAt = i;
+    if (v.kill && !killedAt) killedAt = i;
+  }
+  assert.equal(refusedAt, TOOL_LOOP_REFUSE_CALLS + 1);
+  assert.equal(killedAt, TOOL_LOOP_KILL_CALLS + 1);
+});
+
+test("an exempt tool is never refused and never kills the call", () => {
+  const { note } = breakerAt();
+  // Far past the kill threshold: this is the shape that was dropping calls.
+  for (let i = 1; i <= TOOL_LOOP_KILL_CALLS * 4; i++) {
+    const v = note("transfer_status", true);
+    assert.equal(v.refuse, false, `refused on call ${i}`);
+    assert.equal(v.kill, false, `killed on call ${i}`);
+  }
+});
+
+test("an exempt tool still reports hot, exactly once per spell", () => {
+  const { note, advance } = breakerAt();
+  const hotOn: number[] = [];
+  for (let i = 1; i <= TOOL_LOOP_KILL_CALLS * 2; i++) {
+    if (note("transfer_status", true).hot) hotOn.push(i);
+  }
+  // One diagnostic on the crossing call, then silence for the rest of the
+  // spell — a sustained poll must not flood the size-bounded InvocationLog.
+  assert.deepEqual(hotOn, [TOOL_LOOP_REFUSE_CALLS + 1]);
+
+  // After the window drains, a fresh spell reports again.
+  advance(TOOL_LOOP_WINDOW_MS + 1);
+  const again: number[] = [];
+  for (let i = 1; i <= TOOL_LOOP_REFUSE_CALLS + 2; i++) {
+    if (note("transfer_status", true).hot) again.push(i);
+  }
+  assert.deepEqual(again, [TOOL_LOOP_REFUSE_CALLS + 1]);
+});
+
+test("counts age out of the trailing window", () => {
+  const { note, advance } = breakerAt();
+  for (let i = 0; i < TOOL_LOOP_REFUSE_CALLS; i++) note("lookup_order", false);
+  advance(TOOL_LOOP_WINDOW_MS + 1);
+  const v = note("lookup_order", false);
+  assert.equal(v.calls, 1);
+  assert.equal(v.refuse, false);
+});
+
+test("windows are per tool name, not shared", () => {
+  const { note } = breakerAt();
+  for (let i = 0; i < TOOL_LOOP_REFUSE_CALLS + 2; i++) note("noisy", false);
+  const quiet = note("quiet", false);
+  assert.equal(quiet.calls, 1);
+  assert.equal(quiet.refuse, false);
+});
+
+test("breakers are per session — a new one starts clean", () => {
+  const first = breakerAt();
+  for (let i = 0; i < TOOL_LOOP_REFUSE_CALLS + 2; i++) first.note("t", false);
+  assert.equal(breakerAt().note("t", false).calls, 1);
+});
+
+test("exemption keys on platform, not on the author-chosen name", () => {
+  // The builtin's identity is `platform`; `name` is whatever the agent author
+  // called it in the definition.
+  assert.equal(
+    isLoopExempt({ implementation: "builtin", platform: "transfer_status" }),
+    true,
+  );
+  // A user function that merely happens to be named transfer_status is not a
+  // platform poll and stays under the breaker.
+  assert.equal(
+    isLoopExempt({ implementation: "rest", platform: "transfer_status" }),
+    false,
+  );
+  // Other builtins keep their protection — nothing asks the model to poll them.
+  for (const platform of ["metadata", "transfer", "hangup", "transfer_agent"]) {
+    assert.equal(
+      isLoopExempt({ implementation: "builtin", platform }),
+      false,
+      platform,
+    );
+  }
+  assert.equal(isLoopExempt({ implementation: "builtin" }), false);
+  assert.equal(isLoopExempt({}), false);
+});


### PR DESCRIPTION
transfer_status was rate limited, agents that repeatedly call it could be terminated. 

This fixes that by exempting platform transfer_status calls.

