### PR TITLE
Chat sessions: resume a lost predecessor from a caller-supplied history

### DIFF
--- a/api/paths/agents/{agentId}/chat.js
+++ b/api/paths/agents/{agentId}/chat.js
@@ -58,7 +58,7 @@ const agentChat = async (req, res) => {
     // it the builder root-causes prompt/function bugs blind), and/or a
     // caller-formatted context block (e.g. website-knowledge state) appended
     // verbatim to the opening turn.
-    const { set, testResult, subjectAgent, knowledge, model, headless } = req.body || {};
+    const { set, testResult, subjectAgent, knowledge, model, headless, history, resumedFrom } = req.body || {};
     // Optional per-SESSION model override (e.g. a user's builder-model
     // preference). Two gates: the id must be a loadable `text:` catalogue
     // model, and the caller must be allowed to use it. The override is set
@@ -74,9 +74,9 @@ const agentChat = async (req, res) => {
       }
       agent.modelName = model;
     }
-    const session = createChatSession({ agent, set, testResult, subjectAgent, knowledge, headless, logger: req.log });
+    const session = createChatSession({ agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger: req.log });
     log.info(
-      { agentId, sessionId: session.id, edit: !!set, diagnose: !!testResult, subjectAgent: !!subjectAgent, knowledge: !!knowledge, headless: !!headless, model: model || undefined },
+      { agentId, sessionId: session.id, edit: !!set, diagnose: !!testResult, subjectAgent: !!subjectAgent, knowledge: !!knowledge, headless: !!headless, model: model || undefined, resume: Array.isArray(history) ? history.length : undefined, resumedFrom: resumedFrom || undefined },
       'agent chat session started');
     res.send({ id: session.id, socket: `/chat/${session.id}` });
   }
@@ -120,6 +120,22 @@ agentChat.apiDoc = {
             knowledge: { type: 'string', nullable: true, description: 'A caller-formatted context block appended verbatim to the opening turn (e.g. website-knowledge state).' },
             model: { type: 'string', nullable: true, description: 'Per-session model override (a `text:` catalogue model the caller is allowed to use, e.g. from a user preference). 400 if unknown, 403 if not permitted.' },
             headless: { type: 'boolean', nullable: true, description: 'When true, SKIP the builder opening turn — the session waits for the caller\'s first user message instead of auto-running the build/edit/diagnose greeting. For headless callers (e.g. polite.ai\'s independent reviewer) that drive the agent programmatically over the socket.' },
+            history: {
+              type: 'array',
+              nullable: true,
+              description: 'RESUME seed: the transcript of a prior session this one replaces (the predecessor was '
+                + 'lost to a server restart or a lapsed re-attach grace). The opening turn becomes a resume — the '
+                + 'model continues the embedded conversation instead of greeting afresh. Entries beyond the '
+                + 'server\'s caps are trimmed oldest-first.',
+              items: {
+                type: 'object',
+                properties: {
+                  role: { type: 'string', enum: ['user', 'agent', 'system'] },
+                  text: { type: 'string' },
+                },
+              },
+            },
+            resumedFrom: { type: 'string', nullable: true, description: 'The prior chat session id `history` came from — recorded on the persisted session for lineage (ignored unless it is a UUID).' },
           },
         },
       },

--- a/api/paths/chat-sessions.js
+++ b/api/paths/chat-sessions.js
@@ -76,7 +76,7 @@ const listChatSessions = async (req, res) => {
       ...(agentId ? { agentId } : {}),
     };
     const { count, rows } = await ChatSession.findAndCountAll({
-      attributes: ['id', 'agentId', 'setId', 'mode', 'title', 'modelName', 'startedAt', 'endedAt', 'turns'],
+      attributes: ['id', 'agentId', 'setId', 'mode', 'title', 'modelName', 'startedAt', 'endedAt', 'turns', 'resumedFrom'],
       where,
       order: [['startedAt', 'DESC']],
       limit,

--- a/lib/database.js
+++ b/lib/database.js
@@ -1648,6 +1648,15 @@ ChatSession.init({
     type: DataTypes.JSONB,
     allowNull: true,
   },
+  // Lineage: the session this one RESUMED after an interruption (server
+  // restart, lapsed re-attach grace). The client re-seeds a fresh session
+  // with the prior conversation and names its predecessor here, so the
+  // history UI can present a resumed chain as one conversation. Plain
+  // (un-FK'd), like setId: history must survive its predecessor's pruning.
+  resumedFrom: {
+    type: DataTypes.UUID,
+    allowNull: true,
+  },
 },
   {
     sequelize,
@@ -2648,6 +2657,13 @@ const databaseStarted = sequelize.authenticate()
     // feature's failure mode is the quietest yet: chats keep working, history
     // just never records, and the UI shows an innocuous empty state.
     await ChatSession.sync();
+    // Columns added after first deploy: the unconditional sync above is
+    // create-if-missing only (no alter — the whole point of taking it out of
+    // the gated upgrade chain), so bring an existing table up to date the
+    // same way polite-ai's BFF tables do — idempotent adds.
+    await sequelize.query(
+      `ALTER TABLE "chat_sessions" ADD COLUMN IF NOT EXISTS "resumed_from" UUID`,
+    );
     // Boot sweep: sessions live only in THIS process's memory, so any row
     // still open (ended_at IS NULL) at boot belongs to a previous process and
     // is by definition dead — close it at its last write, or the history UI

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -47,14 +47,51 @@ export function getChatSession(id) {
   return sessions.get(id);
 }
 
+// Caps on a caller-supplied resume history (see sanitizeHistory): enough for
+// a long design conversation, small enough that a hostile caller can't stuff
+// the opening turn. Newest entries win — the tail is where the thread lives.
+const HISTORY_MAX_ENTRIES = 200;
+const HISTORY_MAX_ENTRY_CHARS = 4000;
+const HISTORY_MAX_TOTAL_CHARS = 40000;
+
+/**
+ * Validate + cap a caller-supplied conversation history (the resume seed a
+ * client sends when it restarts a session whose predecessor was lost to a
+ * server restart or a lapsed re-attach grace). Returns a clean
+ * [{ role, text }] array (roles user/agent/system only), newest entries kept
+ * within the caps with an elision marker, or null when nothing survives.
+ */
+export function sanitizeHistory(history) {
+  if (!Array.isArray(history)) return null;
+  const entries = [];
+  for (const e of history) {
+    if (!e || typeof e !== 'object') continue;
+    const role = e.role === 'user' || e.role === 'agent' || e.role === 'system' ? e.role : null;
+    const text = typeof e.text === 'string' ? e.text.trim() : '';
+    if (!role || !text) continue;
+    entries.push({ role, text: text.slice(0, HISTORY_MAX_ENTRY_CHARS) });
+  }
+  let kept = entries.slice(-HISTORY_MAX_ENTRIES);
+  let total = kept.reduce((n, e) => n + e.text.length, 0);
+  while (kept.length > 1 && total > HISTORY_MAX_TOTAL_CHARS) {
+    total -= kept[0].text.length;
+    kept.shift();
+  }
+  if (!kept.length) return null;
+  if (kept.length < entries.length) {
+    kept = [{ role: 'system', text: '[… earlier conversation trimmed …]' }, ...kept];
+  }
+  return kept;
+}
+
 /**
  * Create a chat session for a text agent (a DB row or an in-memory definition)
  * and register it. Returns the session; read `session.id` / `/chat/${id}` for
  * the websocket path.
  */
-export function createChatSession({ agent, set, testResult, subjectAgent, knowledge, headless, logger = defaultLogger }) {
+export function createChatSession({ agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger = defaultLogger }) {
   const id = crypto.randomUUID();
-  const session = new TextChatSession({ id, agent, set, testResult, subjectAgent, knowledge, headless, logger });
+  const session = new TextChatSession({ id, agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger });
   sessions.set(id, session);
   session.expiry = setTimeout(() => {
     if (!session.connected) sessions.delete(id);
@@ -72,7 +109,7 @@ function interactiveSystemPrompt(agent) {
 }
 
 class TextChatSession {
-  constructor({ id, agent, set, testResult, subjectAgent, knowledge, headless, logger }) {
+  constructor({ id, agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger }) {
     Object.assign(this, { id, agent, logger });
     // Headless caller (e.g. polite.ai's independent reviewer): drives the agent
     // programmatically over the socket, so SKIP the builder opening turn — the
@@ -97,6 +134,22 @@ class TextChatSession {
     // state) supplied by the caller and appended to the hidden opening turn.
     // Opaque to this service — relayed verbatim, never parsed.
     this.seedKnowledge = typeof knowledge === 'string' && knowledge.trim() ? knowledge : null;
+    // Resume seed: the prior conversation's transcript, when this session
+    // replaces one that was lost (server restart, lapsed re-attach grace).
+    // The opening turn becomes a RESUME — the model reads the transcript,
+    // doesn't re-greet, and re-asks its own last unanswered question —
+    // instead of the fresh build/edit/diagnose greeting that made a restarted
+    // builder deny designs the user could still see on screen (2026-08-28
+    // beta session s_85a0afe1).
+    this.seedHistory = sanitizeHistory(history);
+    // UUID-gated: the chat_sessions.resumed_from column is UUID-typed, and a
+    // junk value would fail the INSERT and silently disable history for the
+    // whole session.
+    this.resumedFrom =
+      typeof resumedFrom === 'string' &&
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(resumedFrom)
+        ? resumedFrom
+        : null;
     this.functions = Array.isArray(agent.functions)
       ? agent.functions
       : Object.values(agent.functions || {});
@@ -247,7 +300,14 @@ class TextChatSession {
       const isBuilder =
         this.agent.id === 'builtin:set-builder' ||
         String(this.agent.description || '').includes('[polite:agent-builder]');
-      this.transcript = isBuilder ? [] : null;
+      // A resumed session's durable record starts with a marker rather than
+      // a copy of the seed history — the predecessor row already holds that
+      // conversation, and `resumedFrom` is the join.
+      this.transcript = isBuilder
+        ? (this.seedHistory
+          ? [{ role: 'system', text: '[resumed an interrupted earlier session — its transcript continues here]', at: new Date().toISOString() }]
+          : [])
+        : null;
       if (isBuilder) {
         try {
           await ChatSession.create({
@@ -260,7 +320,8 @@ class TextChatSession {
             title: this.latestSet?.name ?? null,
             modelName: this.agent.modelName ?? null,
             startedAt: this.startedAt,
-            transcript: [],
+            resumedFrom: this.resumedFrom,
+            transcript: this.transcript,
           });
           this.persisted = true;
         } catch (e) {
@@ -293,11 +354,11 @@ class TextChatSession {
     if (this.headless) return;
 
     // Open with a hidden turn whose prompt depends on how the session was seeded
-    // (build from scratch / edit an existing set / diagnose a test result). Any
-    // caller-supplied context block (e.g. website-knowledge state) is appended.
-    const opening = this.seedKnowledge
-      ? `${this.openingPrompt()}\n\n${this.seedKnowledge}`
-      : this.openingPrompt();
+    // (build from scratch / edit an existing set / diagnose a test result — or
+    // RESUME a lost predecessor's conversation). Any caller-supplied context
+    // block (e.g. website-knowledge state) is appended.
+    const base = this.seedHistory ? this.resumePrompt() : this.openingPrompt();
+    const opening = this.seedKnowledge ? `${base}\n\n${this.seedKnowledge}` : base;
     await this.turn(opening, send, true);
   }
 
@@ -378,14 +439,26 @@ class TextChatSession {
       // BUILD conversation, not an edit of something that exists — and the one
       // set this session may write to is the placeholder itself.
       if (!Array.isArray(this.latestSet?.agents) || this.latestSet.agents.length === 0) {
-        return 'The user wants to BUILD a new agent team. An empty placeholder set has already been '
-          + 'created for it — build INTO that set: save with patch_agent_set or update_agent_set using '
-          + 'its id, and NEVER call create_agent_set in this session. Greet briefly and ask what the '
-          + 'team should do. As soon as the reply identifies the subject domain, propose a real name: '
+        // An ALREADY-NAMED empty set is a build that got as far as naming
+        // before this session started (e.g. a restart of an interrupted one):
+        // re-proposing names for it reads as amnesia and forced a pointless
+        // rename in the 2026-08-28 beta session — the name stands.
+        const named =
+          typeof this.latestSet?.name === 'string' &&
+          this.latestSet.name.trim() &&
+          this.latestSet.name !== 'Untitled team';
+        const nameInstruction = named
+          ? `The team is already named “${this.latestSet.name}” — keep that name and do not propose `
+          + 'alternatives unless the user asks to change it. '
+          : 'As soon as the reply identifies the subject domain, propose a real name: '
           + 'call ask_user with 2–3 short candidates tailored to their business (the user can always '
           + 'type their own), then save the choice straight away with a name-only patch_agent_set '
           + '({id, name}) before building further — the team must not stay "Untitled team" beyond '
-          + 'your first save.\n\n'
+          + 'your first save. ';
+        return 'The user wants to BUILD a new agent team. An empty placeholder set has already been '
+          + 'created for it — build INTO that set: save with patch_agent_set or update_agent_set using '
+          + 'its id, and NEVER call create_agent_set in this session. Greet briefly and ask what the '
+          + 'team should do. ' + nameInstruction + '\n\n'
           + `CURRENT SET (JSON):\n${setJson}`;
       }
       return 'The user wants to EDIT this existing agent set. Greet briefly, summarise it in one short line '
@@ -395,6 +468,59 @@ class TextChatSession {
         + `CURRENT SET (JSON):\n${setJson}`;
     }
     return 'Greet me briefly and ask what agent set I would like to build.';
+  }
+
+  /**
+   * The hidden opening turn for a session RESUMING a lost predecessor: the
+   * prior conversation (already sanitised/capped) is embedded, and the model
+   * is told to continue it rather than open afresh — no new greeting, no
+   * re-asking answered questions, agreed designs and names stand, and its own
+   * last unanswered question is re-asked. The mode-specific context blocks
+   * (current set, subject agent, test result) still ride, because the fresh
+   * LLM conversation has none of the predecessor's tool results.
+   */
+  resumePrompt() {
+    const setJson = this.latestSet ? JSON.stringify(this.latestSet) : null;
+    const hasMembers = Array.isArray(this.latestSet?.agents) && this.latestSet.agents.length > 0;
+    const named =
+      typeof this.latestSet?.name === 'string' &&
+      this.latestSet.name.trim() &&
+      this.latestSet.name !== 'Untitled team';
+    const transcript = this.seedHistory
+      .map((e) => `${e.role === 'agent' ? 'ASSISTANT' : e.role === 'user' ? 'USER' : 'NOTE'}: ${e.text}`)
+      .join('\n');
+    const saveRules = setJson
+      ? (hasMembers
+        ? ' Continue revising the set below with patch_agent_set (use its id; send only the members '
+        + 'you are changing), reserving update_agent_set for a wholesale restructure.'
+        : ' Build INTO the set below: save with patch_agent_set or update_agent_set using its id, and '
+        + 'NEVER call create_agent_set in this session.')
+      : '';
+    const nameRule = named
+      ? ` The team is already named “${this.latestSet.name}” — keep that name and do not propose `
+      + 'alternatives unless the user asks to change it.'
+      : '';
+    const subject = !setJson && this.seedSubjectAgent
+      ? (Array.isArray(this.seedSubjectAgent)
+        ? `\n\nCURRENT AGENT DEFINITIONS (JSON — one per distinct agent on the call, root first):\n${JSON.stringify(this.seedSubjectAgent)}`
+        : `\n\nCURRENT AGENT DEFINITION (JSON):\n${JSON.stringify(this.seedSubjectAgent)}`)
+      : '';
+    const testBlock = this.seedTestResult
+      ? `\n\nTEST RESULT (JSON — the one the conversation has been analysing):\n${JSON.stringify(this.seedTestResult)}`
+      : '';
+    return 'You are RESUMING a conversation with this user that was interrupted by a service restart. '
+      + 'The transcript so far is below; the user still has it on their screen, and to them this is ONE '
+      + 'continuous conversation. Do NOT greet afresh, do NOT summarise the transcript back, and do NOT '
+      + 're-ask anything it already answers. Designs, decisions and names already agreed in it stand — '
+      + 'carry them forward rather than reopening them; "the design above" or similar refers to what '
+      + 'the transcript shows. Acknowledge the interruption in one short clause, then continue exactly '
+      + 'where it left off: if the transcript ends with a question you asked that has no answer yet, '
+      + 'ask that question again now (via ask_user when it had options); if it ends with a user '
+      + 'instruction or answer, act on it directly.'
+      + saveRules + nameRule
+      + (setJson ? `\n\nCURRENT SET (JSON):\n${setJson}` : '')
+      + subject + testBlock
+      + `\n\nCONVERSATION SO FAR:\n${transcript}`;
   }
 
   /**

--- a/tests/text-chat-resume.test.mjs
+++ b/tests/text-chat-resume.test.mjs
@@ -1,0 +1,171 @@
+// database-test-wrapper sets the POSTGRES_* env for the standard test container
+// BEFORE lib/database.js is imported (text-chat.js pulls it in transitively),
+// and its teardown closes the import-time connections so jest can exit.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+
+const { createChatSession, sanitizeHistory } = await import('../lib/text-chat.js');
+
+// RESUME seeding (2026-08-28 beta session s_85a0afe1): a session that replaces
+// one lost to a server restart is started with the prior conversation as
+// `history`, and its hidden opening turn becomes a resume — continue the
+// embedded transcript, don't re-greet, don't re-ask answered questions, agreed
+// names stand. These tests pin the sanitiser's caps, the resume prompt's
+// contract, and the named-placeholder rule that stops a restarted build
+// re-proposing names for a team the predecessor already named.
+
+const logger = {
+  info() {}, warn() {}, error() {}, debug() {},
+  child() { return this; },
+};
+
+const agent = {
+  id: 'agent-1',
+  organisationId: 'org-1',
+  userId: 'user-1',
+  modelName: 'text:anthropic/claude-sonnet-5',
+  functions: [],
+  keys: [],
+  options: {},
+  mcpServers: [],
+};
+
+beforeAll(async () => {
+  await setupRealDatabase();
+});
+
+afterAll(async () => {
+  await teardownRealDatabase();
+});
+
+describe('sanitizeHistory', () => {
+  test('keeps user/agent/system entries and drops everything else', () => {
+    const out = sanitizeHistory([
+      { role: 'user', text: 'hello' },
+      { role: 'agent', text: 'hi' },
+      { role: 'system', text: 'note' },
+      { role: 'review', text: 'nope' },
+      { role: 'user', text: '' },
+      'garbage',
+      null,
+    ]);
+    expect(out).toEqual([
+      { role: 'user', text: 'hello' },
+      { role: 'agent', text: 'hi' },
+      { role: 'system', text: 'note' },
+    ]);
+  });
+
+  test('returns null for non-arrays and for arrays with nothing usable', () => {
+    expect(sanitizeHistory(undefined)).toBeNull();
+    expect(sanitizeHistory('hello')).toBeNull();
+    expect(sanitizeHistory([{ role: 'user', text: '' }])).toBeNull();
+  });
+
+  test('caps entry count keeping the newest, with an elision marker', () => {
+    const many = Array.from({ length: 250 }, (_, i) => ({ role: 'user', text: `m${i}` }));
+    const out = sanitizeHistory(many);
+    // 200 kept + 1 marker.
+    expect(out).toHaveLength(201);
+    expect(out[0]).toEqual({ role: 'system', text: '[… earlier conversation trimmed …]' });
+    expect(out[1].text).toBe('m50');
+    expect(out[out.length - 1].text).toBe('m249');
+  });
+
+  test('caps total characters by dropping the oldest entries', () => {
+    const big = 'x'.repeat(4000);
+    const entries = Array.from({ length: 20 }, () => ({ role: 'agent', text: big }));
+    const out = sanitizeHistory(entries);
+    const total = out.reduce((n, e) => n + e.text.length, 0);
+    expect(total).toBeLessThanOrEqual(40000 + out[0].text.length);
+    expect(out[0]).toEqual({ role: 'system', text: '[… earlier conversation trimmed …]' });
+  });
+
+  test('truncates a single oversized entry', () => {
+    const out = sanitizeHistory([{ role: 'user', text: 'y'.repeat(9000) }]);
+    expect(out).toHaveLength(1);
+    expect(out[0].text).toHaveLength(4000);
+  });
+});
+
+describe('resume seeding', () => {
+  const history = [
+    { role: 'user', text: 'article summaries' },
+    { role: 'agent', text: 'Here’s the proposed one-agent design: Article Guide with the Olivia voice.' },
+    { role: 'agent', text: 'Should I build this Article Guide? (options: Yes — build as proposed / Change it)' },
+  ];
+
+  test('a session seeded with history opens with the resume prompt', () => {
+    const session = createChatSession({
+      agent,
+      set: { id: 'set-1', name: 'Article Summary Line', agents: [] },
+      history,
+      resumedFrom: '09d05a62-28aa-4a3f-add3-62389fc4bf9b',
+      logger,
+    });
+    expect(session.seedHistory).toHaveLength(3);
+    expect(session.resumedFrom).toBe('09d05a62-28aa-4a3f-add3-62389fc4bf9b');
+    const prompt = session.resumePrompt();
+    expect(prompt).toContain('RESUMING');
+    expect(prompt).toContain('CONVERSATION SO FAR');
+    expect(prompt).toContain('USER: article summaries');
+    expect(prompt).toContain('ASSISTANT: Should I build this Article Guide?');
+    expect(prompt).toContain('CURRENT SET (JSON)');
+    // The predecessor already named the team — the resume must not reopen it.
+    expect(prompt).toContain('already named “Article Summary Line”');
+    // Empty placeholder: build into it, never create a new set.
+    expect(prompt).toContain('NEVER call create_agent_set');
+  });
+
+  test('a non-uuid resumedFrom is dropped (the column is UUID-typed)', () => {
+    const session = createChatSession({ agent, history, resumedFrom: 'not-a-uuid', logger });
+    expect(session.resumedFrom).toBeNull();
+  });
+
+  test('a set with members resumes with patch-style save rules', () => {
+    const session = createChatSession({
+      agent,
+      set: { id: 'set-1', name: 'Team', agents: [{ label: 'reception', name: 'Reception' }] },
+      history,
+      logger,
+    });
+    const prompt = session.resumePrompt();
+    expect(prompt).toContain('patch_agent_set');
+    expect(prompt).not.toContain('NEVER call create_agent_set');
+  });
+
+  test('a troubleshoot resume re-embeds the test result', () => {
+    const session = createChatSession({
+      agent,
+      testResult: { legs: [{ agentLabel: 'reception', transcript: [] }] },
+      history,
+      logger,
+    });
+    const prompt = session.resumePrompt();
+    expect(prompt).toContain('TEST RESULT (JSON');
+    expect(prompt).toContain('CONVERSATION SO FAR');
+  });
+});
+
+describe('named-placeholder opening prompt (no resume)', () => {
+  test('an already-named empty set keeps its name instead of the name dance', () => {
+    const session = createChatSession({
+      agent,
+      set: { id: 'set-1', name: 'Article Summary Line', agents: [] },
+      logger,
+    });
+    const prompt = session.openingPrompt();
+    expect(prompt).toContain('already named “Article Summary Line”');
+    expect(prompt).not.toContain('propose a real name');
+  });
+
+  test('an Untitled placeholder still gets the name proposal instruction', () => {
+    const session = createChatSession({
+      agent,
+      set: { id: 'set-1', name: 'Untitled team', agents: [] },
+      logger,
+    });
+    const prompt = session.openingPrompt();
+    expect(prompt).toContain('propose a real name');
+    expect(prompt).not.toContain('already named');
+  });
+});


### PR DESCRIPTION
## Why

When a builder chat session dies beyond re-attach (server restart, lapsed grace window), the client restarts a fresh session — which until now opened with the ordinary build/edit greeting and no memory of the conversation. In the 2026-08-28 beta session the restarted builder denied the design the user could still see on screen ("I don't yet have a proposed member design to save") and re-ran the whole naming/design interview.

*Scope note: this PR originally also carried DB-outage crash resilience; that half is deliberately split out to aplisay/llm-agent#261 and **held for design review** (exit-on-DB-failure was a deliberate choice with history behind it). What remains here is the resume-seeding feature only — it changes nothing about connection or process lifecycle.*

## What changes

- `POST /agents/{agentId}/chat` accepts `history` (`[{role, text}]`, roles `user`/`agent`/`system`) and `resumedFrom` (predecessor session id, UUID-gated).
- `sanitizeHistory` caps the seed — 200 entries / 4k chars per entry / 40k total, newest kept, elision marker — before it goes near the opening turn.
- A history-seeded session opens with `resumePrompt()` instead of the build/edit/diagnose greeting: continue the embedded transcript, no fresh greeting, never re-ask answered questions, agreed designs and names stand, re-ask the model's own last unanswered question (via `ask_user` when it had options), and save into the seeded set (never `create_agent_set`). The mode context blocks (current set / subject agent / test result) still ride, because the fresh LLM conversation has none of the predecessor's tool results.
- `chat_sessions` gains `resumed_from` (idempotent `ALTER` beside the unconditional sync — the house pattern for this table; plain un-FK'd column like `set_id`) so the history UI can join resumed chains; returned by the list and detail endpoints. The new row's transcript opens with a resume marker rather than duplicating its predecessor's.
- Opening-prompt fix (independent of resume): an **already-named** empty placeholder no longer triggers the propose-a-name instruction — the restarted session was offering rename pills for a team the user had already named.

## Compatibility

Callers that don't send the new fields see no behaviour change. The polite-ai counterpart (history-carrying restarts, aplisay/polite-ai-website#530) is already merged and sends the fields; an older server accepts and ignores them, so either deploy order is safe.

## Tests

`tests/text-chat-resume.test.mjs`: sanitiser caps, resume prompt contract (transcript embedded, name preserved, placeholder save rules, troubleshoot re-embedding), UUID gate on `resumedFrom`, and the named-placeholder opening prompt. Full DB jest suite run locally before merge.
