### PR TITLE
Survive database outages instead of dying with every live session (design review)

### DIFF
--- a/environment-example
+++ b/environment-example
@@ -169,6 +169,9 @@ LIVEKIT_API_SECRET=<LIVEKIT API SECRET>
 # ANTHROPIC_REQUEST_TIMEOUT_MS=   # Anthropic request timeout
 # TEXT_CHAT_MAX_TOOL_HOPS=        # text-chat tool-call recursion cap
 # TEXT_CHAT_PENDING_TTL_MS=       # pending text-chat session TTL
+# DB_BOOT_RETRY_INTERVAL_MS=3000  # boot-time DB connect retry interval
+# DB_BOOT_RETRY_WINDOW_MS=300000  # give up (exit 1) after this long without a DB
+# EXIT_ON_UNHANDLED_REJECTION=    # true = die on unhandled rejections (test rigs)
 # SUBAGENT_TIMEOUT=60000          # agent-invoke/subagent timeout (ms)
 
 # ── Number administration (tools/number.js — manual admin script only) ──────

--- a/index.mjs
+++ b/index.mjs
@@ -18,6 +18,18 @@ logger.info('starting up');
 logger.info(buildInfo(), `build version: ${describeBuild()}`);
 dotenv.config();
 
+// Node's default kills the process on an unhandled rejection — and this
+// server holds live sessions (voice calls, builder chats) whose entire state
+// is in memory, so the blast radius of dying is strictly worse than that of
+// logging and continuing (the same reasoning ws-handler.js applies to its
+// upgrade listener). The 2026-08-28 beta incident: a ~25s DB restart raised
+// rejections on the LISTEN/NOTIFY path and took every live builder session
+// down. Crash-on-unhandled stays available for test rigs via
+// EXIT_ON_UNHANDLED_REJECTION=true.
+process.on('unhandledRejection', (reason) => {
+  logger.error({ err: reason }, 'Unhandled promise rejection (continuing)');
+  if (process.env.EXIT_ON_UNHANDLED_REJECTION === 'true') process.exit(1);
+});
 
 const server = express();
 const httpServer = createServer(server);

--- a/lib/database.js
+++ b/lib/database.js
@@ -136,7 +136,15 @@ const LISTENER_CONNECTION = {
     }
   })
 };
-let listener = new Listener(LISTENER_CONNECTION);
+// retryTimeout 0 disables pg-listen's reconnect give-up (default: 3000ms).
+// With the default, any DB restart longer than 3s — a routine Cloud SQL
+// maintenance restart is 20-30s — exhausts the reconnect window, emits
+// 'error', and (before 2026-08-28) the handler below killed the whole
+// process, taking every in-memory chat session with it. With 0 the
+// subscriber retries every 500ms indefinitely and re-LISTENs all subscribed
+// channels itself once the DB returns (reinitialize() re-subscribes);
+// paranoid checking (30s) still detects silently-dead connections.
+let listener = new Listener(LISTENER_CONNECTION, { retryTimeout: 0 });
 
 let streamIds = {};
 
@@ -1271,7 +1279,12 @@ class TransactionLog extends Model {
         }
       }
       logger.debug({ [type]: data }, `Notifying logs progress${notify.replace(/-/g, '')}`);
-      data && listener.notify(`progress${notify.replace(/-/g, '')}`, { [type]: data, isFinal, callId, timestamp: updatedAt });
+      // NOTIFY rides the listener's dedicated connection: while the DB is
+      // away this rejects, and an uncaught rejection here kills the process
+      // (the second crash vector of the 2026-08-28 incident). A dropped
+      // progress event is the correct degradation.
+      data && listener.notify(`progress${notify.replace(/-/g, '')}`, { [type]: data, isFinal, callId, timestamp: updatedAt })
+        .catch((err) => logger.error({ err: err?.message, callId }, 'listener.notify failed — progress event dropped'));
     }
     return transactionLog;
   }
@@ -2574,7 +2587,33 @@ async function dropTariffOverlapConstraint() {
   }
 }
 
-const databaseStarted = sequelize.authenticate()
+// Boot-time DB retry: exiting on the first failed connect (the old
+// behaviour) hands recovery to the kubelet, whose CrashLoopBackOff delay
+// grows past the DB's return — the 2026-08-28 outage was ~25s of DB
+// downtime but cost extra restart cycles on top. Retrying in-process
+// reconnects the moment the DB accepts again; a genuinely broken config
+// still exits once the window lapses.
+const BOOT_DB_RETRY_INTERVAL_MS = Number(process.env.DB_BOOT_RETRY_INTERVAL_MS || 3000);
+const BOOT_DB_RETRY_WINDOW_MS = Number(process.env.DB_BOOT_RETRY_WINDOW_MS || 5 * 60 * 1000);
+
+async function authenticateWithRetry() {
+  const startedAt = Date.now();
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await sequelize.authenticate();
+    } catch (err) {
+      const elapsed = Date.now() - startedAt;
+      if (elapsed + BOOT_DB_RETRY_INTERVAL_MS > BOOT_DB_RETRY_WINDOW_MS) throw err;
+      logger.warn(
+        { err: err?.message, attempt, elapsedMs: elapsed },
+        'Database not reachable at boot — retrying',
+      );
+      await new Promise((resolve) => setTimeout(resolve, BOOT_DB_RETRY_INTERVAL_MS));
+    }
+  }
+}
+
+const databaseStarted = authenticateWithRetry()
   .then(async () => {
     logger.debug({ POSTGRES_DB, forceSync, dbVersion, schemaVersion }, 'Database connected');
     await addEnumValueIfMissing('enum_instances_type', 'pipecat');
@@ -2677,17 +2716,16 @@ const databaseStarted = sequelize.authenticate()
   .then((instance) => {
     logger.debug('Connected to listener');
     listener.events.on('error', (err) => {
-      // If we've lost the listener connection, then we need to close the database connection
-      //  and start everything again. Because of the risk of leaking resources it is safer to just
-      //  exit the process and let the container restart cleanly.
-      logger.error(err, 'Listener error');
-      try {
-        listener.close();
-        sequelize.close();
-      } catch (e) {
-        logger.error(e, 'Unable to close listener or database');
-      }
-      process.exit(1);
+      // This used to exit(1) ("safer to just exit"), which turned a transient
+      // DB blip into a full process death — every in-memory chat session lost
+      // (2026-08-28 beta incident: a ~25s Cloud SQL restart killed the server
+      // twice over). With retryTimeout disabled the subscriber reconnects and
+      // re-subscribes on its own, so connection loss never reaches this
+      // handler; anything that does is logged loudly and survived — a stalled
+      // listener degrades progress streaming, which is strictly better than
+      // killing live sessions, and the 30s paranoid check keeps forcing
+      // reinitialize() until the connection genuinely heals.
+      logger.error(err, 'Listener error — recovering in place (progress notifications may be delayed)');
     });
   })
   .catch(error => {


### PR DESCRIPTION
## Status: HELD FOR DESIGN REVIEW — do not merge

Split out of #260 so the resume-seeding feature could ship alone. This half changes connection/process lifecycle and needs careful review first: **the current exit-on-DB-failure behaviour is a deliberate design** — an earlier attempt to reconnect the Sequelize and listener connections in-process caused its own problems, and this PR proposes exactly that class of change. Treat everything below as the material for that review, not a settled fix.

## What the 2026-08-28 outage showed

A ~25s database restart killed the process twice over (and every in-memory chat session with it):

1. pg-listen's default `retryTimeout` abandons reconnection after **3 seconds**, emits `error`, and our handler `process.exit(1)`'s — so any DB blip over 3s is fatal.
2. `listener.notify()` is un-awaited: while the DB is away it rejects, and an unhandled rejection kills Node — an independent second crash vector.
3. Boot-time `sequelize.authenticate()` failure exits immediately; the kubelet's CrashLoopBackOff delay then outgrows the outage.

## What this PR proposes (all up for debate)

- Listener constructed with `retryTimeout: 0` (retry every 500ms indefinitely; pg-listen's `reinitialize()` re-LISTENs subscribed channels itself; 30s paranoid check catches silently-dead connections) and a log-and-recover `error` handler.
- `.catch` on `listener.notify()` — a dropped progress event over a dead process.
- In-process boot retry (`DB_BOOT_RETRY_INTERVAL_MS` default 3s within `DB_BOOT_RETRY_WINDOW_MS` default 5 min), then exit as before.
- Process-level `unhandledRejection` guard: log and continue; `EXIT_ON_UNHANDLED_REJECTION=true` restores crash-on-unhandled.

## Questions the review should answer

- What went wrong last time in-process Sequelize/listener recovery was tried, and does pg-listen's own `reinitialize()` path (reconnect + re-LISTEN on a fresh client, old client torn down) avoid it, or repeat it?
- Is Sequelize's pooled-connection recovery after an outage actually clean in our usage (stale connections evicted on error, no wedged transactions), or does the process need to die to guarantee a clean slate?
- If crash-on-failure stays, is a narrower mitigation worth it — e.g. only the boot retry (which changes no runtime semantics), or only the `notify()` catch?

Note: the infrastructure-level mitigation (moving the beta database off the shared Cloud SQL staging instance to DO managed Postgres) is proceeding independently and removes the incident's trigger regardless of what this review decides.
