### PR TITLE
Beta ingress: serve api.polite.ai alongside api.aplisay.com

### DIFF
--- a/deploy/k8s/beta/ingress.yaml
+++ b/deploy/k8s/beta/ingress.yaml
@@ -1,4 +1,6 @@
-# Public ingress for the llm-agent API + websockets at api.aplisay.com.
+# Public ingress for the llm-agent API + websockets at api.aplisay.com and
+# api.polite.ai (dual-hosted while traffic migrates to the polite.ai name;
+# drop the aplisay host once nothing references it).
 # Long-lived connections: the builder chat websocket rides llm-agent's 15-min
 # reconnect grace, and agent SSE streams stay open for whole calls — lift
 # nginx's 60 s proxy timeouts or every quiet connection is cut mid-session.
@@ -19,9 +21,20 @@ spec:
   tls:
     - hosts:
         - api.aplisay.com
+        - api.polite.ai
       secretName: llm-agent-tls
   rules:
     - host: api.aplisay.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: llm-agent
+                port:
+                  name: http
+    - host: api.polite.ai
       http:
         paths:
           - path: /


### PR DESCRIPTION
Adds api.polite.ai as a second host on the beta ingress (same backend, same cert secret — cert-manager reissues with both SANs). Dual-hosted during migration; the aplisay host is removed in a follow-up once nothing references it. Manifest-only; applied manually per the beta deploy docs.