### PR TITLE
Beta ingress: retire api.aplisay.com

### DIFF
--- a/deploy/k8s/beta/ingress.yaml
+++ b/deploy/k8s/beta/ingress.yaml
@@ -1,6 +1,6 @@
-# Public ingress for the llm-agent API + websockets at api.aplisay.com and
-# api.polite.ai (dual-hosted while traffic migrates to the polite.ai name;
-# drop the aplisay host once nothing references it).
+# Public ingress for the llm-agent API + websockets at api.polite.ai
+# (api.aplisay.com retired 2026-08-29: DNS removed, traffic fully on the
+# polite.ai name — a dead SAN would wedge the next multi-SAN cert renewal).
 # Long-lived connections: the builder chat websocket rides llm-agent's 15-min
 # reconnect grace, and agent SSE streams stay open for whole calls — lift
 # nginx's 60 s proxy timeouts or every quiet connection is cut mid-session.
@@ -20,20 +20,9 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - api.aplisay.com
         - api.polite.ai
       secretName: llm-agent-tls
   rules:
-    - host: api.aplisay.com
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: llm-agent
-                port:
-                  name: http
     - host: api.polite.ai
       http:
         paths:


### PR DESCRIPTION
Completes the host migration: DNS for api.aplisay.com was removed 2026-08-29 and traffic is fully on api.polite.ai. Removing the dead host now, before the next cert renewal — a multi-SAN order including a DNS-less name fails outright and would wedge llm-agent-tls. Manifest-only; applied manually per the beta deploy docs.