### PR TITLE
Encrypt Agent.keys tool credentials at rest

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -8,7 +8,7 @@ import { getVoiceNamesForAgentValidation, getTtsVendorsForAgentValidation } from
 import { validateToolsCallsMetadataUsage } from './handlers/toolsCalls-metadata-capability.js';
 import { validatePromptMetadata } from './prompt-metadata-validate.js';
 import { initPhoneRegistration } from './database-models/phone-registration.js';
-import { encryptSecret, decryptSecret } from './utils/credentials.js';
+import { encryptSecret, decryptSecret, credentialsEncryptionEnabled } from './utils/credentials.js';
 import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-limits.js';
 // Import-cycle note: lib/outbound-filter.js is deliberately dependency-free so the
 // Trunk model can validate an operator filter pattern without pulling in the
@@ -225,6 +225,48 @@ class Agent extends Model {
   }
 }
 
+// Agent.keys entries carry REST/MCP tool credentials ({name, in, value,
+// username, password, header} — the api-doc Keys schema). The secret fields
+// (`value`, and `password` for basic auth) are encrypted at rest with
+// CREDENTIALS_KEY, exactly like Agent.options.recording.key below: the enc:
+// prefix marks an already-encrypted value, so a loaded row can round-trip
+// through the setter without double-encrypting, and rows written before this
+// column was covered read through unchanged until the startup sweep
+// (encryptAgentKeysAtRest) rewrites them.
+const AGENT_KEY_SECRET_FIELDS = ['value', 'password'];
+
+function encryptAgentKeyEntry(entry) {
+  if (!entry || typeof entry !== 'object') return entry;
+  const out = { ...entry };
+  for (const field of AGENT_KEY_SECRET_FIELDS) {
+    const secret = out[field];
+    if (secret != null) {
+      out[field] = typeof secret === 'string' && secret.startsWith('enc:')
+        ? secret
+        : encryptSecret(secret);
+    }
+  }
+  return out;
+}
+
+function decryptAgentKeyEntry(entry) {
+  if (!entry || typeof entry !== 'object') return entry;
+  const out = { ...entry };
+  for (const field of AGENT_KEY_SECRET_FIELDS) {
+    if (out[field] != null) {
+      out[field] = decryptSecret(out[field]);
+    }
+  }
+  return out;
+}
+
+/** True when any secret field in a stored keys array is still plaintext. */
+function agentKeysNeedEncryption(raw) {
+  return Array.isArray(raw) && raw.some((entry) =>
+    entry && typeof entry === 'object' && AGENT_KEY_SECRET_FIELDS.some((field) =>
+      typeof entry[field] === 'string' && entry[field].length > 0 && !entry[field].startsWith('enc:')));
+}
+
 Agent.init({
   id: {
     type: DataTypes.UUID,
@@ -306,7 +348,34 @@ Agent.init({
     type: DataTypes.JSONB
   },
   keys: {
-    type: DataTypes.JSONB
+    // REST/MCP tool credentials; secret fields are encrypted at rest — see
+    // encryptAgentKeyEntry above. The getter hands consumers (the function
+    // handler, the LLM drivers, agent-db worker distribution via toJSON)
+    // usable values, so everything must read through it rather than
+    // getDataValue/dataValues.
+    type: DataTypes.JSONB,
+    set(value) {
+      try {
+        if (Array.isArray(value)) {
+          value = value.map(encryptAgentKeyEntry);
+        }
+      } catch (e) {
+        logger.error(e, 'failed to encrypt Agent.keys');
+      }
+      this.setDataValue('keys', value);
+    },
+    get() {
+      const raw = this.getDataValue('keys');
+      if (!Array.isArray(raw)) {
+        return raw;
+      }
+      try {
+        return raw.map(decryptAgentKeyEntry);
+      } catch (e) {
+        logger.error(e, 'failed to decrypt Agent.keys');
+        return raw;
+      }
+    },
   },
   type: {
     // 'interactive-audio' agents are connected to live audio sessions (the default,
@@ -2547,6 +2616,38 @@ async function migrateUsersRoleToString() {
   }
 }
 
+// Encrypt any Agent.keys secrets written before this column was covered by
+// at-rest encryption. Follows the migrateUsersRoleToString pattern: idempotent
+// (the enc: prefix marks a value as already encrypted, so a re-run only
+// touches rows still carrying plaintext), best-effort (a failure is logged,
+// not fatal) and safe to run on every boot. Rewrites go through the model
+// setter so its enc: guard stays the single source of truth for the stored
+// shape. Skipped when CREDENTIALS_KEY is unset — there is nothing to encrypt
+// with, and rewriting plaintext as plaintext would churn every keyed row on
+// every boot. Exported for tests.
+async function encryptAgentKeysAtRest() {
+  if (!credentialsEncryptionEnabled) return;
+  try {
+    const agents = await Agent.findAll({
+      where: { keys: { [Op.ne]: null } },
+      attributes: ['id', 'keys'],
+    });
+    let rewritten = 0;
+    for (const agent of agents) {
+      const raw = agent.getDataValue('keys');
+      if (!agentKeysNeedEncryption(raw)) continue;
+      agent.set('keys', raw);
+      // validate: false — the model-level handlerLimitations validator needs
+      // modelName, which this partial (id, keys) load doesn't carry.
+      await agent.save({ fields: ['keys'], validate: false });
+      rewritten += 1;
+    }
+    if (rewritten) logger.info({ rewritten }, 'Encrypted stored Agent.keys secrets at rest');
+  } catch (err) {
+    logger.warn({ err: err?.message }, 'encryptAgentKeysAtRest: ignoring');
+  }
+}
+
 // Rate cards intentionally have NO period-overlap constraint (schema v59), for
 // the same reason tariffs lost theirs at v53. resolveRateCard is deterministic —
 // the card with the greatest start_date <= billedAt wins — so overlapping (or two
@@ -2649,6 +2750,11 @@ const databaseStarted = sequelize.authenticate()
       logger.info({ dbVersion, schemaVersion }, 'Database upgraded');
       return Metadata.upsert({ key: 'dbVersion', value: schemaVersion }, { returning: true });
     })) || Promise.resolve())
+  // Data migration, not DDL, so it runs UNCONDITIONALLY (outside the
+  // DB_FORCE_SYNC gate) on every boot: rows written before Agent.keys was
+  // covered by at-rest encryption are rewritten in place, and once none are
+  // left it is a no-op.
+  .then(() => encryptAgentKeysAtRest())
   .then(async () => {
     // chat_sessions is ensured UNCONDITIONALLY (plain sync: create-if-missing,
     // no alter), outside the DB_FORCE_SYNC-gated upgrade chain. This class of
@@ -2849,5 +2955,6 @@ export {
   Sequelize,
   databaseStarted,
   stopDatabase,
+  encryptAgentKeysAtRest,
 };
 export { AgentConcurrencyLimitExceededError } from './concurrency/agent-concurrency-limits.js';

--- a/lib/function-handler.js
+++ b/lib/function-handler.js
@@ -315,8 +315,16 @@ async function functionHandler(function_calls, functions, keys, messageHandler, 
             [key.header || 'noused']: `${key.value}`
           },
         }[key.in];
+        // The authHeader shape (header name + scheme) with the secret portion
+        // masked — the form the callout takes everywhere outside the request
+        // itself (logs and telemetry).
+        let displayHeader = key?.in && {
+          basic: { Authorization: 'Basic ***' },
+          bearer: { Authorization: 'Bearer ***' },
+          header: { [key.header || 'noused']: '***' },
+        }[key.in];
 
-        logger.debug({ authHeader, key, keys, key: f.key }, 'authHeader');
+        logger.debug({ displayHeader, keyName: f.key }, 'authHeader');
 
         try {
           logger.debug({ input }, 'input after defaulting');
@@ -338,7 +346,7 @@ async function functionHandler(function_calls, functions, keys, messageHandler, 
               url: url.toString(),
               method: f.method?.toUpperCase(),
               body: f.method === 'post' ? input : '',
-              headers: authHeader
+              headers: displayHeader
             },
           });
           let response = await axios(

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -146,7 +146,12 @@ export default class Handler {
     Object.assign(this, { agent, instance, logger });
     const { handler, implementation, model } = this.constructor.parseName(agent.modelName);
 
-    this.model = implementation && new implementation({ ...agent.dataValues, logger });
+    // Getter-applied values (get({plain:true})), not raw dataValues: JSONB
+    // columns holding at-rest encrypted material (keys, options.recording.key)
+    // must reach the implementation in usable form. An agent that is already a
+    // plain materialised object passes through unchanged.
+    const agentValues = typeof agent?.get === 'function' ? agent.get({ plain: true }) : agent;
+    this.model = implementation && new implementation({ ...agentValues, logger });
     logger.debug({ agent, handler, implementation, model: this.model }, 'NEW handler created');
     Object.assign(this, { agent, implementation });
     this.logger.debug({ handler: this.name, implementation, model, logger: this.logger }, 'client created');

--- a/lib/models/ultravox.js
+++ b/lib/models/ultravox.js
@@ -150,7 +150,7 @@ class Ultravox extends Llm {
         requirements = undefined;
         break;
     };
-    logger.debug({ keyName, key, keys: this.keys, type, header, name, value, requirements }, 'Setting ultravox auth');
+    logger.debug({ keyName, type, header, name, requirements }, 'Setting ultravox auth');
     return requirements
       ? {
         authTokens: {

--- a/lib/utils/credentials.js
+++ b/lib/utils/credentials.js
@@ -6,6 +6,11 @@ const { CREDENTIALS_KEY } = process.env;
 const deriveKey = (secret) => secret && createHash('sha256').update(String(secret)).digest();
 const encryptionKey = deriveKey(CREDENTIALS_KEY);
 
+// True when CREDENTIALS_KEY is configured, i.e. encryptSecret really encrypts.
+// Lets startup sweeps skip rewriting rows they could only store back as
+// plaintext anyway.
+export const credentialsEncryptionEnabled = Boolean(encryptionKey);
+
 export function encryptSecret(plainText) {
   if (plainText == null) return null;
   try {

--- a/tests/agent-keys-encryption.test.mjs
+++ b/tests/agent-keys-encryption.test.mjs
@@ -1,0 +1,199 @@
+import { setupRealDatabase, teardownRealDatabase, Organisation, User, Agent } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+// Agent.keys carries REST/MCP tool credentials; the secret fields (`value`,
+// and `password` for basic auth) are encrypted at rest with CREDENTIALS_KEY,
+// like the platform's other stored credentials (recording keys, SIP
+// passwords). These tests pin the contract: ciphertext in the column,
+// transparent decryption through the model getter (which is also what
+// toJSON — the agent-db worker distribution path — serialises), an enc:
+// write guard so round-tripping a loaded row never double-encrypts, and the
+// idempotent startup sweep that rewrites rows written before the column was
+// covered.
+
+describe('Agent.keys at-rest encryption', () => {
+  let encryptAgentKeysAtRest;
+  let sequelize;
+
+  let testOrgId;
+  let testUserId;
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    ({ encryptAgentKeysAtRest } = await import('../lib/database.js'));
+    sequelize = Agent.sequelize;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 60000);
+
+  beforeEach(async () => {
+    testOrgId = randomUUID();
+    testUserId = randomUUID();
+    await Organisation.create({ id: testOrgId, name: 'Test Org (keys encryption)' });
+    await User.create({
+      id: testUserId,
+      organisationId: testOrgId,
+      name: 'Test User',
+      email: 'test-keys-encryption@example.com',
+    });
+  });
+
+  afterEach(async () => {
+    try {
+      await Agent.destroy({ where: { organisationId: testOrgId } });
+      if (testUserId) await User.destroy({ where: { id: testUserId } });
+      if (testOrgId) await Organisation.destroy({ where: { id: testOrgId } });
+    } catch {}
+  });
+
+  const makeAgent = (keys) => Agent.create({
+    name: 'Keys encryption test agent',
+    modelName: 'livekit:ultravox/ultravox-v0.7',
+    prompt: 'You are a helpful assistant.',
+    keys,
+    userId: testUserId,
+    organisationId: testOrgId,
+  });
+
+  const KEYS = [
+    { name: 'BEARER_KEY', in: 'bearer', value: 'tok_secret_bearer' },
+    { name: 'BASIC_KEY', in: 'basic', value: 'dXNlcjpwYXNz', username: 'alice', password: 'p4ssw0rd' },
+    { name: 'HEADER_KEY', in: 'header', header: 'X-Api-Key', value: 'hdr_secret' },
+    { name: 'NO_SECRET', in: 'header', header: 'X-Trace' },
+  ];
+
+  const isEncrypted = (v) => typeof v === 'string' && v.startsWith('enc:') && v.split(':').length === 4;
+
+  test('secret fields are stored encrypted; the getter reads them back', async () => {
+    const agent = await makeAgent(KEYS);
+
+    const raw = agent.getDataValue('keys');
+    expect(isEncrypted(raw[0].value)).toBe(true);
+    expect(isEncrypted(raw[1].value)).toBe(true);
+    expect(isEncrypted(raw[1].password)).toBe(true);
+    expect(isEncrypted(raw[2].value)).toBe(true);
+    // Non-secret fields stay readable, and an entry with no secret is untouched.
+    expect(raw[1].username).toBe('alice');
+    expect(raw[2].header).toBe('X-Api-Key');
+    expect(raw[3]).toEqual({ name: 'NO_SECRET', in: 'header', header: 'X-Trace' });
+    // Nothing secret survives in the stored JSON.
+    expect(JSON.stringify(raw)).not.toContain('tok_secret_bearer');
+    expect(JSON.stringify(raw)).not.toContain('p4ssw0rd');
+
+    // The getter is the consumer surface: plaintext round-trip.
+    expect(agent.keys).toEqual(KEYS);
+  });
+
+  test('a reloaded row decrypts through the getter and through toJSON', async () => {
+    const { id } = await makeAgent(KEYS);
+    const reloaded = await Agent.findByPk(id);
+    expect(reloaded.keys).toEqual(KEYS);
+    // toJSON is what the internal agent-db distribution serialises for
+    // workers, so it must carry usable values.
+    expect(reloaded.toJSON().keys).toEqual(KEYS);
+  });
+
+  test('round-tripping a loaded row through the setter never double-encrypts', async () => {
+    const agent = await makeAgent(KEYS);
+
+    // Getter output (plaintext) back through update: re-encrypted, still one
+    // layer deep.
+    await agent.update({ keys: agent.keys });
+    expect(agent.keys).toEqual(KEYS);
+    expect(isEncrypted(agent.getDataValue('keys')[0].value)).toBe(true);
+
+    // Already-encrypted values back through update: the enc: guard keeps them
+    // verbatim.
+    const stored = agent.getDataValue('keys');
+    await agent.update({ keys: stored });
+    expect(agent.getDataValue('keys')[0].value).toBe(stored[0].value);
+    expect(agent.getDataValue('keys')[1].password).toBe(stored[1].password);
+    expect(agent.keys).toEqual(KEYS);
+  });
+
+  test('the PUT /keys merge pattern (getter output + replacements) stays encrypted and readable', async () => {
+    const agent = await makeAgent(KEYS);
+
+    // Mirror api/paths/agents/{agentId}/keys.js: existing (getter) entries the
+    // caller did not mention survive, same-name entries are replaced.
+    const incoming = [{ name: 'BEARER_KEY', in: 'bearer', value: 'tok_rotated' }];
+    const existing = agent.keys;
+    const names = new Set(incoming.map((k) => k.name));
+    const merged = [...existing.filter((k) => !names.has(k.name)), ...incoming];
+    await agent.update({ keys: merged });
+
+    const raw = agent.getDataValue('keys');
+    raw.filter((k) => k.value != null).forEach((k) => expect(isEncrypted(k.value)).toBe(true));
+    const byName = Object.fromEntries(agent.keys.map((k) => [k.name, k]));
+    expect(byName.BEARER_KEY.value).toBe('tok_rotated');
+    expect(byName.BASIC_KEY.password).toBe('p4ssw0rd');
+    expect(byName.HEADER_KEY.value).toBe('hdr_secret');
+  });
+
+  test('startup sweep encrypts pre-existing plaintext rows in place, idempotently', async () => {
+    const agent = await makeAgent(undefined);
+    const planted = [
+      { name: 'LEGACY_KEY', in: 'bearer', value: 'legacy_plain_secret' },
+      { name: 'LEGACY_BASIC', in: 'basic', value: 'bGVnYWN5', username: 'bob', password: 'legacy_pass' },
+    ];
+    // Plant plaintext under the setter's back — exactly the state of a row
+    // written before this column was covered.
+    await sequelize.query('UPDATE "agents" SET "keys" = $1::jsonb WHERE "id" = $2', {
+      bind: [JSON.stringify(planted), agent.id],
+    });
+    let reloaded = await Agent.findByPk(agent.id);
+    expect(reloaded.getDataValue('keys')[0].value).toBe('legacy_plain_secret');
+
+    await encryptAgentKeysAtRest();
+
+    reloaded = await Agent.findByPk(agent.id);
+    const raw = reloaded.getDataValue('keys');
+    expect(isEncrypted(raw[0].value)).toBe(true);
+    expect(isEncrypted(raw[1].value)).toBe(true);
+    expect(isEncrypted(raw[1].password)).toBe(true);
+    expect(raw[1].username).toBe('bob');
+    expect(reloaded.keys).toEqual(planted);
+
+    // Second run: nothing left to rewrite, ciphertext byte-identical.
+    await encryptAgentKeysAtRest();
+    const rawAfter = (await Agent.findByPk(agent.id)).getDataValue('keys');
+    expect(rawAfter).toEqual(raw);
+  });
+
+  test('startup sweep leaves mixed rows single-encrypted and skips secretless rows', async () => {
+    const agent = await makeAgent([{ name: 'ALREADY', in: 'bearer', value: 'sealed_secret' }]);
+    const sealed = agent.getDataValue('keys')[0].value;
+    expect(isEncrypted(sealed)).toBe(true);
+
+    // A row that is part-migrated: one sealed entry, one plaintext entry.
+    const mixed = [
+      { name: 'ALREADY', in: 'bearer', value: sealed },
+      { name: 'STRAGGLER', in: 'header', header: 'X-Api-Key', value: 'straggler_plain' },
+    ];
+    await sequelize.query('UPDATE "agents" SET "keys" = $1::jsonb WHERE "id" = $2', {
+      bind: [JSON.stringify(mixed), agent.id],
+    });
+
+    const secretless = await makeAgent([{ name: 'NO_SECRET', in: 'header', header: 'X-Trace' }]);
+    const secretlessRawBefore = secretless.getDataValue('keys');
+    const secretlessUpdatedAt = secretless.updatedAt;
+
+    await encryptAgentKeysAtRest();
+
+    const raw = (await Agent.findByPk(agent.id)).getDataValue('keys');
+    // The sealed entry is untouched (same ciphertext — not re-wrapped)…
+    expect(raw[0].value).toBe(sealed);
+    // …the plaintext straggler is now sealed too, and both read back.
+    expect(isEncrypted(raw[1].value)).toBe(true);
+    const readable = (await Agent.findByPk(agent.id)).keys;
+    expect(readable[0].value).toBe('sealed_secret');
+    expect(readable[1].value).toBe('straggler_plain');
+
+    // The secretless row was not rewritten at all.
+    const secretlessAfter = await Agent.findByPk(secretless.id);
+    expect(secretlessAfter.getDataValue('keys')).toEqual(secretlessRawBefore);
+    expect(secretlessAfter.updatedAt.getTime()).toBe(secretlessUpdatedAt.getTime());
+  });
+});


### PR DESCRIPTION
## What

`Agent.keys` entries (REST/MCP tool credentials) now have their secret fields — `value`, and `password` for basic auth — encrypted at rest with `CREDENTIALS_KEY`, bringing the column in line with the platform's other stored credentials (recording keys, SIP passwords, call encryption keys).

## How

- **Model setter/getter** on `Agent.keys` following the existing `Agent.options.recording.key` pattern: the `enc:` prefix guards writes (a loaded row round-trips through the setter without double-encrypting) and the getter decrypts transparently, so every consumer — the shared function handler, the LLM drivers, and agent-db worker distribution via `toJSON()` — keeps receiving usable values.
- **Handler-constructed voice sessions** (`lib/handlers/handler.js`) now build their implementation from getter-applied values (`get({plain:true})`) instead of raw `dataValues`, so at-rest encrypted JSONB fields reach the drivers in usable form; a plain materialised agent object passes through unchanged.
- **Startup sweep** `encryptAgentKeysAtRest()` (the `migrateUsersRoleToString` pattern: idempotent, best-effort, runs on every boot outside the `DB_FORCE_SYNC` gate) rewrites rows written before the column was covered, and no-ops once none are left. Skipped when `CREDENTIALS_KEY` is unset.
- Tool-call telemetry and debug logs carry the callout's auth shape (header name + scheme) with the secret portion masked.

## Deployment

No schema change (data-only rewrite inside the existing JSONB column), so no `DB_FORCE_SYNC` needed; the sweep runs unconditionally at boot. `CREDENTIALS_KEY` must be set for the sweep to seal existing rows — already a stated requirement for real deployments (docs/running.md).

## Tests

New `tests/agent-keys-encryption.test.mjs` (6 tests): ciphertext in the column with non-secret fields readable, getter + `toJSON` round-trip, no double-encryption, the `PUT /agents/{agentId}/keys` merge pattern, sweep idempotency (byte-identical ciphertext on re-run), and mixed/secretless rows. Full db suite green locally apart from the pre-existing `phone-endpoints-comprehensive` environment failure, which fails identically on pristine `next` in the same environment.