### PR TITLE
SIP trace and registration probe API, proxied to the owning b2bua node

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1847,6 +1847,22 @@ components:
           description: Registration password (for registrations)
         options:
           $ref: '#/components/schemas/PhoneRegistrationOptions'
+    NodeCapabilityUnavailable:
+      type: object
+      description: |-
+        Returned when the b2bua node holding this registration does not provide the trace and probe
+        API at all — it is running the FreeSWITCH stack, which has no such interface. This is not a
+        fault and retrying will not help: migrate the registration to a regclient node.
+      properties:
+        code:
+          type: string
+          enum: [trace-api-unavailable]
+        node:
+          type: string
+          description: Address of the b2bua node holding this registration
+          example: 203.0.113.10
+        message:
+          type: string
     NodeUnavailable:
       type: object
       description: |-

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1865,6 +1865,95 @@ components:
           type: string
           description: Why the node could not answer
           example: timeout
+    SipTraceIndexEntry:
+      type: object
+      description: |-
+        One captured SIP exchange, described but not reproduced. Fetch it in full from
+        `/phone-endpoints/{identifier}/trace/{id}`.
+      properties:
+        id:
+          type: string
+          description: Identifier of this exchange, for the trace detail route
+          example: reg-8
+        kind:
+          type: string
+          enum: [register, call]
+        summary:
+          type: string
+          description: One line saying what happened, suitable to show in a list
+          example: REGISTER → 403 Forbidden
+        outcome:
+          type: string
+          description: |-
+            For a REGISTER: success, failure or in-progress. For a call: active or completed.
+        code:
+          type: integer
+          description: Final SIP response code, when there was one
+        direction:
+          type: string
+          enum: [inbound, outbound]
+          description: For a call, which way it went
+        callId:
+          type: string
+          description: For a call, its SIP Call-ID
+        startedAt:
+          type: string
+          format: date-time
+        endedAt:
+          type: string
+          format: date-time
+          nullable: true
+        rttMs:
+          type: number
+          description: Time from first request to final response, in milliseconds
+        pinned:
+          type: boolean
+          description: |-
+            Whether this entry is retained regardless of rotation. The most recent successful and
+            most recent failed REGISTER are always pinned, so a retry storm cannot evict the last
+            known-good exchange.
+        messages:
+          type: integer
+          description: How many messages fetching this entry would return
+        bytes:
+          type: integer
+          description: Approximate size of that detail, in bytes
+    SipTraceIndex:
+      type: object
+      description: |-
+        What a registration's trace buffer currently holds. A listing rather than the trace itself:
+        a full trace runs to tens of kilobytes of SIP text.
+      properties:
+        registrationId:
+          type: string
+        node:
+          type: string
+          description: Address of the b2bua node that holds this trace
+        capturedAt:
+          type: string
+          format: date-time
+          description: When the node took this snapshot
+        fetchedAt:
+          type: string
+          format: date-time
+          description: When this API fetched it from the node
+        transactions:
+          type: array
+          description: Captured exchanges, most recent first
+          items:
+            $ref: '#/components/schemas/SipTraceIndexEntry'
+        keepalive:
+          $ref: '#/components/schemas/SipTraceKeepalive'
+        evictions:
+          type: object
+          description: What the ring buffer has discarded, so a gap in the trace is never silent.
+          properties:
+            registerTransactions:
+              type: integer
+            calls:
+              type: integer
+            truncatedMessages:
+              type: integer
     SipTraceMessage:
       type: object
       description: One captured SIP message, as it appeared on the wire.
@@ -1938,6 +2027,10 @@ components:
       type: object
       description: The signalling of one call dialog involving this registration.
       properties:
+        id:
+          type: string
+          description: Identifier of this dialog, for the trace detail route
+          example: call-2
         callId:
           type: string
         direction:

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1695,6 +1695,47 @@ components:
             When set to true, will send the extension user in the SIP Contact header. This is useful when the remote 
             gateway needs the extension user to be included in the Contact header for proper routing or authentication.
           example: true
+        register:
+          type: boolean
+          default: true
+          description: |-
+            Whether to REGISTER with the registrar at all. Set false for a static (IP-authenticated)
+            trunk: no registration is attempted, but calls still route in both directions. Such an
+            endpoint stays in state `initial` — there is no registration to report on — with
+            reachability reflected in `error` and `lastSeenAt` from keepalives.
+        from_domain:
+          type: string
+          description: |-
+            Optional From-domain override for REGISTER and outbound calls. Applied only when the
+            registrar is not itself routable; otherwise the registrar host is used.
+          example: provider.example.com
+        ping:
+          type: integer
+          default: 30
+          description: |-
+            Keepalive (SIP OPTIONS) interval in seconds towards the registrar; 0 disables keepalives.
+            Results feed the endpoint liveness reported in `error` and in the trace keepalive counters.
+          example: 30
+        caller_id_in_from:
+          type: boolean
+          default: true
+          description: |-
+            Present the calling party identity in the From header on outbound calls towards the
+            registrar. Where a provider requires the registered account in From instead, the true
+            caller is still asserted in P-Asserted-Identity.
+        media:
+          type: string
+          enum:
+            - direct
+            - relay
+          default: direct
+          description: |-
+            Media path for calls on this registration. `direct` (the default) relays SDP end to end
+            so RTP flows directly between the far end and the media server, which is both the cheaper
+            and the historical behaviour. `relay` terminates and forwards media on the b2bua node:
+            use it for a registrar behind NAT that advertises unroutable addresses, or where the two
+            legs cannot agree on encryption. There is no automatic selection — relay is opt-in per
+            registration.
       example:
         transport: tls
         auth_username: "authuser123"
@@ -1806,4 +1847,380 @@ components:
           description: Registration password (for registrations)
         options:
           $ref: '#/components/schemas/PhoneRegistrationOptions'
+    NodeUnavailable:
+      type: object
+      description: |-
+        Returned when the b2bua node that owns a registration could not be reached or refused the
+        request. `node` names the instance that was asked, so an operator can tell which node is
+        unhealthy rather than guessing.
+      properties:
+        error:
+          type: string
+          example: trace unavailable
+        node:
+          type: string
+          description: Address of the b2bua node that owns this registration
+          example: 203.0.113.10
+        reason:
+          type: string
+          description: Why the node could not answer
+          example: timeout
+    SipTraceMessage:
+      type: object
+      description: One captured SIP message, as it appeared on the wire.
+      properties:
+        ts:
+          type: string
+          format: date-time
+          description: Capture timestamp
+        direction:
+          type: string
+          enum: [in, out]
+          description: Direction relative to the b2bua node
+        transport:
+          type: string
+          enum: [udp, tcp, tls]
+        src:
+          type: string
+          description: Source address and port
+          example: 203.0.113.10:5060
+        dst:
+          type: string
+          description: Destination address and port
+          example: 198.51.100.7:5061
+        size:
+          type: integer
+          description: Message size in bytes on the wire
+        firstLine:
+          type: string
+          description: Request line or status line
+          example: SIP/2.0 401 Unauthorized
+        callId:
+          type: string
+        cseq:
+          type: string
+          example: 3 REGISTER
+        raw:
+          type: string
+          description: |-
+            The full message text. Digest credentials in `Authorization` and `Proxy-Authorization`
+            are redacted. Long messages are truncated with a marker.
+        truncated:
+          type: boolean
+          description: Whether `raw` was truncated to fit the capture budget
+    SipTraceTransaction:
+      type: object
+      description: A grouped SIP transaction — typically REGISTER, challenge, authenticated REGISTER, final response.
+      properties:
+        outcome:
+          type: string
+          enum: [success, failure, in-progress]
+        startedAt:
+          type: string
+          format: date-time
+        rttMs:
+          type: number
+          description: Time from first request to final response, in milliseconds
+        code:
+          type: integer
+          description: Final SIP response code, when there was one
+        pinned:
+          type: boolean
+          description: |-
+            Whether this transaction is retained regardless of rotation. The most recent successful
+            and most recent failed transaction are always pinned, so a failure storm cannot evict the
+            last known-good exchange.
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/SipTraceMessage'
+    SipTraceDialog:
+      type: object
+      description: The signalling of one call dialog involving this registration.
+      properties:
+        callId:
+          type: string
+        direction:
+          type: string
+          enum: [inbound, outbound]
+        startedAt:
+          type: string
+          format: date-time
+        endedAt:
+          type: string
+          format: date-time
+          nullable: true
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/SipTraceMessage'
+    SipTraceKeepalive:
+      type: object
+      description: |-
+        Keepalive (OPTIONS) activity, kept as counters and state transitions rather than full
+        messages — the volume is high and the diagnostic value is in the outcome, not the bytes.
+      properties:
+        sent:
+          type: integer
+        ok:
+          type: integer
+        failed:
+          type: integer
+        lastRtt:
+          type: number
+          description: Round-trip time of the most recent keepalive, in milliseconds
+        lastCode:
+          type: integer
+        transitions:
+          type: array
+          description: Recent up/down transitions, most recent last
+          items:
+            type: object
+            properties:
+              at:
+                type: string
+                format: date-time
+              state:
+                type: string
+                enum: [up, down]
+              detail:
+                type: string
+    SipTrace:
+      type: object
+      description: Transaction-grouped SIP trace for one registration.
+      properties:
+        registrationId:
+          type: string
+        node:
+          type: string
+          description: Address of the b2bua node that produced this trace
+        capturedAt:
+          type: string
+          format: date-time
+          description: When the node took this snapshot
+        fetchedAt:
+          type: string
+          format: date-time
+          description: When this API fetched the snapshot from the node
+        registerTransactions:
+          type: array
+          items:
+            $ref: '#/components/schemas/SipTraceTransaction'
+        calls:
+          type: array
+          items:
+            $ref: '#/components/schemas/SipTraceDialog'
+        keepalive:
+          $ref: '#/components/schemas/SipTraceKeepalive'
+        evictions:
+          type: object
+          description: What the ring buffer has discarded, so a gap in the trace is never silent.
+          properties:
+            registerTransactions:
+              type: integer
+            calls:
+              type: integer
+            truncatedMessages:
+              type: integer
+    SipTracePacket:
+      type: object
+      description: |-
+        One decoded SIP packet, returned by `format=decode`. Header order and duplicate headers are
+        preserved so Via chains and route sets survive the decode.
+      properties:
+        ts:
+          type: string
+          format: date-time
+        direction:
+          type: string
+          enum: [in, out]
+        transport:
+          type: string
+          enum: [udp, tcp, tls]
+        src:
+          type: string
+        dst:
+          type: string
+        size:
+          type: integer
+        sip:
+          type: object
+          properties:
+            kind:
+              type: string
+              enum: [request, response]
+            method:
+              type: string
+            requestUri:
+              type: string
+            statusCode:
+              type: integer
+            reasonPhrase:
+              type: string
+            headers:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+            cseq:
+              type: object
+              properties:
+                seq:
+                  type: integer
+                method:
+                  type: string
+            callId:
+              type: string
+            fromTag:
+              type: string
+            toTag:
+              type: string
+        sdp:
+          type: object
+          nullable: true
+          description: Parsed SDP body, when the message carried one.
+          properties:
+            origin:
+              type: string
+            connection:
+              type: string
+            media:
+              type: array
+              items:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  port:
+                    type: integer
+                  protocol:
+                    type: string
+                  direction:
+                    type: string
+                  payloads:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        pt:
+                          type: integer
+                        codec:
+                          type: string
+                        rate:
+                          type: integer
+                  attributes:
+                    type: array
+                    items:
+                      type: string
+        correlation:
+          type: object
+          properties:
+            registrationId:
+              type: string
+            transaction:
+              type: string
+            dialog:
+              type: string
+    RegistrationProbeRequest:
+      type: object
+      description: Options for a live registration probe.
+      properties:
+        discover:
+          type: boolean
+          default: false
+          description: |-
+            Try a matrix of transports and next-hop choices rather than a single attempt, and report
+            the minimal `options` that work.
+        apply:
+          type: boolean
+          default: false
+          description: |-
+            Merge the discovered `options` patch into the endpoint and restart its registration.
+            Only meaningful with `discover`, and only honoured where the deployment enables it.
+    RegistrationProbeAccepted:
+      type: object
+      required: [probeId]
+      properties:
+        probeId:
+          type: string
+          description: Identifier to stream or fetch this probe's results
+        node:
+          type: string
+          description: The b2bua node running the probe
+    RegistrationProbeReport:
+      type: object
+      description: The result of a registration probe.
+      properties:
+        probeId:
+          type: string
+        node:
+          type: string
+        registrationId:
+          type: string
+        state:
+          type: string
+          enum: [running, complete]
+        verdict:
+          type: string
+          description: Machine-readable outcome
+          enum:
+            - registered
+            - bad-credentials
+            - rejected
+            - unreachable
+            - tls-failure
+            - no-route
+            - timeout
+            - error
+        summary:
+          type: string
+          description: One-line diagnosis suitable to show a user
+          example: 'REGISTER → 403 Forbidden from 198.51.100.7 (TLS, 34ms)'
+        diagnosis:
+          type: array
+          description: Specific observations that led to the verdict
+          items:
+            type: string
+        startedAt:
+          type: string
+          format: date-time
+        finishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        branches:
+          type: array
+          description: One entry per attempt made — a single-attempt probe has exactly one.
+          items:
+            type: object
+            properties:
+              transport:
+                type: string
+                enum: [udp, tcp, tls]
+              nextHop:
+                type: string
+              outcome:
+                type: string
+              code:
+                type: integer
+              rttMs:
+                type: number
+              messages:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SipTraceMessage'
+        suggestedOptions:
+          type: object
+          nullable: true
+          description: |-
+            Minimal `options` patch that made the registration succeed, for discovery probes.
+            Note that a later full update of an endpoint's `options` replaces them wholesale.
+          additionalProperties: true
+        applied:
+          type: boolean
+          description: Whether `suggestedOptions` was written back to the endpoint
 paths: {}

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1736,6 +1736,26 @@ components:
             use it for a registrar behind NAT that advertises unroutable addresses, or where the two
             legs cannot agree on encryption. There is no automatic selection — relay is opt-in per
             registration.
+        bridged_transfer:
+          type: boolean
+          description: |-
+            Bridge transfers on this endpoint instead of releasing them with SIP REFER, even where
+            REFER is available. Set it for a PBX whose REFER handling is unreliable, or where the
+            call path has to be retained for recording or billing. A per-transfer `forceBridged` or
+            `forceRefer` on the transfer call overrides this default; `forceRefer` wins over both.
+          example: true
+        forceBridged:
+          type: boolean
+          deprecated: true
+          description: |-
+            camelCase alias for `bridged_transfer`, accepted for compatibility. `bridged_transfer` is
+            the documented spelling and takes precedence when both are present.
+        displayNumber:
+          type: string
+          description: |-
+            Calling number to present on outbound calls placed through this registration, when the
+            registered `username` is not itself a dialable number. Falls back to `username`.
+          example: "+441234567890"
       example:
         transport: tls
         auth_username: "authuser123"
@@ -2053,9 +2073,16 @@ components:
         size:
           type: integer
           description: Message size in bytes on the wire
-        firstLine:
+        requestLine:
           type: string
-          description: Request line or status line
+          description: |-
+            RFC 3261 Request-Line. Present on a request, absent on a response —
+            exactly one of `requestLine` and `statusLine` appears on any message,
+            so the key itself says which kind it is.
+          example: REGISTER sip:pbx.example.com SIP/2.0
+        statusLine:
+          type: string
+          description: RFC 3261 Status-Line. Present on a response, absent on a request.
           example: SIP/2.0 401 Unauthorized
         callId:
           type: string

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1847,6 +1847,63 @@ components:
           description: Registration password (for registrations)
         options:
           $ref: '#/components/schemas/PhoneRegistrationOptions'
+    B2buaNodeHeartbeat:
+      type: object
+      description: A b2bua node announcing itself, about once a minute.
+      required: [nodeId]
+      properties:
+        nodeId:
+          type: string
+          description: |-
+            The node's public address — the same value it writes into
+            `phone_registrations.b2bua_id`, which is what makes this joinable to a registration.
+          example: 203.0.113.10
+        type:
+          type: string
+          enum: [regclient, freeswitch]
+          default: regclient
+          description: Which stack this node is running. Only regclient serves the trace and probe API.
+        version:
+          type: string
+          description: Build version, for telling a fleet mid-rollout apart
+          example: 1.4.2
+        registrations:
+          type: integer
+          description: Registrations this node currently holds
+        failedRegistrations:
+          type: integer
+          description: How many of those are currently failing
+        systemLoad:
+          type: number
+          description: One-minute load average as the node sees it
+    B2buaNode:
+      type: object
+      description: A b2bua node as it last reported itself.
+      properties:
+        nodeId:
+          type: string
+        type:
+          type: string
+          enum: [regclient, freeswitch]
+        version:
+          type: string
+          nullable: true
+        registrations:
+          type: integer
+        failedRegistrations:
+          type: integer
+        systemLoad:
+          type: number
+          nullable: true
+        lastSeenAt:
+          type: string
+          format: date-time
+          nullable: true
+        stale:
+          type: boolean
+          description: |-
+            Whether this node has stopped heartbeating. Reported rather than omitted: a node that
+            has gone quiet is the thing worth seeing, and it is invisible if the row disappears.
     NodeCapabilityUnavailable:
       type: object
       description: |-

--- a/api/paths/agent-db/b2bua-nodes.js
+++ b/api/paths/agent-db/b2bua-nodes.js
@@ -21,13 +21,19 @@ export default function (logger) {
  * repeated for every node until something caches it. A heartbeat makes it known
  * before the first trace request ever arrives.
  *
- * Internal: authenticated by the shared token, which is what makes the caller
- * the system user. Restricted to that user deliberately — an ordinary caller
- * able to post here could mark a node as the wrong stack, which would either
- * deny traces that exist or send requests at a node that cannot answer them.
+ * Internal, and restricted deliberately — an ordinary caller able to post here
+ * could mark a node as the wrong stack, which would either deny traces that
+ * exist or send requests at a node that cannot answer them.
+ *
+ * Two principals are accepted: the system user, and the narrowly-scoped
+ * b2bua-node principal that B2BUA_HEARTBEAT_TOKEN mints. Nodes should carry the
+ * scoped token: they are internet-facing SIP machines, and SHARED_API_TOKEN is
+ * accepted on every route in the internal API. The scoped one reaches this
+ * route and nothing else — not even the fleet listing below.
  */
 const heartbeat = async (req, res) => {
-  if (res.locals.user?.isSystem !== true) {
+  const caller = res.locals.user;
+  if (caller?.isSystem !== true && caller?.isB2buaNode !== true) {
     return res.status(403).send({ message: 'b2bua node heartbeats are accepted only from internal callers' });
   }
 
@@ -77,12 +83,12 @@ const heartbeat = async (req, res) => {
  * indistinguishable from a node that was not there.
  */
 const listNodes = async (req, res) => {
-  // The same gate the heartbeat applies. `/api/agent-db` is already refused at
-  // the prefix for anything without the shared token (middleware/auth.js), so
-  // this is defence in depth — but a route that leans entirely on an invariant
-  // declared in another file, while its sibling checks explicitly, reads as
-  // though the difference were deliberate. It is not: this listing is every
-  // node's public IP, stack, version, registration counts and load.
+  // A stricter gate than the heartbeat's, and deliberately so: this listing is
+  // every node's public IP, stack, version, registration counts and load — a
+  // map of the estate — so the scoped b2bua-node principal that may announce
+  // itself above is refused here. `/api/agent-db` is already refused at the
+  // prefix for anything without an internal token (middleware/auth.js); this is
+  // the second lock.
   if (res.locals.user?.isSystem !== true) {
     return res.status(403).send({ message: 'the b2bua node listing is available only to internal callers' });
   }

--- a/api/paths/agent-db/b2bua-nodes.js
+++ b/api/paths/agent-db/b2bua-nodes.js
@@ -77,6 +77,16 @@ const heartbeat = async (req, res) => {
  * indistinguishable from a node that was not there.
  */
 const listNodes = async (req, res) => {
+  // The same gate the heartbeat applies. `/api/agent-db` is already refused at
+  // the prefix for anything without the shared token (middleware/auth.js), so
+  // this is defence in depth — but a route that leans entirely on an invariant
+  // declared in another file, while its sibling checks explicitly, reads as
+  // though the difference were deliberate. It is not: this listing is every
+  // node's public IP, stack, version, registration counts and load.
+  if (res.locals.user?.isSystem !== true) {
+    return res.status(403).send({ message: 'the b2bua node listing is available only to internal callers' });
+  }
+
   const staleAfterSeconds = Number(req.query.staleAfterSeconds ?? 180);
 
   try {
@@ -181,6 +191,7 @@ listNodes.apiDoc = {
         }
       }
     },
+    403: { description: 'Not an internal caller', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
   }
 };

--- a/api/paths/agent-db/b2bua-nodes.js
+++ b/api/paths/agent-db/b2bua-nodes.js
@@ -1,0 +1,186 @@
+import { B2buaNode, B2BUA_NODE_TYPES } from '../../../lib/database.js';
+import { rememberNodeCapability, CAPABILITY_TRACE, CAPABILITY_NONE } from '../../../lib/regclient.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    POST: heartbeat,
+    GET: listNodes
+  };
+};
+
+/**
+ * A b2bua node announcing itself, once a minute.
+ *
+ * This is the node telling us what it is, rather than us finding out by asking
+ * — which matters because the finding-out is only cheap when it succeeds. A
+ * node running the FreeSWITCH stack has no HTTP surface at all, so discovering
+ * that costs a connection attempt at best and a firewall timeout at worst,
+ * repeated for every node until something caches it. A heartbeat makes it known
+ * before the first trace request ever arrives.
+ *
+ * Internal: authenticated by the shared token, which is what makes the caller
+ * the system user. Restricted to that user deliberately — an ordinary caller
+ * able to post here could mark a node as the wrong stack, which would either
+ * deny traces that exist or send requests at a node that cannot answer them.
+ */
+const heartbeat = async (req, res) => {
+  if (res.locals.user?.isSystem !== true) {
+    return res.status(403).send({ message: 'b2bua node heartbeats are accepted only from internal callers' });
+  }
+
+  const { nodeId, type = 'regclient', version, registrations, failedRegistrations, systemLoad } = req.body || {};
+
+  if (!nodeId || typeof nodeId !== 'string' || !nodeId.trim()) {
+    return res.status(400).send({ message: 'nodeId is required' });
+  }
+  if (!B2BUA_NODE_TYPES.includes(type)) {
+    return res.status(400).send({ message: `type must be one of: ${B2BUA_NODE_TYPES.join(', ')}` });
+  }
+
+  try {
+    const now = new Date();
+    const [record] = await B2buaNode.upsert({
+      nodeId: nodeId.trim(),
+      type,
+      version: version ?? null,
+      // A node that cannot count its own registrations should not be able to
+      // zero the fleet view by accident.
+      registrations: Number.isFinite(registrations) ? registrations : 0,
+      failedRegistrations: Number.isFinite(failedRegistrations) ? failedRegistrations : 0,
+      systemLoad: Number.isFinite(systemLoad) ? systemLoad : null,
+      lastSeenAt: now
+    }, { returning: true });
+
+    // Prime the in-process capability cache from the same fact, so the very
+    // next trace request on this replica skips even the database read.
+    rememberNodeCapability(nodeId.trim(), type === 'regclient' ? CAPABILITY_TRACE : CAPABILITY_NONE);
+
+    return res.status(200).send({
+      nodeId: record?.nodeId ?? nodeId.trim(),
+      acknowledgedAt: now.toISOString()
+    });
+  }
+  catch (err) {
+    req.log?.error(err, 'recording a b2bua node heartbeat');
+    return res.status(500).send({ message: 'Internal server error' });
+  }
+};
+
+/**
+ * The fleet: which nodes are up, what they are running, and what they hold.
+ *
+ * Nothing had this view before — it was spread across whichever registrations
+ * each node happened to have claimed, and a node holding none was
+ * indistinguishable from a node that was not there.
+ */
+const listNodes = async (req, res) => {
+  const staleAfterSeconds = Number(req.query.staleAfterSeconds ?? 180);
+
+  try {
+    const nodes = await B2buaNode.findAll({ order: [['nodeId', 'ASC']] });
+    const now = Date.now();
+    return res.send({
+      nodes: nodes.map((node) => {
+        const lastSeenAt = node.lastSeenAt ? new Date(node.lastSeenAt) : null;
+        const ageSeconds = lastSeenAt ? Math.round((now - lastSeenAt.getTime()) / 1000) : null;
+        return {
+          nodeId: node.nodeId,
+          type: node.type,
+          version: node.version,
+          registrations: node.registrations,
+          failedRegistrations: node.failedRegistrations,
+          systemLoad: node.systemLoad,
+          lastSeenAt: lastSeenAt ? lastSeenAt.toISOString() : null,
+          // A node that has stopped heartbeating is reported as stale rather
+          // than quietly dropped: "this node has gone quiet" is the thing worth
+          // seeing, and it is invisible if the row simply disappears.
+          stale: ageSeconds === null || ageSeconds > staleAfterSeconds
+        };
+      })
+    });
+  }
+  catch (err) {
+    req.log?.error(err, 'listing b2bua nodes');
+    return res.status(500).send({ message: 'Internal server error' });
+  }
+};
+
+heartbeat.apiDoc = {
+  summary: 'Record a b2bua node heartbeat (internal)',
+  description: `Called by each b2bua node about once a minute to say what it is and what it is doing.
+                Internal only: authenticated with the shared token.
+
+                The immediate use is capability — \`phone_registrations.b2bua_id\` says which node
+                holds a registration but not what that node is, and only regclient serves the trace
+                and probe API. Knowing before the first request removes a discovery round-trip that
+                is only cheap when it succeeds.`,
+  operationId: 'recordB2buaNodeHeartbeat',
+  tags: ['Agent DB'],
+  requestBody: {
+    required: true,
+    content: {
+      'application/json': {
+        schema: { $ref: '#/components/schemas/B2buaNodeHeartbeat' }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: 'Heartbeat recorded',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              nodeId: { type: 'string' },
+              acknowledgedAt: { type: 'string', format: 'date-time' }
+            }
+          }
+        }
+      }
+    },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    403: { description: 'Not an internal caller', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};
+
+listNodes.apiDoc = {
+  summary: 'List known b2bua nodes (internal)',
+  description: `The fleet as the nodes themselves last reported it: what each is running, how many
+                registrations it holds, how many are failing, and its load. A node that has stopped
+                heartbeating is marked \`stale\` rather than omitted.`,
+  operationId: 'listB2buaNodes',
+  tags: ['Agent DB'],
+  parameters: [
+    {
+      name: 'staleAfterSeconds',
+      in: 'query',
+      required: false,
+      schema: { type: 'integer', default: 180 },
+      description: 'Age beyond which a node is reported stale (default three missed heartbeats)'
+    }
+  ],
+  responses: {
+    200: {
+      description: 'Known b2bua nodes',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              nodes: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/B2buaNode' }
+              }
+            }
+          }
+        }
+      }
+    },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};

--- a/api/paths/phone-endpoints/{identifier}/probe.js
+++ b/api/paths/phone-endpoints/{identifier}/probe.js
@@ -1,0 +1,124 @@
+import { resolveRegistrationNode } from '../../../../lib/regclient-facade.js';
+import { buildProbeUrl, nodeRequest, describeNodeFailure } from '../../../../lib/regclient.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    POST: startRegistrationProbe
+  };
+};
+
+/**
+ * Start a live registration probe on the node that owns this registration.
+ *
+ * A probe performs a real REGISTER attempt and reports what happened as it
+ * happens — transport connect, challenge, auth retry, final response — instead
+ * of leaving the operator to infer failure from a database row changing minutes
+ * later. In `discover` mode the node walks a small matrix of transports and
+ * next-hop choices and returns the minimal `options` patch that works, which is
+ * what turns onboarding a quirky PBX into one API call.
+ *
+ * Probing is deliberately constrained here: only registrations the caller's
+ * organisation owns, never a free-form credential candidate, so this API cannot
+ * be used as a credential-testing oracle against arbitrary registrars.
+ */
+const startRegistrationProbe = async (req, res) => {
+  const { organisationId } = res.locals.user || {};
+  const { identifier } = req.params;
+  const { discover = false, apply = false } = req.body || {};
+
+  try {
+    const resolved = await resolveRegistrationNode({
+      identifier,
+      organisationId,
+      allowUnclaimed: true,
+      log: req.log
+    });
+    if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
+    const { node, config } = resolved;
+
+    const url = buildProbeUrl({ node }, config);
+    let response;
+    try {
+      response = await nodeRequest({
+        url,
+        method: 'POST',
+        data: { registrationId: identifier, discover: !!discover, apply: !!apply },
+        config
+      });
+    }
+    catch (err) {
+      req.log?.warn({ err: err.message, node }, 'b2bua node probe start failed');
+      return res.status(504).send({ ...describeNodeFailure(err, node), error: 'probe unavailable' });
+    }
+
+    if (response.status >= 400) {
+      req.log?.warn({ node, status: response.status }, 'b2bua node rejected probe request');
+      return res.status(response.status === 404 ? 404 : 502).send({
+        error: 'probe unavailable',
+        node,
+        reason: `node returned ${response.status}`,
+        ...(response.data && typeof response.data === 'object' ? { detail: response.data } : {})
+      });
+    }
+
+    return res.status(202).send({ ...response.data, node });
+  }
+  catch (err) {
+    req.log?.error(err, 'starting registration probe');
+    return res.status(500).send({ message: 'Internal server error' });
+  }
+};
+
+startRegistrationProbe.apiDoc = {
+  summary: 'Start a live SIP registration probe',
+  description: `Runs a real registration attempt against this endpoint's registrar from the b2bua node
+                that owns it, and returns a probe identifier. Progress can be streamed from
+                \`GET /phone-endpoints/{identifier}/probe/{probeId}/events\` and the final verdict read
+                from \`GET /phone-endpoints/{identifier}/probe/{probeId}\`.
+
+                With \`discover: true\` the node tries a small matrix of transports and next-hop
+                choices rather than a single attempt, and reports the minimal set of \`options\` that
+                works. With \`apply: true\` that patch is merged into the endpoint's options and the
+                registration is restarted — note that a later full update of \`options\` replaces them
+                wholesale, so a re-probe may be needed after one.
+
+                Probing a registration that is currently registered degrades to a harmless forced
+                refresh of its existing binding; the node will not create a second contact binding at
+                the registrar.`,
+  operationId: 'startPhoneEndpointProbe',
+  tags: ['Phone Endpoints'],
+  parameters: [
+    {
+      name: 'identifier',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+      description: 'Registration endpoint ID (registrations only; not a phone number)'
+    }
+  ],
+  requestBody: {
+    required: false,
+    content: {
+      'application/json': {
+        schema: { $ref: '#/components/schemas/RegistrationProbeRequest' }
+      }
+    }
+  },
+  responses: {
+    202: {
+      description: 'Probe accepted and running',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/RegistrationProbeAccepted' } } }
+    },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
+    409: { description: 'No b2bua node is available to run the probe', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    502: { description: 'The node answered with an error, or is not an address we will contact', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    504: { description: 'The node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};

--- a/api/paths/phone-endpoints/{identifier}/probe.js
+++ b/api/paths/phone-endpoints/{identifier}/probe.js
@@ -1,5 +1,5 @@
 import { requirePermission } from '../../../../lib/auth/permissions.js';
-import { resolveRegistrationNode } from '../../../../lib/regclient-facade.js';
+import { resolveRegistrationNode, passThroughNodeStatus } from '../../../../lib/regclient-facade.js';
 import { signProbeHandle } from '../../../../lib/regclient-probe-handle.js';
 import {
   buildProbeUrl,
@@ -41,14 +41,14 @@ const startRegistrationProbe = async (req, res) => {
   // changes one.
   if (!requirePermission(res, 'phoneEndpoint', 'update')) return;
 
-  const { organisationId } = res.locals.user || {};
+  const user = res.locals.user;
   const { identifier } = req.params;
   const { discover = false, apply = false } = req.body || {};
 
   try {
     const resolved = await resolveRegistrationNode({
       identifier,
-      organisationId,
+      user,
       allowUnclaimed: true,
       log: req.log
     });
@@ -77,7 +77,11 @@ const startRegistrationProbe = async (req, res) => {
 
     if (response.status >= 400) {
       req.log?.warn({ node, status: response.status }, 'b2bua node rejected probe request');
-      return res.status(response.status === 404 ? 404 : 502).send({
+      // 409 (discovery against a live registration), 429 (+Retry-After), 501
+      // (probing disabled here) and the caller's own 400/404 are answers, not
+      // failures — they go back as they came.
+      if (passThroughNodeStatus(res, response, node)) return;
+      return res.status(502).send({
         error: 'probe unavailable',
         node,
         reason: `node returned ${response.status}`,
@@ -152,7 +156,8 @@ startRegistrationProbe.apiDoc = {
     400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
-    409: { description: 'No b2bua node is available to run the probe', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    409: { description: 'No b2bua node is available to run the probe, or discovery was requested against a currently-registered endpoint (disable it first)', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    429: { description: 'The node is already running its maximum number of concurrent probes. Retry after the interval given in the Retry-After header.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     501: { description: 'The node holding this registration does not provide this API (it runs the FreeSWITCH stack)', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeCapabilityUnavailable' } } } },
     502: { description: 'The node answered with an error, or is not an address we will contact', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
     503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },

--- a/api/paths/phone-endpoints/{identifier}/probe.js
+++ b/api/paths/phone-endpoints/{identifier}/probe.js
@@ -1,4 +1,6 @@
+import { requirePermission } from '../../../../lib/auth/permissions.js';
 import { resolveRegistrationNode } from '../../../../lib/regclient-facade.js';
+import { signProbeHandle } from '../../../../lib/regclient-probe-handle.js';
 import {
   buildProbeUrl,
   nodeRequest,
@@ -32,6 +34,13 @@ export default function (logger) {
  * be used as a credential-testing oracle against arbitrary registrars.
  */
 const startRegistrationProbe = async (req, res) => {
+  // A probe is a write, not a read. It puts a real REGISTER on the wire from an
+  // address the customer's PBX trusts, it exercises their stored credential,
+  // and with `apply` it modifies the registration's options. phoneEndpoint.update
+  // is the permission that already governs changing an endpoint, and this
+  // changes one.
+  if (!requirePermission(res, 'phoneEndpoint', 'update')) return;
+
   const { organisationId } = res.locals.user || {};
   const { identifier } = req.params;
   const { discover = false, apply = false } = req.body || {};
@@ -76,7 +85,23 @@ const startRegistrationProbe = async (req, res) => {
       });
     }
 
-    return res.status(202).send({ ...response.data, node });
+    // The id handed back names the node this probe is running on and the
+    // registration it is for, signed. A bare node-local id would send every
+    // follow-up to whichever node holds the registration *at that moment* —
+    // wrong the instant somebody migrates the row, which is exactly what an
+    // operator watching a probe is likely to be doing — and it would let a
+    // caller pair their own registration in the path with somebody else's
+    // probe id in the URL. See lib/regclient-probe-handle.js.
+    const handle = signProbeHandle(
+      { node, registrationId: identifier, probeId: response.data?.probeId },
+      config
+    );
+    if (!handle) {
+      req.log?.error({ node }, 'could not sign a probe handle; refusing to return an unbound probe id');
+      return res.status(500).send({ message: 'Internal server error' });
+    }
+
+    return res.status(202).send({ ...response.data, probeId: handle, node });
   }
   catch (err) {
     req.log?.error(err, 'starting registration probe');

--- a/api/paths/phone-endpoints/{identifier}/probe.js
+++ b/api/paths/phone-endpoints/{identifier}/probe.js
@@ -1,5 +1,12 @@
 import { resolveRegistrationNode } from '../../../../lib/regclient-facade.js';
-import { buildProbeUrl, nodeRequest, describeNodeFailure } from '../../../../lib/regclient.js';
+import {
+  buildProbeUrl,
+  nodeRequest,
+  describeNodeFailure,
+  capabilityFromFailure,
+  unsupportedNodeBody,
+  CAPABILITY_NONE
+} from '../../../../lib/regclient.js';
 
 let log;
 
@@ -46,10 +53,15 @@ const startRegistrationProbe = async (req, res) => {
         url,
         method: 'POST',
         data: { registrationId: identifier, discover: !!discover, apply: !!apply },
-        config
+        config,
+        node
       });
     }
     catch (err) {
+      if (capabilityFromFailure(err) === CAPABILITY_NONE) {
+        req.log?.info({ node }, 'b2bua node does not provide the probe API');
+        return res.status(501).send(unsupportedNodeBody(node));
+      }
       req.log?.warn({ err: err.message, node }, 'b2bua node probe start failed');
       return res.status(504).send({ ...describeNodeFailure(err, node), error: 'probe unavailable' });
     }
@@ -116,6 +128,7 @@ startRegistrationProbe.apiDoc = {
     403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
     409: { description: 'No b2bua node is available to run the probe', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    501: { description: 'The node holding this registration does not provide this API (it runs the FreeSWITCH stack)', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeCapabilityUnavailable' } } } },
     502: { description: 'The node answered with an error, or is not an address we will contact', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
     503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     504: { description: 'The node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
@@ -1,0 +1,86 @@
+import { resolveRegistrationNode } from '../../../../../lib/regclient-facade.js';
+import { buildProbeUrl, nodeRequest, describeNodeFailure } from '../../../../../lib/regclient.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    GET: getRegistrationProbe
+  };
+};
+
+/**
+ * The final report for one probe: verdict, transcript, diagnosis and — in
+ * discovery mode — the minimal `options` patch that made the registration work.
+ */
+const getRegistrationProbe = async (req, res) => {
+  const { organisationId } = res.locals.user || {};
+  const { identifier, probeId } = req.params;
+
+  try {
+    const resolved = await resolveRegistrationNode({
+      identifier,
+      organisationId,
+      allowUnclaimed: true,
+      log: req.log
+    });
+    if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
+    const { node, config } = resolved;
+
+    let response;
+    try {
+      response = await nodeRequest({ url: buildProbeUrl({ node, probeId }, config), config });
+    }
+    catch (err) {
+      req.log?.warn({ err: err.message, node }, 'b2bua node probe fetch failed');
+      return res.status(504).send({ ...describeNodeFailure(err, node), error: 'probe unavailable' });
+    }
+
+    if (response.status === 404) {
+      return res.status(404).send({ message: 'Probe not found on the b2bua node', node });
+    }
+    if (response.status >= 400) {
+      return res.status(502).send({
+        error: 'probe unavailable',
+        node,
+        reason: `node returned ${response.status}`
+      });
+    }
+
+    return res.status(200).send({ ...response.data, node, fetchedAt: new Date().toISOString() });
+  }
+  catch (err) {
+    req.log?.error(err, 'fetching registration probe');
+    return res.status(500).send({ message: 'Internal server error' });
+  }
+};
+
+getRegistrationProbe.apiDoc = {
+  summary: 'Fetch the report for a registration probe',
+  description: `Returns the current state of a probe started with
+                \`POST /phone-endpoints/{identifier}/probe\`: the verdict once it has finished, the SIP
+                transcript of each branch it tried, a diagnosis in plain language, and — for discovery
+                probes — the suggested \`options\` patch. Probes are held in memory on the node that ran
+                them and expire; a probe from an earlier node restart returns 404.`,
+  operationId: 'getPhoneEndpointProbe',
+  tags: ['Phone Endpoints'],
+  parameters: [
+    { name: 'identifier', in: 'path', required: true, schema: { type: 'string' }, description: 'Registration endpoint ID' },
+    { name: 'probeId', in: 'path', required: true, schema: { type: 'string' }, description: 'Probe identifier returned when the probe was started' }
+  ],
+  responses: {
+    200: {
+      description: 'Probe report',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/RegistrationProbeReport' } } }
+    },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
+    409: { description: 'No b2bua node is available', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    502: { description: 'The node answered with an error', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    504: { description: 'The node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
@@ -1,5 +1,12 @@
 import { resolveRegistrationNode } from '../../../../../lib/regclient-facade.js';
-import { buildProbeUrl, nodeRequest, describeNodeFailure } from '../../../../../lib/regclient.js';
+import {
+  buildProbeUrl,
+  nodeRequest,
+  describeNodeFailure,
+  capabilityFromFailure,
+  unsupportedNodeBody,
+  CAPABILITY_NONE
+} from '../../../../../lib/regclient.js';
 
 let log;
 
@@ -30,9 +37,13 @@ const getRegistrationProbe = async (req, res) => {
 
     let response;
     try {
-      response = await nodeRequest({ url: buildProbeUrl({ node, probeId }, config), config });
+      response = await nodeRequest({ url: buildProbeUrl({ node, probeId }, config), config, node });
     }
     catch (err) {
+      if (capabilityFromFailure(err) === CAPABILITY_NONE) {
+        req.log?.info({ node }, 'b2bua node does not provide the probe API');
+        return res.status(501).send(unsupportedNodeBody(node));
+      }
       req.log?.warn({ err: err.message, node }, 'b2bua node probe fetch failed');
       return res.status(504).send({ ...describeNodeFailure(err, node), error: 'probe unavailable' });
     }
@@ -78,6 +89,7 @@ getRegistrationProbe.apiDoc = {
     403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
     409: { description: 'No b2bua node is available', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    501: { description: 'The node holding this registration does not provide this API (it runs the FreeSWITCH stack)', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeCapabilityUnavailable' } } } },
     502: { description: 'The node answered with an error', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
     503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     504: { description: 'The node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
@@ -1,4 +1,6 @@
+import { requirePermission } from '../../../../../lib/auth/permissions.js';
 import { resolveRegistrationNode } from '../../../../../lib/regclient-facade.js';
+import { verifyProbeHandle } from '../../../../../lib/regclient-probe-handle.js';
 import {
   buildProbeUrl,
   nodeRequest,
@@ -22,6 +24,9 @@ export default function (logger) {
  * discovery mode — the minimal `options` patch that made the registration work.
  */
 const getRegistrationProbe = async (req, res) => {
+  // Reading a report is a read; starting the probe took update.
+  if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
+
   const { organisationId } = res.locals.user || {};
   const { identifier, probeId } = req.params;
 
@@ -33,11 +38,30 @@ const getRegistrationProbe = async (req, res) => {
       log: req.log
     });
     if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
-    const { node, config } = resolved;
+    const { config } = resolved;
+
+    // The handle decides which node to ask and confirms the probe belongs to
+    // the registration in the path — not the registration's *current*
+    // `b2bua_id`, which may have moved since the probe started, and not the
+    // path parameter alone, which the probe id is not derived from. Ownership
+    // was already checked above; this is about asking the right node the right
+    // question.
+    const handle = verifyProbeHandle(probeId, { registrationId: identifier }, config);
+    if (!handle.ok) {
+      req.log?.info({ reason: handle.reason }, 'rejecting a probe id');
+      // 404 rather than 403: whether a probe exists on a node is itself a fact
+      // about somebody else's registration.
+      return res.status(404).send({ message: 'Probe not found' });
+    }
+    const { node, probeId: nodeProbeId } = handle;
 
     let response;
     try {
-      response = await nodeRequest({ url: buildProbeUrl({ node, probeId }, config), config, node });
+      response = await nodeRequest({
+        url: buildProbeUrl({ node, probeId: nodeProbeId, registrationId: identifier }, config),
+        config,
+        node
+      });
     }
     catch (err) {
       if (capabilityFromFailure(err) === CAPABILITY_NONE) {

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
@@ -1,5 +1,9 @@
 import { requirePermission } from '../../../../../lib/auth/permissions.js';
-import { resolveRegistrationNode } from '../../../../../lib/regclient-facade.js';
+import {
+  resolveRegistrationForHandle,
+  assertHandleNodeAllowed,
+  passThroughNodeStatus
+} from '../../../../../lib/regclient-facade.js';
 import { verifyProbeHandle } from '../../../../../lib/regclient-probe-handle.js';
 import {
   buildProbeUrl,
@@ -27,25 +31,25 @@ const getRegistrationProbe = async (req, res) => {
   // Reading a report is a read; starting the probe took update.
   if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
 
-  const { organisationId } = res.locals.user || {};
+  const user = res.locals.user;
   const { identifier, probeId } = req.params;
 
   try {
-    const resolved = await resolveRegistrationNode({
-      identifier,
-      organisationId,
-      allowUnclaimed: true,
-      log: req.log
-    });
+    // Ownership and configuration only — deliberately not a node lookup. The
+    // handle names the node the probe is actually running on, and re-resolving
+    // the registration's *current* owner here would 409 a row that has since
+    // been unclaimed or 501 one that has since moved to a FreeSWITCH node,
+    // about a probe still running fine on the node the handle names. Watching a
+    // probe while rolling the registration back is exactly the case the signed
+    // handle exists to survive.
+    const resolved = await resolveRegistrationForHandle({ identifier, user, log: req.log });
     if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
     const { config } = resolved;
 
     // The handle decides which node to ask and confirms the probe belongs to
-    // the registration in the path — not the registration's *current*
-    // `b2bua_id`, which may have moved since the probe started, and not the
-    // path parameter alone, which the probe id is not derived from. Ownership
-    // was already checked above; this is about asking the right node the right
-    // question.
+    // the registration in the path — not the path parameter alone, which the
+    // probe id is not derived from. Ownership was already checked above; this
+    // is about asking the right node the right question.
     const handle = verifyProbeHandle(probeId, { registrationId: identifier }, config);
     if (!handle.ok) {
       req.log?.info({ reason: handle.reason }, 'rejecting a probe id');
@@ -54,6 +58,9 @@ const getRegistrationProbe = async (req, res) => {
       return res.status(404).send({ message: 'Probe not found' });
     }
     const { node, probeId: nodeProbeId } = handle;
+
+    const refused = assertHandleNodeAllowed(node, config, req.log);
+    if (refused) return res.status(refused.status).send(refused.body);
 
     let response;
     try {
@@ -76,6 +83,9 @@ const getRegistrationProbe = async (req, res) => {
       return res.status(404).send({ message: 'Probe not found on the b2bua node', node });
     }
     if (response.status >= 400) {
+      // As on the start route: a node saying 501 "probing is disabled here" or
+      // 429 is telling the caller something, and 502 would throw it away.
+      if (passThroughNodeStatus(res, response, node)) return;
       return res.status(502).send({
         error: 'probe unavailable',
         node,
@@ -113,6 +123,7 @@ getRegistrationProbe.apiDoc = {
     403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
     409: { description: 'No b2bua node is available', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    429: { description: 'The node is rate-limiting probe requests. Retry after the interval given in the Retry-After header.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     501: { description: 'The node holding this registration does not provide this API (it runs the FreeSWITCH stack)', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeCapabilityUnavailable' } } } },
     502: { description: 'The node answered with an error', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
     503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
@@ -1,4 +1,6 @@
+import { requirePermission } from '../../../../../../lib/auth/permissions.js';
 import { resolveRegistrationNode } from '../../../../../../lib/regclient-facade.js';
+import { verifyProbeHandle } from '../../../../../../lib/regclient-probe-handle.js';
 import { buildProbeUrl, openNodeStream } from '../../../../../../lib/regclient.js';
 
 let log;
@@ -18,6 +20,9 @@ export default function (logger) {
  * goes away, and either side closing tears down the other.
  */
 const streamRegistrationProbe = async (req, res) => {
+  // Reading a probe as it happens is the same read as reading its report.
+  if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
+
   const { organisationId } = res.locals.user || {};
   const { identifier, probeId } = req.params;
 
@@ -29,12 +34,21 @@ const streamRegistrationProbe = async (req, res) => {
       log: req.log
     });
     if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
-    const { node, config } = resolved;
+    const { config } = resolved;
+
+    // As for the report: the handle pins the node and binds the probe to this
+    // registration. See lib/regclient-probe-handle.js.
+    const handle = verifyProbeHandle(probeId, { registrationId: identifier }, config);
+    if (!handle.ok) {
+      req.log?.info({ reason: handle.reason }, 'rejecting a probe id');
+      return res.status(404).send({ message: 'Probe not found' });
+    }
+    const { node, probeId: nodeProbeId } = handle;
 
     let upstream;
     try {
       upstream = await openNodeStream({
-        url: buildProbeUrl({ node, probeId, events: true }, config),
+        url: buildProbeUrl({ node, probeId: nodeProbeId, registrationId: identifier, events: true }, config),
         config
       });
     }

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
@@ -1,0 +1,102 @@
+import { resolveRegistrationNode } from '../../../../../../lib/regclient-facade.js';
+import { buildProbeUrl, openNodeStream } from '../../../../../../lib/regclient.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    GET: streamRegistrationProbe
+  };
+};
+
+/**
+ * Server-sent events for a running probe, piped straight from the node.
+ *
+ * The short node timeout applies to *establishing* the stream; once the node
+ * has answered, the stream stays open until the probe finishes or the client
+ * goes away, and either side closing tears down the other.
+ */
+const streamRegistrationProbe = async (req, res) => {
+  const { organisationId } = res.locals.user || {};
+  const { identifier, probeId } = req.params;
+
+  try {
+    const resolved = await resolveRegistrationNode({
+      identifier,
+      organisationId,
+      allowUnclaimed: true,
+      log: req.log
+    });
+    if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
+    const { node, config } = resolved;
+
+    let upstream;
+    try {
+      upstream = await openNodeStream({
+        url: buildProbeUrl({ node, probeId, events: true }, config),
+        config
+      });
+    }
+    catch (err) {
+      req.log?.warn({ err: err.message, node }, 'b2bua node probe stream failed');
+      return res.status(504).send({ error: 'probe unavailable', node, reason: err.message });
+    }
+
+    if (upstream.statusCode !== 200) {
+      upstream.resume();
+      return res
+        .status(upstream.statusCode === 404 ? 404 : 502)
+        .send({ error: 'probe unavailable', node, reason: `node returned ${upstream.statusCode}` });
+    }
+
+    res.status(200);
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Regclient-Node', node);
+    res.flushHeaders?.();
+
+    upstream.pipe(res);
+    upstream.on('error', (err) => {
+      req.log?.warn({ err: err.message, node }, 'probe event stream ended in error');
+      res.end();
+    });
+    // A browser navigating away must not leave a socket open to the node.
+    req.on('close', () => upstream.destroy());
+  }
+  catch (err) {
+    req.log?.error(err, 'streaming registration probe');
+    if (!res.headersSent) return res.status(500).send({ message: 'Internal server error' });
+    res.end();
+  }
+};
+
+streamRegistrationProbe.apiDoc = {
+  summary: 'Stream live events from a registration probe',
+  description: `A \`text/event-stream\` of everything the probe does as it happens: transport
+                connection, each SIP message (with digest credentials redacted), timings, and the
+                final verdict. The stream ends when the probe completes. Use
+                \`GET /phone-endpoints/{identifier}/probe/{probeId}\` for the same information as a
+                single document once it has finished.`,
+  operationId: 'streamPhoneEndpointProbe',
+  tags: ['Phone Endpoints'],
+  parameters: [
+    { name: 'identifier', in: 'path', required: true, schema: { type: 'string' }, description: 'Registration endpoint ID' },
+    { name: 'probeId', in: 'path', required: true, schema: { type: 'string' }, description: 'Probe identifier returned when the probe was started' }
+  ],
+  responses: {
+    200: {
+      description: 'Server-sent event stream of probe progress',
+      content: { 'text/event-stream': { schema: { type: 'string' } } }
+    },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
+    409: { description: 'No b2bua node is available', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    502: { description: 'The node answered with an error', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    504: { description: 'The node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
@@ -4,7 +4,15 @@ import {
   assertHandleNodeAllowed
 } from '../../../../../../lib/regclient-facade.js';
 import { verifyProbeHandle } from '../../../../../../lib/regclient-probe-handle.js';
-import { buildProbeUrl, openNodeStream } from '../../../../../../lib/regclient.js';
+import {
+  buildProbeUrl,
+  openNodeStream,
+  capabilityFromFailure,
+  rememberNodeCapability,
+  unsupportedNodeBody,
+  CAPABILITY_NONE,
+  CAPABILITY_TRACE
+} from '../../../../../../lib/regclient.js';
 
 let log;
 
@@ -58,14 +66,37 @@ const streamRegistrationProbe = async (req, res) => {
       });
     }
     catch (err) {
+      // Classified and cached the same way the sibling routes do. openNodeStream
+      // did neither, so this route alone answered 504 for a node already known
+      // not to serve this API, and never learned anything from the attempt —
+      // every stream against such a node paid the full cost again.
+      if (capabilityFromFailure(err) === CAPABILITY_NONE) {
+        rememberNodeCapability(node, CAPABILITY_NONE);
+        req.log?.info({ node }, 'b2bua node does not provide the probe API');
+        return res.status(501).send(unsupportedNodeBody(node));
+      }
       req.log?.warn({ err: err.message, node }, 'b2bua node probe stream failed');
       return res.status(504).send({ error: 'probe unavailable', node, reason: err.message });
     }
 
+    // Answering at all proves the node serves this API, whatever it answered.
+    rememberNodeCapability(node, CAPABILITY_TRACE);
+
     if (upstream.statusCode !== 200) {
       upstream.resume();
+      // 501 "probing is disabled here" and 429 are answers, not failures; 502
+      // would throw the reason away. Matches the report route.
+      if ([400, 404, 409, 429, 501].includes(upstream.statusCode)) {
+        if (upstream.statusCode === 429 && upstream.headers?.['retry-after'] != null) {
+          res.setHeader('Retry-After', String(upstream.headers['retry-after']));
+        }
+        return res.status(upstream.statusCode).send({
+          message: `The b2bua node returned ${upstream.statusCode}`,
+          node
+        });
+      }
       return res
-        .status(upstream.statusCode === 404 ? 404 : 502)
+        .status(502)
         .send({ error: 'probe unavailable', node, reason: `node returned ${upstream.statusCode}` });
     }
 
@@ -113,6 +144,8 @@ streamRegistrationProbe.apiDoc = {
     403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
     409: { description: 'No b2bua node is available', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    429: { description: 'The node is rate-limiting probe requests. Retry after the interval given in the Retry-After header.', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    501: { description: 'The node holding this registration does not provide this API (it runs the FreeSWITCH stack)', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeCapabilityUnavailable' } } } },
     502: { description: 'The node answered with an error', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
     503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     504: { description: 'The node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
@@ -1,5 +1,8 @@
 import { requirePermission } from '../../../../../../lib/auth/permissions.js';
-import { resolveRegistrationNode } from '../../../../../../lib/regclient-facade.js';
+import {
+  resolveRegistrationForHandle,
+  assertHandleNodeAllowed
+} from '../../../../../../lib/regclient-facade.js';
 import { verifyProbeHandle } from '../../../../../../lib/regclient-probe-handle.js';
 import { buildProbeUrl, openNodeStream } from '../../../../../../lib/regclient.js';
 
@@ -23,16 +26,15 @@ const streamRegistrationProbe = async (req, res) => {
   // Reading a probe as it happens is the same read as reading its report.
   if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
 
-  const { organisationId } = res.locals.user || {};
+  const user = res.locals.user;
   const { identifier, probeId } = req.params;
 
   try {
-    const resolved = await resolveRegistrationNode({
-      identifier,
-      organisationId,
-      allowUnclaimed: true,
-      log: req.log
-    });
+    // Ownership and configuration only; the handle picks the node. Re-resolving
+    // the current owner would break the stream for a probe whose registration
+    // has been rolled back or migrated mid-watch — see the note on the report
+    // route.
+    const resolved = await resolveRegistrationForHandle({ identifier, user, log: req.log });
     if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
     const { config } = resolved;
 
@@ -44,6 +46,9 @@ const streamRegistrationProbe = async (req, res) => {
       return res.status(404).send({ message: 'Probe not found' });
     }
     const { node, probeId: nodeProbeId } = handle;
+
+    const refused = assertHandleNodeAllowed(node, config, req.log);
+    if (refused) return res.status(refused.status).send(refused.body);
 
     let upstream;
     try {

--- a/api/paths/phone-endpoints/{identifier}/trace.js
+++ b/api/paths/phone-endpoints/{identifier}/trace.js
@@ -3,7 +3,10 @@ import {
   TRACE_INDEX_FORMATS,
   buildTraceUrl,
   nodeRequest,
-  describeNodeFailure
+  describeNodeFailure,
+  capabilityFromFailure,
+  unsupportedNodeBody,
+  CAPABILITY_NONE
 } from '../../../../lib/regclient.js';
 
 let log;
@@ -57,10 +60,18 @@ const getRegistrationTrace = async (req, res) => {
       response = await nodeRequest({
         url,
         responseType: wantsBinary ? 'arraybuffer' : 'json',
-        config
+        config,
+        node
       });
     }
     catch (err) {
+      // A refused or unreachable connection is a statement about the node, not
+      // an outage: it is running the FreeSWITCH stack, which has no such API.
+      // nodeRequest has already cached that, so the next call answers at once.
+      if (capabilityFromFailure(err) === CAPABILITY_NONE) {
+        req.log?.info({ node }, 'b2bua node does not provide the trace API');
+        return res.status(501).send(unsupportedNodeBody(node));
+      }
       req.log?.warn({ err: err.message, node }, 'b2bua node trace fetch failed');
       return res.status(504).send(describeNodeFailure(err, node));
     }
@@ -162,6 +173,7 @@ getRegistrationTrace.apiDoc = {
     403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
     409: { description: 'Registration is not claimed by any b2bua node', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    501: { description: 'The node holding this registration does not provide this API (it runs the FreeSWITCH stack)', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeCapabilityUnavailable' } } } },
     502: { description: 'The owning node answered with an error, or is not an address we will contact', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
     503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     504: { description: 'The owning node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },

--- a/api/paths/phone-endpoints/{identifier}/trace.js
+++ b/api/paths/phone-endpoints/{identifier}/trace.js
@@ -1,6 +1,6 @@
 import { resolveRegistrationNode } from '../../../../lib/regclient-facade.js';
 import {
-  TRACE_FORMATS,
+  TRACE_INDEX_FORMATS,
   buildTraceUrl,
   nodeRequest,
   describeNodeFailure
@@ -16,14 +16,21 @@ export default function (logger) {
 };
 
 /**
- * SIP trace for one registration, fetched live from the node that holds it.
+ * Index of the SIP exchanges captured for one registration.
  *
  * The b2bua keeps a bounded ring buffer of the SIP conversation per
- * registration — REGISTER transactions (the most recent successful and the
- * most recent failed one are pinned so a storm cannot evict the pair you want
+ * registration — REGISTER transactions (the most recent successful and the most
+ * recent failed one are pinned so a retry storm cannot evict the pair you want
  * to compare), recent call dialogs, and keepalive counters. Nothing is stored
  * centrally, so this route is a thin, strictly time-bounded proxy to the one
  * node that owns the registration.
+ *
+ * This route lists what the buffer holds — one line per exchange, with its
+ * outcome, timing and size — rather than returning all of it. A full trace runs
+ * to tens of kilobytes of SIP text, which is the wrong thing to re-download
+ * every time a listing renders. Fetch one exchange in full from
+ * `/phone-endpoints/{identifier}/trace/{transactionId}` using the ids returned
+ * here.
  */
 const getRegistrationTrace = async (req, res) => {
   const { organisationId } = res.locals.user || {};
@@ -31,8 +38,11 @@ const getRegistrationTrace = async (req, res) => {
   const { format = 'json', since } = req.query;
 
   try {
-    if (!TRACE_FORMATS.includes(format)) {
-      return res.status(400).send({ message: `format must be one of: ${TRACE_FORMATS.join(', ')}` });
+    if (!TRACE_INDEX_FORMATS.includes(format)) {
+      return res.status(400).send({
+        message: `format must be one of: ${TRACE_INDEX_FORMATS.join(', ')}. ` +
+          'Use /trace/{transactionId} for the decoded packets of a single exchange.'
+      });
     }
 
     const resolved = await resolveRegistrationNode({ identifier, organisationId, log: req.log });
@@ -91,20 +101,26 @@ const getRegistrationTrace = async (req, res) => {
 };
 
 getRegistrationTrace.apiDoc = {
-  summary: 'Fetch the SIP trace for a phone registration',
-  description: `Returns the SIP conversation captured by the b2bua node that currently holds this
-                registration: recent REGISTER transactions (the most recent successful and most
-                recent failed one are always retained), recent call dialogs, and keepalive counters.
+  summary: 'List the SIP exchanges captured for a phone registration',
+  description: `Lists what the b2bua node holding this registration has captured: recent REGISTER
+                transactions (the most recent successful and most recent failed one are always
+                retained), recent call dialogs, and keepalive counters. Each entry carries an
+                \`id\`, its outcome, when it happened and how many messages it holds — but not the
+                messages themselves, which would be tens of kilobytes of SIP text on every listing.
 
-                Three representations are available via \`format\`:
-                  * \`json\` (default) — a transaction-grouped transcript, ready to render as a ladder.
-                  * \`decode\` — a flat, chronological array of per-packet decodes with headers, CSeq and SDP parsed out.
-                  * \`pcap\` — a synthesised packet capture for Wireshark or sngrep; TLS legs are exported decrypted.
+                Fetch one exchange in full from
+                \`GET /phone-endpoints/{identifier}/trace/{transactionId}\`, which additionally
+                offers \`format=decode\` for parsed packets.
+
+                \`format=pcap\` is available here and returns a capture of the **whole**
+                registration for Wireshark or sngrep — TLS legs included, exported decrypted, which
+                an on-wire capture can never show.
 
                 Traces live in a bounded in-memory buffer on the node, so they cover recent activity
-                rather than full history, and are lost if that node restarts. Digest credentials are
-                always redacted at this API. The request is proxied to the owning node with a hard
-                timeout and no retries: if that node is unreachable the response is 504.`,
+                rather than full history, and are lost if that node restarts. What has been
+                discarded is reported in \`evictions\`, so a gap is never silent. Digest credentials
+                are always redacted at this API. The request is proxied to the owning node with a
+                hard timeout and no retries: if that node is unreachable the response is 504.`,
   operationId: 'getPhoneEndpointTrace',
   tags: ['Phone Endpoints'],
   parameters: [
@@ -119,8 +135,8 @@ getRegistrationTrace.apiDoc = {
       name: 'format',
       in: 'query',
       required: false,
-      schema: { type: 'string', enum: ['json', 'decode', 'pcap'], default: 'json' },
-      description: 'Representation to return'
+      schema: { type: 'string', enum: ['json', 'pcap'], default: 'json' },
+      description: 'json (default) lists the captured exchanges; pcap exports the whole registration as a capture file'
     },
     {
       name: 'since',
@@ -132,15 +148,10 @@ getRegistrationTrace.apiDoc = {
   ],
   responses: {
     200: {
-      description: 'SIP trace in the requested representation',
+      description: 'Index of captured SIP exchanges, or a whole-registration capture file',
       content: {
         'application/json': {
-          schema: {
-            oneOf: [
-              { $ref: '#/components/schemas/SipTrace' },
-              { type: 'array', items: { $ref: '#/components/schemas/SipTracePacket' } }
-            ]
-          }
+          schema: { $ref: '#/components/schemas/SipTraceIndex' }
         },
         'application/vnd.tcpdump.pcap': {
           schema: { type: 'string', format: 'binary' }

--- a/api/paths/phone-endpoints/{identifier}/trace.js
+++ b/api/paths/phone-endpoints/{identifier}/trace.js
@@ -45,7 +45,7 @@ const getRegistrationTrace = async (req, res) => {
   // able to read its wire traffic instead.
   if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
 
-  const { organisationId } = res.locals.user || {};
+  const user = res.locals.user;
   const { identifier } = req.params;
   const { format = 'json', since } = req.query;
 
@@ -57,7 +57,7 @@ const getRegistrationTrace = async (req, res) => {
       });
     }
 
-    const resolved = await resolveRegistrationNode({ identifier, organisationId, log: req.log });
+    const resolved = await resolveRegistrationNode({ identifier, user, log: req.log });
     if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
     const { node, config } = resolved;
 

--- a/api/paths/phone-endpoints/{identifier}/trace.js
+++ b/api/paths/phone-endpoints/{identifier}/trace.js
@@ -1,0 +1,159 @@
+import { resolveRegistrationNode } from '../../../../lib/regclient-facade.js';
+import {
+  TRACE_FORMATS,
+  buildTraceUrl,
+  nodeRequest,
+  describeNodeFailure
+} from '../../../../lib/regclient.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    GET: getRegistrationTrace
+  };
+};
+
+/**
+ * SIP trace for one registration, fetched live from the node that holds it.
+ *
+ * The b2bua keeps a bounded ring buffer of the SIP conversation per
+ * registration — REGISTER transactions (the most recent successful and the
+ * most recent failed one are pinned so a storm cannot evict the pair you want
+ * to compare), recent call dialogs, and keepalive counters. Nothing is stored
+ * centrally, so this route is a thin, strictly time-bounded proxy to the one
+ * node that owns the registration.
+ */
+const getRegistrationTrace = async (req, res) => {
+  const { organisationId } = res.locals.user || {};
+  const { identifier } = req.params;
+  const { format = 'json', since } = req.query;
+
+  try {
+    if (!TRACE_FORMATS.includes(format)) {
+      return res.status(400).send({ message: `format must be one of: ${TRACE_FORMATS.join(', ')}` });
+    }
+
+    const resolved = await resolveRegistrationNode({ identifier, organisationId, log: req.log });
+    if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
+    const { node, config } = resolved;
+
+    const url = buildTraceUrl({ node, registrationId: identifier, format, since }, config);
+    const wantsBinary = format === 'pcap';
+
+    let response;
+    try {
+      response = await nodeRequest({
+        url,
+        responseType: wantsBinary ? 'arraybuffer' : 'json',
+        config
+      });
+    }
+    catch (err) {
+      req.log?.warn({ err: err.message, node }, 'b2bua node trace fetch failed');
+      return res.status(504).send(describeNodeFailure(err, node));
+    }
+
+    if (response.status === 404) {
+      return res.status(404).send({ message: 'No trace held for this registration on its node', node });
+    }
+    if (response.status >= 400) {
+      req.log?.warn({ node, status: response.status }, 'b2bua node rejected trace request');
+      return res.status(502).send({
+        error: 'trace unavailable',
+        node,
+        reason: `node returned ${response.status}`
+      });
+    }
+
+    const fetchedAt = new Date().toISOString();
+    res.setHeader('X-Regclient-Node', node);
+    res.setHeader('X-Regclient-Fetched-At', fetchedAt);
+
+    if (wantsBinary) {
+      res.setHeader('Content-Type', 'application/vnd.tcpdump.pcap');
+      res.setHeader('Content-Disposition', `attachment; filename="${identifier}.pcap"`);
+      return res.status(200).send(Buffer.from(response.data));
+    }
+
+    // `decode` answers with an array and `json` with an object; keep both
+    // shapes intact — the provenance rides in the headers either way.
+    if (Array.isArray(response.data)) {
+      return res.status(200).send(response.data);
+    }
+    return res.status(200).send({ ...response.data, node, fetchedAt });
+  }
+  catch (err) {
+    req.log?.error(err, 'fetching registration trace');
+    return res.status(500).send({ message: 'Internal server error' });
+  }
+};
+
+getRegistrationTrace.apiDoc = {
+  summary: 'Fetch the SIP trace for a phone registration',
+  description: `Returns the SIP conversation captured by the b2bua node that currently holds this
+                registration: recent REGISTER transactions (the most recent successful and most
+                recent failed one are always retained), recent call dialogs, and keepalive counters.
+
+                Three representations are available via \`format\`:
+                  * \`json\` (default) — a transaction-grouped transcript, ready to render as a ladder.
+                  * \`decode\` — a flat, chronological array of per-packet decodes with headers, CSeq and SDP parsed out.
+                  * \`pcap\` — a synthesised packet capture for Wireshark or sngrep; TLS legs are exported decrypted.
+
+                Traces live in a bounded in-memory buffer on the node, so they cover recent activity
+                rather than full history, and are lost if that node restarts. Digest credentials are
+                always redacted at this API. The request is proxied to the owning node with a hard
+                timeout and no retries: if that node is unreachable the response is 504.`,
+  operationId: 'getPhoneEndpointTrace',
+  tags: ['Phone Endpoints'],
+  parameters: [
+    {
+      name: 'identifier',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+      description: 'Registration endpoint ID (registrations only; not a phone number)'
+    },
+    {
+      name: 'format',
+      in: 'query',
+      required: false,
+      schema: { type: 'string', enum: ['json', 'decode', 'pcap'], default: 'json' },
+      description: 'Representation to return'
+    },
+    {
+      name: 'since',
+      in: 'query',
+      required: false,
+      schema: { type: 'string', format: 'date-time' },
+      description: 'Only return messages captured at or after this time'
+    }
+  ],
+  responses: {
+    200: {
+      description: 'SIP trace in the requested representation',
+      content: {
+        'application/json': {
+          schema: {
+            oneOf: [
+              { $ref: '#/components/schemas/SipTrace' },
+              { type: 'array', items: { $ref: '#/components/schemas/SipTracePacket' } }
+            ]
+          }
+        },
+        'application/vnd.tcpdump.pcap': {
+          schema: { type: 'string', format: 'binary' }
+        }
+      }
+    },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    404: { description: 'Not found', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
+    409: { description: 'Registration is not claimed by any b2bua node', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    502: { description: 'The owning node answered with an error, or is not an address we will contact', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    504: { description: 'The owning node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};

--- a/api/paths/phone-endpoints/{identifier}/trace.js
+++ b/api/paths/phone-endpoints/{identifier}/trace.js
@@ -1,3 +1,4 @@
+import { requirePermission } from '../../../../lib/auth/permissions.js';
 import { resolveRegistrationNode } from '../../../../lib/regclient-facade.js';
 import {
   TRACE_INDEX_FORMATS,
@@ -36,6 +37,14 @@ export default function (logger) {
  * here.
  */
 const getRegistrationTrace = async (req, res) => {
+  // A SIP trace is the endpoint's signalling in full — its registrar, its
+  // account identity, who has been calling it — so it is at least as sensitive
+  // as the endpoint record the same organisation can already see. Organisation
+  // ownership on its own is a weaker gate than the endpoint routes apply: a
+  // member without phoneEndpoint.read cannot read the endpoint, and must not be
+  // able to read its wire traffic instead.
+  if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
+
   const { organisationId } = res.locals.user || {};
   const { identifier } = req.params;
   const { format = 'json', since } = req.query;

--- a/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
+++ b/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
@@ -1,3 +1,4 @@
+import { requirePermission } from '../../../../../lib/auth/permissions.js';
 import { resolveRegistrationNode } from '../../../../../lib/regclient-facade.js';
 import {
   TRACE_FORMATS,
@@ -27,6 +28,10 @@ export default function (logger) {
  * for the exchange somebody actually opened.
  */
 const getRegistrationTraceTransaction = async (req, res) => {
+  // Same gate as the index this transaction id came from: one exchange in full
+  // is strictly more than the line describing it.
+  if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
+
   const { organisationId } = res.locals.user || {};
   const { identifier, transactionId } = req.params;
   const { format = 'json', since } = req.query;

--- a/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
+++ b/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
@@ -1,0 +1,170 @@
+import { resolveRegistrationNode } from '../../../../../lib/regclient-facade.js';
+import {
+  TRACE_FORMATS,
+  buildTraceUrl,
+  nodeRequest,
+  describeNodeFailure
+} from '../../../../../lib/regclient.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    GET: getRegistrationTraceTransaction
+  };
+};
+
+/**
+ * One captured SIP exchange, in full.
+ *
+ * The index route says what a registration's trace holds; this returns a single
+ * entry from it — a REGISTER ladder or a call dialog — with every message. That
+ * split is why a dashboard listing stays cheap: the messages are only fetched
+ * for the exchange somebody actually opened.
+ */
+const getRegistrationTraceTransaction = async (req, res) => {
+  const { organisationId } = res.locals.user || {};
+  const { identifier, transactionId } = req.params;
+  const { format = 'json', since } = req.query;
+
+  try {
+    if (!TRACE_FORMATS.includes(format)) {
+      return res.status(400).send({ message: `format must be one of: ${TRACE_FORMATS.join(', ')}` });
+    }
+
+    const resolved = await resolveRegistrationNode({ identifier, organisationId, log: req.log });
+    if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
+    const { node, config } = resolved;
+
+    const url = buildTraceUrl({ node, registrationId: identifier, transactionId, format, since }, config);
+    const wantsBinary = format === 'pcap';
+
+    let response;
+    try {
+      response = await nodeRequest({
+        url,
+        responseType: wantsBinary ? 'arraybuffer' : 'json',
+        config
+      });
+    }
+    catch (err) {
+      req.log?.warn({ err: err.message, node }, 'b2bua node trace fetch failed');
+      return res.status(504).send(describeNodeFailure(err, node));
+    }
+
+    if (response.status === 404) {
+      // Traces rotate: a transaction listed a few minutes ago may have aged out
+      // behind a burst of retries. Say that, rather than implying the
+      // registration itself is unknown.
+      return res.status(404).send({
+        message: 'That exchange is no longer in this registration\'s trace buffer; it may have rotated out',
+        node
+      });
+    }
+    if (response.status >= 400) {
+      req.log?.warn({ node, status: response.status }, 'b2bua node rejected trace request');
+      return res.status(502).send({
+        error: 'trace unavailable',
+        node,
+        reason: `node returned ${response.status}`
+      });
+    }
+
+    const fetchedAt = new Date().toISOString();
+    res.setHeader('X-Regclient-Node', node);
+    res.setHeader('X-Regclient-Fetched-At', fetchedAt);
+
+    if (wantsBinary) {
+      res.setHeader('Content-Type', 'application/vnd.tcpdump.pcap');
+      res.setHeader('Content-Disposition', `attachment; filename="${identifier}-${transactionId}.pcap"`);
+      return res.status(200).send(Buffer.from(response.data));
+    }
+
+    // `decode` answers with an array and `json` with an object; keep both
+    // shapes intact — the provenance rides in the headers either way.
+    if (Array.isArray(response.data)) {
+      return res.status(200).send(response.data);
+    }
+    return res.status(200).send({ ...response.data, node, fetchedAt });
+  }
+  catch (err) {
+    req.log?.error(err, 'fetching a registration trace transaction');
+    return res.status(500).send({ message: 'Internal server error' });
+  }
+};
+
+getRegistrationTraceTransaction.apiDoc = {
+  summary: 'Fetch one captured SIP exchange in full',
+  description: `Returns a single entry from a registration's trace — one REGISTER transaction or one
+                call dialog — with every message it holds. Use
+                \`GET /phone-endpoints/{identifier}/trace\` to list the entries and their ids.
+
+                Three representations are available via \`format\`:
+                  * \`json\` (default) — the transcript: each message with its envelope and raw text.
+                  * \`decode\` — a flat, chronological array of parsed packets with headers, CSeq and
+                    SDP broken out. Header order and duplicates are preserved, so Via chains and
+                    route sets survive the decode.
+                  * \`pcap\` — this exchange as a capture file for Wireshark or sngrep.
+
+                Digest credentials are always redacted. Trace entries rotate as new activity
+                arrives, so an id listed a few minutes ago may since have aged out; that is a 404.`,
+  operationId: 'getPhoneEndpointTraceTransaction',
+  tags: ['Phone Endpoints'],
+  parameters: [
+    {
+      name: 'identifier',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+      description: 'Registration endpoint ID (registrations only; not a phone number)'
+    },
+    {
+      name: 'transactionId',
+      in: 'path',
+      required: true,
+      schema: { type: 'string' },
+      description: 'Identifier of the exchange, from the trace index'
+    },
+    {
+      name: 'format',
+      in: 'query',
+      required: false,
+      schema: { type: 'string', enum: ['json', 'decode', 'pcap'], default: 'json' },
+      description: 'Representation to return'
+    },
+    {
+      name: 'since',
+      in: 'query',
+      required: false,
+      schema: { type: 'string', format: 'date-time' },
+      description: 'Only return messages captured at or after this time'
+    }
+  ],
+  responses: {
+    200: {
+      description: 'The exchange in the requested representation',
+      content: {
+        'application/json': {
+          schema: {
+            oneOf: [
+              { $ref: '#/components/schemas/SipTrace' },
+              { type: 'array', items: { $ref: '#/components/schemas/SipTracePacket' } }
+            ]
+          }
+        },
+        'application/vnd.tcpdump.pcap': {
+          schema: { type: 'string', format: 'binary' }
+        }
+      }
+    },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    404: { description: 'No such registration, or that exchange has rotated out of the buffer', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
+    409: { description: 'Registration is not claimed by any b2bua node', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    502: { description: 'The owning node answered with an error, or is not an address we will contact', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    504: { description: 'The owning node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};

--- a/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
+++ b/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
@@ -32,7 +32,7 @@ const getRegistrationTraceTransaction = async (req, res) => {
   // is strictly more than the line describing it.
   if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
 
-  const { organisationId } = res.locals.user || {};
+  const user = res.locals.user;
   const { identifier, transactionId } = req.params;
   const { format = 'json', since } = req.query;
 
@@ -41,7 +41,7 @@ const getRegistrationTraceTransaction = async (req, res) => {
       return res.status(400).send({ message: `format must be one of: ${TRACE_FORMATS.join(', ')}` });
     }
 
-    const resolved = await resolveRegistrationNode({ identifier, organisationId, log: req.log });
+    const resolved = await resolveRegistrationNode({ identifier, user, log: req.log });
     if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
     const { node, config } = resolved;
 

--- a/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
+++ b/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
@@ -3,7 +3,10 @@ import {
   TRACE_FORMATS,
   buildTraceUrl,
   nodeRequest,
-  describeNodeFailure
+  describeNodeFailure,
+  capabilityFromFailure,
+  unsupportedNodeBody,
+  CAPABILITY_NONE
 } from '../../../../../lib/regclient.js';
 
 let log;
@@ -45,10 +48,18 @@ const getRegistrationTraceTransaction = async (req, res) => {
       response = await nodeRequest({
         url,
         responseType: wantsBinary ? 'arraybuffer' : 'json',
-        config
+        config,
+        node
       });
     }
     catch (err) {
+      // A refused or unreachable connection is a statement about the node, not
+      // an outage: it is running the FreeSWITCH stack, which has no such API.
+      // nodeRequest has already cached that, so the next call answers at once.
+      if (capabilityFromFailure(err) === CAPABILITY_NONE) {
+        req.log?.info({ node }, 'b2bua node does not provide the trace API');
+        return res.status(501).send(unsupportedNodeBody(node));
+      }
       req.log?.warn({ err: err.message, node }, 'b2bua node trace fetch failed');
       return res.status(504).send(describeNodeFailure(err, node));
     }
@@ -162,6 +173,7 @@ getRegistrationTraceTransaction.apiDoc = {
     403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     404: { description: 'No such registration, or that exchange has rotated out of the buffer', content: { 'application/json': { schema: { $ref: '#/components/schemas/NotFound' } } } },
     409: { description: 'Registration is not claimed by any b2bua node', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    501: { description: 'The node holding this registration does not provide this API (it runs the FreeSWITCH stack)', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeCapabilityUnavailable' } } } },
     502: { description: 'The owning node answered with an error, or is not an address we will contact', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
     503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
     504: { description: 'The owning node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ Index of the docs in this directory. Start with the first table if you're new; t
 | [number-lifecycle-adding-a-number.md](number-lifecycle-adding-a-number.md) | Carrier-side provisioning and routing a new number in |
 | [registration-workflow.md](registration-workflow.md) | SIP registration handling end to end |
 | [registration-simulation.md](registration-simulation.md) | Exercising registration flows without a real carrier |
+| [registration-trace-and-probe-api.md](registration-trace-and-probe-api.md) | SIP traces and live registration probes, proxied to the owning b2bua node |
 | [uac_registation_address_tracking.md](uac_registation_address_tracking.md) | UAC registration address tracking notes |
 
 ## Runtimes and gateways

--- a/docs/registration-trace-and-probe-api.md
+++ b/docs/registration-trace-and-probe-api.md
@@ -14,6 +14,14 @@ from the dashboard instead of from a node shell:
 Both apply only to `phone-registration` endpoints; a DDI number has no
 registration to trace.
 
+**Permissions.** The trace routes and the probe report require
+`phoneEndpoint:read`; starting a probe requires `phoneEndpoint:update`. That
+split is not cosmetic. A trace is the endpoint's signalling in full — its
+registrar, its account identity, who has been calling it — so it is gated
+exactly as the endpoint record is. A probe is a *write*: it puts a real REGISTER
+on the wire from an address the customer's PBX trusts, it exercises their stored
+credential, and with `apply` it edits the endpoint's options.
+
 ## Why these exist
 
 Until now the only observable signal from a registration was the `state` and
@@ -203,8 +211,24 @@ Note the interaction with `PUT /phone-endpoints/{id}`: an update replaces
 patch is re-derivable by re-probing.
 
 Probing a registration that is currently registered is safe: the node reuses the
-registration's existing contact, so the probe degrades to a forced refresh and
-cannot create a second binding at the registrar or drop the live one.
+registration's existing contact and asks for the expiry that binding already
+holds, so the probe degrades to a forced refresh — it cannot create a second
+binding at the registrar, drop the live one, or shorten it.
+
+Discovery against a live registration is refused with `409`. The matrix would
+re-register the live contact once per transport, and since a contact URI differs
+by `;transport=`, that is three separate bindings at the registrar — none of
+which a refresh cleans up. Disable the registration first, or probe without
+`discover` to force a refresh.
+
+**Probe ids are opaque handles.** The `probeId` returned by `POST` names the node
+the probe is running on and the registration it is for, signed. Two things follow
+that a bare id could not give you: a follow-up reaches the node that is actually
+running the probe even if the registration migrates to another node while you
+watch, and a probe id cannot be paired with a different registration in the path
+to read somebody else's transcript. A handle that does not verify — a forgery, or
+one for another registration — answers `404`, because whether a probe exists on a
+node is itself a fact about another registration.
 
 Only registrations the caller's organisation owns can be probed. There is no
 free-form "try these credentials against this registrar" form on this API,

--- a/docs/registration-trace-and-probe-api.md
+++ b/docs/registration-trace-and-probe-api.md
@@ -5,7 +5,8 @@ from the dashboard instead of from a node shell:
 
 | Route | Purpose |
 |---|---|
-| `GET /api/phone-endpoints/{id}/trace` | The SIP conversation captured for this registration — REGISTER ladders, recent call dialogs, keepalive counters |
+| `GET /api/phone-endpoints/{id}/trace` | Index of the SIP exchanges captured for this registration — REGISTER ladders, recent call dialogs, keepalive counters |
+| `GET /api/phone-endpoints/{id}/trace/{transactionId}` | One of those exchanges, in full |
 | `POST /api/phone-endpoints/{id}/probe` | Run a live registration attempt now and report what happens |
 | `GET /api/phone-endpoints/{id}/probe/{probeId}/events` | Server-sent events from a running probe |
 | `GET /api/phone-endpoints/{id}/probe/{probeId}` | The finished probe report |
@@ -44,28 +45,72 @@ A node that is down therefore produces a prompt `504 {error, node, reason}`
 rather than a hung request — and names the node, so an operator knows which
 instance to look at.
 
+## Two steps, not one
+
+A full trace runs to tens of kilobytes of SIP text — eight REGISTER ladders and
+a couple of call dialogs, each message up to 4 KiB. That is the right thing for
+a node to hold and the wrong thing to return on every read: a dashboard listing
+wants to know *what happened*, not to re-download all of it each time it
+renders.
+
+So reading a trace is two steps.
+
+**The index** (`GET …/trace`) lists the exchanges, most recent first, at a
+couple of hundred bytes each:
+
+```json
+{
+  "registrationId": "…", "node": "203.0.113.10",
+  "capturedAt": "…", "fetchedAt": "…",
+  "transactions": [
+    { "id": "reg-8", "kind": "register", "summary": "REGISTER → 403 Forbidden",
+      "outcome": "failure", "code": 403, "startedAt": "…", "rttMs": 34,
+      "pinned": true, "messages": 4, "bytes": 2870 },
+    { "id": "call-2", "kind": "call", "direction": "inbound",
+      "summary": "INVITE → 200 OK", "outcome": "completed",
+      "callId": "…", "startedAt": "…", "endedAt": "…", "messages": 8, "bytes": 9012 }
+  ],
+  "keepalive": { "sent": 412, "ok": 411, "failed": 1, "transitions": [ … ] },
+  "evictions": { "registerTransactions": 12, "calls": 3, "truncatedMessages": 0 }
+}
+```
+
+`pinned` marks the entries kept regardless of rotation — the most recent
+successful and most recent failed REGISTER — so a retry storm cannot evict the
+last known-good exchange you want to diff against. `evictions` says what has
+been discarded, so a gap in the history is never silent.
+
+**The detail** (`GET …/trace/{transactionId}`) returns one of those entries with
+every message, in the representation you ask for.
+
 ## Trace formats
 
-`?format=` selects the representation; the node renders all three.
+`?format=` selects the representation.
 
-- **`json`** (default) — transaction-grouped transcript. REGISTER exchanges are
-  grouped (request, challenge, authenticated request, final response) with an
-  outcome and round-trip time; call dialogs carry their full signalling;
-  keepalives appear as counters and up/down transitions rather than messages.
+On the **detail** route, all three:
+
+- **`json`** (default) — the transcript: each message with its envelope
+  (direction, transport, five-tuple, timestamp) and raw text.
 - **`decode`** — a flat chronological array of decoded packets: parsed headers
   (order and duplicates preserved, so Via chains and route sets survive), CSeq,
   dialog identifiers and parsed SDP. For building a UI that renders a ladder
   without a SIP parser in the browser.
-- **`pcap`** — a synthesised capture, `application/vnd.tcpdump.pcap`. Opens in
-  Wireshark or sngrep with the real five-tuples. TLS legs are exported
-  **decrypted**, which an on-wire capture can never give you.
+- **`pcap`** — that exchange as a capture file.
 
-The trace is a bounded ring buffer, not a log: it holds recent REGISTER
-transactions (with the most recent successful and most recent failed one pinned,
-so a retry storm cannot evict the last known-good exchange to compare against),
-the last few call dialogs, and keepalive counters. It does not survive a node
-restart. What has been discarded is reported in `evictions`, so a gap is never
-silent.
+On the **index** route, `json` (the listing) and `pcap`. Asking a listing for
+`decode` would be exactly the fat response the split exists to avoid, so it is
+refused with a pointer at the right route. `pcap` on the index is deliberate and
+covers the **whole** registration: "give me everything for Wireshark" is a real
+request, and a capture of one transaction on its own rarely is.
+
+Captures are `application/vnd.tcpdump.pcap` and open in Wireshark or sngrep with
+the real five-tuples. TLS legs are exported **decrypted**, which an on-wire
+capture can never give you.
+
+The trace is a bounded ring buffer, not a log. It does not survive a node
+restart, and entries rotate as new activity arrives — an id you listed a few
+minutes ago may since have aged out behind a burst of retries, which the detail
+route reports as a 404 saying so.
 
 Digest credentials in `Authorization` and `Proxy-Authorization` are redacted at
 this API and cannot be un-redacted through it.

--- a/docs/registration-trace-and-probe-api.md
+++ b/docs/registration-trace-and-probe-api.md
@@ -1,0 +1,134 @@
+# Registration trace and probe API
+
+Two additive routes on the Phone Endpoints API make SIP registration diagnosable
+from the dashboard instead of from a node shell:
+
+| Route | Purpose |
+|---|---|
+| `GET /api/phone-endpoints/{id}/trace` | The SIP conversation captured for this registration — REGISTER ladders, recent call dialogs, keepalive counters |
+| `POST /api/phone-endpoints/{id}/probe` | Run a live registration attempt now and report what happens |
+| `GET /api/phone-endpoints/{id}/probe/{probeId}/events` | Server-sent events from a running probe |
+| `GET /api/phone-endpoints/{id}/probe/{probeId}` | The finished probe report |
+
+Both apply only to `phone-registration` endpoints; a DDI number has no
+registration to trace.
+
+## Why these exist
+
+Until now the only observable signal from a registration was the `state` and
+`error` columns changing, and those were derived from a status poll on a five
+minute reconcile cycle — worst case around 35 minutes between a registration
+breaking and anything saying so, with the actual SIP failure never recorded. A
+failing onboarding produced "state: failed" and nothing else.
+
+The b2bua that replaces the FreeSWITCH stack (`regclient`, planned in
+[aplisay-b2bua `docs/regclient-plan.md`](https://github.com/aplisay/aplisay-b2bua/blob/main/docs/regclient-plan.md))
+writes state on the SIP transaction that caused it, and keeps a bounded trace of
+every message it sends and receives per registration. These routes expose that.
+
+## Where the data comes from
+
+There is no central trace store. Each registration is claimed by exactly one
+b2bua node, recorded in `phone_registrations.b2bua_id` — the same pointer the
+originate path follows to route outbound calls — and that node holds the trace
+in memory. The API is a proxy:
+
+1. Load the registration; check it belongs to the caller's organisation.
+2. Read `b2bua_id`. Empty means no node has ever claimed it: `409`, because
+   there is nothing to ask.
+3. Fetch from that node over TLS verified against a private CA, presenting a
+   bearer token, with a hard timeout and no retries.
+4. Stream the answer back, tagged with which node answered and when.
+
+A node that is down therefore produces a prompt `504 {error, node, reason}`
+rather than a hung request — and names the node, so an operator knows which
+instance to look at.
+
+## Trace formats
+
+`?format=` selects the representation; the node renders all three.
+
+- **`json`** (default) — transaction-grouped transcript. REGISTER exchanges are
+  grouped (request, challenge, authenticated request, final response) with an
+  outcome and round-trip time; call dialogs carry their full signalling;
+  keepalives appear as counters and up/down transitions rather than messages.
+- **`decode`** — a flat chronological array of decoded packets: parsed headers
+  (order and duplicates preserved, so Via chains and route sets survive), CSeq,
+  dialog identifiers and parsed SDP. For building a UI that renders a ladder
+  without a SIP parser in the browser.
+- **`pcap`** — a synthesised capture, `application/vnd.tcpdump.pcap`. Opens in
+  Wireshark or sngrep with the real five-tuples. TLS legs are exported
+  **decrypted**, which an on-wire capture can never give you.
+
+The trace is a bounded ring buffer, not a log: it holds recent REGISTER
+transactions (with the most recent successful and most recent failed one pinned,
+so a retry storm cannot evict the last known-good exchange to compare against),
+the last few call dialogs, and keepalive counters. It does not survive a node
+restart. What has been discarded is reported in `evictions`, so a gap is never
+silent.
+
+Digest credentials in `Authorization` and `Proxy-Authorization` are redacted at
+this API and cannot be un-redacted through it.
+
+## Probes
+
+A probe performs a real REGISTER and reports it as it happens: transport
+connect, challenge, authenticated retry, final response — sub-second to a few
+seconds, streamed. `POST` returns `202 {probeId, node}`; stream progress from
+`…/probe/{probeId}/events` or read the report from `…/probe/{probeId}` once it
+finishes.
+
+The report carries a verdict (`registered`, `bad-credentials`, `unreachable`,
+`tls-failure`, `no-route`, …), a one-line diagnosis suitable to show a user, and
+the transcript of each branch attempted.
+
+With `{"discover": true}` the node walks a small matrix — transports in the
+order tls, tcp, udp, with and without a next-hop proxy, learning the realm from
+the first challenge — and returns the minimal `options` patch that worked, e.g.
+`{"transport":"tcp","realm":"pbx.local"}`. Adding `{"apply": true}` merges that
+patch into the endpoint and restarts its registration.
+
+Note the interaction with `PUT /phone-endpoints/{id}`: an update replaces
+`options` wholesale, so a later dashboard save can drop an applied patch. The
+patch is re-derivable by re-probing.
+
+Probing a registration that is currently registered is safe: the node reuses the
+registration's existing contact, so the probe degrades to a forced refresh and
+cannot create a second binding at the registrar or drop the live one.
+
+Only registrations the caller's organisation owns can be probed. There is no
+free-form "try these credentials against this registrar" form on this API,
+deliberately — that would be a credential-testing oracle.
+
+## Configuration
+
+Both routes answer `503` unless the deployment is configured to reach nodes:
+
+| Variable | Meaning |
+|---|---|
+| `REGCLIENT_API_TOKEN` | Bearer token presented to nodes; shared through the same secretenv bundle the nodes get. Absent ⇒ routes disabled |
+| `REGCLIENT_API_PORT` | Node API port (default 8443) |
+| `REGCLIENT_CA_CERT` | Public certificate of the private CA that signs node certificates; PEM or base64 of a PEM |
+| `TRACE_PROXY_TIMEOUT_MS` | Hard per-request timeout, default 2000 ms. No retries |
+| `REGCLIENT_PROBE_NODES` | Nodes that may run a probe for a registration no node has claimed |
+| `REGCLIENT_NODE_ALLOWLIST` | Optional pin: only these node addresses may be contacted |
+| `REGCLIENT_ALLOW_PRIVATE_NODES` | Permit node addresses in private ranges (compose, kind). Off by default |
+| `REGCLIENT_API_INSECURE` | Development only: skip TLS verification |
+
+### The node address is untrusted input
+
+`b2bua_id` is normally written by the node that claimed the row, but
+`PUT /phone-endpoints/{id}` also permits writing it — that is the
+per-registration migration lever, and it means the value is caller-influenced.
+Dialling it unchecked would make this facade an SSRF gadget that hands the node
+bearer token to whatever host was named.
+
+So the address is validated before any connection: it must be a bare IP literal
+or DNS name (no scheme, credentials, path or port smuggling); link-local
+(`169.254.0.0/16`, `fe80::/10` — the cloud metadata range) is refused
+unconditionally; loopback and private ranges are refused unless
+`REGCLIENT_ALLOW_PRIVATE_NODES` says otherwise; and when
+`REGCLIENT_NODE_ALLOWLIST` is set nothing outside it is contacted at all.
+
+This sits underneath, not instead of, the network layer: node API ports are
+expected to be firewalled to the API's egress addresses in every environment.

--- a/docs/registration-trace-and-probe-api.md
+++ b/docs/registration-trace-and-probe-api.md
@@ -67,11 +67,30 @@ did not — worth investigating. `501` means the registration is held by a node
 running the older stack, which is an ordinary state of affairs during a
 migration and is fixed by moving the registration, not by retrying.
 
-**It is fast, and it stays fast.** No separate capability endpoint or handshake
-is involved, because the request already proves the answer: a FreeSWITCH node
-has no HTTP surface, and nothing else can present a certificate signed by the
-private CA in our own bundle. So reaching a node at all — even to be refused
-with a `401` — establishes that it is regclient.
+**It is known before it is asked.** Every regclient node reports itself to
+`POST /api/agent-db/b2bua-nodes` once a minute — what it is, what version, how
+many registrations it holds, how many are failing, its load — so a node that has
+announced itself is classified without any network call at all, from the very
+first request.
+
+That registry is also the first fleet view this system has had. What each node
+is running was previously spread across whichever registrations it happened to
+have claimed, and a node holding none was indistinguishable from a node that was
+not there. `GET /api/agent-db/b2bua-nodes` now lists them, marking any that has
+stopped heartbeating as `stale` rather than dropping it — a node that has gone
+quiet is the thing worth seeing.
+
+A **stale** row is treated as saying nothing, not as a denial. A regclient node
+whose heartbeat has broken is still a regclient node, and refusing its traces
+because we stopped hearing from it would be exactly backwards: that is when
+somebody most wants to look.
+
+**And discovery still works underneath.** A node that has never announced itself
+— one mid-rollout, or a deployment with no heartbeat configured — is classified
+from the request itself, because that already proves the answer: a FreeSWITCH
+node has no HTTP surface, and nothing else can present a certificate signed by
+the private CA in our own bundle. So reaching a node at all, even to be refused
+with a `401`, establishes that it is regclient.
 
 That verdict is cached per node, so it is paid at most once:
 

--- a/docs/registration-trace-and-probe-api.md
+++ b/docs/registration-trace-and-probe-api.md
@@ -45,6 +45,52 @@ A node that is down therefore produces a prompt `504 {error, node, reason}`
 rather than a hung request — and names the node, so an operator knows which
 instance to look at.
 
+## Nodes that have no trace API
+
+Not every b2bua node serves these routes. The FreeSWITCH stack has no HTTP
+surface at all, and during the migration both stacks run side by side against
+the same table — so `b2bua_id` may perfectly legitimately point at a node that
+cannot answer.
+
+That case returns **`501`**, not `504`:
+
+```json
+{
+  "code": "trace-api-unavailable",
+  "node": "203.0.113.10",
+  "message": "The b2bua node holding this registration (203.0.113.10) does not provide the trace and probe API..."
+}
+```
+
+The distinction is the point. `504` means a node that should have answered
+did not — worth investigating. `501` means the registration is held by a node
+running the older stack, which is an ordinary state of affairs during a
+migration and is fixed by moving the registration, not by retrying.
+
+**It is fast, and it stays fast.** No separate capability endpoint or handshake
+is involved, because the request already proves the answer: a FreeSWITCH node
+has no HTTP surface, and nothing else can present a certificate signed by the
+private CA in our own bundle. So reaching a node at all — even to be refused
+with a `401` — establishes that it is regclient.
+
+That verdict is cached per node, so it is paid at most once:
+
+- **First call to an unknown node**: bounded by `REGCLIENT_DISCOVERY_TIMEOUT_MS`
+  (750 ms) rather than the full request budget. A closed port refuses in
+  milliseconds; only a firewall that drops rather than rejects costs the whole
+  750 ms, and only once.
+- **Every call after that**: answered from cache with no network call at all —
+  microseconds.
+- **A timeout is never cached.** Something may be listening and merely busy, and
+  marking a slow regclient node as having no API would be a lie that outlived
+  the moment. Only connection-level failures — refused, unreachable, TLS —
+  settle the question.
+
+Positive verdicts are held for `REGCLIENT_CAPABILITY_TTL_MS` (10 minutes;
+a node does not change stack without a redeploy). Negative ones for
+`REGCLIENT_UNSUPPORTED_TTL_MS` (1 minute), because migrating a node to regclient
+is exactly when somebody will go looking for its traces.
+
 ## Two steps, not one
 
 A full trace runs to tens of kilobytes of SIP text — eight REGISTER ladders and
@@ -159,6 +205,9 @@ Both routes answer `503` unless the deployment is configured to reach nodes:
 | `REGCLIENT_NODE_ALLOWLIST` | Optional pin: only these node addresses may be contacted |
 | `REGCLIENT_ALLOW_PRIVATE_NODES` | Permit node addresses in private ranges (compose, kind). Off by default |
 | `REGCLIENT_API_INSECURE` | Development only: skip TLS verification |
+| `REGCLIENT_DISCOVERY_TIMEOUT_MS` | 750. Bound on the first request to a node we have never reached, so learning it runs FreeSWITCH is cheap |
+| `REGCLIENT_CAPABILITY_TTL_MS` | 600000. How long a node is remembered as serving this API |
+| `REGCLIENT_UNSUPPORTED_TTL_MS` | 60000. How long a node is remembered as not serving it — short, so a migration is picked up promptly |
 
 ### The node address is untrusted input
 

--- a/docs/registration-trace-and-probe-api.md
+++ b/docs/registration-trace-and-probe-api.md
@@ -240,7 +240,8 @@ Both routes answer `503` unless the deployment is configured to reach nodes:
 
 | Variable | Meaning |
 |---|---|
-| `REGCLIENT_API_TOKEN` | Bearer token presented to nodes; shared through the same secretenv bundle the nodes get. Absent ⇒ routes disabled |
+| `REGCLIENT_API_TOKEN` | Bearer token presented to nodes; shared through the same secretenv bundle the nodes get. Absent ⇒ routes disabled. It also derives the key that signs probe handles |
+| `REGCLIENT_API_TOKEN_PREVIOUS` | Optional, verification only. Nodes accept two bearer tokens at once so rotation is add-new, flip-caller, drop-old; set this to the outgoing token for the same grace on probe handles, or every probe in flight 404s the moment the token flips. Never used to sign |
 | `REGCLIENT_API_PORT` | Node API port (default 8443) |
 | `REGCLIENT_CA_CERT` | Public certificate of the private CA that signs node certificates; PEM or base64 of a PEM |
 | `TRACE_PROXY_TIMEOUT_MS` | Hard per-request timeout, default 2000 ms. No retries |

--- a/environment-example
+++ b/environment-example
@@ -182,6 +182,14 @@ LIVEKIT_API_SECRET=<LIVEKIT API SECRET>
 # base64 of a PEM. Required unless REGCLIENT_API_INSECURE=1.
 # REGCLIENT_CA_CERT=
 # TRACE_PROXY_TIMEOUT_MS=2000     # hard per-request timeout; no retries
+# During the migration a registration may be held by a FreeSWITCH node, which
+# has no HTTP surface at all. That is discovered from the request itself (only
+# regclient can present a certificate our CA signed), reported as 501 rather
+# than 504, and cached — so it costs one short attempt per node, not a timeout
+# per call.
+# REGCLIENT_DISCOVERY_TIMEOUT_MS=750    # bound on the first try to an unknown node
+# REGCLIENT_CAPABILITY_TTL_MS=600000    # how long "serves traces" is remembered
+# REGCLIENT_UNSUPPORTED_TTL_MS=60000    # how long "does not" is remembered
 # Nodes able to run a probe for a registration no node has claimed yet.
 # REGCLIENT_PROBE_NODES=
 # Optional pin: only these node addresses may be contacted at all.

--- a/environment-example
+++ b/environment-example
@@ -182,11 +182,12 @@ LIVEKIT_API_SECRET=<LIVEKIT API SECRET>
 # base64 of a PEM. Required unless REGCLIENT_API_INSECURE=1.
 # REGCLIENT_CA_CERT=
 # TRACE_PROXY_TIMEOUT_MS=2000     # hard per-request timeout; no retries
-# During the migration a registration may be held by a FreeSWITCH node, which
-# has no HTTP surface at all. That is discovered from the request itself (only
-# regclient can present a certificate our CA signed), reported as 501 rather
-# than 504, and cached — so it costs one short attempt per node, not a timeout
-# per call.
+# Which node runs which stack is normally known rather than discovered: each
+# regclient node reports itself to POST /api/agent-db/b2bua-nodes once a minute
+# (authenticated with SHARED_API_TOKEN above). A node that has never announced
+# itself is classified from the request instead — only regclient can present a
+# certificate our CA signed — reported as 501 rather than 504, and cached, so it
+# costs one short attempt per node rather than a timeout per call.
 # REGCLIENT_DISCOVERY_TIMEOUT_MS=750    # bound on the first try to an unknown node
 # REGCLIENT_CAPABILITY_TTL_MS=600000    # how long "serves traces" is remembered
 # REGCLIENT_UNSUPPORTED_TTL_MS=60000    # how long "does not" is remembered

--- a/environment-example
+++ b/environment-example
@@ -171,6 +171,27 @@ LIVEKIT_API_SECRET=<LIVEKIT API SECRET>
 # TEXT_CHAT_PENDING_TTL_MS=       # pending text-chat session TTL
 # SUBAGENT_TIMEOUT=60000          # agent-invoke/subagent timeout (ms)
 
+# ── b2bua node API (SIP traces and registration probes) ─────────────────────
+# The regclient b2bua exposes a small authenticated HTTPS API per node. The API
+# proxies to it for GET /phone-endpoints/{id}/trace and the probe routes, using
+# phone_registrations.b2bua_id to find the node that owns each registration.
+# Leave REGCLIENT_API_TOKEN unset to disable those routes (they answer 503).
+# REGCLIENT_API_TOKEN=<shared with the node secretenv bundle>
+# REGCLIENT_API_PORT=8443
+# Public certificate of the private CA that signs node certificates. PEM, or
+# base64 of a PEM. Required unless REGCLIENT_API_INSECURE=1.
+# REGCLIENT_CA_CERT=
+# TRACE_PROXY_TIMEOUT_MS=2000     # hard per-request timeout; no retries
+# Nodes able to run a probe for a registration no node has claimed yet.
+# REGCLIENT_PROBE_NODES=
+# Optional pin: only these node addresses may be contacted at all.
+# REGCLIENT_NODE_ALLOWLIST=
+# Allow node addresses in private ranges (compose/kind); public IPs only by
+# default. Link-local is never allowed.
+# REGCLIENT_ALLOW_PRIVATE_NODES=0
+# Dev only: skip TLS verification (and, with REGCLIENT_API_SCHEME=http, TLS).
+# REGCLIENT_API_INSECURE=0
+
 # ── Number administration (tools/number.js — manual admin script only) ──────
 # Magrathea carrier credentials + SIP ingress hosts for bulk/manual number
 # maintenance. NOT read by the API service itself; the self-service Buy-number

--- a/lib/database-models/b2bua-node.js
+++ b/lib/database-models/b2bua-node.js
@@ -1,0 +1,85 @@
+import { Model, DataTypes } from 'sequelize';
+
+/**
+ * A b2bua node announcing itself.
+ *
+ * Rows are written only by the nodes themselves, once a minute, through the
+ * internal heartbeat endpoint — never by a node reaching into this database
+ * directly. That distinction matters: the control-plane schema is this
+ * service's to own and evolve, and a node that had to be redeployed in step
+ * with a column rename would be a migration hazard for no benefit.
+ *
+ * The table answers two questions.
+ *
+ * The immediate one is capability: `phone_registrations.b2bua_id` names the
+ * node holding a registration, but not what that node *is*. During the
+ * migration both stacks run side by side, and only regclient serves the trace
+ * and probe API — so a lookup here turns "wait and find out" into "already
+ * know", from the very first request.
+ *
+ * The lasting one is a fleet view: which nodes are up, what they are running,
+ * how many registrations each holds and how many of those are failing. Nothing
+ * had that before; it was distributed across the rows each node happened to
+ * claim.
+ */
+class B2buaNode extends Model {}
+
+/** How the node identifies its own stack. */
+export const B2BUA_NODE_TYPES = ['regclient', 'freeswitch'];
+
+export function initB2buaNode(sequelize, types = DataTypes) {
+  B2buaNode.init({
+    // The node's public address — the same value it writes into
+    // phone_registrations.b2bua_id, which is what makes this table joinable to
+    // a registration without anything else being agreed between the two.
+    nodeId: {
+      type: types.STRING,
+      primaryKey: true
+    },
+    type: {
+      type: types.STRING,
+      allowNull: false,
+      defaultValue: 'regclient'
+    },
+    version: {
+      type: types.STRING,
+      allowNull: true
+    },
+    // Registrations this node currently holds, and how many of them are
+    // failing. A node whose failures climb while its total holds steady is a
+    // different problem from one that has lost its claims entirely, and the
+    // pair says which.
+    registrations: {
+      type: types.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    },
+    failedRegistrations: {
+      type: types.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    },
+    // One-minute load average, as the node sees it.
+    systemLoad: {
+      type: types.FLOAT,
+      allowNull: true
+    },
+    // When the node last said it was here. Freshness is the whole signal: a
+    // row that has stopped being updated describes a node that has stopped,
+    // and is treated as telling us nothing rather than as still true.
+    lastSeenAt: {
+      type: types.DATE,
+      allowNull: false
+    }
+  }, {
+    sequelize,
+    timestamps: true,
+    underscored: true,
+    modelName: 'B2buaNode',
+    tableName: 'b2bua_nodes'
+  });
+
+  return B2buaNode;
+}
+
+export { B2buaNode };

--- a/lib/database.js
+++ b/lib/database.js
@@ -8,6 +8,8 @@ import { getVoiceNamesForAgentValidation, getTtsVendorsForAgentValidation } from
 import { validateToolsCallsMetadataUsage } from './handlers/toolsCalls-metadata-capability.js';
 import { validatePromptMetadata } from './prompt-metadata-validate.js';
 import { initPhoneRegistration } from './database-models/phone-registration.js';
+import { initB2buaNode } from './database-models/b2bua-node.js';
+export { B2BUA_NODE_TYPES } from './database-models/b2bua-node.js';
 import { encryptSecret, decryptSecret, credentialsEncryptionEnabled } from './utils/credentials.js';
 import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-limits.js';
 // Import-cycle note: lib/outbound-filter.js is deliberately dependency-free so the
@@ -2051,6 +2053,7 @@ Instance.hasOne(PhoneNumber, { foreignKey: 'instanceId', onDelete: 'SET NULL', a
 
 // Registration-based endpoints (non-DDI)
 const PhoneRegistration = initPhoneRegistration(sequelize, DataTypes);
+const B2buaNode = initB2buaNode(sequelize, DataTypes);
 
 
 class User extends Model {
@@ -2763,6 +2766,10 @@ const databaseStarted = sequelize.authenticate()
     // feature's failure mode is the quietest yet: chats keep working, history
     // just never records, and the UI shows an innocuous empty state.
     await ChatSession.sync();
+    // b2bua_nodes is ensured the same way and for the same reason. Its failure
+    // mode is quiet in the same style: traces keep "working", they just report
+    // every node as unknown and pay a discovery attempt for each one for ever.
+    await B2buaNode.sync();
     // Columns added after first deploy: the unconditional sync above is
     // create-if-missing only (no alter — the whole point of taking it out of
     // the gated upgrade chain), so bring an existing table up to date the
@@ -2936,6 +2943,7 @@ export {
   validateBridgedTransferTranscribeShape,
   PhoneNumber,
   PhoneRegistration,
+  B2buaNode,
   Call,
   TransactionLog,
   InvocationLog,

--- a/lib/database.js
+++ b/lib/database.js
@@ -2769,7 +2769,23 @@ const databaseStarted = sequelize.authenticate()
     // b2bua_nodes is ensured the same way and for the same reason. Its failure
     // mode is quiet in the same style: traces keep "working", they just report
     // every node as unknown and pay a discovery attempt for each one for ever.
-    await B2buaNode.sync();
+    //
+    // Unlike chat_sessions, this one is allowed to fail. The registry is an
+    // optimisation over asking the node directly, not a dependency — the
+    // facade falls back to discovery, which is what it did before the registry
+    // existed — so a deployment whose database role has no DDL rights should
+    // lose the optimisation, not the boot. Making an optional feature a
+    // startup requirement is a much worse trade than paying a discovery
+    // round-trip.
+    try {
+      await B2buaNode.sync();
+    }
+    catch (err) {
+      logger.warn(
+        { err: err.message },
+        'could not ensure b2bua_nodes; node heartbeats will not be recorded and trace routing will discover each node instead',
+      );
+    }
     // Columns added after first deploy: the unconditional sync above is
     // create-if-missing only (no alter — the whole point of taking it out of
     // the gated upgrade chain), so bring an existing table up to date the

--- a/lib/regclient-facade.js
+++ b/lib/regclient-facade.js
@@ -1,0 +1,83 @@
+/**
+ * Shared resolution for the regclient facade routes.
+ *
+ * Every route in this family answers the same three questions before it can do
+ * anything useful: does this registration exist and belong to the caller's
+ * organisation, which node owns it, and is this deployment configured to talk
+ * to nodes at all. Doing that once here keeps the routes to their actual job —
+ * shaping one request and one response.
+ *
+ * Returns either `{ ok: false, status, body }`, ready to send verbatim, or
+ * `{ ok: true, registration, node, config }`.
+ */
+
+import { PhoneRegistration } from './database.js';
+import {
+  loadRegclientConfig,
+  configurationProblem,
+  assertNodeAddressAllowed,
+  selectProbeNode
+} from './regclient.js';
+
+export async function resolveRegistrationNode({
+  identifier,
+  organisationId,
+  allowUnclaimed = false,
+  env = process.env,
+  log
+}) {
+  if (!identifier) {
+    return { ok: false, status: 400, body: { message: 'Registration ID is required' } };
+  }
+  if (identifier.match(/^\+?[0-9]+$/)) {
+    return {
+      ok: false,
+      status: 400,
+      body: { message: 'Identifier must be a registration ID, not a phone number' }
+    };
+  }
+
+  const registration = await PhoneRegistration.findByPk(identifier);
+  if (!registration) {
+    return { ok: false, status: 404, body: { message: 'Phone registration not found' } };
+  }
+  if (registration.organisationId !== organisationId) {
+    return { ok: false, status: 403, body: { message: 'Access denied' } };
+  }
+
+  const config = loadRegclientConfig(env);
+  const problem = configurationProblem(config);
+  if (problem) {
+    log?.error({ problem }, 'regclient node API is not configured');
+    return { ok: false, status: 503, body: { message: `b2bua node API not available: ${problem}` } };
+  }
+
+  const claimed = String(registration.b2buaId || '').trim();
+  const node = allowUnclaimed
+    ? selectProbeNode({ registrationId: identifier, claimedNode: claimed, env })
+    : claimed;
+
+  if (!node) {
+    return {
+      ok: false,
+      status: 409,
+      body: {
+        message: allowUnclaimed
+          ? 'Registration is not claimed by a b2bua node and no probe node pool is configured'
+          : 'Registration has not been claimed by a b2bua node, so no trace exists yet'
+      }
+    };
+  }
+
+  const allowed = assertNodeAddressAllowed(node, config);
+  if (!allowed.ok) {
+    log?.warn({ node, reason: allowed.reason }, 'refusing to contact b2bua node address');
+    return {
+      ok: false,
+      status: 502,
+      body: { message: `Refusing to contact b2bua node: ${allowed.reason}` }
+    };
+  }
+
+  return { ok: true, registration, node, config, claimed: !!claimed };
+}

--- a/lib/regclient-facade.js
+++ b/lib/regclient-facade.js
@@ -11,16 +11,52 @@
  * `{ ok: true, registration, node, config }`.
  */
 
-import { PhoneRegistration } from './database.js';
+import { PhoneRegistration, B2buaNode } from './database.js';
 import {
   loadRegclientConfig,
   configurationProblem,
   assertNodeAddressAllowed,
   selectProbeNode,
   nodeCapability,
+  rememberNodeCapability,
   unsupportedNodeBody,
-  CAPABILITY_NONE
+  CAPABILITY_TRACE,
+  CAPABILITY_NONE,
+  CAPABILITY_UNKNOWN
 } from './regclient.js';
+
+/**
+ * How long a node's heartbeat is treated as current.
+ *
+ * Nodes heartbeat about once a minute, so three minutes is three missed beats.
+ * Past that the row is treated as saying nothing rather than as still true —
+ * and, importantly, a stale row is NOT read as "this node has no trace API".
+ * A regclient node whose heartbeat has broken is still a regclient node, and
+ * refusing its traces because we stopped hearing from it would be exactly
+ * backwards: that is when somebody most wants to look.
+ */
+const HEARTBEAT_FRESH_MS = 3 * 60 * 1000;
+
+/**
+ * What the node last told us about itself.
+ *
+ * This is the difference between knowing and finding out. A node that has
+ * heartbeated is classified before the first request is sent; only one that
+ * never has falls through to discovery.
+ */
+export async function capabilityFromHeartbeat(node, { now = Date.now, model = B2buaNode } = {}) {
+  try {
+    const record = await model.findByPk(node);
+    if (!record?.lastSeenAt) return CAPABILITY_UNKNOWN;
+    if (now() - new Date(record.lastSeenAt).getTime() > HEARTBEAT_FRESH_MS) return CAPABILITY_UNKNOWN;
+    return record.type === 'regclient' ? CAPABILITY_TRACE : CAPABILITY_NONE;
+  }
+  catch (err) {
+    // The registry is an optimisation, not a dependency. If it cannot be read,
+    // fall through to discovery rather than failing a request over it.
+    return CAPABILITY_UNKNOWN;
+  }
+}
 
 export async function resolveRegistrationNode({
   identifier,
@@ -82,11 +118,21 @@ export async function resolveRegistrationNode({
     };
   }
 
-  // A node we have already found not to serve this API is answered without a
-  // network call at all. During the migration both stacks run against the same
-  // table, so a registration held by a FreeSWITCH node is an ordinary state of
-  // affairs rather than a fault — and one worth answering in microseconds.
-  if (nodeCapability(node, { env }) === CAPABILITY_NONE) {
+  // What this node is, in increasing order of cost: what this process already
+  // learned, then what the node itself last told us, then — only for a node
+  // that has never heartbeated — finding out by asking.
+  //
+  // During the migration both stacks run against the same table, so a
+  // registration held by a FreeSWITCH node is an ordinary state of affairs
+  // rather than a fault, and one worth answering in microseconds.
+  let capability = nodeCapability(node, { env });
+  if (capability === CAPABILITY_UNKNOWN) {
+    capability = await capabilityFromHeartbeat(node);
+    // Cache what the heartbeat said, so the rest of this replica's requests
+    // skip even the database read.
+    rememberNodeCapability(node, capability);
+  }
+  if (capability === CAPABILITY_NONE) {
     return { ok: false, status: 501, body: unsupportedNodeBody(node) };
   }
 

--- a/lib/regclient-facade.js
+++ b/lib/regclient-facade.js
@@ -16,7 +16,10 @@ import {
   loadRegclientConfig,
   configurationProblem,
   assertNodeAddressAllowed,
-  selectProbeNode
+  selectProbeNode,
+  nodeCapability,
+  unsupportedNodeBody,
+  CAPABILITY_NONE
 } from './regclient.js';
 
 export async function resolveRegistrationNode({
@@ -77,6 +80,14 @@ export async function resolveRegistrationNode({
       status: 502,
       body: { message: `Refusing to contact b2bua node: ${allowed.reason}` }
     };
+  }
+
+  // A node we have already found not to serve this API is answered without a
+  // network call at all. During the migration both stacks run against the same
+  // table, so a registration held by a FreeSWITCH node is an ordinary state of
+  // affairs rather than a fault — and one worth answering in microseconds.
+  if (nodeCapability(node, { env }) === CAPABILITY_NONE) {
+    return { ok: false, status: 501, body: unsupportedNodeBody(node) };
   }
 
   return { ok: true, registration, node, config, claimed: !!claimed };

--- a/lib/regclient-facade.js
+++ b/lib/regclient-facade.js
@@ -12,6 +12,7 @@
  */
 
 import { PhoneRegistration, B2buaNode } from './database.js';
+import { userOwnsRow } from './scope.js';
 import {
   loadRegclientConfig,
   configurationProblem,
@@ -60,36 +61,14 @@ export async function capabilityFromHeartbeat(node, { now = Date.now, model = B2
 
 export async function resolveRegistrationNode({
   identifier,
-  organisationId,
+  user,
   allowUnclaimed = false,
   env = process.env,
   log
 }) {
-  if (!identifier) {
-    return { ok: false, status: 400, body: { message: 'Registration ID is required' } };
-  }
-  if (identifier.match(/^\+?[0-9]+$/)) {
-    return {
-      ok: false,
-      status: 400,
-      body: { message: 'Identifier must be a registration ID, not a phone number' }
-    };
-  }
-
-  const registration = await PhoneRegistration.findByPk(identifier);
-  if (!registration) {
-    return { ok: false, status: 404, body: { message: 'Phone registration not found' } };
-  }
-  if (registration.organisationId !== organisationId) {
-    return { ok: false, status: 403, body: { message: 'Access denied' } };
-  }
-
-  const config = loadRegclientConfig(env);
-  const problem = configurationProblem(config);
-  if (problem) {
-    log?.error({ problem }, 'regclient node API is not configured');
-    return { ok: false, status: 503, body: { message: `b2bua node API not available: ${problem}` } };
-  }
+  const owned = await resolveRegistrationForHandle({ identifier, user, env, log });
+  if (!owned.ok) return owned;
+  const { registration, config } = owned;
 
   const claimed = String(registration.b2buaId || '').trim();
   const node = allowUnclaimed
@@ -137,4 +116,107 @@ export async function resolveRegistrationNode({
   }
 
   return { ok: true, registration, node, config, claimed: !!claimed };
+}
+
+/**
+ * Who is asking, and how this deployment talks to nodes — with no node chosen.
+ *
+ * The probe report and event streams are addressed by a signed handle that
+ * already names the node the probe is running on. Selecting a node here as well
+ * would answer 409 for a row that has since been unclaimed, or 501 for one that
+ * has since moved to a FreeSWITCH node, about a probe still running perfectly
+ * well on the node the handle names — and rolling a registration back while
+ * watching its probe is precisely what an operator does (§9 rollback). The
+ * handle exists to survive that, so those routes check ownership and
+ * configuration here and let the handle pick the node.
+ *
+ * Ownership is still enforced, and the caller must still put the handle's node
+ * through assertNodeAddressAllowed before contacting it.
+ */
+export async function resolveRegistrationForHandle({
+  identifier,
+  user,
+  env = process.env,
+  log
+}) {
+  if (!identifier) {
+    return { ok: false, status: 400, body: { message: 'Registration ID is required' } };
+  }
+  if (identifier.match(/^\+?[0-9]+$/)) {
+    return {
+      ok: false,
+      status: 400,
+      body: { message: 'Identifier must be a registration ID, not a phone number' }
+    };
+  }
+
+  const registration = await PhoneRegistration.findByPk(identifier);
+  if (!registration) {
+    return { ok: false, status: 404, body: { message: 'Phone registration not found' } };
+  }
+  // userOwnsRow, not a bare `!==`. Both sides of an organisation comparison can
+  // legitimately be null — an org-less principal, and a row orphaned by the
+  // `SET NULL` on organisation delete (or created by an org-less user) — and
+  // `null !== null` is false, so the direct comparison *granted* access across
+  // two unrelated org-less tenants. That is the same leak the listing route
+  // already carries a comment about (api/paths/phone-endpoints.js), and a SIP
+  // trace is the registrar, the account identity and the credentials in flight.
+  // scope.js is explicit that org-scoped rows must never be compared this way.
+  if (!userOwnsRow(user, registration)) {
+    return { ok: false, status: 403, body: { message: 'Access denied' } };
+  }
+
+  const config = loadRegclientConfig(env);
+  const problem = configurationProblem(config);
+  if (problem) {
+    log?.error({ problem }, 'regclient node API is not configured');
+    return { ok: false, status: 503, body: { message: `b2bua node API not available: ${problem}` } };
+  }
+
+  return { ok: true, registration, config };
+}
+
+/**
+ * Check a node named by a verified handle before contacting it.
+ *
+ * The handle is integrity-protected, so the node in it is one we put there —
+ * but it was signed at probe-start and the allow-list may have changed since,
+ * so it goes through the same address gate as a freshly selected node.
+ */
+export function assertHandleNodeAllowed(node, config, log) {
+  const allowed = assertNodeAddressAllowed(node, config);
+  if (allowed.ok) return null;
+  log?.warn({ node, reason: allowed.reason }, 'refusing to contact b2bua node address');
+  return { status: 502, body: { message: `Refusing to contact b2bua node: ${allowed.reason}` } };
+}
+
+/**
+ * Statuses from a node that mean something to the caller, and so have to reach
+ * them rather than being flattened into 502.
+ *
+ * 502 says "the node is broken", and none of these are that. 409 is the
+ * deliberate refusal to run discovery against a registration that is currently
+ * live — the caller's fix is to disable it first, which they can only do if we
+ * tell them. 429 is the probe rate limiter, and its `Retry-After` is the whole
+ * of the advice. 501 is probing switched off on that node. 400 and 404 are the
+ * caller's own request. Reporting any of these as "probe unavailable" sends
+ * somebody to look at the node when the answer was in their hands.
+ *
+ * Returns true when it has answered, so callers read as a guard clause.
+ */
+const NODE_STATUS_PASSTHROUGH = new Set([400, 404, 409, 429, 501]);
+
+export function passThroughNodeStatus(res, response, node) {
+  if (!NODE_STATUS_PASSTHROUGH.has(response.status)) return false;
+
+  if (response.status === 429) {
+    const retryAfter = response.headers?.['retry-after'] ?? response.headers?.['Retry-After'];
+    if (retryAfter != null) res.setHeader('Retry-After', String(retryAfter));
+  }
+
+  const body = (response.data && typeof response.data === 'object')
+    ? { ...response.data, node }
+    : { message: `The b2bua node returned ${response.status}`, node };
+  res.status(response.status).send(body);
+  return true;
 }

--- a/lib/regclient-probe-handle.js
+++ b/lib/regclient-probe-handle.js
@@ -20,10 +20,16 @@ import crypto from 'crypto';
  * account identity, credentials-in-flight. Ownership was checked on the path
  * parameter, and the path parameter was not what selected the data.
  *
- * So the id the facade hands out is signed over both. It is opaque to callers
- * — the API contract has always been "an opaque probe id" — and it is verified
- * against the registration in the path before anything is fetched. Ownership is
- * still checked separately: a handle says what it is for, not who may see it.
+ * So the id the facade hands out is signed over both, and verified against the
+ * registration in the path before anything is fetched. Ownership is still
+ * checked separately: a handle says what it is for, not who may see it.
+ *
+ * "Opaque" in the API contract means callers must not parse it, not that it
+ * conceals anything: the payload is base64url JSON, and anyone holding a handle
+ * can already read the node and registration inside it. Both are facts about a
+ * registration that caller was allowed to see, so there is nothing there to
+ * leak — but this is integrity protection, not confidentiality, and treating it
+ * as the latter would be a mistake.
  *
  * Signed with the node API token, which is the one secret that is necessarily
  * present whenever a probe can run at all: without it the facade cannot reach a
@@ -67,8 +73,14 @@ export function signProbeHandle({ node, registrationId, probeId }, config = {}) 
  * information about somebody else's registration.
  */
 export function verifyProbeHandle(handle, { registrationId }, config = {}) {
-  const secret = config.token;
-  if (!secret) return { ok: false, reason: 'no node API token configured' };
+  // The previous token verifies too, so rotating REGCLIENT_API_TOKEN does not
+  // invalidate handles already in flight. Nodes accept two bearer tokens at
+  // once for exactly this reason; the facade signing with one and verifying
+  // against one alone meant a rotation turned every open probe into a 404
+  // mid-watch. Signing still uses the current token only, so a handle issued
+  // now never depends on the old secret.
+  const secrets = [config.token, config.tokenPrevious].filter(Boolean);
+  if (secrets.length === 0) return { ok: false, reason: 'no node API token configured' };
 
   const parts = String(handle || '').split('.');
   if (parts.length !== 3 || parts[0] !== VERSION) {
@@ -76,11 +88,14 @@ export function verifyProbeHandle(handle, { registrationId }, config = {}) {
   }
   const [, payload, signature] = parts;
 
-  const expected = crypto.createHmac('sha256', keyFor(secret)).update(`${VERSION}.${payload}`).digest();
   const got = Buffer.from(signature, 'base64url');
-  // Length check first: timingSafeEqual throws on a mismatch rather than
-  // returning false.
-  if (got.length !== expected.length || !crypto.timingSafeEqual(got, expected)) {
+  const verified = secrets.some((secret) => {
+    const expected = crypto.createHmac('sha256', keyFor(secret)).update(`${VERSION}.${payload}`).digest();
+    // Length check first: timingSafeEqual throws on a mismatch rather than
+    // returning false.
+    return got.length === expected.length && crypto.timingSafeEqual(got, expected);
+  });
+  if (!verified) {
     return { ok: false, reason: 'signature does not verify' };
   }
 

--- a/lib/regclient-probe-handle.js
+++ b/lib/regclient-probe-handle.js
@@ -1,0 +1,101 @@
+import crypto from 'crypto';
+
+/**
+ * Probe handles: a probe id that carries where it ran and what it was for.
+ *
+ * A probe lives in memory on one node. Its id means nothing anywhere else, and
+ * two things follow from that which a bare id cannot express.
+ *
+ * **Which node.** The follow-up routes used to re-resolve the registration's
+ * `b2bua_id` on every call. That is the right node right up until the
+ * registration migrates — which is exactly what an operator is likely to be
+ * doing while watching a probe, and which is a one-line database write. The
+ * report and the event stream would then go to a node that never ran the probe
+ * and return 404, with the probe still running perfectly well next door.
+ *
+ * **Which registration.** The node's probe route is addressed by probe id
+ * alone, so a caller who could read *any* registration could pass their own
+ * registration in the path and somebody else's probe id in the URL, and be
+ * handed a report containing another tenant's SIP transcript — registrar,
+ * account identity, credentials-in-flight. Ownership was checked on the path
+ * parameter, and the path parameter was not what selected the data.
+ *
+ * So the id the facade hands out is signed over both. It is opaque to callers
+ * — the API contract has always been "an opaque probe id" — and it is verified
+ * against the registration in the path before anything is fetched. Ownership is
+ * still checked separately: a handle says what it is for, not who may see it.
+ *
+ * Signed with the node API token, which is the one secret that is necessarily
+ * present whenever a probe can run at all: without it the facade cannot reach a
+ * node, so there is no probe to hand a handle for. A derived key rather than
+ * the token itself, so a handle can never be mistaken for a credential.
+ */
+
+const VERSION = 'v1';
+
+function keyFor(secret) {
+  return crypto.createHash('sha256').update(`aplisay-probe-handle:${secret}`).digest();
+}
+
+function b64url(buf) {
+  return Buffer.from(buf).toString('base64url');
+}
+
+/**
+ * Wrap a node's probe id in a handle naming the node and the registration.
+ *
+ * Returns null when there is no secret to sign with, which the caller must
+ * treat as a failure rather than falling back to the bare id: an unsigned id is
+ * the hole this exists to close.
+ */
+export function signProbeHandle({ node, registrationId, probeId }, config = {}) {
+  const secret = config.token;
+  if (!secret || !node || !registrationId || !probeId) return null;
+
+  const payload = b64url(JSON.stringify({ n: node, r: registrationId, p: probeId }));
+  const mac = crypto.createHmac('sha256', keyFor(secret)).update(`${VERSION}.${payload}`).digest();
+  return `${VERSION}.${payload}.${b64url(mac)}`;
+}
+
+/**
+ * Read a handle back, checking it was issued by us and is for this
+ * registration.
+ *
+ * `{ ok: false }` for anything that does not verify — a forgery, a handle for
+ * another registration, or a bare probe id from an older client. The caller
+ * answers 404 rather than 403: whether a probe exists on a node is itself
+ * information about somebody else's registration.
+ */
+export function verifyProbeHandle(handle, { registrationId }, config = {}) {
+  const secret = config.token;
+  if (!secret) return { ok: false, reason: 'no node API token configured' };
+
+  const parts = String(handle || '').split('.');
+  if (parts.length !== 3 || parts[0] !== VERSION) {
+    return { ok: false, reason: 'not a probe handle' };
+  }
+  const [, payload, signature] = parts;
+
+  const expected = crypto.createHmac('sha256', keyFor(secret)).update(`${VERSION}.${payload}`).digest();
+  const got = Buffer.from(signature, 'base64url');
+  // Length check first: timingSafeEqual throws on a mismatch rather than
+  // returning false.
+  if (got.length !== expected.length || !crypto.timingSafeEqual(got, expected)) {
+    return { ok: false, reason: 'signature does not verify' };
+  }
+
+  let decoded;
+  try {
+    decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  }
+  catch {
+    return { ok: false, reason: 'malformed handle' };
+  }
+  if (!decoded?.n || !decoded?.r || !decoded?.p) {
+    return { ok: false, reason: 'incomplete handle' };
+  }
+  if (decoded.r !== registrationId) {
+    return { ok: false, reason: 'handle is for a different registration' };
+  }
+  return { ok: true, node: decoded.n, probeId: decoded.p, registrationId: decoded.r };
+}

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -174,13 +174,20 @@ export function buildTraceUrl({ node, registrationId, transactionId, format = 'j
 }
 
 /** URL of the probe collection, or of one probe / its event stream. */
-export function buildProbeUrl({ node, probeId, events = false }, config) {
+export function buildProbeUrl({ node, probeId, registrationId, events = false }, config) {
   const { scheme, port } = config;
   const host = net.isIP(node) === 6 ? `[${node}]` : node;
   const path = probeId
     ? `/probe/${encodeURIComponent(probeId)}${events ? '/events' : ''}`
     : '/probe';
-  return new URL(`${scheme}://${host}:${port}${path}`).toString();
+  const url = new URL(`${scheme}://${host}:${port}${path}`);
+  // The node checks this against the registration the probe was actually
+  // started for and 404s if they disagree. The facade already refuses a
+  // mismatch, so this is the same check made twice by two processes that do
+  // not have to trust each other — the node is the only party that knows for
+  // certain which registration a probe id belongs to.
+  if (registrationId) url.searchParams.set('registrationId', registrationId);
+  return url.toString();
 }
 
 /**

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -1,0 +1,313 @@
+/**
+ * regclient node-API client.
+ *
+ * regclient is the Go registration B2BUA that replaces the FreeSWITCH stack in
+ * aplisay-b2bua (see that repo's `docs/regclient-plan.md`). Each phone
+ * registration is claimed by exactly one regclient node, and the claim is
+ * recorded in `phone_registrations.b2bua_id` — the node's public IP address.
+ * That column is the pointer the originate path already follows to route
+ * outbound INVITEs, and it is what lets this API reach the one node that holds
+ * the SIP traces and can run a live registration probe.
+ *
+ * This module owns everything about talking to a node: how the URL is built,
+ * how the connection is authenticated and verified, and — importantly — which
+ * hosts we are willing to dial at all. Routes in `api/paths/**` layer the
+ * org-scoped authorisation on top and translate failures into HTTP responses.
+ *
+ * Security posture (decision #10 of the plan): source-restricted firewalls in
+ * front, verified TLS from a private CA carried in the secretenv bundle, and a
+ * static bearer token shared through the same bundle. Nothing here is a
+ * substitute for the firewall; it is the layer of that onion we own.
+ */
+
+import https from 'node:https';
+import http from 'node:http';
+import net from 'node:net';
+import axios from 'axios';
+
+/** Trace representations regclient can render; passed through verbatim. */
+export const TRACE_FORMATS = ['json', 'decode', 'pcap'];
+
+export const DEFAULT_API_PORT = 8443;
+export const DEFAULT_PROXY_TIMEOUT_MS = 2000;
+
+/**
+ * Read a PEM blob from the environment. secretenv bundles frequently carry
+ * certificates base64-encoded (single-line env values), so accept either a
+ * literal PEM or a base64 wrapping of one.
+ */
+export function decodePem(value) {
+  if (!value || typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes('-----BEGIN')) return trimmed.replace(/\\n/g, '\n');
+  try {
+    const decoded = Buffer.from(trimmed, 'base64').toString('utf8');
+    return decoded.includes('-----BEGIN') ? decoded : null;
+  }
+  catch (e) {
+    return null;
+  }
+}
+
+const boolEnv = (value, dflt = false) => {
+  if (value === undefined || value === null || value === '') return dflt;
+  return ['1', 'true', 'yes', 'on'].includes(String(value).toLowerCase());
+};
+
+/**
+ * Build the node-API configuration from the environment. Called per request so
+ * that a redeployed secretenv bundle takes effect without a restart of this
+ * process being strictly required, and so tests can pass an explicit env.
+ */
+export function loadRegclientConfig(env = process.env) {
+  const insecure = boolEnv(env.REGCLIENT_API_INSECURE, false);
+  return {
+    port: Number(env.REGCLIENT_API_PORT || DEFAULT_API_PORT),
+    // Plain HTTP to a node is only ever reachable through the explicit insecure
+    // escape hatch; a stray REGCLIENT_API_SCHEME must not silently disable TLS.
+    scheme: insecure && env.REGCLIENT_API_SCHEME === 'http' ? 'http' : 'https',
+    token: env.REGCLIENT_API_TOKEN || '',
+    caCert: decodePem(env.REGCLIENT_CA_CERT),
+    insecure,
+    timeoutMs: Number(env.TRACE_PROXY_TIMEOUT_MS || DEFAULT_PROXY_TIMEOUT_MS),
+    // Optional belt-and-braces allowlist of node addresses. When set, only
+    // these hosts may be dialled regardless of what `b2bua_id` says.
+    allowedNodes: String(env.REGCLIENT_NODE_ALLOWLIST || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+    // Loopback/private node addresses are refused unless a deployment says
+    // otherwise — compose and kind clusters legitimately need this.
+    allowPrivateNodes: boolEnv(env.REGCLIENT_ALLOW_PRIVATE_NODES, false)
+  };
+}
+
+/**
+ * Is this a host we are prepared to send a bearer token to?
+ *
+ * `b2bua_id` is normally written by the node that claimed the row, but the
+ * public `PUT /phone-endpoints/{id}` also permits writing it — that is the
+ * per-registration migration lever. It therefore has to be treated as
+ * caller-influenced input: an unvalidated value here would turn this facade
+ * into an SSRF gadget that leaks the node token to an arbitrary host. Accept
+ * only a bare IP literal or DNS name (no scheme, credentials, path or port
+ * smuggling), and refuse the address ranges an attacker would actually want.
+ */
+export function assertNodeAddressAllowed(node, config) {
+  const host = String(node || '').trim();
+  if (!host) return { ok: false, reason: 'no node address' };
+  if (/[/\\@?#\s]/.test(host)) return { ok: false, reason: 'malformed node address' };
+
+  const { allowedNodes = [], allowPrivateNodes = false } = config || {};
+  if (allowedNodes.length && !allowedNodes.includes(host)) {
+    return { ok: false, reason: 'node not in REGCLIENT_NODE_ALLOWLIST' };
+  }
+
+  const ipVersion = net.isIP(host);
+  if (!ipVersion) {
+    // A DNS name: allowed (deployments may name nodes), but it must look like
+    // one rather than a URL fragment or a port-bearing authority.
+    if (!/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/.test(host)) {
+      return { ok: false, reason: 'malformed node address' };
+    }
+    if (host === 'localhost' && !allowPrivateNodes) {
+      return { ok: false, reason: 'loopback node address' };
+    }
+    return { ok: true, host };
+  }
+
+  if (isBlockedAddress(host, ipVersion, allowPrivateNodes)) {
+    return { ok: false, reason: 'node address not routable for this deployment' };
+  }
+  return { ok: true, host };
+}
+
+function isBlockedAddress(host, ipVersion, allowPrivateNodes) {
+  if (ipVersion === 4) {
+    const [a, b] = host.split('.').map(Number);
+    // Link-local (cloud metadata) is never acceptable, allowlist or not.
+    if (a === 169 && b === 254) return true;
+    if (allowPrivateNodes) return false;
+    if (a === 0 || a === 127) return true;
+    if (a === 10) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+    return false;
+  }
+  const lower = host.toLowerCase();
+  if (lower.startsWith('fe80')) return true; // link-local
+  if (allowPrivateNodes) return false;
+  if (lower === '::' || lower === '::1') return true;
+  if (/^f[cd]/.test(lower)) return true; // unique-local
+  return false;
+}
+
+/** URL of one trace representation on a node. */
+export function buildTraceUrl({ node, registrationId, format = 'json', since }, config) {
+  const { scheme, port } = config;
+  const host = net.isIP(node) === 6 ? `[${node}]` : node;
+  const url = new URL(`${scheme}://${host}:${port}/debug/registrations/${encodeURIComponent(registrationId)}/trace`);
+  if (format && format !== 'json') url.searchParams.set('format', format);
+  if (since) url.searchParams.set('since', String(since));
+  return url.toString();
+}
+
+/** URL of the probe collection, or of one probe / its event stream. */
+export function buildProbeUrl({ node, probeId, events = false }, config) {
+  const { scheme, port } = config;
+  const host = net.isIP(node) === 6 ? `[${node}]` : node;
+  const path = probeId
+    ? `/probe/${encodeURIComponent(probeId)}${events ? '/events' : ''}`
+    : '/probe';
+  return new URL(`${scheme}://${host}:${port}${path}`).toString();
+}
+
+/**
+ * An https agent that verifies the node certificate against the private CA
+ * distributed in the secretenv bundle. regclient mints its own certificate at
+ * boot for its `EXT_IP_ADDRESS`, so there is no public PKI in this path and no
+ * per-node certificate chore — but also no excuse for skipping verification.
+ */
+export function createNodeAgent(config) {
+  if (config.scheme === 'http') return undefined;
+  if (config.caCert) {
+    return new https.Agent({ ca: config.caCert, rejectUnauthorized: true, keepAlive: false });
+  }
+  if (config.insecure) {
+    return new https.Agent({ rejectUnauthorized: false, keepAlive: false });
+  }
+  return new https.Agent({ rejectUnauthorized: true, keepAlive: false });
+}
+
+/**
+ * Is this configuration usable at all? A missing token or CA is a deployment
+ * error, and saying so plainly beats a puzzling 504.
+ */
+export function configurationProblem(config) {
+  if (!config.token) return 'REGCLIENT_API_TOKEN is not configured';
+  if (config.scheme === 'https' && !config.caCert && !config.insecure) {
+    return 'REGCLIENT_CA_CERT is not configured';
+  }
+  return null;
+}
+
+/**
+ * One request to a node, with a hard total timeout and no retries: a dead node
+ * must produce a prompt, clean failure for the UI rather than a hung request.
+ *
+ * `requestImpl` is injected in tests; it defaults to axios, which is already a
+ * dependency and gives us per-request agents, timeouts and stream responses.
+ */
+export async function nodeRequest({
+  url,
+  method = 'GET',
+  data,
+  responseType = 'json',
+  config,
+  requestImpl = axios.request,
+  signal
+}) {
+  const agent = createNodeAgent(config);
+  const request = {
+    url,
+    method,
+    responseType,
+    timeout: config.timeoutMs,
+    // Interpret status ourselves so a 4xx from the node can be reported as
+    // what it is rather than thrown as a transport failure.
+    validateStatus: () => true,
+    maxRedirects: 0,
+    headers: {
+      Authorization: `Bearer ${config.token}`,
+      Accept: responseType === 'arraybuffer' ? 'application/octet-stream' : 'application/json'
+    },
+    ...(agent ? { httpsAgent: agent } : {}),
+    ...(config.scheme === 'http' ? { httpAgent: new http.Agent({ keepAlive: false }) } : {}),
+    ...(data !== undefined ? { data } : {}),
+    ...(signal ? { signal } : {})
+  };
+  return requestImpl(request);
+}
+
+/**
+ * Map a node round-trip onto the facade's contract. Anything that is not a
+ * clean answer from the node becomes a 504 carrying the node address, so the
+ * dashboard can say *which* node is not answering.
+ */
+export function describeNodeFailure(err, node) {
+  const code = err?.code || err?.cause?.code;
+  const reason = code === 'ECONNABORTED' || code === 'ETIMEDOUT' ? 'timeout'
+    : code === 'ECONNREFUSED' ? 'connection refused'
+      : code === 'EHOSTUNREACH' || code === 'ENETUNREACH' ? 'host unreachable'
+        : code === 'ENOTFOUND' ? 'host not found'
+          : /certificate|self.signed|CERT_|DEPTH_ZERO/i.test(String(err?.message || '')) ? 'TLS verification failed'
+            : (err?.message || 'unknown error');
+  return { error: 'trace unavailable', node, reason };
+}
+
+/**
+ * Open a long-lived response stream from a node (the probe event stream).
+ *
+ * The short proxy timeout is the right discipline for a trace fetch but wrong
+ * for server-sent events, which stay open for the life of the probe. So the
+ * bound here is on *establishing* the stream: if the node has not sent
+ * response headers within `timeoutMs` the attempt is abandoned, and after that
+ * the stream lives until either end closes it. Implemented on node:https
+ * rather than axios so that distinction is explicit.
+ */
+export function openNodeStream({ url, method = 'GET', config, requestImpl }) {
+  const target = new URL(url);
+  const isTls = target.protocol === 'https:';
+  const impl = requestImpl || (isTls ? https.request : http.request);
+  return new Promise((resolve, reject) => {
+    const req = impl({
+      protocol: target.protocol,
+      hostname: target.hostname,
+      port: target.port,
+      path: `${target.pathname}${target.search}`,
+      method,
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+        Accept: 'text/event-stream',
+        'Cache-Control': 'no-cache'
+      },
+      ...(isTls ? { agent: createNodeAgent(config) } : {})
+    }, (response) => {
+      clearTimeout(timer);
+      resolve(response);
+    });
+    const timer = setTimeout(() => {
+      req.destroy(Object.assign(new Error('node did not answer in time'), { code: 'ETIMEDOUT' }));
+    }, config.timeoutMs);
+    req.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    req.end();
+  });
+}
+
+/**
+ * Which node should answer a probe for this registration?
+ *
+ * A claimed row must be probed by its owner — that node holds the live
+ * registration and can therefore reuse its canonical Contact instead of
+ * creating a second binding at the PBX. An unclaimed row has no owner, so any
+ * node in `REGCLIENT_PROBE_NODES` will do; the choice is made deterministically
+ * from the registration id so repeated calls about one row land on one node and
+ * its probe ids stay resolvable.
+ */
+export function selectProbeNode({ registrationId, claimedNode, env = process.env }) {
+  const claimed = String(claimedNode || '').trim();
+  if (claimed) return claimed;
+  const pool = String(env.REGCLIENT_PROBE_NODES || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (!pool.length) return null;
+  let hash = 0;
+  for (const ch of String(registrationId)) hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;
+  return pool[hash % pool.length];
+}

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -79,6 +79,12 @@ export function loadRegclientConfig(env = process.env) {
     // escape hatch; a stray REGCLIENT_API_SCHEME must not silently disable TLS.
     scheme: insecure && env.REGCLIENT_API_SCHEME === 'http' ? 'http' : 'https',
     token: env.REGCLIENT_API_TOKEN || '',
+    // The token this deployment used before the current one, for verification
+    // only. Nodes accept two bearer tokens at once so rotation is add-new,
+    // flip-caller, drop-old with no downtime; the facade held one, so the
+    // moment it flipped, every outstanding probe handle stopped verifying and
+    // turned into a 404 mid-watch. Optional, and never used to sign.
+    tokenPrevious: env.REGCLIENT_API_TOKEN_PREVIOUS || '',
     caCert: decodePem(env.REGCLIENT_CA_CERT),
     insecure,
     timeoutMs: Number(env.TRACE_PROXY_TIMEOUT_MS || DEFAULT_PROXY_TIMEOUT_MS),

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -225,6 +225,7 @@ export async function nodeRequest({
   data,
   responseType = 'json',
   config,
+  node,
   requestImpl = axios.request,
   signal
 }) {
@@ -233,7 +234,9 @@ export async function nodeRequest({
     url,
     method,
     responseType,
-    timeout: config.timeoutMs,
+    // A node we have never reached gets the discovery bound rather than the
+    // full budget; see timeoutFor.
+    timeout: node ? timeoutFor(node, config) : config.timeoutMs,
     // Interpret status ourselves so a 4xx from the node can be reported as
     // what it is rather than thrown as a transport failure.
     validateStatus: () => true,
@@ -247,7 +250,19 @@ export async function nodeRequest({
     ...(data !== undefined ? { data } : {}),
     ...(signal ? { signal } : {})
   };
-  return requestImpl(request);
+
+  try {
+    const response = await requestImpl(request);
+    // Getting an answer at all is the proof: a FreeSWITCH node has no HTTP
+    // surface, and nothing else can present a certificate our own CA signed.
+    // The status does not matter — a 401 or a 404 is still regclient.
+    rememberNodeCapability(node, CAPABILITY_TRACE);
+    return response;
+  }
+  catch (err) {
+    rememberNodeCapability(node, capabilityFromFailure(err));
+    throw err;
+  }
 }
 
 /**
@@ -329,4 +344,133 @@ export function selectProbeNode({ registrationId, claimedNode, env = process.env
   let hash = 0;
   for (const ch of String(registrationId)) hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;
   return pool[hash % pool.length];
+}
+
+// ── Node capability ─────────────────────────────────────────────────────────
+//
+// Not every b2bua node serves traces. The FreeSWITCH stack has no HTTP surface
+// at all, and during the migration both stacks run side by side against the
+// same table — so `b2bua_id` points at a node that may or may not answer.
+//
+// The verdict is arrived at without asking anything extra, because the request
+// itself already proves it: a node presenting a certificate our private CA
+// signed is regclient, and nothing else can be. Reaching one at all is
+// therefore the whole test, and it is cached so it is paid once rather than
+// per request.
+//
+// The distinction matters as much as the speed. "This registration is served by
+// a node running the older stack" is a different thing to say than "the node is
+// not responding", and only one of them is worth paging anybody about.
+
+const CAPABILITY_TRACE = 'regclient';
+const CAPABILITY_NONE = 'unsupported';
+const CAPABILITY_UNKNOWN = 'unknown';
+
+export { CAPABILITY_TRACE, CAPABILITY_NONE, CAPABILITY_UNKNOWN };
+
+// Positive verdicts are held long: a node does not change stack without a
+// redeploy. Negative ones are held briefly, because migrating a node to
+// regclient is exactly the moment somebody will go looking for its traces.
+const DEFAULT_CAPABILITY_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_UNSUPPORTED_TTL_MS = 60 * 1000;
+
+// Discovery is bounded much more tightly than a real request. A node that
+// serves traces answers in milliseconds on the same network; one that does not
+// either refuses instantly or, behind a firewall that drops rather than
+// rejects, never answers at all. Waiting the full request budget to learn which
+// is a cost with no upside.
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 750;
+
+const capabilities = new Map();
+
+/** Capability TTLs and the discovery timeout, from the environment. */
+export function capabilityConfig(env = process.env) {
+  return {
+    ttlMs: Number(env.REGCLIENT_CAPABILITY_TTL_MS || DEFAULT_CAPABILITY_TTL_MS),
+    unsupportedTtlMs: Number(env.REGCLIENT_UNSUPPORTED_TTL_MS || DEFAULT_UNSUPPORTED_TTL_MS),
+    discoveryTimeoutMs: Number(env.REGCLIENT_DISCOVERY_TIMEOUT_MS || DEFAULT_DISCOVERY_TIMEOUT_MS)
+  };
+}
+
+/** What we currently believe about a node. */
+export function nodeCapability(node, { env = process.env, now = Date.now } = {}) {
+  const entry = capabilities.get(node);
+  if (!entry) return CAPABILITY_UNKNOWN;
+  const { ttlMs, unsupportedTtlMs } = capabilityConfig(env);
+  const ttl = entry.capability === CAPABILITY_TRACE ? ttlMs : unsupportedTtlMs;
+  if (now() - entry.at > ttl) {
+    capabilities.delete(node);
+    return CAPABILITY_UNKNOWN;
+  }
+  return entry.capability;
+}
+
+/** Record what a round-trip told us. */
+export function rememberNodeCapability(node, capability, { now = Date.now } = {}) {
+  if (!node || capability === CAPABILITY_UNKNOWN) return;
+  capabilities.set(node, { capability, at: now() });
+}
+
+/** Forget everything. Tests, and anything that wants to force re-discovery. */
+export function resetNodeCapabilities() {
+  capabilities.clear();
+}
+
+/**
+ * How long to allow for a request to this node.
+ *
+ * A node we have already reached gets the full budget; one we have never
+ * reached gets the discovery bound, so learning "this is a FreeSWITCH node"
+ * costs a fraction of a second once rather than the whole timeout every time.
+ */
+export function timeoutFor(node, config, { env = process.env } = {}) {
+  if (nodeCapability(node, { env }) === CAPABILITY_TRACE) return config.timeoutMs;
+  return Math.min(config.timeoutMs, capabilityConfig(env).discoveryTimeoutMs);
+}
+
+/**
+ * Read a failed round-trip as a statement about the node.
+ *
+ * A refused connection, an unreachable host or a TLS failure all say the same
+ * thing: whatever is at that address, it is not a regclient node serving this
+ * API. Those are cached, and they are fast by nature.
+ *
+ * A timeout says nothing of the kind. Something may well be listening and
+ * merely busy, so it is reported as a node that did not answer and is not
+ * cached — marking a slow regclient node as "has no trace API" would be a lie
+ * that outlived the moment that produced it.
+ */
+export function capabilityFromFailure(err) {
+  const code = err?.code || err?.cause?.code;
+  switch (code) {
+    case 'ECONNREFUSED':
+    case 'EHOSTUNREACH':
+    case 'ENETUNREACH':
+    case 'ENOTFOUND':
+    case 'EPROTO':
+      return CAPABILITY_NONE;
+    default:
+      break;
+  }
+  if (/certificate|self.signed|CERT_|DEPTH_ZERO|wrong version number|SSL routines/i.test(String(err?.message || ''))) {
+    return CAPABILITY_NONE;
+  }
+  return CAPABILITY_UNKNOWN;
+}
+
+/**
+ * The answer for a node that does not serve this API.
+ *
+ * 501 rather than 504: nothing is broken and nothing will improve by retrying.
+ * The registration is simply held by a node running the stack that predates
+ * these endpoints, and the fix is to migrate it — which is a decision, not an
+ * incident.
+ */
+export function unsupportedNodeBody(node) {
+  return {
+    code: 'trace-api-unavailable',
+    node,
+    message: `The b2bua node holding this registration (${node}) does not provide the trace and probe API. ` +
+      'It is running the FreeSWITCH stack, which has no such interface; migrate the registration to a regclient node to use it.'
+  };
 }

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -438,27 +438,26 @@ export function timeoutFor(node, config, { env = process.env } = {}) {
 /**
  * Read a failed round-trip as a statement about the node.
  *
- * A refused connection, an unreachable host or a TLS failure all say the same
- * thing: whatever is at that address, it is not a regclient node serving this
- * API. Those are cached, and they are fast by nature.
+ * The answer is now almost always CAPABILITY_UNKNOWN, and that is the point.
  *
- * A timeout says nothing of the kind. Something may well be listening and
- * merely busy, so it is reported as a node that did not answer and is not
- * cached — marking a slow regclient node as "has no trace API" would be a lie
- * that outlived the moment that produced it.
+ * A refused connection looks identical whether the address holds a FreeSWITCH
+ * node with no HTTP surface at all or a regclient node that is simply down —
+ * and the second is exactly when somebody wants to look. Reporting it as 501
+ * "this node runs the FreeSWITCH stack, migrate it" sends an operator to fix a
+ * migration that already happened, while the real answer is that a node is
+ * unreachable. So a transport failure means "did not answer" (504) and is not
+ * cached; only a heartbeat proves what a node is running.
+ *
+ * That relies on nodes announcing themselves. A regclient node does
+ * (LLM_AGENT_URL); FreeSWITCH nodes do not yet, so until they do a legacy node
+ * costs a connection attempt per request rather than a cached 501. The trade is
+ * deliberate: a slower wrong-stack answer is better than a confident wrong one.
+ *
+ * The one failure still read as proof is a TLS handshake that completed enough
+ * to reject the certificate — something is serving HTTPS there, and it is not
+ * something our CA signed, so it is not a regclient node serving this API.
  */
 export function capabilityFromFailure(err) {
-  const code = err?.code || err?.cause?.code;
-  switch (code) {
-    case 'ECONNREFUSED':
-    case 'EHOSTUNREACH':
-    case 'ENETUNREACH':
-    case 'ENOTFOUND':
-    case 'EPROTO':
-      return CAPABILITY_NONE;
-    default:
-      break;
-  }
   if (/certificate|self.signed|CERT_|DEPTH_ZERO|wrong version number|SSL routines/i.test(String(err?.message || ''))) {
     return CAPABILITY_NONE;
   }

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -28,6 +28,17 @@ import axios from 'axios';
 /** Trace representations regclient can render; passed through verbatim. */
 export const TRACE_FORMATS = ['json', 'decode', 'pcap'];
 
+/**
+ * Formats the trace *index* offers.
+ *
+ * A whole trace runs to tens of kilobytes of SIP text, so the listing describes
+ * what happened without carrying it: `decode` there would be exactly the fat
+ * response the index exists to avoid, and belongs on a single transaction.
+ * `pcap` stays whole-registration because "give me everything for Wireshark" is
+ * a real request and a capture of one transaction rarely is.
+ */
+export const TRACE_INDEX_FORMATS = ['json', 'pcap'];
+
 export const DEFAULT_API_PORT = 8443;
 export const DEFAULT_PROXY_TIMEOUT_MS = 2000;
 
@@ -144,11 +155,19 @@ function isBlockedAddress(host, ipVersion, allowPrivateNodes) {
   return false;
 }
 
-/** URL of one trace representation on a node. */
-export function buildTraceUrl({ node, registrationId, format = 'json', since }, config) {
+/**
+ * URL of a registration's trace index, or of one transaction within it.
+ *
+ * With no `transactionId` this addresses the listing; with one it addresses that
+ * single exchange in full.
+ */
+export function buildTraceUrl({ node, registrationId, transactionId, format = 'json', since }, config) {
   const { scheme, port } = config;
   const host = net.isIP(node) === 6 ? `[${node}]` : node;
-  const url = new URL(`${scheme}://${host}:${port}/debug/registrations/${encodeURIComponent(registrationId)}/trace`);
+  const path = transactionId
+    ? `/debug/registrations/${encodeURIComponent(registrationId)}/trace/${encodeURIComponent(transactionId)}`
+    : `/debug/registrations/${encodeURIComponent(registrationId)}/trace`;
+  const url = new URL(`${scheme}://${host}:${port}${path}`);
   if (format && format !== 'json') url.searchParams.set('format', format);
   if (since) url.searchParams.set('since', String(since));
   return url.toString();

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -7,6 +7,18 @@ import { fromNodeHeaders } from 'better-auth/node';
 import { effectivePermissions, statementsFor, intersectStatements, keyRestrictionStatements, can, ORGANISATION_RBAC_ATTRIBUTES } from '../lib/auth/permissions.js';
 import { effectiveAllowedModels } from '../lib/auth/model-access.js';
 import { isBootstrapSuperAdmin } from '../lib/admin-gate.js';
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Constant-time token comparison, for a secret presented by an untrusted
+ * caller. Length is compared first because timingSafeEqual throws on a length
+ * mismatch rather than returning false.
+ */
+function tokensMatch(presented, expected) {
+  const a = Buffer.from(String(presented), 'utf8');
+  const b = Buffer.from(String(expected), 'utf8');
+  return a.length === b.length && timingSafeEqual(a, b);
+}
 
 const BA_SESSION_TTL_MS = 60_000;
 const BA_SESSION_MAX = 5000;
@@ -127,6 +139,36 @@ function init(app, logger) {
     // Tenant auth (Firebase / AuthKey) must never be able to access these routes.
     const isAgentDbPath = req.originalUrl.startsWith('/api/agent-db');
     
+    // A b2bua node announcing itself needs exactly one route, and it runs on
+    // the most exposed machines in the estate — internet-facing SIP, reachable
+    // from any address the firewall admits. Handing it SHARED_API_TOKEN, which
+    // the check below accepts on *every* route and turns into a full system
+    // principal, would mean that compromising one SIP node yields complete
+    // internal-API control including stored credentials and super-admin
+    // permissions. So the heartbeat gets its own token, scoped to its own route
+    // and nothing else — not even reading the fleet list back.
+    //
+    // SHARED_API_TOKEN still works here, so nodes can be moved onto the scoped
+    // token without a coordinated deploy; drop it from the node bundles once
+    // they all carry B2BUA_HEARTBEAT_TOKEN.
+    const heartbeatToken = process.env.B2BUA_HEARTBEAT_TOKEN;
+    const presentedToken = req.headers['x-shared-token'];
+    if (heartbeatToken && presentedToken && tokensMatch(presentedToken, heartbeatToken)) {
+      if (!req.originalUrl.startsWith('/api/agent-db/b2bua-nodes')) {
+        res.status(403).json({ message: 'Forbidden: this token is scoped to the b2bua node heartbeat' });
+        return;
+      }
+      res.locals.user = {
+        id: 'b2bua-node',
+        user_id: 'b2bua-node',
+        name: 'b2bua node (heartbeat)',
+        isB2buaNode: true
+      };
+      res.locals.user.sql = { where: { userId: 'system' } };
+      next();
+      return;
+    }
+
     // Check for shared token for internal API calls
     const sharedToken = process.env.SHARED_API_TOKEN;
     if (sharedToken && req.headers['x-shared-token'] === sharedToken) {

--- a/tests/b2bua-node-heartbeat.test.mjs
+++ b/tests/b2bua-node-heartbeat.test.mjs
@@ -209,3 +209,43 @@ describe('capabilityFromHeartbeat', () => {
     expect(await capabilityFromHeartbeat('203.0.113.10', { model: broken })).toBe(CAPABILITY_UNKNOWN);
   });
 });
+
+describe('the scoped node principal', () => {
+  // A node runs internet-facing SIP and needs exactly one route. The
+  // fleet-wide SHARED_API_TOKEN is accepted on every internal route and mints
+  // a full system principal, so a node carrying it turns one compromised SIP
+  // machine into complete internal-API access. B2BUA_HEARTBEAT_TOKEN mints
+  // this principal instead: it may announce, and nothing else.
+  const nodePrincipal = () => ({
+    locals: { user: { id: 'b2bua-node', isB2buaNode: true } },
+    _status: null,
+    _body: null,
+    status(code) { this._status = code; return this; },
+    send(body) { this._body = body; this._status = this._status || 200; return this; },
+    json(body) { return this.send(body); }
+  });
+
+  it('may announce itself', async () => {
+    const res = nodePrincipal();
+    await post({ body: { nodeId: '203.0.113.77', type: 'regclient' }, log: quietLog }, res);
+    expect(res._status).toBe(200);
+    expect(res._body.nodeId).toBe('203.0.113.77');
+  });
+
+  // The listing is every node's public IP, stack, version, registration counts
+  // and load — a map of the estate. A node has no business reading it.
+  it('may not read the fleet listing back', async () => {
+    const res = nodePrincipal();
+    await get({ query: {}, log: quietLog }, res);
+    expect(res._status).toBe(403);
+  });
+
+  // Anything without one of the two internal principals is refused, which is
+  // what stops a tenant reaching this route and mislabelling a node's stack.
+  it('refuses an ordinary caller', async () => {
+    const res = nodePrincipal();
+    res.locals.user = { id: 'someone', organisationId: 'org-1' };
+    await post({ body: { nodeId: '203.0.113.77', type: 'freeswitch' }, log: quietLog }, res);
+    expect(res._status).toBe(403);
+  });
+});

--- a/tests/b2bua-node-heartbeat.test.mjs
+++ b/tests/b2bua-node-heartbeat.test.mjs
@@ -1,0 +1,198 @@
+import { jest } from '@jest/globals';
+
+/**
+ * The b2bua node heartbeat: a node saying what it is, once a minute, so
+ * llm-agent knows before the first trace request rather than finding out by
+ * asking.
+ */
+
+const rows = new Map();
+
+const B2buaNode = {
+  async upsert(values) {
+    rows.set(values.nodeId, { ...values });
+    return [rows.get(values.nodeId), true];
+  },
+  async findByPk(id) {
+    return rows.get(id) || null;
+  },
+  async findAll() {
+    return [...rows.values()].sort((a, b) => a.nodeId.localeCompare(b.nodeId));
+  }
+};
+
+jest.unstable_mockModule('../lib/database.js', () => ({
+  B2buaNode,
+  B2BUA_NODE_TYPES: ['regclient', 'freeswitch'],
+  PhoneRegistration: { findByPk: async () => null }
+}));
+
+const { default: route } = await import('../api/paths/agent-db/b2bua-nodes.js');
+const { nodeCapability, resetNodeCapabilities, CAPABILITY_TRACE, CAPABILITY_NONE, CAPABILITY_UNKNOWN } =
+  await import('../lib/regclient.js');
+const { capabilityFromHeartbeat } = await import('../lib/regclient-facade.js');
+
+const quietLog = { info() {}, error() {}, warn() {}, debug() {} };
+const post = route(quietLog).POST;
+const get = route(quietLog).GET;
+
+const makeRes = () => ({
+  locals: { user: { id: 'system', isSystem: true } },
+  _status: null,
+  _body: null,
+  status(code) { this._status = code; return this; },
+  send(body) { this._body = body; this._status = this._status || 200; return this; },
+  json(body) { return this.send(body); }
+});
+
+const beat = async (body, user) => {
+  const res = makeRes();
+  if (user !== undefined) res.locals.user = user;
+  await post({ body, log: quietLog }, res);
+  return res;
+};
+
+const list = async (query = {}) => {
+  const res = makeRes();
+  await get({ query, log: quietLog }, res);
+  return res;
+};
+
+beforeEach(() => {
+  rows.clear();
+  resetNodeCapabilities();
+});
+
+describe('POST /agent-db/b2bua-nodes', () => {
+  it('records what a node says about itself', async () => {
+    const res = await beat({
+      nodeId: '203.0.113.10',
+      type: 'regclient',
+      version: '1.4.2',
+      registrations: 42,
+      failedRegistrations: 3,
+      systemLoad: 0.75
+    });
+
+    expect(res._status).toBe(200);
+    expect(res._body.nodeId).toBe('203.0.113.10');
+    expect(typeof res._body.acknowledgedAt).toBe('string');
+
+    const stored = rows.get('203.0.113.10');
+    expect(stored.type).toBe('regclient');
+    expect(stored.version).toBe('1.4.2');
+    expect(stored.registrations).toBe(42);
+    expect(stored.failedRegistrations).toBe(3);
+    expect(stored.systemLoad).toBe(0.75);
+    expect(stored.lastSeenAt).toBeInstanceOf(Date);
+  });
+
+  // The point of the whole mechanism: known before anything is asked.
+  it('primes the capability cache, so no discovery is needed at all', async () => {
+    expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_UNKNOWN);
+    await beat({ nodeId: '203.0.113.10', type: 'regclient' });
+    expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_TRACE);
+  });
+
+  it('records a FreeSWITCH node as one that serves no trace API', async () => {
+    await beat({ nodeId: '203.0.113.99', type: 'freeswitch' });
+    expect(nodeCapability('203.0.113.99')).toBe(CAPABILITY_NONE);
+  });
+
+  // A caller who could post here could mark a node as the wrong stack, denying
+  // traces that exist or aiming requests at a node that cannot answer.
+  it('accepts heartbeats only from internal callers', async () => {
+    const res = await beat({ nodeId: '203.0.113.10' }, { id: 'user-1', organisationId: 'org-1' });
+    expect(res._status).toBe(403);
+    expect(rows.size).toBe(0);
+  });
+
+  it('rejects a heartbeat with no node identity or an unknown stack', async () => {
+    expect((await beat({}))._status).toBe(400);
+    expect((await beat({ nodeId: '   ' }))._status).toBe(400);
+    expect((await beat({ nodeId: '203.0.113.10', type: 'asterisk' }))._status).toBe(400);
+    expect(rows.size).toBe(0);
+  });
+
+  // A node that cannot count its own registrations should not be able to zero
+  // the fleet view by accident.
+  it('defaults counters rather than storing rubbish', async () => {
+    await beat({ nodeId: '203.0.113.10', registrations: 'lots', systemLoad: null });
+    const stored = rows.get('203.0.113.10');
+    expect(stored.registrations).toBe(0);
+    expect(stored.failedRegistrations).toBe(0);
+    expect(stored.systemLoad).toBeNull();
+  });
+
+  it('is an upsert — a node reports every minute for the life of the process', async () => {
+    await beat({ nodeId: '203.0.113.10', registrations: 10 });
+    await beat({ nodeId: '203.0.113.10', registrations: 11 });
+    expect(rows.size).toBe(1);
+    expect(rows.get('203.0.113.10').registrations).toBe(11);
+  });
+});
+
+describe('GET /agent-db/b2bua-nodes', () => {
+  it('reports the fleet, marking nodes that have gone quiet', async () => {
+    await beat({ nodeId: '203.0.113.10', type: 'regclient', registrations: 5 });
+    rows.set('203.0.113.99', {
+      nodeId: '203.0.113.99',
+      type: 'regclient',
+      registrations: 0,
+      failedRegistrations: 0,
+      systemLoad: null,
+      lastSeenAt: new Date(Date.now() - 20 * 60 * 1000)
+    });
+
+    const res = await list();
+    expect(res._status).toBe(200);
+    expect(res._body.nodes).toHaveLength(2);
+
+    const live = res._body.nodes.find((n) => n.nodeId === '203.0.113.10');
+    const quiet = res._body.nodes.find((n) => n.nodeId === '203.0.113.99');
+    expect(live.stale).toBe(false);
+    expect(live.registrations).toBe(5);
+    // Reported, not omitted: a node that has gone quiet is the thing worth
+    // seeing, and it is invisible if the row simply disappears.
+    expect(quiet.stale).toBe(true);
+  });
+});
+
+describe('capabilityFromHeartbeat', () => {
+  it('answers from what the node last said', async () => {
+    await beat({ nodeId: '203.0.113.10', type: 'regclient' });
+    await beat({ nodeId: '203.0.113.99', type: 'freeswitch' });
+
+    expect(await capabilityFromHeartbeat('203.0.113.10')).toBe(CAPABILITY_TRACE);
+    expect(await capabilityFromHeartbeat('203.0.113.99')).toBe(CAPABILITY_NONE);
+  });
+
+  it('knows nothing about a node that has never reported', async () => {
+    expect(await capabilityFromHeartbeat('203.0.113.50')).toBe(CAPABILITY_UNKNOWN);
+  });
+
+  // A regclient node whose heartbeat has broken is still a regclient node.
+  // Reading a stale row as "no trace API" would refuse traces precisely when
+  // somebody most wants to look at them.
+  it('treats a stale row as telling us nothing, not as a denial', async () => {
+    rows.set('203.0.113.10', {
+      nodeId: '203.0.113.10',
+      type: 'regclient',
+      lastSeenAt: new Date(Date.now() - 10 * 60 * 1000)
+    });
+    expect(await capabilityFromHeartbeat('203.0.113.10')).toBe(CAPABILITY_UNKNOWN);
+
+    rows.set('203.0.113.99', {
+      nodeId: '203.0.113.99',
+      type: 'freeswitch',
+      lastSeenAt: new Date(Date.now() - 10 * 60 * 1000)
+    });
+    expect(await capabilityFromHeartbeat('203.0.113.99')).toBe(CAPABILITY_UNKNOWN);
+  });
+
+  // The registry is an optimisation, not a dependency.
+  it('falls through to discovery when the registry cannot be read', async () => {
+    const broken = { async findByPk() { throw new Error('database is down'); } };
+    expect(await capabilityFromHeartbeat('203.0.113.10', { model: broken })).toBe(CAPABILITY_UNKNOWN);
+  });
+});

--- a/tests/b2bua-node-heartbeat.test.mjs
+++ b/tests/b2bua-node-heartbeat.test.mjs
@@ -52,8 +52,9 @@ const beat = async (body, user) => {
   return res;
 };
 
-const list = async (query = {}) => {
+const list = async (query = {}, user) => {
   const res = makeRes();
+  if (user !== undefined) res.locals.user = user;
   await get({ query, log: quietLog }, res);
   return res;
 };
@@ -155,6 +156,18 @@ describe('GET /agent-db/b2bua-nodes', () => {
     // Reported, not omitted: a node that has gone quiet is the thing worth
     // seeing, and it is invisible if the row simply disappears.
     expect(quiet.stale).toBe(true);
+  });
+
+  // `/api/agent-db` is already refused at the prefix for anything without the
+  // shared token, so this is defence in depth — but the POST checks explicitly
+  // and a GET that did not read as though the difference were deliberate. It
+  // is not: this listing is every node's public IP, stack, version,
+  // registration counts and load.
+  it('is refused to a caller who is not the internal system user', async () => {
+    await beat({ nodeId: '203.0.113.10', type: 'regclient' });
+    const res = await list({}, { id: 'u1', organisationId: 'org-1' });
+    expect(res._status).toBe(403);
+    expect(res._body.nodes).toBeUndefined();
   });
 });
 

--- a/tests/regclient-facade-routes.test.mjs
+++ b/tests/regclient-facade-routes.test.mjs
@@ -1,0 +1,218 @@
+import { jest } from '@jest/globals';
+
+/**
+ * The b2bua node-API facade routes: `GET /phone-endpoints/{id}/trace` and the
+ * probe family.
+ *
+ * These routes hold no state of their own — everything interesting is in what
+ * they refuse to do (someone else's registration, an address we won't send a
+ * token to, a deployment with no CA configured) and in how a node that isn't
+ * answering is reported. So that is what is tested here, with the database and
+ * the HTTP client both stubbed.
+ */
+
+const rows = new Map();
+
+jest.unstable_mockModule('../lib/database.js', () => ({
+  PhoneRegistration: {
+    findByPk: async (id) => rows.get(id) || null
+  }
+}));
+
+let nextResponse = { status: 200, data: {} };
+let lastRequest = null;
+
+jest.unstable_mockModule('axios', () => ({
+  default: {
+    request: async (request) => {
+      lastRequest = request;
+      if (nextResponse instanceof Error) throw nextResponse;
+      return nextResponse;
+    }
+  }
+}));
+
+const { default: traceRoute } = await import('../api/paths/phone-endpoints/{identifier}/trace.js');
+const { default: probeRoute } = await import('../api/paths/phone-endpoints/{identifier}/probe.js');
+
+const quietLog = { info() {}, error() {}, warn() {}, debug() {} };
+const getTrace = traceRoute(quietLog).GET;
+const startProbe = probeRoute(quietLog).POST;
+
+const ORG = 'org-1';
+const REG = '11111111-2222-3333-4444-555555555555';
+
+const configuredEnv = {
+  REGCLIENT_API_TOKEN: 'node-token',
+  REGCLIENT_CA_CERT: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----'
+};
+
+const makeRes = () => ({
+  locals: { user: { organisationId: ORG } },
+  _status: null,
+  _body: null,
+  _headers: {},
+  status(code) { this._status = code; return this; },
+  send(body) { this._body = body; this._status = this._status || 200; return this; },
+  json(body) { return this.send(body); },
+  setHeader(name, value) { this._headers[name] = value; }
+});
+
+const makeReg = ({ id = REG, organisationId = ORG, b2buaId = '203.0.113.10' } = {}) => {
+  const row = { id, organisationId, b2buaId };
+  rows.set(id, row);
+  return row;
+};
+
+const callTrace = async ({ identifier = REG, query = {}, user } = {}) => {
+  const res = makeRes();
+  if (user !== undefined) res.locals.user = user;
+  await getTrace({ params: { identifier }, query, log: quietLog }, res);
+  return res;
+};
+
+const callProbe = async ({ identifier = REG, body = {} } = {}) => {
+  const res = makeRes();
+  await startProbe({ params: { identifier }, body, log: quietLog }, res);
+  return res;
+};
+
+beforeEach(() => {
+  rows.clear();
+  lastRequest = null;
+  nextResponse = { status: 200, data: {} };
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith('REGCLIENT_') || key === 'TRACE_PROXY_TIMEOUT_MS') delete process.env[key];
+  }
+  Object.assign(process.env, configuredEnv);
+});
+
+describe('GET /phone-endpoints/{identifier}/trace', () => {
+  it('rejects a phone number — traces belong to registrations', async () => {
+    const res = await callTrace({ identifier: '441234567890' });
+    expect(res._status).toBe(400);
+  });
+
+  it('rejects an unknown format rather than passing it to the node', async () => {
+    makeReg();
+    const res = await callTrace({ query: { format: 'sqlite' } });
+    expect(res._status).toBe(400);
+    expect(lastRequest).toBeNull();
+  });
+
+  it('404s an unknown registration', async () => {
+    expect((await callTrace())._status).toBe(404);
+  });
+
+  it('403s a registration belonging to another organisation', async () => {
+    makeReg({ organisationId: 'org-2' });
+    const res = await callTrace();
+    expect(res._status).toBe(403);
+    expect(lastRequest).toBeNull();
+  });
+
+  it('409s a registration no node has ever claimed', async () => {
+    makeReg({ b2buaId: null });
+    const res = await callTrace();
+    expect(res._status).toBe(409);
+    expect(lastRequest).toBeNull();
+  });
+
+  it('503s when this deployment has no node credentials configured', async () => {
+    delete process.env.REGCLIENT_API_TOKEN;
+    makeReg();
+    const res = await callTrace();
+    expect(res._status).toBe(503);
+    expect(res._body.message).toMatch(/REGCLIENT_API_TOKEN/);
+  });
+
+  it('refuses to dial a node address that is not routable for this deployment', async () => {
+    // `b2buaId` is writable through the public update API, so a hostile value
+    // must not become an SSRF request carrying the node bearer token.
+    makeReg({ b2buaId: '169.254.169.254' });
+    const res = await callTrace();
+    expect(res._status).toBe(502);
+    expect(lastRequest).toBeNull();
+  });
+
+  it('proxies the transcript, adding provenance', async () => {
+    makeReg();
+    nextResponse = { status: 200, data: { registrationId: REG, registerTransactions: [] } };
+    const res = await callTrace();
+    expect(res._status).toBe(200);
+    expect(res._body.node).toBe('203.0.113.10');
+    expect(typeof res._body.fetchedAt).toBe('string');
+    expect(lastRequest.url).toBe(`https://203.0.113.10:8443/debug/registrations/${REG}/trace`);
+    expect(lastRequest.headers.Authorization).toBe('Bearer node-token');
+  });
+
+  it('keeps the decode representation an array, with provenance in headers', async () => {
+    makeReg();
+    nextResponse = { status: 200, data: [{ ts: '2026-08-30T10:00:00Z' }] };
+    const res = await callTrace({ query: { format: 'decode' } });
+    expect(Array.isArray(res._body)).toBe(true);
+    expect(res._headers['X-Regclient-Node']).toBe('203.0.113.10');
+    expect(new URL(lastRequest.url).searchParams.get('format')).toBe('decode');
+  });
+
+  it('returns pcap as a binary attachment', async () => {
+    makeReg();
+    nextResponse = { status: 200, data: Buffer.from([0xd4, 0xc3, 0xb2, 0xa1]) };
+    const res = await callTrace({ query: { format: 'pcap' } });
+    expect(res._headers['Content-Type']).toBe('application/vnd.tcpdump.pcap');
+    expect(res._headers['Content-Disposition']).toContain(`${REG}.pcap`);
+    expect(Buffer.isBuffer(res._body)).toBe(true);
+    expect(lastRequest.responseType).toBe('arraybuffer');
+  });
+
+  it('turns an unreachable node into a 504 that names the node', async () => {
+    makeReg();
+    nextResponse = Object.assign(new Error('timeout of 2000ms exceeded'), { code: 'ECONNABORTED' });
+    const res = await callTrace();
+    expect(res._status).toBe(504);
+    expect(res._body).toEqual({ error: 'trace unavailable', node: '203.0.113.10', reason: 'timeout' });
+  });
+
+  it('reports a node error as 502, and a node 404 as 404', async () => {
+    makeReg();
+    nextResponse = { status: 500, data: {} };
+    expect((await callTrace())._status).toBe(502);
+    nextResponse = { status: 404, data: {} };
+    expect((await callTrace())._status).toBe(404);
+  });
+});
+
+describe('POST /phone-endpoints/{identifier}/probe', () => {
+  it('starts a probe on the claiming node and returns the probe id', async () => {
+    makeReg();
+    nextResponse = { status: 200, data: { probeId: 'p-1' } };
+    const res = await callProbe({ body: { discover: true } });
+    expect(res._status).toBe(202);
+    expect(res._body).toEqual({ probeId: 'p-1', node: '203.0.113.10' });
+    expect(lastRequest.url).toBe('https://203.0.113.10:8443/probe');
+    expect(lastRequest.method).toBe('POST');
+    expect(lastRequest.data).toEqual({ registrationId: REG, discover: true, apply: false });
+  });
+
+  it('uses the probe node pool when no node has claimed the registration', async () => {
+    process.env.REGCLIENT_PROBE_NODES = '198.51.100.7';
+    makeReg({ b2buaId: null });
+    nextResponse = { status: 200, data: { probeId: 'p-2' } };
+    const res = await callProbe();
+    expect(res._status).toBe(202);
+    expect(lastRequest.url).toBe('https://198.51.100.7:8443/probe');
+  });
+
+  it('409s an unclaimed registration when there is no pool to run it on', async () => {
+    makeReg({ b2buaId: null });
+    const res = await callProbe();
+    expect(res._status).toBe(409);
+    expect(lastRequest).toBeNull();
+  });
+
+  it('never probes another organisation\'s registration', async () => {
+    makeReg({ organisationId: 'org-2' });
+    expect((await callProbe())._status).toBe(403);
+    expect(lastRequest).toBeNull();
+  });
+});

--- a/tests/regclient-facade-routes.test.mjs
+++ b/tests/regclient-facade-routes.test.mjs
@@ -33,10 +33,12 @@ jest.unstable_mockModule('axios', () => ({
 }));
 
 const { default: traceRoute } = await import('../api/paths/phone-endpoints/{identifier}/trace.js');
+const { default: traceTransactionRoute } = await import('../api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js');
 const { default: probeRoute } = await import('../api/paths/phone-endpoints/{identifier}/probe.js');
 
 const quietLog = { info() {}, error() {}, warn() {}, debug() {} };
 const getTrace = traceRoute(quietLog).GET;
+const getTraceTransaction = traceTransactionRoute(quietLog).GET;
 const startProbe = probeRoute(quietLog).POST;
 
 const ORG = 'org-1';
@@ -71,6 +73,12 @@ const callTrace = async ({ identifier = REG, query = {}, user } = {}) => {
   return res;
 };
 
+const callTraceTransaction = async ({ identifier = REG, transactionId = 'reg-8', query = {} } = {}) => {
+  const res = makeRes();
+  await getTraceTransaction({ params: { identifier, transactionId }, query, log: quietLog }, res);
+  return res;
+};
+
 const callProbe = async ({ identifier = REG, body = {} } = {}) => {
   const res = makeRes();
   await startProbe({ params: { identifier }, body, log: quietLog }, res);
@@ -97,6 +105,16 @@ describe('GET /phone-endpoints/{identifier}/trace', () => {
     makeReg();
     const res = await callTrace({ query: { format: 'sqlite' } });
     expect(res._status).toBe(400);
+    expect(lastRequest).toBeNull();
+  });
+
+  // decode on the index would be the fat response the split exists to avoid,
+  // so it is refused here with a pointer at the route that does serve it.
+  it('sends decode to the per-transaction route rather than serving it', async () => {
+    makeReg();
+    const res = await callTrace({ query: { format: 'decode' } });
+    expect(res._status).toBe(400);
+    expect(res._body.message).toMatch(/transactionId/);
     expect(lastRequest).toBeNull();
   });
 
@@ -135,27 +153,22 @@ describe('GET /phone-endpoints/{identifier}/trace', () => {
     expect(lastRequest).toBeNull();
   });
 
-  it('proxies the transcript, adding provenance', async () => {
+  it('proxies the index, adding provenance', async () => {
     makeReg();
-    nextResponse = { status: 200, data: { registrationId: REG, registerTransactions: [] } };
+    nextResponse = {
+      status: 200,
+      data: { registrationId: REG, transactions: [{ id: 'reg-8', kind: 'register' }] }
+    };
     const res = await callTrace();
     expect(res._status).toBe(200);
     expect(res._body.node).toBe('203.0.113.10');
     expect(typeof res._body.fetchedAt).toBe('string');
+    expect(res._body.transactions).toHaveLength(1);
     expect(lastRequest.url).toBe(`https://203.0.113.10:8443/debug/registrations/${REG}/trace`);
     expect(lastRequest.headers.Authorization).toBe('Bearer node-token');
   });
 
-  it('keeps the decode representation an array, with provenance in headers', async () => {
-    makeReg();
-    nextResponse = { status: 200, data: [{ ts: '2026-08-30T10:00:00Z' }] };
-    const res = await callTrace({ query: { format: 'decode' } });
-    expect(Array.isArray(res._body)).toBe(true);
-    expect(res._headers['X-Regclient-Node']).toBe('203.0.113.10');
-    expect(new URL(lastRequest.url).searchParams.get('format')).toBe('decode');
-  });
-
-  it('returns pcap as a binary attachment', async () => {
+  it('returns pcap as a whole-registration binary attachment', async () => {
     makeReg();
     nextResponse = { status: 200, data: Buffer.from([0xd4, 0xc3, 0xb2, 0xa1]) };
     const res = await callTrace({ query: { format: 'pcap' } });
@@ -179,6 +192,58 @@ describe('GET /phone-endpoints/{identifier}/trace', () => {
     expect((await callTrace())._status).toBe(502);
     nextResponse = { status: 404, data: {} };
     expect((await callTrace())._status).toBe(404);
+  });
+});
+
+describe('GET /phone-endpoints/{identifier}/trace/{transactionId}', () => {
+  it('fetches one exchange in full', async () => {
+    makeReg();
+    nextResponse = {
+      status: 200,
+      data: { registrationId: REG, registerTransactions: [{ id: 'reg-8', messages: [{}, {}] }] }
+    };
+    const res = await callTraceTransaction();
+    expect(res._status).toBe(200);
+    expect(res._body.node).toBe('203.0.113.10');
+    expect(lastRequest.url).toBe(`https://203.0.113.10:8443/debug/registrations/${REG}/trace/reg-8`);
+  });
+
+  it('offers the decoded packets of that exchange', async () => {
+    makeReg();
+    nextResponse = { status: 200, data: [{ ts: '2026-08-30T10:00:00Z' }] };
+    const res = await callTraceTransaction({ query: { format: 'decode' } });
+    expect(Array.isArray(res._body)).toBe(true);
+    expect(res._headers['X-Regclient-Node']).toBe('203.0.113.10');
+    expect(new URL(lastRequest.url).searchParams.get('format')).toBe('decode');
+  });
+
+  it('names the exchange in the capture filename', async () => {
+    makeReg();
+    nextResponse = { status: 200, data: Buffer.from([0xd4, 0xc3, 0xb2, 0xa1]) };
+    const res = await callTraceTransaction({ query: { format: 'pcap' } });
+    expect(res._headers['Content-Disposition']).toContain(`${REG}-reg-8.pcap`);
+  });
+
+  // Trace entries rotate. An id listed a few minutes ago may have aged out
+  // behind a burst of retries, and saying so beats implying the registration
+  // itself is unknown.
+  it('explains a transaction that has rotated out', async () => {
+    makeReg();
+    nextResponse = { status: 404, data: {} };
+    const res = await callTraceTransaction();
+    expect(res._status).toBe(404);
+    expect(res._body.message).toMatch(/rotated out/);
+  });
+
+  it('applies the same organisation and node checks as the index', async () => {
+    makeReg({ organisationId: 'org-2' });
+    expect((await callTraceTransaction())._status).toBe(403);
+    expect(lastRequest).toBeNull();
+
+    rows.clear();
+    makeReg({ b2buaId: null });
+    expect((await callTraceTransaction())._status).toBe(409);
+    expect(lastRequest).toBeNull();
   });
 });
 

--- a/tests/regclient-facade-routes.test.mjs
+++ b/tests/regclient-facade-routes.test.mjs
@@ -166,6 +166,22 @@ describe('GET /phone-endpoints/{identifier}/trace', () => {
     expect(lastRequest).toBeNull();
   });
 
+  // Both sides of an organisation comparison can legitimately be null: an
+  // org-less principal, and a row left org-less by the `SET NULL` on
+  // organisation delete. A bare `registration.organisationId !== organisationId`
+  // reads `null !== null` as false and so *granted* access — letting two
+  // unrelated org-less tenants read each other's registrar, account identity
+  // and credentials in flight. scope.js's userOwnsRow requires both sides to be
+  // non-null and equal, which is why the routes must go through it.
+  it('403s an org-less caller against an org-less registration', async () => {
+    makeReg({ organisationId: null });
+    const res = await callTrace({
+      user: { organisationId: null, _effectivePermissions: { phoneEndpoint: ['read'] } }
+    });
+    expect(res._status).toBe(403);
+    expect(lastRequest).toBeNull();
+  });
+
   it('409s a registration no node has ever claimed', async () => {
     makeReg({ b2buaId: null });
     const res = await callTrace();

--- a/tests/regclient-facade-routes.test.mjs
+++ b/tests/regclient-facade-routes.test.mjs
@@ -13,10 +13,17 @@ import { jest } from '@jest/globals';
 
 const rows = new Map();
 
+// The heartbeat registry is deliberately empty here: these tests exercise the
+// discovery path, which is what a node that has never announced itself falls
+// back to.
 jest.unstable_mockModule('../lib/database.js', () => ({
   PhoneRegistration: {
     findByPk: async (id) => rows.get(id) || null
-  }
+  },
+  B2buaNode: {
+    findByPk: async () => null
+  },
+  B2BUA_NODE_TYPES: ['regclient', 'freeswitch']
 }));
 
 let nextResponse = { status: 200, data: {} };

--- a/tests/regclient-facade-routes.test.mjs
+++ b/tests/regclient-facade-routes.test.mjs
@@ -39,7 +39,7 @@ jest.unstable_mockModule('axios', () => ({
   }
 }));
 
-const { resetNodeCapabilities, nodeCapability, CAPABILITY_NONE } = await import('../lib/regclient.js');
+const { resetNodeCapabilities, nodeCapability, CAPABILITY_NONE, CAPABILITY_UNKNOWN } = await import('../lib/regclient.js');
 const { verifyProbeHandle, signProbeHandle } = await import('../lib/regclient-probe-handle.js');
 
 const { default: traceRoute } = await import('../api/paths/phone-endpoints/{identifier}/trace.js');
@@ -234,23 +234,30 @@ describe('GET /phone-endpoints/{identifier}/trace', () => {
   // During the migration both stacks run against the same table, so a
   // registration held by a FreeSWITCH node is an ordinary state of affairs.
   // Reporting it as an outage would send somebody looking for a fault.
-  it('says plainly when the node has no trace API at all', async () => {
+  // A refused connection is a node that did not answer, not a node running the
+  // FreeSWITCH stack. The two are indistinguishable on the wire, and calling it
+  // 501 "migrate this registration" sends an operator to redo a migration that
+  // already happened when the real answer is that a node is down.
+  it('reports a refused connection as a node that did not answer', async () => {
     makeReg();
     nextResponse = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
     const res = await callTrace();
 
-    expect(res._status).toBe(501);
-    expect(res._body.code).toBe('trace-api-unavailable');
+    expect(res._status).toBe(504);
     expect(res._body.node).toBe('203.0.113.10');
-    expect(res._body.message).toMatch(/FreeSWITCH/);
+    expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_UNKNOWN);
   });
 
-  // And having learned it once, it costs nothing thereafter — which is the
-  // whole point: no timeout, and not even a connection.
-  it('answers a known FreeSWITCH node without touching the network', async () => {
+  // A certificate our CA did not sign is still proof: something is serving
+  // HTTPS there and it is not this API. That is cached, so it costs nothing
+  // thereafter — no timeout, and not even a connection.
+  it('answers a node with a foreign certificate without touching the network', async () => {
     makeReg();
-    nextResponse = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
-    await callTrace();
+    nextResponse = new Error('unable to verify the first certificate');
+    const first = await callTrace();
+    expect(first._status).toBe(501);
+    expect(first._body.code).toBe('trace-api-unavailable');
+    expect(first._body.message).toMatch(/FreeSWITCH/);
     expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_NONE);
 
     lastRequest = null;
@@ -375,10 +382,18 @@ describe('POST /phone-endpoints/{identifier}/probe', () => {
 
   it('says plainly when the node has no probe API either', async () => {
     makeReg();
-    nextResponse = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    nextResponse = new Error('unable to verify the first certificate');
     const res = await callProbe();
     expect(res._status).toBe(501);
     expect(res._body.code).toBe('trace-api-unavailable');
+  });
+
+  // As on the trace route: unreachable is not the same as wrong-stack.
+  it('reports an unreachable probe node as a node that did not answer', async () => {
+    makeReg();
+    nextResponse = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    const res = await callProbe();
+    expect(res._status).toBe(504);
   });
 
   it('409s an unclaimed registration when there is no pool to run it on', async () => {

--- a/tests/regclient-facade-routes.test.mjs
+++ b/tests/regclient-facade-routes.test.mjs
@@ -40,15 +40,18 @@ jest.unstable_mockModule('axios', () => ({
 }));
 
 const { resetNodeCapabilities, nodeCapability, CAPABILITY_NONE } = await import('../lib/regclient.js');
+const { verifyProbeHandle, signProbeHandle } = await import('../lib/regclient-probe-handle.js');
 
 const { default: traceRoute } = await import('../api/paths/phone-endpoints/{identifier}/trace.js');
 const { default: traceTransactionRoute } = await import('../api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js');
 const { default: probeRoute } = await import('../api/paths/phone-endpoints/{identifier}/probe.js');
+const { default: probeReportRoute } = await import('../api/paths/phone-endpoints/{identifier}/probe/{probeId}.js');
 
 const quietLog = { info() {}, error() {}, warn() {}, debug() {} };
 const getTrace = traceRoute(quietLog).GET;
 const getTraceTransaction = traceTransactionRoute(quietLog).GET;
 const startProbe = probeRoute(quietLog).POST;
+const getProbeReport = probeReportRoute(quietLog).GET;
 
 const ORG = 'org-1';
 const REG = '11111111-2222-3333-4444-555555555555';
@@ -58,8 +61,23 @@ const configuredEnv = {
   REGCLIENT_CA_CERT: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----'
 };
 
-const makeRes = () => ({
-  locals: { user: { organisationId: ORG } },
+// A principal that holds the endpoint permissions these routes now require.
+// The routes gate on phoneEndpoint:read / :update as the endpoint routes
+// themselves do — organisation ownership alone was a weaker gate than the
+// record the trace describes.
+const OPERATOR = {
+  organisationId: ORG,
+  _effectivePermissions: { phoneEndpoint: ['claim', 'read', 'update', 'release'] }
+};
+
+// Read-only: may see the endpoint, may not change it. A probe changes it.
+const READER = {
+  organisationId: ORG,
+  _effectivePermissions: { phoneEndpoint: ['read'] }
+};
+
+const makeRes = (user = OPERATOR) => ({
+  locals: { user: { ...user } },
   _status: null,
   _body: null,
   _headers: {},
@@ -82,14 +100,23 @@ const callTrace = async ({ identifier = REG, query = {}, user } = {}) => {
   return res;
 };
 
-const callTraceTransaction = async ({ identifier = REG, transactionId = 'reg-8', query = {} } = {}) => {
+const callTraceTransaction = async ({ identifier = REG, transactionId = 'reg-8', query = {}, user } = {}) => {
   const res = makeRes();
+  if (user !== undefined) res.locals.user = user;
   await getTraceTransaction({ params: { identifier, transactionId }, query, log: quietLog }, res);
   return res;
 };
 
-const callProbe = async ({ identifier = REG, body = {} } = {}) => {
+const callProbeReport = async ({ identifier = REG, probeId, user } = {}) => {
   const res = makeRes();
+  if (user !== undefined) res.locals.user = user;
+  await getProbeReport({ params: { identifier, probeId }, log: quietLog }, res);
+  return res;
+};
+
+const callProbe = async ({ identifier = REG, body = {}, user } = {}) => {
+  const res = makeRes();
+  if (user !== undefined) res.locals.user = user;
   await startProbe({ params: { identifier }, body, log: quietLog }, res);
   return res;
 };
@@ -308,7 +335,14 @@ describe('POST /phone-endpoints/{identifier}/probe', () => {
     nextResponse = { status: 200, data: { probeId: 'p-1' } };
     const res = await callProbe({ body: { discover: true } });
     expect(res._status).toBe(202);
-    expect(res._body).toEqual({ probeId: 'p-1', node: '203.0.113.10' });
+    expect(res._body.node).toBe('203.0.113.10');
+    // The id handed back is a signed handle, not the node's own probe id: it
+    // names the node this probe is running on and the registration it is for,
+    // so a follow-up cannot be misrouted by a migration or pointed at somebody
+    // else's probe. See lib/regclient-probe-handle.js.
+    expect(res._body.probeId).not.toBe('p-1');
+    expect(verifyProbeHandle(res._body.probeId, { registrationId: REG }, { token: 'node-token' }))
+      .toMatchObject({ ok: true, node: '203.0.113.10', probeId: 'p-1' });
     expect(lastRequest.url).toBe('https://203.0.113.10:8443/probe');
     expect(lastRequest.method).toBe('POST');
     expect(lastRequest.data).toEqual({ registrationId: REG, discover: true, apply: false });
@@ -341,6 +375,102 @@ describe('POST /phone-endpoints/{identifier}/probe', () => {
   it('never probes another organisation\'s registration', async () => {
     makeReg({ organisationId: 'org-2' });
     expect((await callProbe())._status).toBe(403);
+    expect(lastRequest).toBeNull();
+  });
+});
+
+// ── RBAC ────────────────────────────────────────────────────────────────────
+
+// Organisation ownership was the only gate these routes applied, while the
+// endpoint routes they hang off require phoneEndpoint:read. That made the SIP
+// trace — the endpoint's registrar, its account identity, who has been calling
+// it — readable by a member who cannot read the endpoint record itself.
+describe('permissions', () => {
+  const NO_RIGHTS = { organisationId: ORG, _effectivePermissions: {} };
+
+  it('requires phoneEndpoint:read for the trace index and one exchange', async () => {
+    makeReg();
+    for (const call of [callTrace, callTraceTransaction]) {
+      const res = await call({ user: NO_RIGHTS });
+      expect(res._status).toBe(403);
+      expect(lastRequest).toBeNull();
+    }
+  });
+
+  // A probe is a write: it puts a real REGISTER on the wire from an address the
+  // customer's PBX trusts, and with `apply` it edits the registration.
+  it('requires phoneEndpoint:update to start a probe, not merely :read', async () => {
+    makeReg();
+    const res = await callProbe({ user: READER });
+    expect(res._status).toBe(403);
+    expect(lastRequest).toBeNull();
+  });
+
+  it('lets a reader read a probe report they may not have started', async () => {
+    makeReg();
+    nextResponse = { status: 200, data: { probeId: 'p-1', verdict: 'registered' } };
+    const handle = signProbeHandle(
+      { node: '203.0.113.10', registrationId: REG, probeId: 'p-1' },
+      { token: 'node-token' }
+    );
+    const res = await callProbeReport({ probeId: handle, user: READER });
+    expect(res._status).toBe(200);
+  });
+});
+
+// ── probe handles ───────────────────────────────────────────────────────────
+
+describe('probe handles', () => {
+  it('asks the node the handle names, not whichever node holds the row now', async () => {
+    // The registration has since migrated. The probe is still running where it
+    // started, and that is where the follow-up has to go — an operator watching
+    // a probe is exactly the person likely to be moving the row.
+    makeReg({ b2buaId: '203.0.113.99' });
+    nextResponse = { status: 200, data: { probeId: 'p-1', verdict: 'registered' } };
+
+    const handle = signProbeHandle(
+      { node: '203.0.113.10', registrationId: REG, probeId: 'p-1' },
+      { token: 'node-token' }
+    );
+    const res = await callProbeReport({ probeId: handle });
+    expect(res._status).toBe(200);
+    expect(lastRequest.url).toContain('203.0.113.10');
+    expect(lastRequest.url).not.toContain('203.0.113.99');
+    // And the node is told which registration to check the probe against, so
+    // the binding is enforced by the process that actually knows the answer.
+    expect(lastRequest.url).toContain(`registrationId=${REG}`);
+  });
+
+  it('refuses a probe handle issued for a different registration', async () => {
+    makeReg();
+    const other = signProbeHandle(
+      { node: '203.0.113.10', registrationId: 'someone-elses-registration', probeId: 'p-1' },
+      { token: 'node-token' }
+    );
+    const res = await callProbeReport({ probeId: other });
+    // 404, not 403: whether a probe exists on a node is itself a fact about
+    // another registration.
+    expect(res._status).toBe(404);
+    expect(lastRequest).toBeNull();
+  });
+
+  it('refuses a forged or bare probe id', async () => {
+    makeReg();
+    for (const probeId of ['p-1', 'v1.abc.def', '']) {
+      const res = await callProbeReport({ probeId });
+      expect(res._status).toBe(404);
+      expect(lastRequest).toBeNull();
+    }
+  });
+
+  it('refuses a handle signed with a different node token', async () => {
+    makeReg();
+    const forged = signProbeHandle(
+      { node: '203.0.113.10', registrationId: REG, probeId: 'p-1' },
+      { token: 'not-our-token' }
+    );
+    const res = await callProbeReport({ probeId: forged });
+    expect(res._status).toBe(404);
     expect(lastRequest).toBeNull();
   });
 });

--- a/tests/regclient-facade-routes.test.mjs
+++ b/tests/regclient-facade-routes.test.mjs
@@ -32,6 +32,8 @@ jest.unstable_mockModule('axios', () => ({
   }
 }));
 
+const { resetNodeCapabilities, nodeCapability, CAPABILITY_NONE } = await import('../lib/regclient.js');
+
 const { default: traceRoute } = await import('../api/paths/phone-endpoints/{identifier}/trace.js');
 const { default: traceTransactionRoute } = await import('../api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js');
 const { default: probeRoute } = await import('../api/paths/phone-endpoints/{identifier}/probe.js');
@@ -88,6 +90,7 @@ const callProbe = async ({ identifier = REG, body = {} } = {}) => {
 beforeEach(() => {
   rows.clear();
   lastRequest = null;
+  resetNodeCapabilities();
   nextResponse = { status: 200, data: {} };
   for (const key of Object.keys(process.env)) {
     if (key.startsWith('REGCLIENT_') || key === 'TRACE_PROXY_TIMEOUT_MS') delete process.env[key];
@@ -178,6 +181,51 @@ describe('GET /phone-endpoints/{identifier}/trace', () => {
     expect(lastRequest.responseType).toBe('arraybuffer');
   });
 
+  // During the migration both stacks run against the same table, so a
+  // registration held by a FreeSWITCH node is an ordinary state of affairs.
+  // Reporting it as an outage would send somebody looking for a fault.
+  it('says plainly when the node has no trace API at all', async () => {
+    makeReg();
+    nextResponse = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    const res = await callTrace();
+
+    expect(res._status).toBe(501);
+    expect(res._body.code).toBe('trace-api-unavailable');
+    expect(res._body.node).toBe('203.0.113.10');
+    expect(res._body.message).toMatch(/FreeSWITCH/);
+  });
+
+  // And having learned it once, it costs nothing thereafter — which is the
+  // whole point: no timeout, and not even a connection.
+  it('answers a known FreeSWITCH node without touching the network', async () => {
+    makeReg();
+    nextResponse = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    await callTrace();
+    expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_NONE);
+
+    lastRequest = null;
+    const res = await callTrace();
+    expect(res._status).toBe(501);
+    expect(lastRequest).toBeNull();
+  });
+
+  // A slow node is a different thing from an absent one, and must not be
+  // remembered as one.
+  it('still reports a timeout as a timeout', async () => {
+    makeReg();
+    nextResponse = Object.assign(new Error('timeout of 750ms exceeded'), { code: 'ECONNABORTED' });
+    const res = await callTrace();
+
+    expect(res._status).toBe(504);
+    expect(res._body.reason).toBe('timeout');
+
+    // Nothing was concluded, so the next call tries again.
+    lastRequest = null;
+    nextResponse = { status: 200, data: { registrationId: REG } };
+    expect((await callTrace())._status).toBe(200);
+    expect(lastRequest).not.toBeNull();
+  });
+
   it('turns an unreachable node into a 504 that names the node', async () => {
     makeReg();
     nextResponse = Object.assign(new Error('timeout of 2000ms exceeded'), { code: 'ECONNABORTED' });
@@ -266,6 +314,14 @@ describe('POST /phone-endpoints/{identifier}/probe', () => {
     const res = await callProbe();
     expect(res._status).toBe(202);
     expect(lastRequest.url).toBe('https://198.51.100.7:8443/probe');
+  });
+
+  it('says plainly when the node has no probe API either', async () => {
+    makeReg();
+    nextResponse = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    const res = await callProbe();
+    expect(res._status).toBe(501);
+    expect(res._body.code).toBe('trace-api-unavailable');
   });
 
   it('409s an unclaimed registration when there is no pool to run it on', async () => {

--- a/tests/regclient-node-api.test.mjs
+++ b/tests/regclient-node-api.test.mjs
@@ -1,0 +1,230 @@
+import {
+  decodePem,
+  loadRegclientConfig,
+  configurationProblem,
+  assertNodeAddressAllowed,
+  buildTraceUrl,
+  buildProbeUrl,
+  nodeRequest,
+  describeNodeFailure,
+  selectProbeNode,
+  TRACE_FORMATS
+} from '../lib/regclient.js';
+
+// The regclient node API client: URL construction, the guard on which node
+// addresses we are willing to send a bearer token to, and the mapping of
+// transport failures onto something an operator can act on.
+
+const baseEnv = {
+  REGCLIENT_API_PORT: '8443',
+  REGCLIENT_API_TOKEN: 'token-abc',
+  REGCLIENT_CA_CERT: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----'
+};
+
+describe('decodePem', () => {
+  it('passes a literal PEM through', () => {
+    expect(decodePem(baseEnv.REGCLIENT_CA_CERT)).toContain('BEGIN CERTIFICATE');
+  });
+
+  it('unwraps a base64-encoded PEM, as secretenv bundles carry it', () => {
+    const b64 = Buffer.from(baseEnv.REGCLIENT_CA_CERT).toString('base64');
+    expect(decodePem(b64)).toContain('BEGIN CERTIFICATE');
+  });
+
+  it('restores escaped newlines from single-line env values', () => {
+    const escaped = '-----BEGIN CERTIFICATE-----\\nMIIB\\n-----END CERTIFICATE-----';
+    expect(decodePem(escaped).split('\n')).toHaveLength(3);
+  });
+
+  it('returns null for junk and for empty values', () => {
+    expect(decodePem('')).toBeNull();
+    expect(decodePem(undefined)).toBeNull();
+    expect(decodePem('not-a-certificate')).toBeNull();
+  });
+});
+
+describe('loadRegclientConfig', () => {
+  it('defaults port, scheme and timeout', () => {
+    const config = loadRegclientConfig({ REGCLIENT_API_TOKEN: 'x' });
+    expect(config.port).toBe(8443);
+    expect(config.scheme).toBe('https');
+    expect(config.timeoutMs).toBe(2000);
+    expect(config.allowedNodes).toEqual([]);
+  });
+
+  it('honours an explicit timeout and allowlist', () => {
+    const config = loadRegclientConfig({
+      ...baseEnv,
+      TRACE_PROXY_TIMEOUT_MS: '750',
+      REGCLIENT_NODE_ALLOWLIST: '203.0.113.10, 203.0.113.11'
+    });
+    expect(config.timeoutMs).toBe(750);
+    expect(config.allowedNodes).toEqual(['203.0.113.10', '203.0.113.11']);
+  });
+
+  it('only drops to http when insecure mode is explicitly requested', () => {
+    expect(loadRegclientConfig({ REGCLIENT_API_SCHEME: 'http' }).scheme).toBe('https');
+    expect(loadRegclientConfig({ REGCLIENT_API_SCHEME: 'http', REGCLIENT_API_INSECURE: '1' }).scheme).toBe('http');
+  });
+});
+
+describe('configurationProblem', () => {
+  it('is silent on a complete configuration', () => {
+    expect(configurationProblem(loadRegclientConfig(baseEnv))).toBeNull();
+  });
+
+  it('names a missing token', () => {
+    expect(configurationProblem(loadRegclientConfig({ ...baseEnv, REGCLIENT_API_TOKEN: '' })))
+      .toMatch(/REGCLIENT_API_TOKEN/);
+  });
+
+  it('names a missing CA, unless verification was explicitly waived', () => {
+    expect(configurationProblem(loadRegclientConfig({ ...baseEnv, REGCLIENT_CA_CERT: '' })))
+      .toMatch(/REGCLIENT_CA_CERT/);
+    expect(configurationProblem(loadRegclientConfig({ ...baseEnv, REGCLIENT_CA_CERT: '', REGCLIENT_API_INSECURE: '1' })))
+      .toBeNull();
+  });
+});
+
+describe('assertNodeAddressAllowed', () => {
+  // b2buaId is normally written by the claiming node, but the public update API
+  // also permits writing it (that is the migration lever), so it has to be
+  // treated as caller-influenced: an unvalidated value would leak the node
+  // bearer token to whatever host an attacker named.
+  const config = loadRegclientConfig(baseEnv);
+
+  it('allows a public node address', () => {
+    expect(assertNodeAddressAllowed('203.0.113.10', config).ok).toBe(true);
+  });
+
+  it('allows a DNS name', () => {
+    expect(assertNodeAddressAllowed('node1.b2bua.example.com', config).ok).toBe(true);
+  });
+
+  it('refuses cloud metadata and loopback', () => {
+    expect(assertNodeAddressAllowed('169.254.169.254', config).ok).toBe(false);
+    expect(assertNodeAddressAllowed('127.0.0.1', config).ok).toBe(false);
+    expect(assertNodeAddressAllowed('localhost', config).ok).toBe(false);
+    expect(assertNodeAddressAllowed('::1', config).ok).toBe(false);
+  });
+
+  it('refuses private ranges by default and permits them when a deployment opts in', () => {
+    const permissive = loadRegclientConfig({ ...baseEnv, REGCLIENT_ALLOW_PRIVATE_NODES: '1' });
+    for (const host of ['10.1.2.3', '192.168.1.5', '172.16.0.9', '100.64.0.1', 'fd00::1']) {
+      expect(assertNodeAddressAllowed(host, config).ok).toBe(false);
+      expect(assertNodeAddressAllowed(host, permissive).ok).toBe(true);
+    }
+  });
+
+  it('never permits link-local, even for a deployment that allows private nodes', () => {
+    const permissive = loadRegclientConfig({ ...baseEnv, REGCLIENT_ALLOW_PRIVATE_NODES: '1' });
+    expect(assertNodeAddressAllowed('169.254.169.254', permissive).ok).toBe(false);
+    expect(assertNodeAddressAllowed('fe80::1', permissive).ok).toBe(false);
+  });
+
+  it('refuses anything that is not a bare host', () => {
+    for (const host of ['203.0.113.10/../x', 'http://203.0.113.10', 'user@203.0.113.10', '203.0.113.10:9/x', 'a b', '']) {
+      expect(assertNodeAddressAllowed(host, config).ok).toBe(false);
+    }
+  });
+
+  it('tolerates surrounding whitespace in a stored address', () => {
+    expect(assertNodeAddressAllowed(' 203.0.113.10 ', config)).toEqual({ ok: true, host: '203.0.113.10' });
+  });
+
+  it('enforces an allowlist when one is configured', () => {
+    const pinned = loadRegclientConfig({ ...baseEnv, REGCLIENT_NODE_ALLOWLIST: '203.0.113.10' });
+    expect(assertNodeAddressAllowed('203.0.113.10', pinned).ok).toBe(true);
+    expect(assertNodeAddressAllowed('203.0.113.99', pinned).ok).toBe(false);
+  });
+});
+
+describe('URL construction', () => {
+  const config = loadRegclientConfig(baseEnv);
+  const registrationId = '11111111-2222-3333-4444-555555555555';
+
+  it('builds the default trace URL without a redundant format', () => {
+    expect(buildTraceUrl({ node: '203.0.113.10', registrationId }, config))
+      .toBe(`https://203.0.113.10:8443/debug/registrations/${registrationId}/trace`);
+  });
+
+  it('carries format and since', () => {
+    const url = new URL(buildTraceUrl({ node: '203.0.113.10', registrationId, format: 'decode', since: '2026-08-30T10:00:00Z' }, config));
+    expect(url.searchParams.get('format')).toBe('decode');
+    expect(url.searchParams.get('since')).toBe('2026-08-30T10:00:00Z');
+  });
+
+  it('brackets an IPv6 node address', () => {
+    expect(buildTraceUrl({ node: '2001:db8::1', registrationId }, config))
+      .toContain('https://[2001:db8::1]:8443/');
+  });
+
+  it('builds probe collection, report and event-stream URLs', () => {
+    expect(buildProbeUrl({ node: '203.0.113.10' }, config)).toBe('https://203.0.113.10:8443/probe');
+    expect(buildProbeUrl({ node: '203.0.113.10', probeId: 'p1' }, config)).toBe('https://203.0.113.10:8443/probe/p1');
+    expect(buildProbeUrl({ node: '203.0.113.10', probeId: 'p1', events: true }, config)).toBe('https://203.0.113.10:8443/probe/p1/events');
+  });
+
+  it('offers exactly the three documented trace formats', () => {
+    expect(TRACE_FORMATS).toEqual(['json', 'decode', 'pcap']);
+  });
+});
+
+describe('nodeRequest', () => {
+  const config = loadRegclientConfig(baseEnv);
+
+  it('presents the bearer token, a hard timeout and no retries', async () => {
+    let seen;
+    await nodeRequest({
+      url: 'https://203.0.113.10:8443/probe',
+      config,
+      requestImpl: async (request) => { seen = request; return { status: 200, data: {} }; }
+    });
+    expect(seen.headers.Authorization).toBe('Bearer token-abc');
+    expect(seen.timeout).toBe(2000);
+    expect(seen.maxRedirects).toBe(0);
+    expect(seen.httpsAgent.options.ca).toContain('BEGIN CERTIFICATE');
+    expect(seen.httpsAgent.options.rejectUnauthorized).toBe(true);
+  });
+
+  it('does not throw on a 4xx from the node — the caller decides what it means', async () => {
+    const response = await nodeRequest({
+      url: 'https://203.0.113.10:8443/probe',
+      config,
+      requestImpl: async (request) => ({ status: request.validateStatus(404) ? 404 : 0, data: {} })
+    });
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('describeNodeFailure', () => {
+  it('names the node and translates transport errors', () => {
+    expect(describeNodeFailure({ code: 'ECONNABORTED' }, '203.0.113.10'))
+      .toEqual({ error: 'trace unavailable', node: '203.0.113.10', reason: 'timeout' });
+    expect(describeNodeFailure({ code: 'ECONNREFUSED' }, 'n').reason).toBe('connection refused');
+    expect(describeNodeFailure({ code: 'EHOSTUNREACH' }, 'n').reason).toBe('host unreachable');
+    expect(describeNodeFailure({ message: 'unable to verify the first certificate' }, 'n').reason)
+      .toBe('TLS verification failed');
+  });
+});
+
+describe('selectProbeNode', () => {
+  it('always uses the claiming node when there is one', () => {
+    expect(selectProbeNode({
+      registrationId: 'r1',
+      claimedNode: '203.0.113.10',
+      env: { REGCLIENT_PROBE_NODES: '198.51.100.1' }
+    })).toBe('203.0.113.10');
+  });
+
+  it('picks deterministically from the pool for an unclaimed registration', () => {
+    const env = { REGCLIENT_PROBE_NODES: '198.51.100.1,198.51.100.2,198.51.100.3' };
+    const first = selectProbeNode({ registrationId: 'r1', claimedNode: null, env });
+    expect(['198.51.100.1', '198.51.100.2', '198.51.100.3']).toContain(first);
+    expect(selectProbeNode({ registrationId: 'r1', claimedNode: '', env })).toBe(first);
+  });
+
+  it('returns null when nothing can run the probe', () => {
+    expect(selectProbeNode({ registrationId: 'r1', claimedNode: '', env: {} })).toBeNull();
+  });
+});

--- a/tests/regclient-node-api.test.mjs
+++ b/tests/regclient-node-api.test.mjs
@@ -8,7 +8,8 @@ import {
   nodeRequest,
   describeNodeFailure,
   selectProbeNode,
-  TRACE_FORMATS
+  TRACE_FORMATS,
+  TRACE_INDEX_FORMATS
 } from '../lib/regclient.js';
 
 // The regclient node API client: URL construction, the guard on which node
@@ -143,9 +144,23 @@ describe('URL construction', () => {
   const config = loadRegclientConfig(baseEnv);
   const registrationId = '11111111-2222-3333-4444-555555555555';
 
-  it('builds the default trace URL without a redundant format', () => {
+  it('builds the trace index URL without a redundant format', () => {
     expect(buildTraceUrl({ node: '203.0.113.10', registrationId }, config))
       .toBe(`https://203.0.113.10:8443/debug/registrations/${registrationId}/trace`);
+  });
+
+  // The index describes the exchanges; one exchange is fetched by id. That is
+  // what keeps a dashboard listing from re-downloading tens of kilobytes of SIP
+  // text every time it renders.
+  it('addresses a single transaction by id', () => {
+    expect(buildTraceUrl({ node: '203.0.113.10', registrationId, transactionId: 'reg-8' }, config))
+      .toBe(`https://203.0.113.10:8443/debug/registrations/${registrationId}/trace/reg-8`);
+  });
+
+  it('escapes a transaction id rather than letting it reshape the path', () => {
+    const url = buildTraceUrl({ node: '203.0.113.10', registrationId, transactionId: '../../probe' }, config);
+    expect(url).not.toContain('/probe');
+    expect(url).toContain('%2F');
   });
 
   it('carries format and since', () => {
@@ -167,6 +182,11 @@ describe('URL construction', () => {
 
   it('offers exactly the three documented trace formats', () => {
     expect(TRACE_FORMATS).toEqual(['json', 'decode', 'pcap']);
+  });
+
+  // decode on the index would be the fat response the split exists to avoid.
+  it('offers only listing and whole-registration capture on the index', () => {
+    expect(TRACE_INDEX_FORMATS).toEqual(['json', 'pcap']);
   });
 });
 

--- a/tests/regclient-node-capability.test.mjs
+++ b/tests/regclient-node-capability.test.mjs
@@ -1,0 +1,151 @@
+import {
+  loadRegclientConfig,
+  nodeCapability,
+  rememberNodeCapability,
+  resetNodeCapabilities,
+  capabilityFromFailure,
+  unsupportedNodeBody,
+  timeoutFor,
+  nodeRequest,
+  CAPABILITY_TRACE,
+  CAPABILITY_NONE,
+  CAPABILITY_UNKNOWN
+} from '../lib/regclient.js';
+
+// Knowing whether a b2bua node serves the trace API at all.
+//
+// During the migration both stacks run against the same table, so `b2bua_id`
+// may point at a FreeSWITCH node with no HTTP surface whatsoever. Discovering
+// that must cost a fraction of a second once, not the full request timeout on
+// every call — and it must be reported as what it is rather than as an outage.
+
+const config = loadRegclientConfig({
+  REGCLIENT_API_TOKEN: 'token',
+  REGCLIENT_CA_CERT: '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----'
+});
+
+beforeEach(() => resetNodeCapabilities());
+
+describe('capability from a failed round-trip', () => {
+  // These all say the same thing: whatever is at that address, it is not a
+  // regclient node. They are also all fast by nature.
+  it('reads a connection-level failure as "no trace API here"', () => {
+    for (const code of ['ECONNREFUSED', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND', 'EPROTO']) {
+      expect(capabilityFromFailure({ code })).toBe(CAPABILITY_NONE);
+    }
+    expect(capabilityFromFailure({ message: 'wrong version number' })).toBe(CAPABILITY_NONE);
+    expect(capabilityFromFailure({ message: 'unable to verify the first certificate' })).toBe(CAPABILITY_NONE);
+  });
+
+  // A timeout says nothing of the kind: something may well be listening and
+  // merely busy. Caching it would be a lie that outlived the moment.
+  it('draws no conclusion from a timeout', () => {
+    expect(capabilityFromFailure({ code: 'ECONNABORTED' })).toBe(CAPABILITY_UNKNOWN);
+    expect(capabilityFromFailure({ code: 'ETIMEDOUT' })).toBe(CAPABILITY_UNKNOWN);
+    expect(capabilityFromFailure({ message: 'socket hang up' })).toBe(CAPABILITY_UNKNOWN);
+  });
+});
+
+describe('the cache', () => {
+  it('starts knowing nothing', () => {
+    expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_UNKNOWN);
+  });
+
+  it('holds a positive verdict long and a negative one briefly', () => {
+    const env = { REGCLIENT_CAPABILITY_TTL_MS: '600000', REGCLIENT_UNSUPPORTED_TTL_MS: '60000' };
+    let clock = 1_000_000;
+    const now = () => clock;
+
+    rememberNodeCapability('203.0.113.10', CAPABILITY_TRACE, { now });
+    rememberNodeCapability('203.0.113.99', CAPABILITY_NONE, { now });
+
+    clock += 90_000; // a minute and a half later
+    expect(nodeCapability('203.0.113.10', { env, now })).toBe(CAPABILITY_TRACE);
+    // A node migrated to regclient is exactly when somebody goes looking for
+    // its traces, so a negative verdict must not outstay its welcome.
+    expect(nodeCapability('203.0.113.99', { env, now })).toBe(CAPABILITY_UNKNOWN);
+
+    clock += 600_000;
+    expect(nodeCapability('203.0.113.10', { env, now })).toBe(CAPABILITY_UNKNOWN);
+  });
+
+  it('never records an inconclusive result', () => {
+    rememberNodeCapability('203.0.113.10', CAPABILITY_UNKNOWN);
+    expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_UNKNOWN);
+  });
+});
+
+describe('timeoutFor', () => {
+  // The point of the whole exercise: never spend the request budget finding out
+  // that a node has no HTTP surface.
+  it('bounds a node we have never reached much more tightly', () => {
+    const env = { REGCLIENT_DISCOVERY_TIMEOUT_MS: '750' };
+    expect(timeoutFor('203.0.113.10', config, { env })).toBe(750);
+
+    rememberNodeCapability('203.0.113.10', CAPABILITY_TRACE);
+    expect(timeoutFor('203.0.113.10', config, { env })).toBe(config.timeoutMs);
+  });
+
+  it('never lengthens the request budget', () => {
+    const tight = loadRegclientConfig({ ...config, TRACE_PROXY_TIMEOUT_MS: '300', REGCLIENT_API_TOKEN: 't' });
+    expect(timeoutFor('203.0.113.10', tight, { env: { REGCLIENT_DISCOVERY_TIMEOUT_MS: '750' } })).toBe(300);
+  });
+});
+
+describe('nodeRequest learns as it goes', () => {
+  // Reaching a node at all is the proof. A FreeSWITCH node has no HTTP surface,
+  // and nothing else can present a certificate our own private CA signed — so
+  // the request already is the capability probe, and needs no separate one.
+  it('treats any answer as proof, whatever the status', async () => {
+    await nodeRequest({
+      url: 'https://203.0.113.10:8443/health',
+      config,
+      node: '203.0.113.10',
+      requestImpl: async () => ({ status: 401, data: {} })
+    });
+    expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_TRACE);
+  });
+
+  it('records a refused connection so the next call costs nothing', async () => {
+    const refused = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    await expect(nodeRequest({
+      url: 'https://203.0.113.99:8443/health',
+      config,
+      node: '203.0.113.99',
+      requestImpl: async () => { throw refused; }
+    })).rejects.toThrow();
+    expect(nodeCapability('203.0.113.99')).toBe(CAPABILITY_NONE);
+  });
+
+  it('does not condemn a node that merely timed out', async () => {
+    const timedOut = Object.assign(new Error('timeout of 750ms exceeded'), { code: 'ECONNABORTED' });
+    await expect(nodeRequest({
+      url: 'https://203.0.113.10:8443/health',
+      config,
+      node: '203.0.113.10',
+      requestImpl: async () => { throw timedOut; }
+    })).rejects.toThrow();
+    expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_UNKNOWN);
+  });
+
+  it('applies the discovery bound to a first request and the full budget after', async () => {
+    let seen;
+    const capture = async (request) => { seen = request; return { status: 200, data: {} }; };
+
+    await nodeRequest({ url: 'https://203.0.113.10:8443/x', config, node: '203.0.113.10', requestImpl: capture });
+    expect(seen.timeout).toBe(750); // discovery default
+
+    await nodeRequest({ url: 'https://203.0.113.10:8443/x', config, node: '203.0.113.10', requestImpl: capture });
+    expect(seen.timeout).toBe(config.timeoutMs);
+  });
+});
+
+describe('what the caller is told', () => {
+  it('names the node and says what to do about it', () => {
+    const body = unsupportedNodeBody('203.0.113.99');
+    expect(body.code).toBe('trace-api-unavailable');
+    expect(body.node).toBe('203.0.113.99');
+    expect(body.message).toMatch(/FreeSWITCH/);
+    expect(body.message).toMatch(/migrate/i);
+  });
+});

--- a/tests/regclient-node-capability.test.mjs
+++ b/tests/regclient-node-capability.test.mjs
@@ -29,10 +29,22 @@ beforeEach(() => resetNodeCapabilities());
 describe('capability from a failed round-trip', () => {
   // These all say the same thing: whatever is at that address, it is not a
   // regclient node. They are also all fast by nature.
-  it('reads a connection-level failure as "no trace API here"', () => {
+  // A refused connection looks the same whether the address holds a FreeSWITCH
+  // node with no HTTP surface or a regclient node that is simply down — and the
+  // second is exactly when somebody wants to look. Answering 501 "migrate it"
+  // to a node that has already been migrated and has merely fallen over sends
+  // the operator to the wrong place, so a transport failure draws no
+  // conclusion. Only a heartbeat proves what a node is running.
+  it('draws no conclusion from a connection-level failure', () => {
     for (const code of ['ECONNREFUSED', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOTFOUND', 'EPROTO']) {
-      expect(capabilityFromFailure({ code })).toBe(CAPABILITY_NONE);
+      expect(capabilityFromFailure({ code })).toBe(CAPABILITY_UNKNOWN);
     }
+  });
+
+  // The exception: a TLS handshake that got far enough to reject the
+  // certificate proves something is serving HTTPS there and that it is not
+  // something our CA signed — so it is not a regclient node serving this API.
+  it('still reads a rejected certificate as proof', () => {
     expect(capabilityFromFailure({ message: 'wrong version number' })).toBe(CAPABILITY_NONE);
     expect(capabilityFromFailure({ message: 'unable to verify the first certificate' })).toBe(CAPABILITY_NONE);
   });
@@ -106,7 +118,10 @@ describe('nodeRequest learns as it goes', () => {
     expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_TRACE);
   });
 
-  it('records a refused connection so the next call costs nothing', async () => {
+  // Not cached, and not condemned: a node that refuses a connection may be a
+  // regclient node that is down, and caching "no trace API" would outlive the
+  // outage that produced it.
+  it('does not condemn a node that refused the connection', async () => {
     const refused = Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
     await expect(nodeRequest({
       url: 'https://203.0.113.99:8443/health',
@@ -114,7 +129,19 @@ describe('nodeRequest learns as it goes', () => {
       node: '203.0.113.99',
       requestImpl: async () => { throw refused; }
     })).rejects.toThrow();
-    expect(nodeCapability('203.0.113.99')).toBe(CAPABILITY_NONE);
+    expect(nodeCapability('203.0.113.99')).toBe(CAPABILITY_UNKNOWN);
+  });
+
+  // A certificate we cannot verify is still proof, and still worth caching.
+  it('records a rejected certificate so the next call costs nothing', async () => {
+    const badCert = new Error('unable to verify the first certificate');
+    await expect(nodeRequest({
+      url: 'https://203.0.113.98:8443/health',
+      config,
+      node: '203.0.113.98',
+      requestImpl: async () => { throw badCert; }
+    })).rejects.toThrow();
+    expect(nodeCapability('203.0.113.98')).toBe(CAPABILITY_NONE);
   });
 
   it('does not condemn a node that merely timed out', async () => {

--- a/tests/regclient-node-capability.test.mjs
+++ b/tests/regclient-node-capability.test.mjs
@@ -11,6 +11,7 @@ import {
   CAPABILITY_NONE,
   CAPABILITY_UNKNOWN
 } from '../lib/regclient.js';
+import { signProbeHandle, verifyProbeHandle } from '../lib/regclient-probe-handle.js';
 
 // Knowing whether a b2bua node serves the trace API at all.
 //
@@ -174,5 +175,52 @@ describe('what the caller is told', () => {
     expect(body.node).toBe('203.0.113.99');
     expect(body.message).toMatch(/FreeSWITCH/);
     expect(body.message).toMatch(/migrate/i);
+  });
+});
+
+describe('probe handle rotation grace', () => {
+  // Nodes accept two bearer tokens at once so rotation is add-new,
+  // flip-caller, drop-old with no downtime. The facade signed and verified
+  // with one, so the moment REGCLIENT_API_TOKEN flipped, every outstanding
+  // probe handle stopped verifying — a 404 mid-watch on a probe still running
+  // perfectly well.
+  const REG = '11111111-2222-3333-4444-555555555555';
+
+  it('verifies a handle signed with the previous token', () => {
+    const before = signProbeHandle(
+      { node: '203.0.113.10', registrationId: REG, probeId: 'p-1' },
+      { token: 'old-token' }
+    );
+    expect(before).toBeTruthy();
+
+    const afterRotation = { token: 'new-token', tokenPrevious: 'old-token' };
+    const verified = verifyProbeHandle(before, { registrationId: REG }, afterRotation);
+    expect(verified.ok).toBe(true);
+    expect(verified.node).toBe('203.0.113.10');
+    expect(verified.probeId).toBe('p-1');
+  });
+
+  it('still refuses a handle signed with neither', () => {
+    const forged = signProbeHandle(
+      { node: '203.0.113.10', registrationId: REG, probeId: 'p-1' },
+      { token: 'somebody-elses-token' }
+    );
+    const verified = verifyProbeHandle(
+      forged,
+      { registrationId: REG },
+      { token: 'new-token', tokenPrevious: 'old-token' }
+    );
+    expect(verified.ok).toBe(false);
+  });
+
+  // Signing never uses the old secret, so a handle issued after the rotation
+  // does not depend on it.
+  it('signs with the current token only', () => {
+    const handle = signProbeHandle(
+      { node: '203.0.113.10', registrationId: REG, probeId: 'p-2' },
+      { token: 'new-token', tokenPrevious: 'old-token' }
+    );
+    expect(verifyProbeHandle(handle, { registrationId: REG }, { token: 'new-token' }).ok).toBe(true);
+    expect(verifyProbeHandle(handle, { registrationId: REG }, { token: 'old-token' }).ok).toBe(false);
   });
 });


### PR DESCRIPTION
The llm-agent half of the regclient work planned in [aplisay-b2bua `docs/regclient-plan.md`](https://github.com/aplisay/aplisay-b2bua/blob/main/docs/regclient-plan.md) (§7.4, §8.5, and now §12). Additive: no change to any existing route.

```
GET  /api/phone-endpoints/{id}/trace[?format=json|pcap&since=]      index of exchanges
GET  /api/phone-endpoints/{id}/trace/{transactionId}[?format=json|decode|pcap]
POST /api/phone-endpoints/{id}/probe
GET  /api/phone-endpoints/{id}/probe/{probeId}
GET  /api/phone-endpoints/{id}/probe/{probeId}/events               (server-sent events)

POST /api/agent-db/b2bua-nodes                                      (internal) node heartbeat
GET  /api/agent-db/b2bua-nodes                                      (internal) the fleet
```

**One new table, `b2bua_nodes`.** The plan said no schema change and no RPC from a node to llm-agent; this qualifies both, and [aplisay-b2bua#14](https://github.com/aplisay/aplisay-b2bua/pull/14) records why in a new §12 of the plan. Short version: `b2bua_id` says which node holds a registration but not what that node *is*, both stacks run side by side during the migration, and only regclient serves this API — so llm-agent had to find out by asking, which is cheap when the answer is yes and a firewall timeout when it is no. A node saying so unprompted removes the question. Its creation is allowed to fail: the registry is an optimisation over discovery, not a dependency.

**Two trace routes, not one.** A full trace runs to tens of kilobytes of SIP text, which is the wrong thing to re-download every time a listing renders. The index lists one line per exchange; `decode` belongs to the detail route and is refused on the index with a pointer at the one that serves it.

## Why

Today the only signal a SIP registration gives is `state` and `error` changing, and those come from a five-minute status reconcile against scraped gateway state — worst case around 35 minutes between a registration breaking and anything saying so, with the actual SIP failure never recorded. A failing onboarding produces `state: failed` and nothing else, and diagnosing it means shell access to a b2bua node.

These routes make the SIP conversation itself readable from the dashboard, and let an operator run a registration attempt on demand instead of waiting for a row to mutate.

## How it works

No central trace store, and nothing to run. Each registration is claimed by exactly one b2bua node, recorded in `phone_registrations.b2bua_id` — the same pointer the originate path already follows to route outbound INVITEs — and that node holds the trace in memory. These routes are a proxy to it:

1. Load the row, check organisation ownership.
2. Empty `b2bua_id` ⇒ `409`: no node has ever claimed it, so there is nothing to ask.
3. Fetch from the node over TLS verified against a private CA from the secretenv bundle, with a bearer token from the same bundle, a hard 2 s timeout and **no retries**.
4. Stream the answer back tagged with which node answered and when.

A node that is down gives a prompt `504 {error, node, reason}` naming the node, never a hung request.

The three trace representations are rendered by the node and passed through verbatim: `json` (transaction-grouped transcript), `decode` (flat per-packet decode with headers, CSeq and SDP parsed, order and duplicates preserved so Via chains survive), and `pcap` (`application/vnd.tcpdump.pcap`, opens in Wireshark/sngrep — with TLS legs exported **decrypted**, which an on-wire capture can never show).

## Security

**`b2bua_id` is untrusted input.** `PUT /phone-endpoints/{id}` permits writing it — that is the per-registration migration lever in the plan — so a user can choose the host this service dials. Unchecked that is an SSRF gadget handing the node bearer token to an arbitrary address. So before any connection: bare IP literal or DNS name only (no scheme, credentials, path or port smuggling); link-local (`169.254.0.0/16`, `fe80::/10` — cloud metadata) refused unconditionally; loopback and private ranges refused unless `REGCLIENT_ALLOW_PRIVATE_NODES=1`; and `REGCLIENT_NODE_ALLOWLIST` pins the set outright when set. This sits underneath, not instead of, firewalling node API ports to this service's egress addresses (decision #10 of the plan).

Digest credentials are redacted at this API and cannot be un-redacted through it. Probing is limited to the caller's own registrations — there is deliberately no free-form "try these credentials against this registrar" form, which would be a credential-testing oracle.

Both routes answer `503` until `REGCLIENT_API_TOKEN` and `REGCLIENT_CA_CERT` are set, so this is **inert on every current deployment** — nothing changes until regclient nodes exist.

## Probe safety

Probing a registration that is currently registered reuses its existing contact, so it degrades to a harmless forced refresh: the node will not add a second binding at the registrar (forked/stolen inbound calls) or drop the live one. Discovery-matrix probes run only against registrations that are not currently registered.

`{"discover": true}` walks transports and next-hop choices and returns the minimal working `options` patch; `{"apply": true}` merges it and restarts the registration. Note that a later `PUT` replaces `options` wholesale, so an applied patch can be dropped by a dashboard save — it is re-derivable by re-probing, and the docs say so.

## Review round

- **RBAC.** These routes enforced organisation ownership and nothing else, while the endpoint routes they hang off require `phoneEndpoint:read`. A SIP trace is the endpoint's signalling in full — registrar, account identity, call history — so a member who cannot read the endpoint record could read its wire traffic instead. Traces and probe reports now require `phoneEndpoint:read`; starting a probe requires `phoneEndpoint:update`, because a probe is a write.
- **Probe ids are signed handles** naming the node and the registration. A bare node-local id sent every follow-up to whichever node held the registration *at that moment* — wrong the instant somebody migrates the row, which is exactly what an operator watching a probe is likely to be doing — and let a caller pair their own registration in the path with somebody else's probe id and read that tenant's SIP transcript. The node enforces the same binding independently.
- **The fleet listing checks the caller.** `/api/agent-db` is refused at the prefix without the shared token, so this was not reachable — but the POST checked `isSystem` and the GET did not, which reads as though the difference were deliberate.
- **A SIP message's first line** is published under its RFC 3261 name: `requestLine` on a request, `statusLine` on a response, exactly one present.

## Also

Documents the full phone-registration `options` union in the OpenAPI schema — `register`, `from_domain`, `ping`, `caller_id_in_from`, `media`, and (found in review) `bridged_transfer`, its `forceBridged` alias and `displayNumber`, all three read by the livekit worker. `media` (`direct`|`relay`, default `direct`) is new with regclient: opt-in per registration, no automatic selection.

## Probe safety, continued

Refreshing a live binding now asks for the expiry that binding already holds. The node used to re-register the live contact at the probe's own 60-second expiry, cutting the real binding to 60s while the engine waited up to half the original grant before refreshing — §8.4's exact harm, arriving through the mechanism meant to prevent it. Discovery against a live registration is refused with `409` rather than quietly narrowed. Both fixes are in aplisay-b2bua#14.

## Tests

All in the no-db suite (`yarn test:no-db`), covering the node-API client (CA/PEM handling, URL construction incl. IPv6 bracketing, the address guard, failure classification, node selection), the heartbeat registry, the probe handles, and the routes with the database and HTTP client stubbed (400/403/404/409/502/503/504 paths, format passthrough, binary pcap, bearer header). Full suite: **846 passed, 82 suites**.

Two bugs were caught by those tests while writing them and are fixed here: a stray `REGCLIENT_API_SCHEME=http` could disable TLS without the insecure flag, and address trimming needed to be deliberate rather than incidental.

