### PR TITLE
b2bua nodes report where they answer privately, and llm-agent can dial it

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1878,6 +1878,14 @@ components:
             The node's public address — the same value it writes into
             `phone_registrations.b2bua_id`, which is what makes this joinable to a registration.
           example: 203.0.113.10
+        privateAddress:
+          type: string
+          description: |-
+            Where this node answers from inside its own network, when that differs from `nodeId`.
+            Used in preference to the public address when llm-agent shares a network with the node
+            (`REGCLIENT_USE_PRIVATE_NODE_ADDRESS`), so the request never leaves the VPC and the node
+            API needs no public exposure. Omitted by a node with no distinct private address.
+          example: 10.154.0.62
         type:
           type: string
           enum: [regclient, freeswitch]
@@ -1902,6 +1910,10 @@ components:
       properties:
         nodeId:
           type: string
+        privateAddress:
+          type: string
+          nullable: true
+          description: Where the node answers from inside its own network, or null if it reported none.
         type:
           type: string
           enum: [regclient, freeswitch]

--- a/api/paths/agent-db/b2bua-nodes.js
+++ b/api/paths/agent-db/b2bua-nodes.js
@@ -37,7 +37,7 @@ const heartbeat = async (req, res) => {
     return res.status(403).send({ message: 'b2bua node heartbeats are accepted only from internal callers' });
   }
 
-  const { nodeId, type = 'regclient', version, registrations, failedRegistrations, systemLoad } = req.body || {};
+  const { nodeId, privateAddress, type = 'regclient', version, registrations, failedRegistrations, systemLoad } = req.body || {};
 
   if (!nodeId || typeof nodeId !== 'string' || !nodeId.trim()) {
     return res.status(400).send({ message: 'nodeId is required' });
@@ -50,6 +50,11 @@ const heartbeat = async (req, res) => {
     const now = new Date();
     const [record] = await B2buaNode.upsert({
       nodeId: nodeId.trim(),
+      // Trusted only as far as it goes: this is an internal caller, but the
+      // address still passes the same allow-list as any other before anything
+      // dials it — see nodeDialAddress. Stored as null rather than "" so
+      // "never told us" and "told us nothing" read the same downstream.
+      privateAddress: (typeof privateAddress === 'string' && privateAddress.trim()) ? privateAddress.trim() : null,
       type,
       version: version ?? null,
       // A node that cannot count its own registrations should not be able to
@@ -104,6 +109,10 @@ const listNodes = async (req, res) => {
         const ageSeconds = lastSeenAt ? Math.round((now - lastSeenAt.getTime()) / 1000) : null;
         return {
           nodeId: node.nodeId,
+          // Part of how the node is reached, so it belongs in the view of the
+          // fleet: "why is llm-agent dialling that address" should be
+          // answerable from here rather than from the database.
+          privateAddress: node.privateAddress ?? null,
           type: node.type,
           version: node.version,
           registrations: node.registrations,

--- a/api/paths/phone-endpoints/{identifier}/probe.js
+++ b/api/paths/phone-endpoints/{identifier}/probe.js
@@ -1,5 +1,9 @@
 import { requirePermission } from '../../../../lib/auth/permissions.js';
-import { resolveRegistrationNode, passThroughNodeStatus } from '../../../../lib/regclient-facade.js';
+import {
+  resolveRegistrationNode,
+  passThroughNodeStatus,
+  nodeDialAddress
+} from '../../../../lib/regclient-facade.js';
 import { signProbeHandle } from '../../../../lib/regclient-probe-handle.js';
 import {
   buildProbeUrl,
@@ -55,7 +59,8 @@ const startRegistrationProbe = async (req, res) => {
     if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
     const { node, config } = resolved;
 
-    const url = buildProbeUrl({ node }, config);
+    const address = await nodeDialAddress(node, config, { log: req.log });
+    const url = buildProbeUrl({ node: address }, config);
     let response;
     try {
       response = await nodeRequest({

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}.js
@@ -2,7 +2,8 @@ import { requirePermission } from '../../../../../lib/auth/permissions.js';
 import {
   resolveRegistrationForHandle,
   assertHandleNodeAllowed,
-  passThroughNodeStatus
+  passThroughNodeStatus,
+  nodeDialAddress
 } from '../../../../../lib/regclient-facade.js';
 import { verifyProbeHandle } from '../../../../../lib/regclient-probe-handle.js';
 import {
@@ -62,10 +63,12 @@ const getRegistrationProbe = async (req, res) => {
     const refused = assertHandleNodeAllowed(node, config, req.log);
     if (refused) return res.status(refused.status).send(refused.body);
 
+    const address = await nodeDialAddress(node, config, { log: req.log });
+
     let response;
     try {
       response = await nodeRequest({
-        url: buildProbeUrl({ node, probeId: nodeProbeId, registrationId: identifier }, config),
+        url: buildProbeUrl({ node: address, probeId: nodeProbeId, registrationId: identifier }, config),
         config,
         node
       });

--- a/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
+++ b/api/paths/phone-endpoints/{identifier}/probe/{probeId}/events.js
@@ -1,7 +1,8 @@
 import { requirePermission } from '../../../../../../lib/auth/permissions.js';
 import {
   resolveRegistrationForHandle,
-  assertHandleNodeAllowed
+  assertHandleNodeAllowed,
+  nodeDialAddress
 } from '../../../../../../lib/regclient-facade.js';
 import { verifyProbeHandle } from '../../../../../../lib/regclient-probe-handle.js';
 import {
@@ -58,10 +59,12 @@ const streamRegistrationProbe = async (req, res) => {
     const refused = assertHandleNodeAllowed(node, config, req.log);
     if (refused) return res.status(refused.status).send(refused.body);
 
+    const address = await nodeDialAddress(node, config, { log: req.log });
+
     let upstream;
     try {
       upstream = await openNodeStream({
-        url: buildProbeUrl({ node, probeId: nodeProbeId, registrationId: identifier, events: true }, config),
+        url: buildProbeUrl({ node: address, probeId: nodeProbeId, registrationId: identifier, events: true }, config),
         config
       });
     }

--- a/api/paths/phone-endpoints/{identifier}/trace.js
+++ b/api/paths/phone-endpoints/{identifier}/trace.js
@@ -1,5 +1,5 @@
 import { requirePermission } from '../../../../lib/auth/permissions.js';
-import { resolveRegistrationNode } from '../../../../lib/regclient-facade.js';
+import { resolveRegistrationNode, nodeDialAddress } from '../../../../lib/regclient-facade.js';
 import {
   TRACE_INDEX_FORMATS,
   buildTraceUrl,
@@ -61,7 +61,8 @@ const getRegistrationTrace = async (req, res) => {
     if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
     const { node, config } = resolved;
 
-    const url = buildTraceUrl({ node, registrationId: identifier, format, since }, config);
+    const address = await nodeDialAddress(node, config, { log: req.log });
+    const url = buildTraceUrl({ node: address, registrationId: identifier, format, since }, config);
     const wantsBinary = format === 'pcap';
 
     let response;

--- a/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
+++ b/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
@@ -1,5 +1,5 @@
 import { requirePermission } from '../../../../../lib/auth/permissions.js';
-import { resolveRegistrationNode } from '../../../../../lib/regclient-facade.js';
+import { resolveRegistrationNode, nodeDialAddress } from '../../../../../lib/regclient-facade.js';
 import {
   TRACE_FORMATS,
   buildTraceUrl,
@@ -45,7 +45,8 @@ const getRegistrationTraceTransaction = async (req, res) => {
     if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
     const { node, config } = resolved;
 
-    const url = buildTraceUrl({ node, registrationId: identifier, transactionId, format, since }, config);
+    const address = await nodeDialAddress(node, config, { log: req.log });
+    const url = buildTraceUrl({ node: address, registrationId: identifier, transactionId, format, since }, config);
     const wantsBinary = format === 'pcap';
 
     let response;

--- a/lib/database-models/b2bua-node.js
+++ b/lib/database-models/b2bua-node.js
@@ -36,6 +36,17 @@ export function initB2buaNode(sequelize, types = DataTypes) {
       type: types.STRING,
       primaryKey: true
     },
+    // Where this node answers from inside its own network, when that differs
+    // from nodeId. It lives here rather than in phone_registrations.b2bua_id
+    // because that column is also read as a SIP gateway address by the LiveKit
+    // agent and the pipecat poller — a compound value there would break
+    // outbound call routing, where this table is read by nothing that predates
+    // it. Null for a node that has no distinct private address, or that
+    // predates this field, and the public address is used exactly as before.
+    privateAddress: {
+      type: types.STRING,
+      allowNull: true
+    },
     type: {
       type: types.STRING,
       allowNull: false,

--- a/lib/regclient-facade.js
+++ b/lib/regclient-facade.js
@@ -23,7 +23,8 @@ import {
   unsupportedNodeBody,
   CAPABILITY_TRACE,
   CAPABILITY_NONE,
-  CAPABILITY_UNKNOWN
+  CAPABILITY_UNKNOWN,
+  boolEnv
 } from './regclient.js';
 
 /**
@@ -174,6 +175,51 @@ export async function resolveRegistrationForHandle({
   }
 
   return { ok: true, registration, config };
+}
+
+/**
+ * Where to actually dial a node, which is not always the address it is known by.
+ *
+ * A node reports a private address in its heartbeat when it has one, and when
+ * llm-agent shares a network with it that address is the better route: the
+ * request never leaves the VPC, so the node API needs no public exposure and no
+ * firewall rule keyed to an egress address that Cloud Run does not have.
+ *
+ * Off unless REGCLIENT_USE_PRIVATE_NODE_ADDRESS says otherwise, because a
+ * deployment with no route to the node's private network would otherwise start
+ * failing every trace the moment a node learned its own private address.
+ *
+ * The address still goes through assertNodeAddressAllowed. It arrives from an
+ * authenticated internal caller rather than from the public update API, so it is
+ * better-sourced than b2bua_id — but the heartbeat token is shared across nodes,
+ * and the guard refuses link-local (169.254.0.0/16, the metadata server)
+ * regardless of what is allowed, which is the property worth keeping.
+ *
+ * The node's public address remains its identity everywhere else: what a probe
+ * handle is signed over, what a 501 names, what the fleet listing shows. Only
+ * the socket changes.
+ */
+export async function nodeDialAddress(node, config, { env = process.env, model = B2buaNode, log } = {}) {
+  if (!boolEnv(env.REGCLIENT_USE_PRIVATE_NODE_ADDRESS)) return node;
+  let priv;
+  try {
+    const record = await model.findByPk(node);
+    priv = record?.privateAddress;
+  }
+  catch (err) {
+    // The registry is an optimisation. Failing to read it means dialling the
+    // public address, which is what every deployment did until now.
+    return node;
+  }
+  if (!priv || priv === node) return node;
+
+  const allowed = assertNodeAddressAllowed(priv, { ...config, allowPrivateNodes: true });
+  if (!allowed.ok) {
+    log?.warn({ node, privateAddress: priv, reason: allowed.reason },
+      'refusing the private address a node reported; using its public one');
+    return node;
+  }
+  return priv;
 }
 
 /**

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -61,7 +61,7 @@ export function decodePem(value) {
   }
 }
 
-const boolEnv = (value, dflt = false) => {
+export const boolEnv = (value, dflt = false) => {
   if (value === undefined || value === null || value === '') return dflt;
   return ['1', 'true', 'yes', 'on'].includes(String(value).toLowerCase());
 };

--- a/tests/b2bua-node-heartbeat.test.mjs
+++ b/tests/b2bua-node-heartbeat.test.mjs
@@ -30,7 +30,7 @@ jest.unstable_mockModule('../lib/database.js', () => ({
 const { default: route } = await import('../api/paths/agent-db/b2bua-nodes.js');
 const { nodeCapability, resetNodeCapabilities, CAPABILITY_TRACE, CAPABILITY_NONE, CAPABILITY_UNKNOWN } =
   await import('../lib/regclient.js');
-const { capabilityFromHeartbeat } = await import('../lib/regclient-facade.js');
+const { capabilityFromHeartbeat, nodeDialAddress } = await import('../lib/regclient-facade.js');
 
 const quietLog = { info() {}, error() {}, warn() {}, debug() {} };
 const post = route(quietLog).POST;
@@ -247,5 +247,85 @@ describe('the scoped node principal', () => {
     res.locals.user = { id: 'someone', organisationId: 'org-1' };
     await post({ body: { nodeId: '203.0.113.77', type: 'freeswitch' }, log: quietLog }, res);
     expect(res._status).toBe(403);
+  });
+});
+
+describe('the private address a node reports', () => {
+  // A node reports where it answers from inside its own network, and llm-agent
+  // uses that when the two share a VPC: the request never leaves it, so the
+  // node API needs no public exposure and no firewall rule keyed to an egress
+  // address Cloud Run does not have.
+  //
+  // It lives here and not in phone_registrations.b2bua_id because that column
+  // is also read as a SIP gateway address by the LiveKit agent and the pipecat
+  // poller, where a compound value would break outbound call routing.
+  const PUBLIC = '203.0.113.10';
+  const PRIVATE = '10.154.0.62';
+
+  const internal = () => ({
+    locals: { user: { id: 'system', isSystem: true } },
+    _status: null,
+    _body: null,
+    status(code) { this._status = code; return this; },
+    send(body) { this._body = body; this._status = this._status || 200; return this; },
+    json(body) { return this.send(body); }
+  });
+
+  const announce = async (body) => {
+    const res = internal();
+    await post({ body, log: quietLog }, res);
+    return res;
+  };
+
+  beforeEach(() => { rows.clear(); });
+
+  it('is stored when the node reports one', async () => {
+    expect((await announce({ nodeId: PUBLIC, privateAddress: PRIVATE }))._status).toBe(200);
+    expect(rows.get(PUBLIC).privateAddress).toBe(PRIVATE);
+  });
+
+  // A node that has no distinct private address, or predates the field, must
+  // leave the column null rather than empty — so "never told us" and "told us
+  // nothing" read the same downstream.
+  it('is null when the node reports none', async () => {
+    await announce({ nodeId: PUBLIC });
+    expect(rows.get(PUBLIC).privateAddress).toBeNull();
+    await announce({ nodeId: PUBLIC, privateAddress: '   ' });
+    expect(rows.get(PUBLIC).privateAddress).toBeNull();
+  });
+
+  it('is only dialled when the deployment opts in', async () => {
+    await announce({ nodeId: PUBLIC, privateAddress: PRIVATE });
+    const config = { scheme: 'https', port: 8443 };
+
+    expect(await nodeDialAddress(PUBLIC, config, { env: {}, model: B2buaNode }))
+      .toBe(PUBLIC);
+    expect(await nodeDialAddress(PUBLIC, config, { env: { REGCLIENT_USE_PRIVATE_NODE_ADDRESS: '1' }, model: B2buaNode }))
+      .toBe(PRIVATE);
+  });
+
+  // The heartbeat token is shared across nodes, so a node reporting the
+  // metadata server's address must not be believed. assertNodeAddressAllowed
+  // refuses link-local whatever else is permitted, and that is the property
+  // this asserts.
+  it('never dials link-local, opted in or not', async () => {
+    await announce({ nodeId: PUBLIC, privateAddress: '169.254.169.254' });
+    const got = await nodeDialAddress(PUBLIC, { scheme: 'https', port: 8443 }, {
+      env: { REGCLIENT_USE_PRIVATE_NODE_ADDRESS: '1' },
+      model: B2buaNode,
+      log: quietLog
+    });
+    expect(got).toBe(PUBLIC);
+  });
+
+  // A node that has never heartbeated, or a registry read that fails, must fall
+  // back to the public address rather than failing the request.
+  it('falls back to the public address when nothing is known', async () => {
+    const env = { REGCLIENT_USE_PRIVATE_NODE_ADDRESS: '1' };
+    const config = { scheme: 'https', port: 8443 };
+    expect(await nodeDialAddress('198.51.100.7', config, { env, model: B2buaNode })).toBe('198.51.100.7');
+
+    const broken = { async findByPk() { throw new Error('database is down'); } };
+    expect(await nodeDialAddress(PUBLIC, config, { env, model: broken })).toBe(PUBLIC);
   });
 });


### PR DESCRIPTION
The llm-agent half of the private-address route. Pairs with aplisay/aplisay-b2bua#17.

A node behind NAT answers on two addresses: its public one, which is its identity, and a private one reachable only from inside its own network. When llm-agent shares that network the private address is the better route — the request never leaves the VPC, so the node API needs no public exposure and no firewall rule keyed to an egress address Cloud Run doesn't have.

## Why `b2bua_nodes` and not `b2bua_id`

`phone_registrations.b2bua_id` reads as free-form text but is consumed as a **SIP gateway address**: `transfer-handler.ts:387` → `findOrCreateRegistrationTrunk()`, which does `registrar.split(':')[0]` and appends `:5070`; and the pipecat poller runs it through `validateHost` and puts it in `X-Lk-RealIp`. A compound value breaks outbound routing and needs a coordinated rollout across two workers and a vendored copy.

`b2bua_nodes` is read by nothing that predates it — one additive column, no coordination, and `capabilityFromHeartbeat()` already looks the node up there on every trace/probe request.

## Opt-in, and still not trusted

Off unless `REGCLIENT_USE_PRIVATE_NODE_ADDRESS` is set: a deployment with no route to the node's private network would otherwise start failing every trace the moment a node learned its own private address.

The address arrives over an authenticated channel, but the heartbeat token is **shared across nodes** — so it still goes through `assertNodeAddressAllowed` with private ranges permitted, and that guard refuses link-local (`169.254.0.0/16`, the metadata server) whatever else is allowed. Anything it rejects, an unknown node, or a failed registry read all fall back to the public address.

The public address stays the node's identity everywhere else — what a probe handle is signed over, what a 501 names, what the fleet is keyed by. Only the socket changes.

Six new tests: stored / null-when-absent / opt-in gating / link-local refused / unknown node / registry failure. 132 green across the five regclient suites.
