### PR TITLE
Give existing databases the b2bua_nodes.private_address column

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -2573,6 +2573,33 @@ let dbVersion = 0;
 // `ADD VALUE IF NOT EXISTS` is a no-op when the value already exists, so this
 // is safe to retry. The statements must run outside a transaction in some PG
 // versions; sequelize.query() uses autocommit by default which is fine.
+/**
+ * `b2bua_nodes.private_address`, added to the model in #266 with no way for an
+ * existing database to acquire it.
+ *
+ * The alter-sync that would normally add a column is gated behind both a
+ * schemaVersion bump and DB_FORCE_SYNC, and neither travelled with the model
+ * change. So every database that already had `b2bua_nodes` kept the old shape,
+ * and every heartbeat failed on `column "private_address" of relation
+ * "b2bua_nodes" does not exist` — a 500 the node reports only once, as
+ * "llm-agent answered 403/500", after which further failures are counted rather
+ * than logged. A node that cannot heartbeat cannot report the private address
+ * llm-agent needs to reach its trace API over the VPC, which is what keeps 8443
+ * off the public internet.
+ *
+ * Idempotent, and outside the doUpgrade gate for the same reason
+ * migrateUsersRoleToString is: the fix has to reach databases nobody is about to
+ * force-sync. A missing table is not an error worth stopping for — sync() will
+ * create it from the model with this column already in it.
+ */
+async function addB2buaNodePrivateAddress() {
+  try {
+    await sequelize.query('ALTER TABLE "b2bua_nodes" ADD COLUMN IF NOT EXISTS "private_address" VARCHAR(255)');
+  } catch (err) {
+    logger.warn({ err: err?.message }, 'addB2buaNodePrivateAddress: ignoring');
+  }
+}
+
 async function addEnumValueIfMissing(typeName, value) {
   try {
     await sequelize.query(`ALTER TYPE "${typeName}" ADD VALUE IF NOT EXISTS '${value}'`);
@@ -2692,6 +2719,7 @@ const databaseStarted = sequelize.authenticate()
     logger.debug({ POSTGRES_DB, forceSync, dbVersion, schemaVersion }, 'Database connected');
     await addEnumValueIfMissing('enum_instances_type', 'pipecat');
     await addEnumValueIfMissing('enum_invocation_logs_subsystem', 'pipecat-agent');
+    await addB2buaNodePrivateAddress();
     return Metadata.sync({ alter: true })
     .then(() => Metadata.findOne({ where: { key: 'dbVersion' } }))
       .then((res) => {


### PR DESCRIPTION
Found while bringing up the regclient node trace API on staging.

[#266](https://github.com/aplisay/llm-agent/pull/266) added `privateAddress` to the `B2buaNode` model, but nothing that lets a database which already had `b2bua_nodes` acquire the column. The alter-sync that would normally add one is gated behind **both** a `schemaVersion` bump and `DB_FORCE_SYNC`, and neither travelled with the model change.

So on staging, every node heartbeat failed:

```
column "private_address" of relation "b2bua_nodes" does not exist
```

which the route turns into a 500.

## Why this was hard to see

The node logs a heartbeat failure **once** and then counts further failures rather than logging them:

```
node heartbeat failed; llm-agent will fall back to discovering this node
  (further failures counted, not logged)
```

Success is logged at `debug`. So at `info` the symptom is not an error — it is silence, indistinguishable from a heartbeat that is working. It took a direct `POST` to the endpoint to see a status code at all, and the Cloud Run logs to see the cause.

## Why it matters beyond a missing row

A node that cannot heartbeat cannot report the private address `nodeDialAddress` uses. Dialling the private address is what allows the node API to stay off the public internet — the alternative is exposing 8443, an endpoint that originates SIP from telco-trusted addresses. **Traces do not work without this column.**

## The fix

An idempotent targeted migration outside the `doUpgrade` gate, beside `migrateUsersRoleToString` and `addEnumValueIfMissing` — the pattern this codebase already uses for precisely this situation, because the fix has to reach databases nobody is about to force-sync.

`ADD COLUMN IF NOT EXISTS` is a no-op once applied, and a missing table is not an error worth stopping for: `sync()` creates it from the model with the column already in it.

The alternative — bumping `schemaVersion` and setting `DB_FORCE_SYNC` — would run `sync({alter: true})` across every model on a shared database, applying all accumulated drift to fix one nullable column. Not worth the blast radius.

## Verification

861 tests pass across 82 suites (`yarn test:no-db`).
