### PR TITLE
schema v60: b2bua_nodes.private_address

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -17,7 +17,16 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 59;  // 59: billing — DROP the rate_cards period-overlap EXCLUDE constraint, exactly as
+const schemaVersion = 60;  // 60: `b2bua_nodes.private_address` — the address a node reports for itself
+                           //     inside the VPC, added to the model in #266 without a version bump, so no
+                           //     existing database ever got the column and every node heartbeat failed on
+                           //     `column "private_address" ... does not exist`. B2buaNode joins the gated
+                           //     alter chain here to carry it; the unconditional create-if-missing sync
+                           //     stays as well, for the same reason chat_sessions keeps both. llm-agent
+                           //     dials this address in preference to the public one when
+                           //     REGCLIENT_USE_PRIVATE_NODE_ADDRESS is set, which is what keeps the node
+                           //     trace API's 8443 off the public internet.
+                           // 59: billing — DROP the rate_cards period-overlap EXCLUDE constraint, exactly as
                            //     v53 did for tariffs. resolveRateCard (greatest start_date <= billedAt wins)
                            //     makes overlapping / open-ended same-name cards unambiguous, so the constraint
                            //     was too strict: it made the sanctioned "supersede with a later card" workflow
@@ -2738,6 +2747,16 @@ const databaseStarted = sequelize.authenticate()
     .then(() => InvocationLog.sync({ alter: true }))
     .then(() => UsageRecord.sync({ alter: true }))
     .then(() => ChatSession.sync({ alter: true }))
+    // Alone in this chain, this one may not take the boot down. b2bua_nodes is
+    // an optimisation over asking each node directly, and the facade falls back
+    // to discovery without it, so a deployment whose database role lacks DDL
+    // rights should lose the optimisation rather than the service — the same
+    // trade the unconditional sync below is written around. It is here at all
+    // because only an alter can add a column to a table that already exists.
+    .then(() => B2buaNode.sync({ alter: true }).catch((err) => {
+      logger.warn({ err: err?.message },
+        'could not alter b2bua_nodes; a column added after first deploy may be missing');
+    }))
     .then(() => RateCard.sync({ alter: true }))
     .then(() => dropRateCardOverlapConstraint())
     .then(() => BalanceCredit.sync({ alter: true }))
@@ -2769,6 +2788,15 @@ const databaseStarted = sequelize.authenticate()
     // b2bua_nodes is ensured the same way and for the same reason. Its failure
     // mode is quiet in the same style: traces keep "working", they just report
     // every node as unknown and pay a discovery attempt for each one for ever.
+    //
+    // It is ALSO in the gated alter chain above, exactly as chat_sessions is,
+    // and the two do different jobs: this plain sync creates the table on a
+    // deployment nobody force-syncs, and the gated one adds columns to a table
+    // that already exists. Only the second can do the second job — a plain
+    // sync() is create-if-missing and silently leaves an existing table at its
+    // old shape, which is how `private_address` (v60) reached the model in #266
+    // and never reached staging's database. Every heartbeat 500'd on the
+    // missing column for as long as that lasted.
     //
     // Unlike chat_sessions, this one is allowed to fail. The registry is an
     // optimisation over asking the node directly, not a dependency — the


### PR DESCRIPTION
Found while bringing up the regclient node trace API on staging.

[#266](https://github.com/aplisay/llm-agent/pull/266) added `privateAddress` to the `B2buaNode` model without bumping `schemaVersion` — and `B2buaNode` was not in the gated alter chain in any case. Its only sync was the unconditional create-if-missing one, which leaves an existing table at its old shape. So no database that already had `b2bua_nodes` ever acquired the column:

```
column "private_address" of relation "b2bua_nodes" does not exist
```

## Why it matters beyond a missing row

The address a node reports for itself inside the VPC is what `nodeDialAddress` prefers over the public one when `REGCLIENT_USE_PRIVATE_NODE_ADDRESS` is set. Dialling privately is what allows the node trace API to stay off the public internet — the alternative is exposing 8443, an endpoint that originates SIP from telco-trusted addresses. **Traces do not work without this column.**

## Why it was hard to see

The node logs a heartbeat failure **once**, then counts the rest:

```
node heartbeat failed; llm-agent will fall back to discovering this node
  (further failures counted, not logged)
```

Success logs at `debug`. At `info` the symptom is silence — indistinguishable from a heartbeat that is working. It took a direct `POST` to the endpoint to get a status code, and the Cloud Run logs to get the cause.

## The change

`B2buaNode` joins the gated alter chain, as `chat_sessions` does, and keeps its unconditional create-if-missing sync as well. The two do different jobs:

| sync | job |
|---|---|
| unconditional `B2buaNode.sync()` | creates the table on a deployment nobody force-syncs |
| gated `B2buaNode.sync({alter: true})` | adds columns to a table that already exists |

Only the second can do the second job.

## One deliberate difference from its neighbours

The gated call is the only member of that chain wrapped so it cannot fail the boot. That property is not new — it is why the unconditional sync was written with a `try/catch` and a comment saying so:

> the registry is an optimisation over asking the node directly, not a dependency … so a deployment whose database role has no DDL rights should lose the optimisation, not the boot

Moving the sync into a chain whose other members are fatal would have silently discarded that. The wrapper keeps it.

## Applying it

`tools/agent-admin.js --command upgrade-db` (sets `DB_FORCE_SYNC`, runs the chain, stamps `dbVersion`). Staging is not deployed with `DB_FORCE_SYNC` set, which is correct.

## Verification

861 tests pass across 82 suites against a **clean** test database. Worth noting: an accumulated local test database fails `User.sync` on `users_organisation_id_fkey` regardless of this change, which is easy to misread as a regression — `yarn test:cleanup && yarn test:setup` first.
