### PR TITLE
Credentials at rest: audit + manual sweep CLI for legacy plaintext databases

### DIFF
--- a/docs/credentials-at-rest.md
+++ b/docs/credentials-at-rest.md
@@ -1,0 +1,101 @@
+# Credentials at rest: audit and migration sweep
+
+Credential values (SIP registration passwords, recording keys, call encryption
+keys) are encrypted at rest with AES-256-GCM under a key derived from the
+`CREDENTIALS_KEY` environment variable (`lib/utils/credentials.js`). Every
+encrypted value has the form:
+
+```
+enc:<base64 12-byte iv>:<base64 16-byte tag>:<base64 ciphertext>
+```
+
+Instances deployed **without** a `CREDENTIALS_KEY` stored these values as raw
+plaintext (the write path failed open). The read path tolerates that — any
+stored value without the `enc:` prefix is passed through unchanged — so setting
+a key on a legacy instance is safe and backward compatible, but rows written
+before the key existed stay plaintext until rewritten. `tools/credentials-audit.js`
+(backed by `lib/utils/credentials-sweep.js`) closes that gap: run it by hand,
+against a chosen database, on your own schedule — nothing runs this
+automatically at boot.
+
+## Where credentials live
+
+| Location | Storage |
+| --- | --- |
+| `phone_registrations.password` | text column |
+| `calls.encryption_key` | varchar column |
+| `agents.options.recording.key` | string nested in JSONB |
+| `instances.recording.key` | string nested in JSONB |
+
+(Organisation BYOK provider keys — `organisation_keys.value` — are fail-closed
+from birth and never have plaintext rows, so they are not part of this sweep.)
+
+## Classification
+
+`classifyStoredSecret()` distinguishes, per stored value:
+
+- **plaintext** — no `enc:` prefix: a legacy value. The sweep encrypts these.
+- **encrypted** — structurally valid and the GCM auth tag verifies under the
+  current key. Because GCM is authenticated, this is cryptographic proof the
+  value was written under this key, not a heuristic.
+- **encrypted-foreign** — structurally valid but the tag fails: written under
+  a *different* key, or corrupted. Never touched; investigate (usually the
+  instance once ran with another key).
+- **enc-lookalike** — `enc:`-prefixed but structurally invalid (wrong part
+  count, iv ≠ 12 bytes, tag ≠ 16 bytes). In reality plaintext that happens to
+  start with `enc:`; today's read path returns null for these. Surfaced by the
+  audit, never modified by the sweep.
+- **encrypted-unverified** — structurally valid, but no `CREDENTIALS_KEY` in
+  this process to verify the tag against (keyless audit only).
+
+## CLI: audit and sweep a database directly
+
+`tools/credentials-audit.js` connects with the `POSTGRES_*` environment only —
+no schema sync, no listener, nothing written in audit mode — so it can be run
+against a live legacy instance before or after any deploy, pointed at whichever
+`.env` you choose:
+
+```
+node tools/credentials-audit.js [--path <envfile>] [--json]   # read-only audit
+node tools/credentials-audit.js --sweep [--path <envfile>]    # encrypt plaintext, then re-audit
+```
+
+`--path`/`-p` loads that env file (via `dotenv`) before connecting, so a single
+checkout can target any instance's database by pointing at its `.env`.
+`--sweep` refuses to run without `CREDENTIALS_KEY` present (in the environment
+or the loaded file).
+
+Sweep behaviour: any definitely-plaintext value (`NOT LIKE 'enc:%'`, and for
+JSONB locations only JSON strings) is encrypted in place, row by row, with an
+optimistic `AND value = original` guard so a concurrent writer wins and the
+row is simply picked up on the next sweep. `updated_at` is not bumped and
+values are never logged. Idempotent by construction: a second run matches
+nothing. The readable value is identical before and after (plaintext
+passthrough vs decrypt); only the at-rest form changes.
+
+Exit codes: `0` every stored credential verified encrypted under the current
+key; `1` findings (plaintext / lookalike / foreign / unverified, or a location
+that errored); `2` usage or connection error. Row ids are reported for
+anomalous classes; credential values are never printed.
+
+## Migrating a legacy instance
+
+1. **Audit first**, without a key: expect `plaintext` counts and nothing
+   `encrypted` (a legacy instance never encrypted anything). Anything
+   `encrypted-unverified` means the instance was not keyless all along — stop
+   and work out which key wrote it.
+2. **Back up the database, then mint and set `CREDENTIALS_KEY`** in the
+   instance's secret store. Key custody is the critical step: once swept,
+   values are unrecoverable without the key (the plaintext state, ironically,
+   is the recoverable one). The key must never change afterwards — a changed
+   key turns every stored credential into `encrypted-foreign` (reads return
+   null).
+3. **Run the tool with `--sweep`** against that instance's database (e.g.
+   `node tools/credentials-audit.js --path .env.staging --sweep`). Nothing
+   encrypts automatically — this is the step that does it. Reads keep working
+   with a plaintext row either way, so there is no urgency beyond your own
+   change window.
+4. **Re-audit**: expect only `encrypted`. Exit code 0 is the fleet-scriptable
+   signal.
+5. Old database backups still contain plaintext — rotate them on the normal
+   retention schedule as part of the remediation.

--- a/lib/utils/credentials-sweep.js
+++ b/lib/utils/credentials-sweep.js
@@ -1,0 +1,164 @@
+import { QueryTypes } from 'sequelize';
+import logger from '../logger.js';
+import { classifyStoredSecret, encryptSecret, isEncryptedSecretFormat, hasCredentialsKey } from './credentials.js';
+
+/**
+ * Every place a credential is stored at rest under the CREDENTIALS_KEY scheme
+ * (docs/security: encryptSecret/decryptSecret). Instances deployed before a
+ * key was configured hold these as raw plaintext; the audit classifies them
+ * and the sweep encrypts them in place.
+ *
+ * kind 'column': the column itself is the stored secret (text/varchar).
+ * kind 'jsonb':  the secret is a nested string inside a JSONB column, at
+ *                `path` (Postgres text[] path literal).
+ */
+export const CREDENTIAL_LOCATIONS = [
+  { label: 'phone_registrations.password', table: 'phone_registrations', column: 'password', kind: 'column' },
+  { label: 'calls.encryption_key', table: 'calls', column: 'encryption_key', kind: 'column' },
+  { label: 'agents.options.recording.key', table: 'agents', column: 'options', kind: 'jsonb', path: '{recording,key}' },
+  { label: 'instances.recording.key', table: 'instances', column: 'recording', kind: 'jsonb', path: '{key}' },
+];
+
+const PAGE_SIZE = 500;
+const ANOMALY_ID_CAP = 50;
+
+/** SQL expression for the stored secret's text value. */
+const valueExpr = ({ kind, column, path }) =>
+  kind === 'jsonb' ? `"${column}"#>>'${path}'` : `"${column}"`;
+
+/**
+ * Predicate selecting rows whose stored value is definitely plaintext: a
+ * non-null string with no enc: prefix. enc:-prefixed values — including
+ * structurally invalid lookalikes and foreign-key blobs — are deliberately
+ * excluded: the sweep never rewrites a value it cannot classify beyond doubt
+ * (the audit surfaces those instead). JSONB non-string values (never written
+ * by encryptSecret) are likewise left alone.
+ */
+const plaintextPredicate = (location) => {
+  const expr = valueExpr(location);
+  const stringGuard = location.kind === 'jsonb'
+    ? ` AND jsonb_typeof("${location.column}"#>'${location.path}') = 'string'`
+    : '';
+  return `${expr} IS NOT NULL AND ${expr} NOT LIKE 'enc:%'${stringGuard}`;
+};
+
+/**
+ * Page rows as {id, value, jtype} ordered by id::text (uniform keyset cursor
+ * for UUID and string ids). `jtype` is the underlying JSON type for jsonb
+ * locations (null for plain columns): #>> stringifies every JSONB scalar, so
+ * without it a nested number would masquerade as a plaintext string.
+ */
+async function* pageRows(sequelize, location, { where }) {
+  const expr = valueExpr(location);
+  const jtypeExpr = location.kind === 'jsonb'
+    ? `jsonb_typeof("${location.column}"#>'${location.path}')`
+    : 'NULL';
+  let cursor = '';
+  for (;;) {
+    const rows = await sequelize.query(
+      `SELECT "id", ${expr} AS value, ${jtypeExpr} AS jtype FROM "${location.table}"
+         WHERE ${where} AND CAST("id" AS text) > :cursor
+         ORDER BY CAST("id" AS text) LIMIT :limit`,
+      { type: QueryTypes.SELECT, replacements: { cursor, limit: PAGE_SIZE } },
+    );
+    if (!rows.length) return;
+    yield rows;
+    cursor = String(rows[rows.length - 1].id);
+  }
+}
+
+/**
+ * Read-only audit: classify every stored credential value at every location.
+ * Never returns or logs the values themselves — only counts, and row ids for
+ * the anomalous classes (enc-lookalike, encrypted-foreign, non-string).
+ *
+ * Without a CREDENTIALS_KEY in the environment, encrypted values report as
+ * encrypted-unverified (structure checks still run; tag verification cannot).
+ */
+export async function auditStoredCredentials(sequelize) {
+  const report = { hasCredentialsKey, locations: [] };
+  for (const location of CREDENTIAL_LOCATIONS) {
+    const expr = valueExpr(location);
+    const entry = { label: location.label, total: 0, counts: {}, anomalies: {}, error: null };
+    report.locations.push(entry);
+    try {
+      for await (const rows of pageRows(sequelize, location, { where: `${expr} IS NOT NULL` })) {
+        for (const { id, value, jtype } of rows) {
+          const cls = (location.kind === 'jsonb' && jtype !== 'string')
+            ? 'non-string'
+            : classifyStoredSecret(value);
+          entry.total += 1;
+          entry.counts[cls] = (entry.counts[cls] || 0) + 1;
+          if (cls === 'enc-lookalike' || cls === 'encrypted-foreign' || cls === 'non-string') {
+            const ids = (entry.anomalies[cls] ||= []);
+            if (ids.length < ANOMALY_ID_CAP) ids.push(id);
+          }
+        }
+      }
+    } catch (err) {
+      entry.error = err?.message;
+      logger.warn({ location: location.label, err: err?.message }, 'credentials audit: location skipped');
+    }
+  }
+  return report;
+}
+
+/**
+ * Startup sweep: encrypt-in-place every definitely-plaintext credential, so a
+ * legacy database created before CREDENTIALS_KEY was configured converges to
+ * encrypted-at-rest on the first boot with a key. Idempotent (the predicate
+ * matches nothing once swept) and cheap when clean: one count per location.
+ *
+ * Each row is updated with an optimistic `AND value = original` guard, so a
+ * concurrent write wins and the row is skipped (a later boot re-sweeps it).
+ * Rows are never deleted, values never logged, updated_at never bumped — the
+ * readable value is identical before and after (plaintext passthrough vs
+ * decrypt), only the at-rest form changes.
+ */
+export async function sweepPlaintextCredentials(sequelize) {
+  if (!hasCredentialsKey) {
+    logger.info('CREDENTIALS_KEY not set; skipping credentials-at-rest sweep');
+    return { swept: false, locations: [] };
+  }
+  const summary = { swept: true, locations: [] };
+  for (const location of CREDENTIAL_LOCATIONS) {
+    const entry = { label: location.label, candidates: 0, updated: 0, skipped: 0, error: null };
+    summary.locations.push(entry);
+    try {
+      const where = plaintextPredicate(location);
+      const [{ count }] = await sequelize.query(
+        `SELECT CAST(count(*) AS int) AS count FROM "${location.table}" WHERE ${where}`,
+        { type: QueryTypes.SELECT },
+      );
+      if (!count) continue;
+      entry.candidates = count;
+      logger.info({ location: location.label, count }, 'Encrypting legacy plaintext credentials at rest');
+
+      const updateSql = location.kind === 'jsonb'
+        ? `UPDATE "${location.table}"
+             SET "${location.column}" = jsonb_set("${location.column}", '${location.path}', to_jsonb(CAST(:enc AS text)))
+           WHERE "id" = :id AND ${plaintextPredicate(location)} AND ${valueExpr(location)} = :orig`
+        : `UPDATE "${location.table}" SET "${location.column}" = :enc
+           WHERE "id" = :id AND ${valueExpr(location)} = :orig`;
+
+      for await (const rows of pageRows(sequelize, location, { where })) {
+        for (const { id, value } of rows) {
+          if (classifyStoredSecret(value) !== 'plaintext') { entry.skipped += 1; continue; }
+          const enc = encryptSecret(value);
+          if (!isEncryptedSecretFormat(enc)) { entry.skipped += 1; continue; }
+          const [, meta] = await sequelize.query(updateSql, { replacements: { id, enc, orig: value } });
+          const changed = meta?.rowCount ?? meta ?? 0;
+          if (changed) entry.updated += 1; else entry.skipped += 1;
+        }
+      }
+      logger.info(
+        { location: location.label, updated: entry.updated, skipped: entry.skipped },
+        'Credentials-at-rest sweep complete for location',
+      );
+    } catch (err) {
+      entry.error = err?.message;
+      logger.warn({ location: location.label, err: err?.message }, 'credentials sweep: location skipped');
+    }
+  }
+  return summary;
+}

--- a/lib/utils/credentials.js
+++ b/lib/utils/credentials.js
@@ -11,6 +11,69 @@ const encryptionKey = deriveKey(CREDENTIALS_KEY);
 // plaintext anyway.
 export const credentialsEncryptionEnabled = Boolean(encryptionKey);
 
+/** Whether a usable CREDENTIALS_KEY was configured at process start. */
+export const hasCredentialsKey = !!encryptionKey;
+
+/**
+ * Structural test: does `value` have the exact shape encryptSecret writes —
+ * enc:<b64 12-byte iv>:<b64 16-byte tag>:<b64 ciphertext>? A plaintext
+ * credential that merely starts with "enc:" fails this, so it is a stronger
+ * discriminator than the bare prefix. Passing says nothing about WHICH key
+ * encrypted it — use classifyStoredSecret for that.
+ */
+export function isEncryptedSecretFormat(value) {
+  if (typeof value !== 'string' || !value.startsWith('enc:')) return false;
+  const parts = value.split(':');
+  if (parts.length !== 4) return false;
+  const [, ivB64, tagB64, dataB64] = parts;
+  try {
+    const iv = Buffer.from(ivB64, 'base64');
+    const tag = Buffer.from(tagB64, 'base64');
+    const data = Buffer.from(dataB64, 'base64');
+    // Round-trip the base64 so "enc:AAAA:!!!!:junk"-style lookalikes (which
+    // Buffer.from silently truncates) are rejected, not misread.
+    return iv.length === 12 && tag.length === 16 && data.length > 0
+      && iv.toString('base64') === ivB64 && tag.toString('base64') === tagB64;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Classify a stored credential value for the at-rest audit/sweep
+ * (lib/utils/credentials-sweep.js). GCM's auth tag makes 'encrypted' a
+ * cryptographic verdict, not a guess: a successful decrypt proves the value
+ * was written under the current CREDENTIALS_KEY.
+ *
+ * @returns {'empty'|'non-string'|'plaintext'|'enc-lookalike'|'encrypted'|'encrypted-foreign'|'encrypted-unverified'}
+ *  - empty: null/undefined
+ *  - non-string: stored as a non-string (never produced by encryptSecret)
+ *  - plaintext: no enc: prefix — a legacy value stored before a key was set
+ *  - enc-lookalike: enc:-prefixed but structurally invalid; in reality
+ *    plaintext, but today's read path nulls it — surfaced, never swept
+ *  - encrypted: tag verifies under the current key
+ *  - encrypted-foreign: valid structure, tag fails — written under some other
+ *    key, or corrupted
+ *  - encrypted-unverified: valid structure but no CREDENTIALS_KEY in this
+ *    process to verify against
+ */
+export function classifyStoredSecret(value) {
+  if (value == null) return 'empty';
+  if (typeof value !== 'string') return 'non-string';
+  if (!value.startsWith('enc:')) return 'plaintext';
+  if (!isEncryptedSecretFormat(value)) return 'enc-lookalike';
+  if (!encryptionKey) return 'encrypted-unverified';
+  const [, ivB64, tagB64, dataB64] = value.split(':');
+  try {
+    const decipher = createDecipheriv('aes-256-gcm', encryptionKey, Buffer.from(ivB64, 'base64'));
+    decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+    Buffer.concat([decipher.update(Buffer.from(dataB64, 'base64')), decipher.final()]);
+    return 'encrypted';
+  } catch {
+    return 'encrypted-foreign';
+  }
+}
+
 export function encryptSecret(plainText) {
   if (plainText == null) return null;
   try {

--- a/tests/credentials-sweep.test.mjs
+++ b/tests/credentials-sweep.test.mjs
@@ -1,0 +1,210 @@
+// Credentials-at-rest audit + sweep (lib/utils/credentials-sweep.js).
+//
+// Legacy databases created while CREDENTIALS_KEY was empty hold raw plaintext
+// credentials. These tests simulate that state by creating rows through the
+// models (which encrypt, since the test wrapper sets a key) and then raw-SQL
+// updating the stored values back to plaintext — then verify the audit
+// classifies them and the boot sweep encrypts them in place without changing
+// what the models read. All row-level assertions are scoped to the ids seeded
+// here, so suites sharing the test database cannot interfere.
+import {
+  setupRealDatabase, teardownRealDatabase,
+  Organisation, User, Agent, Instance, Call, PhoneRegistration, databaseStarted,
+} from './setup/database-test-wrapper.js';
+import { randomUUID, createHash, createCipheriv, randomBytes } from 'crypto';
+import { auditStoredCredentials, sweepPlaintextCredentials } from '../lib/utils/credentials-sweep.js';
+import { encryptSecret, decryptSecret, classifyStoredSecret, isEncryptedSecretFormat } from '../lib/utils/credentials.js';
+
+// A structurally valid blob encrypted under a DIFFERENT key: what an audit
+// should call encrypted-foreign and a sweep must never touch.
+const foreignBlob = (plain) => {
+  const key = createHash('sha256').update('some-other-credentials-key').digest();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const ct = Buffer.concat([cipher.update(plain, 'utf8'), cipher.final()]);
+  return `enc:${iv.toString('base64')}:${cipher.getAuthTag().toString('base64')}:${ct.toString('base64')}`;
+};
+
+const LOOKALIKE = 'enc:not-a-real-blob';
+
+describe('classifyStoredSecret', () => {
+  test('classifies plaintext, round-trip encrypted, lookalike, and foreign values', () => {
+    expect(classifyStoredSecret(null)).toBe('empty');
+    expect(classifyStoredSecret(42)).toBe('non-string');
+    expect(classifyStoredSecret('hunter2')).toBe('plaintext');
+    expect(classifyStoredSecret(LOOKALIKE)).toBe('enc-lookalike');
+    expect(classifyStoredSecret('enc:AAAA:BBBB:CCCC')).toBe('enc-lookalike');
+
+    const blob = encryptSecret('hunter2');
+    expect(isEncryptedSecretFormat(blob)).toBe(true);
+    expect(classifyStoredSecret(blob)).toBe('encrypted');
+    expect(decryptSecret(blob)).toBe('hunter2');
+
+    expect(classifyStoredSecret(foreignBlob('hunter2'))).toBe('encrypted-foreign');
+  });
+
+  test('a plaintext credential that happens to start with enc: is not misread as encrypted', () => {
+    expect(classifyStoredSecret('enc:ode-my-password')).toBe('enc-lookalike');
+  });
+});
+
+describe('credentials-at-rest audit and sweep', () => {
+  let sequelize;
+  let orgId, userId, agentId, instanceId, callId;
+  let regPlainId, regLookalikeId, regForeignId;
+  const AGENT_SECRET = 'agent-recording-secret';
+  const INSTANCE_SECRET = 'instance-recording-secret';
+  const CALL_SECRET = 'call-encryption-secret';
+  const REG_SECRET = 'registration-password-secret';
+
+  const storedValue = async (sql, id) => {
+    const [rows] = await sequelize.query(sql, { replacements: { id } });
+    return rows[0]?.value;
+  };
+  const storedPassword = (id) =>
+    storedValue('SELECT "password" AS value FROM "phone_registrations" WHERE "id" = :id', id);
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    await databaseStarted;
+    sequelize = Agent.sequelize;
+
+    orgId = randomUUID();
+    userId = randomUUID();
+    agentId = randomUUID();
+    instanceId = randomUUID();
+
+    await Organisation.create({ id: orgId, name: 'Sweep Org' });
+    await User.create({
+      id: userId, name: 'Sweep User', email: `sweep-${userId}@example.com`,
+      emailVerified: true, phone: '', phoneVerified: false, picture: '', role: 'owner', organisationId: orgId,
+    });
+    // validate:false skips the heavy handler/voice validation (irrelevant here).
+    await Agent.create(
+      {
+        id: agentId, name: 'Sweep Agent', modelName: 'livekit:test-model', userId, organisationId: orgId,
+        options: { temperature: 0.5, recording: { key: AGENT_SECRET, url: 'gs://bucket/prefix' } },
+      },
+      { validate: false },
+    );
+    await Instance.create({
+      id: instanceId, agentId, type: 'livekit', userId, organisationId: orgId,
+      recording: { key: INSTANCE_SECRET, mode: 'full' },
+    });
+    const call = await Call.create({
+      instanceId, agentId, organisationId: orgId, userId,
+      calledId: '441234567890', callerId: '447700900000',
+      platform: 'livekit', modelName: 'livekit:test-model',
+    });
+    callId = call.id;
+
+    const makeReg = (name) => PhoneRegistration.create({
+      name, registrar: 'sip:provider.example.com:5060', username: `u-${randomUUID().slice(0, 8)}`,
+      password: 'to-be-replaced', handler: 'livekit', organisationId: orgId,
+    });
+    regPlainId = (await makeReg('Sweep plaintext')).id;
+    regLookalikeId = (await makeReg('Sweep lookalike')).id;
+    regForeignId = (await makeReg('Sweep foreign')).id;
+
+    // Simulate the legacy (empty-CREDENTIALS_KEY) database: plant raw stored
+    // values underneath the models, bypassing the encrypting setters.
+    await sequelize.query(
+      `UPDATE "agents" SET "options" = jsonb_set("options", '{recording,key}', to_jsonb(CAST(:v AS text))) WHERE "id" = :id`,
+      { replacements: { v: AGENT_SECRET, id: agentId } });
+    await sequelize.query(
+      `UPDATE "instances" SET "recording" = jsonb_set("recording", '{key}', to_jsonb(CAST(:v AS text))) WHERE "id" = :id`,
+      { replacements: { v: INSTANCE_SECRET, id: instanceId } });
+    await sequelize.query(
+      `UPDATE "calls" SET "encryption_key" = :v WHERE "id" = :id`,
+      { replacements: { v: CALL_SECRET, id: callId } });
+    await sequelize.query(
+      `UPDATE "phone_registrations" SET "password" = :v WHERE "id" = :id`,
+      { replacements: { v: REG_SECRET, id: regPlainId } });
+    await sequelize.query(
+      `UPDATE "phone_registrations" SET "password" = :v WHERE "id" = :id`,
+      { replacements: { v: LOOKALIKE, id: regLookalikeId } });
+    await sequelize.query(
+      `UPDATE "phone_registrations" SET "password" = :v WHERE "id" = :id`,
+      { replacements: { v: foreignBlob(REG_SECRET), id: regForeignId } });
+  }, 30000);
+
+  afterAll(async () => {
+    await PhoneRegistration.destroy({ where: { organisationId: orgId } });
+    await Organisation.destroy({ where: { id: orgId } }); // cascades user/agent/instance/call
+    await teardownRealDatabase();
+  }, 60000);
+
+  test('audit classifies the legacy rows and surfaces anomalies by id, never by value', async () => {
+    const report = await auditStoredCredentials(sequelize);
+    expect(report.hasCredentialsKey).toBe(true);
+    const byLabel = Object.fromEntries(report.locations.map((l) => [l.label, l]));
+
+    for (const label of [
+      'phone_registrations.password', 'calls.encryption_key',
+      'agents.options.recording.key', 'instances.recording.key',
+    ]) {
+      expect(byLabel[label]).toBeDefined();
+      expect(byLabel[label].error).toBeNull();
+      expect(byLabel[label].counts.plaintext).toBeGreaterThanOrEqual(1);
+    }
+    const regs = byLabel['phone_registrations.password'];
+    expect(regs.anomalies['enc-lookalike']).toContain(regLookalikeId);
+    expect(regs.anomalies['encrypted-foreign']).toContain(regForeignId);
+    expect(JSON.stringify(report)).not.toContain(REG_SECRET);
+  });
+
+  test('sweep encrypts exactly the plaintext rows, leaving lookalike and foreign values untouched', async () => {
+    const summary = await sweepPlaintextCredentials(sequelize);
+    expect(summary.swept).toBe(true);
+    for (const loc of summary.locations) {
+      expect(loc.error).toBeNull();
+      expect(loc.updated).toBeGreaterThanOrEqual(1);
+    }
+
+    const agentStored = await storedValue(
+      `SELECT "options"#>>'{recording,key}' AS value FROM "agents" WHERE "id" = :id`, agentId);
+    const instanceStored = await storedValue(
+      `SELECT "recording"#>>'{key}' AS value FROM "instances" WHERE "id" = :id`, instanceId);
+    const callStored = await storedValue(
+      `SELECT "encryption_key" AS value FROM "calls" WHERE "id" = :id`, callId);
+    const regStored = await storedPassword(regPlainId);
+
+    for (const stored of [agentStored, instanceStored, callStored, regStored]) {
+      expect(classifyStoredSecret(stored)).toBe('encrypted');
+    }
+    expect(await storedPassword(regLookalikeId)).toBe(LOOKALIKE);
+    expect(classifyStoredSecret(await storedPassword(regForeignId))).toBe('encrypted-foreign');
+  });
+
+  test('models read the swept values back decrypted, with JSONB siblings intact', async () => {
+    const agent = await Agent.findByPk(agentId);
+    expect(agent.options.recording.key).toBe(AGENT_SECRET);
+    expect(agent.options.recording.url).toBe('gs://bucket/prefix');
+    expect(agent.options.temperature).toBe(0.5);
+
+    const instance = await Instance.findByPk(instanceId);
+    expect(instance.recording.key).toBe(INSTANCE_SECRET);
+    expect(instance.recording.mode).toBe('full');
+
+    const call = await Call.findByPk(callId);
+    expect(call.encryptionKey).toBe(CALL_SECRET);
+
+    const reg = await PhoneRegistration.findByPk(regPlainId);
+    expect(reg.password).toBe(REG_SECRET);
+  });
+
+  test('sweep is idempotent: a second run finds nothing and rewrites nothing', async () => {
+    // Converge first (a no-op when the earlier test already swept), so this
+    // test also stands alone under jest -t.
+    await sweepPlaintextCredentials(sequelize);
+    const before = await storedPassword(regPlainId);
+    const summary = await sweepPlaintextCredentials(sequelize);
+    for (const loc of summary.locations) {
+      expect(loc.error).toBeNull();
+      expect(loc.candidates).toBe(0);
+      expect(loc.updated).toBe(0);
+    }
+    // Same blob byte-for-byte: an idempotent pass must not re-encrypt (new IV).
+    expect(await storedPassword(regPlainId)).toBe(before);
+  });
+});

--- a/tools/credentials-audit.js
+++ b/tools/credentials-audit.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Credentials-at-rest audit / sweep for a legacy database (one created while
+// CREDENTIALS_KEY was empty, so credentials were stored as raw plaintext).
+//
+//   node tools/credentials-audit.js [--path .env] [--json]     read-only audit
+//   node tools/credentials-audit.js --sweep [--path .env]      encrypt plaintext in place, then re-audit
+//
+// Connects directly with the POSTGRES_* environment (no model sync, no
+// listener, nothing written in audit mode), so it is safe to run against a
+// live legacy instance BEFORE deploying anything. Without CREDENTIALS_KEY in
+// the environment the audit still runs, but encrypted values can only be
+// reported as encrypted-unverified (the GCM tag cannot be checked) and
+// --sweep is refused. Credential values are never printed or logged.
+//
+// Exit codes: 0 = every stored credential verified encrypted under the
+// current key; 1 = findings (plaintext / lookalike / foreign / unverified /
+// non-string, or a location that errored); 2 = usage or connection error.
+import dotenv from 'dotenv';
+import dir from 'path';
+import commandLineArgs from 'command-line-args';
+
+const optionDefinitions = [
+  { name: 'path', alias: 'p', type: String },
+  { name: 'json', alias: 'j', type: Boolean },
+  { name: 'sweep', alias: 's', type: Boolean },
+  { name: 'help', alias: 'h', type: Boolean },
+];
+const options = commandLineArgs(optionDefinitions);
+if (options.help) {
+  console.log('Usage: node tools/credentials-audit.js [--path <.env>] [--json] [--sweep]');
+  process.exit(0);
+}
+dotenv.config(options.path ? { path: dir.resolve(process.cwd(), options.path) } : {});
+
+// Import AFTER dotenv: lib/utils/credentials.js captures CREDENTIALS_KEY at load.
+const { Sequelize } = await import('sequelize');
+const { auditStoredCredentials, sweepPlaintextCredentials } = await import('../lib/utils/credentials-sweep.js');
+const { hasCredentialsKey } = await import('../lib/utils/credentials.js');
+
+const {
+  POSTGRES_DB, POSTGRES_USER, POSTGRES_HOST, POSTGRES_PASSWORD, POSTGRES_PORT,
+  POSTGRES_KEY, POSTGRES_CERT, POSTGRES_CA, POSTGRES_RO_SERVER_NAME,
+} = process.env;
+
+const sequelize = new Sequelize(POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD, {
+  dialect: 'postgres',
+  host: POSTGRES_HOST,
+  port: POSTGRES_PORT,
+  dialectOptions: POSTGRES_CA ? {
+    ssl: { ca: POSTGRES_CA, key: POSTGRES_KEY, cert: POSTGRES_CERT, servername: POSTGRES_RO_SERVER_NAME },
+  } : {},
+  logging: false,
+});
+
+const CLEAN_CLASSES = new Set(['encrypted', 'empty']);
+
+function printAudit(report) {
+  console.log(`Credentials-at-rest audit  (CREDENTIALS_KEY: ${report.hasCredentialsKey ? 'present' : 'ABSENT — encrypted values cannot be verified'})`);
+  console.log('');
+  let findings = 0;
+  for (const loc of report.locations) {
+    const counts = Object.entries(loc.counts)
+      .map(([cls, n]) => `${cls} ${n}`)
+      .join('   ');
+    console.log(`  ${loc.label.padEnd(32)} total ${String(loc.total).padEnd(6)} ${counts}`);
+    for (const [cls, ids] of Object.entries(loc.anomalies)) {
+      console.log(`    ${cls} ids: ${ids.join(', ')}${loc.counts[cls] > ids.length ? ` … (${loc.counts[cls]} total)` : ''}`);
+    }
+    if (loc.error) console.log(`    ERROR: ${loc.error}`);
+    findings += Object.entries(loc.counts)
+      .filter(([cls]) => !CLEAN_CLASSES.has(cls))
+      .reduce((sum, [, n]) => sum + n, 0);
+    findings += loc.error ? 1 : 0;
+  }
+  console.log('');
+  if (findings) {
+    console.log(`Findings: ${findings} value(s) not verified encrypted under the current key.`);
+    if (report.locations.some((l) => l.counts.plaintext)) {
+      console.log('Run this tool with --sweep to encrypt plaintext values in place.');
+    }
+  } else {
+    console.log('Clean: every stored credential verified encrypted under the current key.');
+  }
+  return findings;
+}
+
+const hasFindings = (report) => report.locations.some((l) =>
+  l.error || Object.keys(l.counts).some((cls) => !CLEAN_CLASSES.has(cls)));
+
+let exitCode = 0;
+try {
+  if (options.sweep && !hasCredentialsKey) {
+    console.error('--sweep requires CREDENTIALS_KEY in the environment; refusing.');
+    exitCode = 2;
+  } else {
+    const summary = options.sweep ? await sweepPlaintextCredentials(sequelize) : null;
+    const report = await auditStoredCredentials(sequelize);
+    if (options.json) {
+      console.log(JSON.stringify(summary ? { sweep: summary, audit: report } : report, null, 2));
+      exitCode = hasFindings(report) ? 1 : 0;
+    } else {
+      for (const loc of summary?.locations || []) {
+        if (loc.candidates || loc.error) {
+          console.log(`Sweep ${loc.label}: ${loc.updated} encrypted, ${loc.skipped} skipped${loc.error ? `, ERROR: ${loc.error}` : ''}`);
+        }
+      }
+      if (summary) console.log('');
+      exitCode = printAudit(report) ? 1 : 0;
+    }
+  }
+} catch (err) {
+  console.error(`Audit failed: ${err?.message}`);
+  exitCode = 2;
+}
+await sequelize.close().catch(() => {});
+process.exit(exitCode);


### PR DESCRIPTION
## Summary
- Adds `tools/credentials-audit.js`, a standalone CLI (`--path/-p <envfile>`, `--json`, `--sweep`) that audits and, on request, encrypts in place any legacy plaintext credential at the four at-rest locations: `phone_registrations.password`, `calls.encryption_key`, `agents.options.recording.key`, `instances.recording.key`.
- Classification (`classifyStoredSecret`/`isEncryptedSecretFormat` in `lib/utils/credentials.js`) uses the GCM auth tag as a cryptographic verdict, distinguishing plaintext / encrypted-under-this-key / encrypted-foreign / lookalike, so the sweep never touches a value it can't classify beyond doubt.
- No automatic boot-time hook — nothing runs unless this tool is invoked explicitly, against whichever instance's `.env` you point it at.
- `docs/credentials-at-rest.md` documents the scheme and the per-instance migration runbook (audit → back up + set key → run `--sweep` → re-audit).

## Background
`PhoneRegistration.password` and friends encrypt on write via the model setter, but rows written before `CREDENTIALS_KEY` was set stay plaintext forever since nothing rewrites them. This closes that gap as an operator-run tool rather than an implicit boot sweep.

## Test plan
- [x] `tests/credentials-sweep.test.mjs` — 6/6 passing against the local test-db container
- [x] Full existing suite (84 suites / 957 tests) still green after removing the boot-sweep hook from `lib/database.js`
- [x] Manually ran `node tools/credentials-audit.js -p <envfile>` against the test DB and confirmed `-p`/`--path` loads the target env and reports correctly