### PR TITLE
Inbound calls resolve a number by (number, trunk) or not at all

### DIFF
--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -635,11 +635,6 @@ export async function getInstanceById(instanceId: string): Promise<any> {
   return makeApiRequest(`/api/agent-db/instance?instanceId=${instanceId}`);
 }
 
-// Get instance by phone number from the API
-export async function getInstanceByNumber(number: string): Promise<any> {
-  return makeApiRequest(`/api/agent-db/instance?number=${encodeURIComponent(number)}`);
-}
-
 // Get phone numbers from the API
 export async function getPhoneNumbers(handler?: string): Promise<any[]> {
   const query = handler ? `?handler=${encodeURIComponent(handler)}` : '';
@@ -680,11 +675,6 @@ export async function getPhoneEndpointByNumber(
     logger.error({ number, trunkId, err: error }, 'Failed to get phone endpoint by number');
     return null;
   }
-}
-
-// Legacy function - kept for backward compatibility, now uses phone-endpoints endpoint
-export async function getPhoneNumberByNumber(number: string): Promise<PhoneNumberInfo | null> {
-  return getPhoneEndpointByNumber(number);
 }
 
 // Mark a phone number as provisioned (or not) in the platform after LiveKit sync

--- a/agents/livekit/lib/worker.ts
+++ b/agents/livekit/lib/worker.ts
@@ -17,7 +17,6 @@ import { invocationLogs } from "./invocation-log-buffer.js";
 import { bridgeParticipant, chargeableOutboundTrunkId } from "./telephony.js";
 import {
   getInstanceById,
-  getInstanceByNumber,
   createCall,
   createTransactionLog,
   type Instance,
@@ -27,7 +26,6 @@ import {
   type OutboundInfo,
   getPhoneEndpointById,
   getPhoneEndpointByNumber,
-  getPhoneNumberByNumber,
   type PhoneNumberInfo,
   type PhoneRegistrationInfo,
   type TrunkInfo,
@@ -1165,17 +1163,15 @@ async function getCallInfo(ctx: JobContext, room: Room): Promise<CallScenario> {
                     "trunk info retrieved from phone endpoint",
                   );
                 }
-                // PhoneNumber has instanceId, so we can lookup the instance
+                // The number row names its instance. There is deliberately no
+                // lookup by bare number behind this: an inbound call is
+                // resolved by (number, trunk) or not at all, so a number that
+                // failed the trunk check above, or has no agent, is "no
+                // instance" rather than "try again without the trunk".
                 if (numInfo.instanceId) {
                   instance = await getInstanceById(numInfo.instanceId);
-                } else {
-                  // Fallback to old behavior
-                  instance = await getInstanceByNumber(calledId);
                 }
                 aplisayId = numInfo.aplisayId || aplisayId;
-              } else {
-                // Fallback: try direct instance lookup by number
-                instance = await getInstanceByNumber(calledId);
               }
             }
           }

--- a/agents/pipecat/pipecat_aplisay/api_client.py
+++ b/agents/pipecat/pipecat_aplisay/api_client.py
@@ -116,10 +116,6 @@ async def get_instance_by_id(instance_id: str) -> dict:
     return await _request("GET", "/api/agent-db/instance", params={"instanceId": instance_id})
 
 
-async def get_instance_by_number(number: str) -> dict:
-    return await _request("GET", "/api/agent-db/instance", params={"number": number})
-
-
 async def get_agent_by_id(agent_id: str) -> dict:
     return await _request("GET", f"/api/agents/{agent_id}")
 

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -266,7 +266,10 @@ async def _lookup_instance_for_inbound(
 
     All three inbound paths (voiceblender VSI event, sipbridge WS headers,
     FreeSWITCH /inbound-dispatch) need the same lookup ladder:
-    phone_registration → trunk+number → bare number. Each step can return
+    phone_registration → trunk+number. There is deliberately no bare-number
+    rung after that: an inbound call resolves by (number, trunk) or not at
+    all, so a number that failed the trunk check, or has no agent, is "no
+    instance" rather than "try again without the trunk". Each step can return
     404 from the REST API; that's a "this step found nothing", not an
     error — we want to continue to the next step (and ultimately tell the
     SIP / gateway layer "no agent for this call"), not let an
@@ -314,8 +317,6 @@ async def _lookup_instance_for_inbound(
                     origin.force_refer_transfer = bool(flags.get("forceReferTransfer"))
                 elif flags.get("canRefer") is True:
                     origin.force_refer_transfer = True
-    if not instance and to_number:
-        instance = await _maybe(api_client.get_instance_by_number(to_number))
     return instance, origin
 
 
@@ -1283,8 +1284,6 @@ async def freeswitch_audio(websocket: WebSocket) -> None:
         )
         if endpoint and endpoint.get("instanceId"):
             instance = await api_client.get_instance_by_id(endpoint["instanceId"])
-    if not instance and start.called_id:
-        instance = await api_client.get_instance_by_number(start.called_id)
     if not instance:
         logger.bind(start=start.raw).error("no instance for inbound freeswitch call")
         await websocket.close(code=1011)

--- a/agents/pipecat/tests/test_inbound_lookup_ladder.py
+++ b/agents/pipecat/tests/test_inbound_lookup_ladder.py
@@ -1,0 +1,100 @@
+"""The inbound instance lookup ladder resolves by (number, trunk) or not at all.
+
+Pins the removal of the bare-number rung: after the trunk-qualified lookup
+finds nothing (404) or finds a number with no agent, the ladder stops. It
+must never re-ask for the number without the trunk, because that answer
+could belong to a different trunk entirely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pipecat_aplisay import api_client, worker
+
+
+def _run(**kwargs):
+    return asyncio.run(worker._lookup_instance_for_inbound(**kwargs))
+
+
+def _install(monkeypatch, *, by_id=None, by_number=None, instance_by_id=None, calls=None):
+    calls = calls if calls is not None else []
+
+    async def fake_by_id(reg_id):
+        calls.append(("by_id", reg_id))
+        if by_id is None:
+            raise api_client.ApiRequestError(404, {}, "not found")
+        return by_id
+
+    async def fake_by_number(number, trunk_id=None):
+        calls.append(("by_number", number, trunk_id))
+        if by_number is None:
+            raise api_client.ApiRequestError(404, {}, "not found")
+        return by_number
+
+    async def fake_instance(instance_id):
+        calls.append(("instance", instance_id))
+        if instance_by_id is None:
+            raise api_client.ApiRequestError(404, {}, "not found")
+        return instance_by_id
+
+    monkeypatch.setattr(api_client, "get_phone_endpoint_by_id", fake_by_id)
+    monkeypatch.setattr(api_client, "get_phone_endpoint_by_number", fake_by_number)
+    monkeypatch.setattr(api_client, "get_instance_by_id", fake_instance)
+    return calls
+
+
+def test_number_lookup_carries_the_trunk(monkeypatch):
+    calls = _install(
+        monkeypatch,
+        by_number={"number": "445678", "instanceId": "i1", "trunk": {"flags": {"canRefer": True}}},
+        instance_by_id={"id": "i1", "Agent": {"id": "a"}},
+    )
+    instance, origin = _run(phone_registration=None, to_number="445678", aplisay_id="tk")
+    assert instance == {"id": "i1", "Agent": {"id": "a"}}
+    assert ("by_number", "445678", "tk") in calls
+    assert origin.force_refer_transfer is True
+
+
+def test_no_bare_number_rung_after_a_404(monkeypatch):
+    calls = _install(monkeypatch)  # everything 404s
+    instance, _ = _run(phone_registration=None, to_number="445678", aplisay_id="tk")
+    assert instance is None
+    # Exactly one number lookup, and it was trunk-qualified.
+    assert [c for c in calls if c[0] == "by_number"] == [("by_number", "445678", "tk")]
+
+
+def test_no_bare_number_rung_when_the_number_has_no_agent(monkeypatch):
+    calls = _install(monkeypatch, by_number={"number": "445678", "instanceId": None})
+    instance, _ = _run(phone_registration=None, to_number="445678", aplisay_id="tk")
+    assert instance is None
+    assert [c for c in calls if c[0] == "by_number"] == [("by_number", "445678", "tk")]
+    assert not [c for c in calls if c[0] == "instance"]
+
+
+def test_registration_without_an_agent_falls_through_to_trunk_and_number(monkeypatch):
+    calls = _install(
+        monkeypatch,
+        by_id={"id": "reg-1", "instanceId": None, "username": "8092"},
+        by_number={"number": "445678", "instanceId": "i2"},
+        instance_by_id={"id": "i2", "Agent": {"id": "a"}},
+    )
+    instance, origin = _run(phone_registration="reg-1", to_number="445678", aplisay_id="tk")
+    assert instance == {"id": "i2", "Agent": {"id": "a"}}
+    assert ("by_number", "445678", "tk") in calls
+    assert origin.registration_originated is False
+
+
+def test_a_trunk_mismatch_is_not_absorbed(monkeypatch):
+    async def fake_by_number(number, trunk_id=None):
+        raise api_client.ApiRequestError(400, {}, "Trunk mismatch")
+
+    monkeypatch.setattr(api_client, "get_phone_endpoint_by_number", fake_by_number)
+    with pytest.raises(api_client.ApiRequestError):
+        _run(phone_registration=None, to_number="445678", aplisay_id="tk")
+
+
+def test_bare_number_client_helper_is_gone():
+    assert not hasattr(api_client, "get_instance_by_number")

--- a/api/paths/agent-db/instance.js
+++ b/api/paths/agent-db/instance.js
@@ -1,4 +1,4 @@
-import { Instance, Agent, PhoneNumber } from '../../../lib/database.js';
+import { Instance, Agent } from '../../../lib/database.js';
 
 let appParameters, log;
 
@@ -15,41 +15,26 @@ export default function (logger, voices, wsServer) {
 };
 
 const instanceGet = (async (req, res) => {
-  let { instanceId, number } = req.query;
+  let { instanceId } = req.query;
 
-  log.debug({ instanceId, number }, 'instanceGet');
+  log.debug({ instanceId }, 'instanceGet');
 
-  if (!instanceId && !number) {
-    return res.status(400).send({ error: 'Either instanceId or number query parameter is required' });
-  }
-
-  if (instanceId && number) {
-    return res.status(400).send({ error: 'Only one of instanceId or number should be provided' });
+  // By id only. The former `?number=` form resolved an instance from a bare
+  // number with no trunk, which is not a question an inbound call may ask:
+  // a number resolves through GET /api/agent-db/phone-endpoints?number=&trunkId=
+  // to its endpoint, and the endpoint names the instance.
+  if (!instanceId) {
+    return res.status(400).send({ error: 'instanceId query parameter is required' });
   }
 
   try {
-    let instance, agent, phoneNumber;
+    let instance, agent;
 
-    if (instanceId) {
-      // Get by instance ID
-      instance = await Instance.findByPk(instanceId, { include: Agent });
-      agent = instance?.Agent;
-    } else if (number) {
-      // Get by phone number
-      phoneNumber = await PhoneNumber.findByPk(number, {
-        include: [
-          {
-            model: Instance,
-            include: [Agent]
-          }
-        ]
-      });
-      instance = phoneNumber?.Instance;
-      agent = instance?.Agent;
-    }
-    
+    instance = await Instance.findByPk(instanceId, { include: Agent });
+    agent = instance?.Agent;
+
     if (!instance) {
-      log.error({ instanceId, number }, 'instance not found');
+      log.error({ instanceId }, 'instance not found');
       return res.status(404).send({ error: 'Instance not found' });
     }
 
@@ -73,7 +58,7 @@ const instanceGet = (async (req, res) => {
 });
 
 instanceGet.apiDoc = {
-  summary: 'Returns an instance by ID or phone number with its associated agent.',
+  summary: 'Returns an instance by ID with its associated agent.',
   operationId: 'getInstance',
   tags: ["Agent"],
   parameters: [
@@ -87,15 +72,6 @@ instanceGet.apiDoc = {
       },
       description: 'The ID of the instance to retrieve'
     },
-    {
-      name: 'number',
-      in: 'query',
-      required: false,
-      schema: {
-        type: 'string'
-      },
-      description: 'The phone number to look up the instance for'
-    }
   ],
   responses: {
     200: {

--- a/api/paths/agent-db/phone-endpoints.js
+++ b/api/paths/agent-db/phone-endpoints.js
@@ -68,8 +68,11 @@ const phoneEndpointsList = (async (req, res) => {
         }
 
 
-        // Validate trunkId if provided (for inbound call validation)
-        if (trunkId && phoneNumber.aplisayId !== null && !trunkCandidates.includes(phoneNumber.aplisayId)) {
+        // A trunk-qualified lookup is an inbound call asking "is this number
+        // reachable through this trunk". A number with no trunk is not
+        // reachable through any trunk, so it fails the check like any other
+        // mismatch rather than being waved through.
+        if (trunkId && !trunkCandidates.includes(phoneNumber.aplisayId)) {
           return res.status(400).send({
             error: `Trunk mismatch: call arrived on trunk ${trunkId} but number is assigned to trunk ${phoneNumber.aplisayId || 'none'}`
           });
@@ -316,7 +319,7 @@ phoneEndpointsList.apiDoc = {
       in: 'query',
       required: false,
       schema: { type: 'string' },
-      description: 'Trunk ID (aplisayId) for validation when looking up by number. If provided, validates that the call arrived on the same trunk that the number is assigned to. Returns 400 error if mismatch.'
+      description: 'Trunk ID (aplisayId) the call arrived on, when looking up by number. Several candidates may be separated by ";". When provided, the number must be assigned to one of them; a number assigned to a different trunk, or to no trunk, returns 400.'
     }
   ],
   responses: {

--- a/docs/livekit-agent-architecture.md
+++ b/docs/livekit-agent-architecture.md
@@ -384,7 +384,7 @@ On an inbound INVITE from the SBC, the contract is:
 - Request-URI — supplies the called number.
 - From header — supplies the caller number.
 
-Lookup chain: (called number, `aplisayId`) → PhoneEndpoint → Instance → Agent. The PhoneEndpoint record carries any per-trunk flags, notably `canRefer` (see 6.7).
+Lookup chain: (called number, `aplisayId`) → PhoneEndpoint → Instance → Agent. The PhoneEndpoint record carries any per-trunk flags, notably `canRefer` (see 6.7). The pair is the whole key: there is no lookup by bare number behind it, so a number the trunk check refuses, or one with no instance, is "no agent for this call" rather than a second attempt without the trunk.
 
 Beyond routing, **all** `X-` headers on the inbound INVITE (including the routing ones above) are surfaced to the agent as `metadata.aplisay.sipHeaders` (a `{ "x-header-name": value }` map, keys lowercased) so agent logic and tools can read per-call context the SBC/carrier attached — see [`sip-headers.md`](sip-headers.md). LiveKit delivers them as `sip.h.x-*` participant attributes (the trunk is created with `includeHeaders = SIP_X_HEADERS`); on the Pipecat runtime the sipbridge and voiceblender gateways carry the same set.
 
@@ -600,7 +600,7 @@ The header name (`x-shared-token`) and the env var names (`SHARED_API_TOKEN`, `S
 
 Called during call setup to resolve the agent and its phone-number context. All are GET, read-only, idempotent.
 
-- **`GET /api/agent-db/instance`** — resolve Instance (with embedded Agent) by `?instanceId=` or `?number=`.
+- **`GET /api/agent-db/instance`** — resolve Instance (with embedded Agent) by `?instanceId=`.
 - **`GET /api/agent-db/agent`** — resolve Agent by `?agentId=`. Used for fallback-agent loading (section 9).
 - **`GET /api/agent-db/phone-endpoints`** — resolve PhoneEndpoint by `?number=&trunkId=` (trunk-based) or `?id=` (registration endpoint).
 

--- a/tests/agent-db-phone-endpoints.test.mjs
+++ b/tests/agent-db-phone-endpoints.test.mjs
@@ -1,4 +1,4 @@
-import { setupRealDatabase, teardownRealDatabase, PhoneNumber, PhoneRegistration, Organisation, Op, databaseStarted } from './setup/database-test-wrapper.js';
+import { setupRealDatabase, teardownRealDatabase, PhoneNumber, PhoneRegistration, Organisation, Trunk, Op, databaseStarted } from './setup/database-test-wrapper.js';
 import { randomUUID } from 'crypto';
 
 describe('Agent DB Phone Endpoints API', () => {
@@ -286,6 +286,76 @@ describe('Agent DB Phone Endpoints API', () => {
       expect(res._status).toBe(200);
       expect(res._body.items.length).toBeLessThanOrEqual(1);
       expect(res._body.nextOffset).toBeDefined();
+    });
+  });
+
+  describe('Trunk-qualified lookup', () => {
+    let trunkA;
+    let trunkB;
+    let onTrunkA;
+    let onNoTrunk;
+
+    beforeEach(async () => {
+      trunkA = await Trunk.create({ id: `trunk-a-${testOrgId.slice(0, 8)}`, name: 'Trunk A', handler: 'livekit' });
+      trunkB = await Trunk.create({ id: `trunk-b-${testOrgId.slice(0, 8)}`, name: 'Trunk B', handler: 'livekit' });
+      onTrunkA = await PhoneNumber.create({
+        number: '1555333333',
+        handler: 'livekit',
+        organisationId: testOrgId,
+        aplisayId: trunkA.id,
+      });
+      onNoTrunk = await PhoneNumber.create({
+        number: '1555444444',
+        handler: 'livekit',
+        organisationId: testOrgId,
+        aplisayId: null,
+      });
+    });
+
+    afterEach(async () => {
+      await PhoneNumber.destroy({ where: { number: [onTrunkA.number, onNoTrunk.number] } });
+      await Trunk.destroy({ where: { id: [trunkA.id, trunkB.id] } });
+    });
+
+    test('returns the number when the call arrived on its trunk', async () => {
+      const req = createMockRequest({ number: onTrunkA.number, trunkId: trunkA.id });
+      const res = createMockResponse();
+      await phoneEndpointsList(req, res);
+      expect(res._status).toBe(200);
+      expect(res._body.items[0]).toHaveProperty('number', onTrunkA.number);
+      expect(res._body.items[0].trunk).toHaveProperty('id', trunkA.id);
+    });
+
+    test('accepts a ;-separated list of candidate trunks', async () => {
+      const req = createMockRequest({ number: onTrunkA.number, trunkId: `${trunkB.id};${trunkA.id}` });
+      const res = createMockResponse();
+      await phoneEndpointsList(req, res);
+      expect(res._status).toBe(200);
+    });
+
+    test('rejects a call that arrived on a different trunk', async () => {
+      const req = createMockRequest({ number: onTrunkA.number, trunkId: trunkB.id });
+      const res = createMockResponse();
+      await phoneEndpointsList(req, res);
+      expect(res._status).toBe(400);
+      expect(res._body.error).toContain('Trunk mismatch');
+    });
+
+    /* A number with no trunk is reachable through no trunk. Waving it through
+       would make "unassigned" the one state a trunk check never applies to. */
+    test('rejects a trunk-qualified lookup of a number assigned to no trunk', async () => {
+      const req = createMockRequest({ number: onNoTrunk.number, trunkId: trunkA.id });
+      const res = createMockResponse();
+      await phoneEndpointsList(req, res);
+      expect(res._status).toBe(400);
+      expect(res._body.error).toContain('Trunk mismatch');
+    });
+
+    test('still answers an unqualified lookup of a number with no trunk', async () => {
+      const req = createMockRequest({ number: onNoTrunk.number });
+      const res = createMockResponse();
+      await phoneEndpointsList(req, res);
+      expect(res._status).toBe(200);
     });
   });
 


### PR DESCRIPTION
An inbound call is resolved by the pair (called number, trunk), as `docs/livekit-agent-architecture.md` §6.2 specifies. Both workers still carried a second attempt behind that lookup which resolved the number with no trunk at all, so a number the trunk check had just refused, or one with no instance, could still be answered from a different trunk's row. This removes that second attempt everywhere and makes the trunk check apply to every trunk-qualified lookup.

**Workers**
- LiveKit `worker.ts`: the two `getInstanceByNumber(calledId)` fallbacks after the trunk-qualified endpoint lookup are gone. `getInstanceByNumber` and the legacy `getPhoneNumberByNumber` wrapper are removed from `api-client.ts`; nothing else called them.
- Pipecat `worker.py`: the bare-number rung is removed from `_lookup_instance_for_inbound` (voiceblender, sipbridge, dial-in) and from the FreeSWITCH `/freeswitch/audio` ladder. `get_instance_by_number` is removed from `api_client.py`.

**API**
- `GET /api/agent-db/phone-endpoints?number=&trunkId=`: a number assigned to no trunk now fails the trunk check like any other mismatch (400), instead of being exempt from it. Unqualified lookups (no `trunkId`) are unchanged. apiDoc text updated.
- `GET /api/agent-db/instance`: the `?number=` form is removed. It had no remaining callers, and it was the only route that resolved an instance from a bare number.

**Tests**
- `tests/agent-db-phone-endpoints.test.mjs`: five trunk-qualified cases (match, `;`-separated candidates, wrong trunk, no trunk, unqualified lookup of a no-trunk number). There was no test of the mismatch path before.
- `agents/pipecat/tests/test_inbound_lookup_ladder.py`: the ladder carries the trunk, stops after a 404 or a number with no agent, falls through from a registration with no instance to (number, trunk), and does not absorb a trunk mismatch.

Full DB suite on a clean volume: 85 suites / 965 tests pass. Pipecat tests pass. LiveKit `tsc` reports one pre-existing error in `livekit-model-registry.ts:99` that is present on `next` and unrelated.

Out of scope: the jambonz path (`Agent.fromNumber`), which has no trunk on the wire.
