### PR TITLE
Schema 61: a phone number is unique per organisation and per trunk, not platform-wide

### DIFF
--- a/api/paths/agent-db/outbound-authorisation.js
+++ b/api/paths/agent-db/outbound-authorisation.js
@@ -1,3 +1,4 @@
+import { Op } from 'sequelize';
 import { Agent, PhoneNumber } from '../../../lib/database.js';
 import { authoriseOutboundDestination } from '../../../lib/outbound-authorisation.js';
 import { normalizeE164 } from '../../../lib/validation.js';
@@ -71,7 +72,16 @@ const authoriseOutbound = (async (req, res) => {
     // does not silently fall back to the platform default trunk.
     let egressAplisayId = aplisayId || null;
     if (!egressAplisayId && callerId && registrationOriginated !== true) {
-      const caller = await PhoneNumber.findByPk(normalizeE164(callerId), { attributes: ['aplisayId'] });
+      // Qualified by the owner's organisation when it is known (agentId or
+      // organisationId in the body), so another organisation's row for the
+      // same number cannot pick the egress trunk.
+      const caller = await PhoneNumber.findOne({
+        where: owner.organisationId
+          ? { number: normalizeE164(callerId), [Op.or]: [{ organisationId: owner.organisationId }, { organisationId: null }] }
+          : { number: normalizeE164(callerId) },
+        order: [[PhoneNumber.sequelize.literal('organisation_id IS NULL'), 'ASC']],
+        attributes: ['aplisayId'],
+      });
       egressAplisayId = caller?.aplisayId || null;
     }
 

--- a/api/paths/agent-db/phone-endpoints.js
+++ b/api/paths/agent-db/phone-endpoints.js
@@ -43,8 +43,13 @@ const phoneEndpointsList = (async (req, res) => {
         const normalizedNumber = String(number).replace(/^\+/, '');
         // Use a single query with LEFT JOINs to fetch phone number, trunk ownership
         // checks on pool numbers via userOwnsPhoneNumber.
+        // A trunk-qualified lookup SELECTS by (number, trunk) — since schema
+        // 61 the same number can legitimately exist on several trunks — and
+        // an unqualified one takes whichever row exists.
         const phoneNumber = await PhoneNumber.findOne({
-          where: { number: normalizedNumber },
+          where: trunkCandidates.length
+            ? { number: normalizedNumber, aplisayId: trunkCandidates }
+            : { number: normalizedNumber },
           include: [
             {
               model: Trunk,
@@ -60,6 +65,16 @@ const phoneEndpointsList = (async (req, res) => {
           ]
         });
         if (!phoneNumber) {
+          // Distinguish "no such number" from "not on that trunk", which is
+          // what a worker needs to refuse the call rather than search on.
+          if (trunkCandidates.length) {
+            const elsewhere = await PhoneNumber.findOne({ where: { number: normalizedNumber }, attributes: ['aplisayId'] });
+            if (elsewhere) {
+              return res.status(400).send({
+                error: `Trunk mismatch: call arrived on trunk ${trunkId} but number is assigned to trunk ${elsewhere.aplisayId || 'none'}`
+              });
+            }
+          }
           return res.status(404).send({ error: 'Phone endpoint not found' });
         }
         // Apply handler filter if provided
@@ -68,15 +83,6 @@ const phoneEndpointsList = (async (req, res) => {
         }
 
 
-        // A trunk-qualified lookup is an inbound call asking "is this number
-        // reachable through this trunk". A number with no trunk is not
-        // reachable through any trunk, so it fails the check like any other
-        // mismatch rather than being waved through.
-        if (trunkId && !trunkCandidates.includes(phoneNumber.aplisayId)) {
-          return res.status(400).send({
-            error: `Trunk mismatch: call arrived on trunk ${trunkId} but number is assigned to trunk ${phoneNumber.aplisayId || 'none'}`
-          });
-        }
 
         // Record the first inbound call time for this endpoint (best-effort, idempotent).
         // We only set it when returning a single endpoint lookup by number.
@@ -86,13 +92,15 @@ const phoneEndpointsList = (async (req, res) => {
           stampedCallReceived = new Date();
           await PhoneNumber.update(
             { callReceived: stampedCallReceived },
-            { where: { number: phoneNumber.number, callReceived: { [Op.is]: null } } }
+            { where: { id: phoneNumber.id, callReceived: { [Op.is]: null } } }
           );
         }
 
 
         // Build response object with trunk info if available
         const phoneNumberJson = phoneNumber.toJSON();
+        // The surrogate id is internal (schema 61); a DDI is addressed by number.
+        delete phoneNumberJson.id;
         phoneNumberJson.callReceived = stampedCallReceived;
         if (phoneNumber.Trunk) {
           phoneNumberJson.trunk = {
@@ -133,7 +141,10 @@ const phoneEndpointsList = (async (req, res) => {
         });
         const nextOffset = rows.length === size ? startOffset + size : null;
 
-        return res.send({ items: rows, nextOffset });
+        return res.send({
+          items: rows.map((r) => { const j = r.toJSON(); delete j.id; return j; }),
+          nextOffset,
+        });
       }
     }
 
@@ -242,17 +253,17 @@ export const updatePhoneEndpointProvisioning = async (req, res) => {
 
   try {
     const normalizedNumber = String(number).replace(/^\+/, '');
-    const phoneNumber = await PhoneNumber.findByPk(normalizedNumber);
-    if (!phoneNumber) {
+    // Provisioning is a fact about the number at the carrier, not about one
+    // organisation's row for it, so every row carrying the number is stamped.
+    const [updated] = await PhoneNumber.update({ provisioned }, { where: { number: normalizedNumber } });
+    if (!updated) {
       return res.status(404).send({ error: 'Phone endpoint not found' });
     }
 
-    await phoneNumber.update({ provisioned });
-
     return res.send({
       success: true,
-      number: phoneNumber.number,
-      provisioned: !!phoneNumber.provisioned
+      number: normalizedNumber,
+      provisioned,
     });
   } catch (err) {
     log.error(err, 'error updating phone endpoint provisioning');

--- a/api/paths/agent-db/phone-numbers.js
+++ b/api/paths/agent-db/phone-numbers.js
@@ -27,7 +27,13 @@ const phoneNumbersList = (async (req, res) => {
       whereClause.number = String(number).replace(/^\+/, '');
     }
 
-    let phoneNumbers = await PhoneNumber.findAll({ where: whereClause });
+    // Several organisations may hold the same number (schema 61); an
+    // organisation's row sorts before the pool's so a caller taking the first
+    // result gets a deterministic answer.
+    let phoneNumbers = await PhoneNumber.findAll({
+      where: whereClause,
+      order: [[PhoneNumber.sequelize.literal('organisation_id IS NULL'), 'ASC'], ['number', 'ASC']],
+    });
     
     res.send(phoneNumbers);
   }

--- a/api/paths/agents/{agentId}/listen.js
+++ b/api/paths/agents/{agentId}/listen.js
@@ -31,7 +31,9 @@ export default function (wsServer) {
       
       // If number is provided, look up the PhoneNumber record
       if (number) {
-        const phoneNumber = await PhoneNumber.findByPk(number);
+        // Existence only; ownership and allocation are decided in
+        // Instance.linkNumber, which is organisation-scoped.
+        const phoneNumber = await PhoneNumber.findOne({ where: { number: String(number).replace(/^\+/, '') } });
         if (!phoneNumber) {
           throw new Error(`Phone number ${number} not found`);
         }

--- a/api/paths/listener/{listenerId}/originate.js
+++ b/api/paths/listener/{listenerId}/originate.js
@@ -1,3 +1,4 @@
+import { Op } from 'sequelize';
 import { Agent, Instance, PhoneNumber, PhoneRegistration } from '../../../../lib/database.js';
 import { AgentConcurrencyLimitExceededError } from '../../../../lib/concurrency/agent-concurrency-limits.js';
 import { getHandler } from '../../../../lib/handlers/index.js';
@@ -49,7 +50,14 @@ const originateCall = (async (req, res) => {
     }
 
     // Check if callerId is present in phoneNumbers table or phoneRegistrations table and belongs to the user/org.
-    let callerPhoneNumber = await PhoneNumber.findByPk(callerId, {
+    // The caller's own row for this number first, then the pool's; a row
+    // another organisation holds for the same number must never be picked.
+    let callerPhoneNumber = await PhoneNumber.findOne({
+      where: {
+        number: callerId,
+        [Op.or]: [{ organisationId: res.locals.user?.organisationId ?? null }, { organisationId: null }],
+      },
+      order: [[PhoneNumber.sequelize.literal('"PhoneNumber"."organisation_id" IS NULL'), 'ASC']],
       include: [{ model: Instance, attributes: ['id', 'userId', 'organisationId'] }]
     });
     let callerPhoneRegistration = null;

--- a/api/paths/phone-endpoints.js
+++ b/api/paths/phone-endpoints.js
@@ -259,11 +259,24 @@ const createPhoneEndpoint = async (req, res) => {
 
       const normalizedNumber = normalizeE164(data.phoneNumber);
       
-      // Check if number already exists
-      const existingNumber = await PhoneNumber.findByPk(normalizedNumber);
+      // A number is unique per organisation and per trunk (schema 61), not
+      // platform-wide: another organisation holding the same number on its
+      // own trunk is not a conflict. The unique indexes are the backstop for
+      // the race this pre-check cannot close.
+      const existingNumber = await PhoneNumber.findOne({
+        where: {
+          number: normalizedNumber,
+          [Op.or]: [
+            { organisationId: organisationId ?? null },
+            { aplisayId: data.trunkId },
+          ],
+        },
+      });
       if (existingNumber) {
         return res.status(409).send({
-          error: 'Phone number already exists'
+          error: existingNumber.aplisayId === data.trunkId && existingNumber.organisationId !== (organisationId ?? null)
+            ? 'Phone number already exists on this trunk'
+            : 'Phone number already exists'
         });
       }
 
@@ -352,8 +365,8 @@ const createPhoneEndpoint = async (req, res) => {
             used: err.used
           });
         }
-        // The pre-check above races exact simultaneous claims; the PK constraint
-        // is the backstop — report it as the same conflict.
+        // The pre-check above races exact simultaneous claims; the unique
+        // indexes are the backstop — report it as the same conflict.
         if (err.name === 'SequelizeUniqueConstraintError') {
           return res.status(409).send({
             error: 'Phone number already exists'

--- a/api/paths/phone-endpoints/{identifier}.js
+++ b/api/paths/phone-endpoints/{identifier}.js
@@ -4,6 +4,22 @@ import { TELEPHONY_HANDLER_NAMES } from '../../../lib/handlers/index.js';
 import { userOwnsRow } from '../../../lib/scope.js';
 import { requirePermission } from '../../../lib/auth/permissions.js';
 
+/**
+ * A DDI addressed by number, as the caller sees it: their organisation's own
+ * row first, else the unallocated pool's (organisationId null). Identity is
+ * (number, organisation) since schema 61, so the same number held by another
+ * organisation is simply not found here.
+ */
+async function findOwnOrPoolNumber(number, organisationId) {
+  return PhoneNumber.findOne({
+    where: {
+      number,
+      [Op.or]: [{ organisationId: organisationId ?? null }, { organisationId: null }],
+    },
+    order: [[PhoneNumber.sequelize.literal('organisation_id IS NULL'), 'ASC']],
+  });
+}
+
 let log;
 
 export default function (logger) {
@@ -33,7 +49,10 @@ const getPhoneEndpoint = async (req, res) => {
       if (!normalizedNumber) {
         return res.status(400).send({ error: 'Invalid phone number format' });
       }
-      record = await PhoneNumber.findByPk(normalizedNumber);
+      // The caller's own row for this number, else the pool's (no
+      // organisation). Another organisation's row for the same number is not
+      // visible here at all.
+      record = await findOwnOrPoolNumber(normalizedNumber, organisationId);
     } else {
       // registration id lookup
       const registration = await PhoneRegistration.findByPk(identifier);
@@ -184,7 +203,7 @@ const updatePhoneEndpoint = async (req, res) => {
     // Check if identifier is a phone number (contains digits and possibly +)
     if (identifier.match(/^\+?[0-9]+$/)) {
       const normalizedNumber = normalizeE164(identifier);
-      const phoneNumber = await PhoneNumber.findByPk(normalizedNumber);
+      const phoneNumber = await findOwnOrPoolNumber(normalizedNumber, organisationId);
       
       if (!phoneNumber) {
         return res.status(404).send({ error: 'Phone endpoint not found' });
@@ -333,7 +352,7 @@ const deletePhoneEndpoint = async (req, res) => {
     // Check if identifier is a phone number (contains digits and possibly +)
     if (identifier.match(/^\+?[0-9]+$/)) {
       const normalizedNumber = normalizeE164(identifier);
-      const phoneNumber = await PhoneNumber.findByPk(normalizedNumber);
+      const phoneNumber = await findOwnOrPoolNumber(normalizedNumber, organisationId);
       
       if (!phoneNumber) {
         return res.status(404).send({ error: 'Phone endpoint not found' });

--- a/docs/livekit-agent-architecture.md
+++ b/docs/livekit-agent-architecture.md
@@ -630,7 +630,7 @@ Two endpoints capture call activity, distinguished by when they fire and what da
 Some handlers — including LiveKit — need their upstream platform to be configured for a phone number before the number can route calls (e.g. trunk numbers must be registered with the SIP service). This is handled out-of-band:
 
 - The operator runs the agent in a dedicated **setup mode** (cron-driven, batch).
-- The setup process walks the platform's phone-number database, provisions any unprovisioned numbers in the upstream platform, and PATCHes **`/api/agent-db/phone-endpoints/:number`** with `{ provisioned: true }` for each number it has configured.
+- The setup process walks the platform's phone-number database, provisions any unprovisioned numbers in the upstream platform, and PATCHes **`/api/agent-db/phone-endpoints/:number`** with `{ provisioned: true }` for each number it has configured (every organisation's row for that number is stamped; provisioning is a fact about the number at the carrier).
 - A handler-level config flag (forthcoming) tells the REST server whether the handler requires this provisioning workflow, so number-creation can short-circuit when not needed (e.g. handlers that talk directly to a PSTN provider with no per-number trunk configuration).
 
 This workflow is part of the contract only for handlers that need it.

--- a/docs/phone-endpoints-api.md
+++ b/docs/phone-endpoints-api.md
@@ -185,7 +185,7 @@ The `options` object carries provider-specific and behavioural settings for the 
 
 Updates an existing phone endpoint.
 
-- **Path**: `identifier` is the E.164 number (with or without `+`) for DDI, or the registration ID for phone-registration.
+- **Path**: `identifier` is the E.164 number (with or without `+`) for DDI, or the registration ID for phone-registration. A number resolves to the caller's organisation's own row, else the unallocated pool's; a number another organisation holds is not visible.
 - **Body**: Only send fields you want to change. For E.164 DDI, `outbound`, `handler` and
   `provisioned` are updatable (`provisioned` marks carrier-side provisioning complete — the
   dashboard Buy-number flow sets it once the provider has activated the number and pointed it
@@ -254,7 +254,7 @@ Trunks are a curated platform resource. Ordinary callers get the org-scoped list
 
 - **Single number**: POST with `type`, `number`, `trunkId`, and `outbound`. Default `outbound` from the trunk when possible so the UI matches trunk capabilities.
 - **Multiple numbers**: The API creates one number per request. To add a range or list, your client can loop over normalized E.164 values and POST each (with optional client-side limit, e.g. max 40 per batch) and surface errors per number if needed.
-- **Validation**: Numbers are validated as E.164 (7–15 digits, optional leading `+`). Duplicate number returns 409.
+- **Validation**: Numbers are validated as E.164 (7–15 digits, optional leading `+`). A number is unique per organisation and per trunk, not platform-wide: creating one your organisation already holds, or one already on the same trunk, returns 409. Another organisation holding the same number on its own trunk is not a conflict.
 
 ### Agent assignment (inUse, agentId, agentName)
 

--- a/docs/phone-numbers-api.md
+++ b/docs/phone-numbers-api.md
@@ -81,7 +81,7 @@ curl -X GET "https://llm-agent.aplisay.com/api/phone-numbers?originate=true" \
 
 Phone numbers are stored in the `phone_numbers` table with the following structure:
 
-- `number` (primary key): The phone number string
+- `number`: The phone number string. Unique per organisation and per trunk (not platform-wide); the row's primary key is an internal `id`.
 - `handler`: The handler type ("livekit" or "jambonz")
 - `reservation`: Boolean flag for reservation status
 - `outbound`: Boolean flag for outbound capability

--- a/lib/database.js
+++ b/lib/database.js
@@ -17,7 +17,15 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 60;  // 60: `b2bua_nodes.private_address` — the address a node reports for itself
+const schemaVersion = 61;  // 61: phone_numbers identity — a surrogate `id` UUID becomes the primary key
+                           //     and `number` stops being one. Uniqueness is now (number, organisation_id),
+                           //     with a partial unique index on `number` where organisation_id IS NULL so the
+                           //     unallocated pool still holds a number once, plus (number, aplisay_id) so a
+                           //     trunk carries a number once. Run by migratePhoneNumbersIdentity() in the
+                           //     gated chain BEFORE PhoneNumber.sync — sync({alter}) will not move a primary
+                           //     key. Nothing public reads `id`; the API still addresses a DDI by number,
+                           //     qualified by the caller's organisation.
+                           // 60: `b2bua_nodes.private_address` — the address a node reports for itself
                            //     inside the VPC, added to the model in #266 without a version bump, so no
                            //     existing database ever got the column and every node heartbeat failed on
                            //     `column "private_address" ... does not exist`. B2buaNode joins the gated
@@ -217,7 +225,12 @@ class Agent extends Model {
    * @memberof Agent
    */
   static async fromNumber(target) {
-    const number = await PhoneNumber.findByPk(target, {
+    // No trunk arrives on this path, so this is the one lookup that resolves a
+    // bare number; with (number, organisation) identity the row with an
+    // instance attached is the one that can answer a call.
+    const number = await PhoneNumber.findOne({
+      where: { number: target },
+      order: [[sequelize.literal('"PhoneNumber"."instance_id" IS NULL'), 'ASC']],
       include: [
         {
           model: Instance,
@@ -819,7 +832,8 @@ class Instance extends Model {
       async transaction => {
         const row = await PhoneNumber.findOne({
           where,
-          order: [["number", "asc"]],
+          // The org's own row before a pool row for the same number.
+          order: [[sequelize.literal('organisation_id IS NULL'), 'ASC'], ["number", "asc"]],
           transaction
         });
         if (!row) {
@@ -2013,9 +2027,17 @@ class PhoneNumber extends Model {
 }
 
 PhoneNumber.init({
+  // Surrogate key. The number used to be the primary key, which made a number
+  // unique across the whole platform; identity is now (number, organisation)
+  // — see the indexes below and schema note 61. Nothing public reads this id.
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
   number: {
     type: DataTypes.STRING,
-    primaryKey: true,
+    allowNull: false,
     required: true
   },
   handler: {
@@ -2050,6 +2072,20 @@ PhoneNumber.init({
     underscored: true,
     charset: 'utf8',
     collate: 'utf8_general_ci',
+    // Names match migratePhoneNumbersIdentity(), so a fresh database gets them
+    // from sync and an existing one from the migration, idempotently by name.
+    indexes: [
+      // An organisation holds a number once.
+      { name: 'phone_numbers_number_organisation', unique: true, fields: ['number', 'organisation_id'] },
+      // The unallocated pool (no organisation) holds a number once. A plain
+      // unique index treats NULLs as distinct, which is the one case that must
+      // not be allowed to duplicate.
+      { name: 'phone_numbers_number_pool', unique: true, fields: ['number'], where: { organisation_id: null } },
+      // A trunk carries a number once. Inbound routing keys on (number, trunk)
+      // and chargeable carrier trunks are shared across organisations, so the
+      // organisation index alone would let two orgs both hold a number there.
+      { name: 'phone_numbers_number_trunk', unique: true, fields: ['number', 'aplisay_id'] },
+    ],
   }
 );
 
@@ -2674,6 +2710,50 @@ async function encryptAgentKeysAtRest() {
 // required end-dating the incumbent, and the beforeUpdate guard above refuses an
 // endDate change once costed usage references that card. This DROP removes the
 // earlier constraint on existing DBs.
+/**
+ * Schema 61: move phone_numbers from `number` as primary key to a surrogate
+ * `id`, and add the uniqueness that replaces it. Idempotent: every step checks
+ * before it acts, so re-running on a migrated database is a no-op, and a
+ * fresh database (where sync created the table from the model) needs nothing.
+ *
+ * Runs in the gated upgrade chain BEFORE PhoneNumber.sync({ alter: true }) —
+ * sync will add columns and indexes but never moves a primary key, and an
+ * alter against a model whose PK differs from the table's would fail.
+ */
+export async function migratePhoneNumbersIdentity() {
+  const [[table]] = await sequelize.query(
+    `SELECT to_regclass('public.phone_numbers') AS name`,
+  );
+  if (!table?.name) return; // fresh database: sync creates it from the model
+
+  await sequelize.query('ALTER TABLE "phone_numbers" ADD COLUMN IF NOT EXISTS "id" UUID');
+  await sequelize.query('UPDATE "phone_numbers" SET "id" = gen_random_uuid() WHERE "id" IS NULL');
+  await sequelize.query('ALTER TABLE "phone_numbers" ALTER COLUMN "id" SET NOT NULL');
+
+  const [pk] = await sequelize.query(
+    `SELECT a.attname
+       FROM pg_index i
+       JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY (i.indkey)
+      WHERE i.indrelid = 'public.phone_numbers'::regclass AND i.indisprimary`,
+  );
+  const pkCols = pk.map((r) => r.attname);
+  if (!(pkCols.length === 1 && pkCols[0] === 'id')) {
+    await sequelize.query('ALTER TABLE "phone_numbers" DROP CONSTRAINT IF EXISTS "phone_numbers_pkey"');
+    await sequelize.query('ALTER TABLE "phone_numbers" ADD CONSTRAINT "phone_numbers_pkey" PRIMARY KEY ("id")');
+    logger.info({ from: pkCols }, 'phone_numbers: primary key moved to id');
+  }
+
+  await sequelize.query(
+    'CREATE UNIQUE INDEX IF NOT EXISTS "phone_numbers_number_organisation" ON "phone_numbers" ("number", "organisation_id")',
+  );
+  await sequelize.query(
+    'CREATE UNIQUE INDEX IF NOT EXISTS "phone_numbers_number_pool" ON "phone_numbers" ("number") WHERE "organisation_id" IS NULL',
+  );
+  await sequelize.query(
+    'CREATE UNIQUE INDEX IF NOT EXISTS "phone_numbers_number_trunk" ON "phone_numbers" ("number", "aplisay_id")',
+  );
+}
+
 async function dropRateCardOverlapConstraint() {
   try {
     await sequelize.query('ALTER TABLE "rate_cards" DROP CONSTRAINT IF EXISTS rate_cards_name_period_excl');
@@ -2764,6 +2844,7 @@ const databaseStarted = sequelize.authenticate()
     .then(() => dropTariffOverlapConstraint())
     .then(() => TariffPrefix.sync({ alter: true }))
     .then(() => Trunk.sync({ alter: true }))
+    .then(() => migratePhoneNumbersIdentity())
     .then(() => PhoneNumber.sync({ alter: true }))
     .then(() => PhoneRegistration.sync({ alter: true }))
     .then(() => TrunkOrganisation.sync({ alter: true }))

--- a/tests/agent-db-phone-endpoints.test.mjs
+++ b/tests/agent-db-phone-endpoints.test.mjs
@@ -404,7 +404,7 @@ describe('Agent DB Phone Endpoints API', () => {
   describe('callReceived stamping', () => {
     test('should set callReceived on first single-number lookup and return it in the response', async () => {
       const number = testPhoneNumber.number;
-      const before = await PhoneNumber.findByPk(number);
+      const before = await PhoneNumber.findOne({ where: { number: number } });
       expect(before).toBeTruthy();
       expect(before.callReceived).toBeNull();
 
@@ -418,7 +418,7 @@ describe('Agent DB Phone Endpoints API', () => {
       expect(item).toHaveProperty('number', number);
       expect(item.callReceived).toBeTruthy();
 
-      const after = await PhoneNumber.findByPk(number);
+      const after = await PhoneNumber.findOne({ where: { number: number } });
       expect(after.callReceived).toBeTruthy();
     });
 

--- a/tests/chargeable-number-limit.test.mjs
+++ b/tests/chargeable-number-limit.test.mjs
@@ -239,7 +239,7 @@ describe('Chargeable number limit', () => {
     await updatePhoneEndpoint(req, res);
     expect(res._status).toBe(200);
 
-    const row = await PhoneNumber.findByPk(number.replace(/^\+/, ''));
+    const row = await PhoneNumber.findOne({ where: { number: number.replace(/^\+/, '') } });
     expect(row.provisioned).toBe(true);
 
     // Bad type is rejected.

--- a/tests/chargeable-trunk-global.test.mjs
+++ b/tests/chargeable-trunk-global.test.mjs
@@ -96,7 +96,7 @@ describe('Chargeable trunks are global (not org-owned)', () => {
     const s = await claim(chargeableTrunkId);
     expect(s._status).toBe(201);
     expect(s._body).toMatchObject({ success: true, trunkId: chargeableTrunkId });
-    const row = await PhoneNumber.findByPk(s._body.number);
+    const row = await PhoneNumber.findOne({ where: { number: s._body.number } });
     expect(row.organisationId).toBe(orgId);
     expect(row.aplisayId).toBe(chargeableTrunkId);
     // Handler is derived from the trunk (routes the number to the right ingress).

--- a/tests/deployment-guard.test.mjs
+++ b/tests/deployment-guard.test.mjs
@@ -149,7 +149,7 @@ describe('Deployment guard and listener repoint', () => {
     // Transactional: the member, listener and number binding all survive.
     expect(await Agent.findByPk(byLabel.back.id)).not.toBeNull();
     expect(await Instance.findByPk(instance.id)).not.toBeNull();
-    expect((await PhoneNumber.findByPk(phoneNumber.number)).instanceId).toBe(instance.id);
+    expect((await PhoneNumber.findOne({ where: { number: phoneNumber.number } })).instanceId).toBe(instance.id);
   });
 
   test('PUT still reconciles away an unwired member, and one holding only a bare WebRTC listener', async () => {
@@ -195,7 +195,7 @@ describe('Deployment guard and listener repoint', () => {
 
     await instance.destroy();
     // Number detached (SET NULL), not deleted, when the listener goes.
-    expect((await PhoneNumber.findByPk(phoneNumber.number)).instanceId).toBeNull();
+    expect((await PhoneNumber.findOne({ where: { number: phoneNumber.number } })).instanceId).toBeNull();
     const ok = makeRes(user);
     await deleteAgent(makeReq({}, { agentId: byLabel.front.id }), ok);
     expect(ok.statusCode).toBe(200);
@@ -212,7 +212,7 @@ describe('Deployment guard and listener repoint', () => {
     expect(res.body).toEqual({ id: instance.id, agentId: byLabel.back.id });
     const after = await Instance.findByPk(instance.id);
     expect(after.agentId).toBe(byLabel.back.id);
-    expect((await PhoneNumber.findByPk(phoneNumber.number)).instanceId).toBe(instance.id);
+    expect((await PhoneNumber.findOne({ where: { number: phoneNumber.number } })).instanceId).toBe(instance.id);
 
     // The old agent is now unwired and can be reconciled away.
     const doc = setDocument();

--- a/tests/phone-endpoints-comprehensive.test.mjs
+++ b/tests/phone-endpoints-comprehensive.test.mjs
@@ -647,7 +647,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
       expect(res._body).toHaveProperty('error');
     });
 
-    test('should return 403 for endpoint from different organisation', async () => {
+    test('should not find an endpoint held by a different organisation', async () => {
       const req = createMockRequest({
         params: { identifier: testPhoneId },
         headers: {}
@@ -657,7 +657,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
 
       await getPhoneEndpoint(req, res);
 
-      expect(res._status).toBe(403);
+      expect(res._status).toBe(404);
       expect(res._body).toHaveProperty('error');
     });
 
@@ -876,7 +876,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
         await createPhoneEndpoint(createReq1, res1);
         expect(res1._status).toBe(201);
 
-        const created = await PhoneNumber.findByPk('15556667777');
+        const created = await PhoneNumber.findOne({ where: { number: '15556667777' } });
         expect(created).not.toBeNull();
         expect(created.handler).toBe('jambonz');
         expect(created.outbound).toBe(false);
@@ -1398,7 +1398,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
       expect(res._body).toHaveProperty('error');
     });
 
-    test('should return 403 for endpoint from different organisation', async () => {
+    test('should not find an endpoint held by a different organisation', async () => {
       const req = createMockRequest({
         params: { identifier: testPhoneId },
         body: {
@@ -1411,7 +1411,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
 
       await updatePhoneEndpoint(req, res);
 
-      expect(res._status).toBe(403);
+      expect(res._status).toBe(404);
       expect(res._body).toHaveProperty('error');
     });
 
@@ -1546,7 +1546,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
       expect(res._body).toHaveProperty('error');
     });
 
-    test('should return 403 for endpoint from different organisation', async () => {
+    test('should not find an endpoint held by a different organisation', async () => {
       const req = createMockRequest({
         params: { identifier: testPhoneId },
         query: {},
@@ -1557,7 +1557,7 @@ describe('Phone Endpoints API - Comprehensive Coverage', () => {
 
       await deletePhoneEndpoint(req, res);
 
-      expect(res._status).toBe(403);
+      expect(res._status).toBe(404);
       expect(res._body).toHaveProperty('error');
     });
 

--- a/tests/phone-numbers-org-scoped.test.mjs
+++ b/tests/phone-numbers-org-scoped.test.mjs
@@ -1,0 +1,215 @@
+/**
+ * Schema 61: a phone number's identity is (number, organisation), not the
+ * number alone. Two organisations may each hold the same number on their own
+ * trunks; one organisation may not hold it twice; one trunk may not carry it
+ * twice; and every route addressed by number resolves to the caller's own row
+ * (else the pool's), never to another organisation's.
+ */
+import {
+  setupRealDatabase,
+  teardownRealDatabase,
+  PhoneNumber,
+  Organisation,
+  Trunk,
+  databaseStarted,
+} from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+const NUMBER = '442071234567';
+
+describe('Phone numbers are organisation-scoped', () => {
+  let createEndpoint;
+  let getEndpoint;
+  let agentDbList;
+  let migrate;
+  let org1;
+  let org2;
+  let trunk1;
+  let trunk2;
+  let carrier;
+
+  const mockLogger = { info() {}, error() {}, warn() {}, debug() {}, trace() {}, child: () => mockLogger };
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    await databaseStarted;
+    const collection = await import('../api/paths/phone-endpoints.js');
+    const item = await import('../api/paths/phone-endpoints/{identifier}.js');
+    const agentDb = await import('../api/paths/agent-db/phone-endpoints.js');
+    ({ migratePhoneNumbersIdentity: migrate } = await import('../lib/database.js'));
+    createEndpoint = collection.default(mockLogger, {}, {}).POST;
+    getEndpoint = item.default(mockLogger, {}, {}).GET;
+    agentDbList = agentDb.default(mockLogger, {}, {}).GET;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 30000);
+
+  beforeEach(async () => {
+    org1 = randomUUID();
+    org2 = randomUUID();
+    await Organisation.create({ id: org1, name: 'Org one' });
+    await Organisation.create({ id: org2, name: 'Org two' });
+    trunk1 = await Trunk.create({ id: `t1-${org1.slice(0, 8)}`, name: 'Org one PBX', handler: 'livekit' });
+    await trunk1.addOrganisation(org1);
+    trunk2 = await Trunk.create({ id: `t2-${org2.slice(0, 8)}`, name: 'Org two PBX', handler: 'livekit' });
+    await trunk2.addOrganisation(org2);
+    carrier = await Trunk.create({ id: `carrier-${org1.slice(0, 8)}`, name: 'Shared carrier', handler: 'livekit', chargeable: true });
+  });
+
+  afterEach(async () => {
+    await PhoneNumber.destroy({ where: { number: NUMBER } });
+    await Trunk.destroy({ where: { id: [trunk1.id, trunk2.id, carrier.id] } });
+    await Organisation.destroy({ where: { id: [org1, org2] } });
+  });
+
+  const req = (extra = {}) => ({ params: {}, query: {}, body: {}, headers: {}, log: mockLogger, ...extra });
+  const res = (organisationId) => {
+    const r = {
+      locals: { user: organisationId ? { role: 'owner', organisationId } : null },
+      _status: null,
+      _body: null,
+      status(code) { this._status = code; return this; },
+      send(body) { this._body = body; this._status = this._status || 200; return this; },
+      json(body) { return this.send(body); },
+      setHeader() { return this; },
+    };
+    return r;
+  };
+
+  const create = async (organisationId, trunkId) => {
+    const r = res(organisationId);
+    await createEndpoint(req({ body: { type: 'e164-ddi', number: `+${NUMBER}`, trunkId } }), r);
+    return r;
+  };
+
+  test('two organisations may each hold the same number on their own trunks', async () => {
+    expect((await create(org1, trunk1.id))._status).toBe(201);
+    expect((await create(org2, trunk2.id))._status).toBe(201);
+    const rows = await PhoneNumber.findAll({ where: { number: NUMBER } });
+    expect(rows.map((r) => r.organisationId).sort()).toEqual([org1, org2].sort());
+    // Each row has its own surrogate id; the number is no longer the key.
+    expect(new Set(rows.map((r) => r.id)).size).toBe(2);
+  });
+
+  test('an organisation may not hold the same number twice', async () => {
+    expect((await create(org1, trunk1.id))._status).toBe(201);
+    const again = await create(org1, trunk1.id);
+    expect(again._status).toBe(409);
+  });
+
+  test('a shared trunk carries a number once, whichever organisation asks second', async () => {
+    expect((await create(org1, carrier.id))._status).toBe(201);
+    const second = await create(org2, carrier.id);
+    expect(second._status).toBe(409);
+    expect(second._body.error).toContain('trunk');
+  });
+
+  test('the unique indexes hold even when the pre-check is bypassed', async () => {
+    await PhoneNumber.create({ number: NUMBER, handler: 'livekit', organisationId: org1, aplisayId: trunk1.id });
+    await expect(
+      PhoneNumber.create({ number: NUMBER, handler: 'livekit', organisationId: org1, aplisayId: trunk2.id }),
+    ).rejects.toThrow(/unique|Validation/i);
+    await expect(
+      PhoneNumber.create({ number: NUMBER, handler: 'livekit', organisationId: org2, aplisayId: trunk1.id }),
+    ).rejects.toThrow(/unique|Validation/i);
+    // The pool holds a number once too: NULLs must not be treated as distinct.
+    await PhoneNumber.create({ number: NUMBER, handler: 'livekit', organisationId: null, aplisayId: null });
+    await expect(
+      PhoneNumber.create({ number: NUMBER, handler: 'livekit', organisationId: null, aplisayId: null }),
+    ).rejects.toThrow(/unique|Validation/i);
+  });
+
+  test('GET by number returns the caller’s own row, and another organisation’s is not found', async () => {
+    await create(org1, trunk1.id);
+    await create(org2, trunk2.id);
+    const mine = res(org1);
+    await getEndpoint(req({ params: { identifier: `+${NUMBER}` } }), mine);
+    expect(mine._status).toBe(200);
+    expect(mine._body.trunkId).toBe(trunk1.id);
+    const theirs = res(org2);
+    await getEndpoint(req({ params: { identifier: NUMBER } }), theirs);
+    expect(theirs._status).toBe(200);
+    expect(theirs._body.trunkId).toBe(trunk2.id);
+    const nobody = res(randomUUID());
+    await getEndpoint(req({ params: { identifier: NUMBER } }), nobody);
+    expect(nobody._status).toBe(404);
+  });
+
+  test('a pool row is visible to any organisation that has no row of its own', async () => {
+    await PhoneNumber.create({ number: NUMBER, handler: 'livekit', organisationId: null, aplisayId: carrier.id });
+    await create(org1, trunk1.id);
+    const own = res(org1);
+    await getEndpoint(req({ params: { identifier: NUMBER } }), own);
+    expect(own._body.trunkId).toBe(trunk1.id); // own row wins over the pool's
+    const pool = res(org2);
+    await getEndpoint(req({ params: { identifier: NUMBER } }), pool);
+    expect(pool._status).toBe(200);
+    expect(pool._body.trunkId).toBe(carrier.id);
+  });
+
+  test('the worker lookup selects by (number, trunk)', async () => {
+    await create(org1, trunk1.id);
+    await create(org2, trunk2.id);
+    const r1 = res();
+    await agentDbList(req({ query: { number: NUMBER, trunkId: trunk1.id } }), r1);
+    expect(r1._status).toBe(200);
+    expect(r1._body.items[0].organisationId).toBe(org1);
+    const r2 = res();
+    await agentDbList(req({ query: { number: NUMBER, trunkId: trunk2.id } }), r2);
+    expect(r2._body.items[0].organisationId).toBe(org2);
+    const r3 = res();
+    await agentDbList(req({ query: { number: NUMBER, trunkId: carrier.id } }), r3);
+    expect(r3._status).toBe(400);
+    expect(r3._body.error).toContain('Trunk mismatch');
+  });
+
+  test('the migration moves a schema-60 table (number as primary key) to the new identity', async () => {
+    const q = (sql) => PhoneNumber.sequelize.query(sql);
+    // Rebuild the pre-61 shape: no surrogate id, number as the primary key,
+    // none of the new indexes. The table must be empty of cross-org duplicates
+    // for the old key to be re-creatable, which on the test database it is.
+    await PhoneNumber.destroy({ where: {} });
+    await q('DROP INDEX IF EXISTS "phone_numbers_number_organisation"');
+    await q('DROP INDEX IF EXISTS "phone_numbers_number_pool"');
+    await q('DROP INDEX IF EXISTS "phone_numbers_number_trunk"');
+    await q('ALTER TABLE "phone_numbers" DROP CONSTRAINT IF EXISTS "phone_numbers_pkey"');
+    await q('ALTER TABLE "phone_numbers" DROP COLUMN IF EXISTS "id"');
+    await q('ALTER TABLE "phone_numbers" ADD CONSTRAINT "phone_numbers_pkey" PRIMARY KEY ("number")');
+    await q(`INSERT INTO "phone_numbers" ("number", "handler", "organisation_id", "aplisay_id", "created_at", "updated_at")
+             VALUES ('${NUMBER}', 'livekit', '${org1}', '${trunk1.id}', now(), now())`);
+
+    await migrate();
+
+    const [pk] = await q(
+      `SELECT a.attname FROM pg_index i
+         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY (i.indkey)
+        WHERE i.indrelid = 'public.phone_numbers'::regclass AND i.indisprimary`,
+    );
+    expect(pk.map((r) => r.attname)).toEqual(['id']);
+    const [idx] = await q(
+      `SELECT indexname FROM pg_indexes WHERE tablename = 'phone_numbers' AND indexname LIKE 'phone_numbers_number_%' ORDER BY indexname`,
+    );
+    expect(idx.map((r) => r.indexname)).toEqual([
+      'phone_numbers_number_organisation',
+      'phone_numbers_number_pool',
+      'phone_numbers_number_trunk',
+    ]);
+    // The existing row was given an id and is still addressable by number.
+    const row = await PhoneNumber.findOne({ where: { number: NUMBER } });
+    expect(row.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(row.organisationId).toBe(org1);
+    // And the identity now permits what the old key forbade.
+    expect((await create(org2, trunk2.id))._status).toBe(201);
+  });
+
+  test('the migration is idempotent on a database that already has the new identity', async () => {
+    await create(org1, trunk1.id);
+    await migrate();
+    await migrate();
+    const rows = await PhoneNumber.findAll({ where: { number: NUMBER } });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});

--- a/tests/setup/test-api-helpers.js
+++ b/tests/setup/test-api-helpers.js
@@ -123,7 +123,7 @@ export function createTestGetPhoneEndpoint(models) {
       let record = null;
       if (identifier.match(/^\+?[0-9]+$/)) {
         // E.164 number lookup
-        record = await PhoneNumber.findByPk(identifier);
+        record = await PhoneNumber.findOne({ where: { number: identifier } });
       } else {
         // Registration ID lookup - validate UUID format first
         if (!identifier.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)) {
@@ -191,7 +191,7 @@ export function createTestCreatePhoneEndpoint(models) {
         }
 
         // Check for duplicates
-        const existing = await PhoneNumber.findByPk(number);
+        const existing = await PhoneNumber.findOne({ where: { number: number } });
         if (existing) {
           return res.status(409).send({ error: 'Phone number already exists' });
         }
@@ -259,7 +259,7 @@ export function createTestUpdatePhoneEndpoint(models) {
 
       if (identifier.match(/^\+?[0-9]+$/)) {
         // E.164 number update
-        const phoneNumber = await PhoneNumber.findByPk(identifier);
+        const phoneNumber = await PhoneNumber.findOne({ where: { number: identifier } });
         if (!phoneNumber) {
           return res.status(404).send({ error: 'Phone number not found' });
         }
@@ -341,7 +341,7 @@ export function createTestDeletePhoneEndpoint(models) {
 
       if (identifier.match(/^\+?[0-9]+$/)) {
         // E.164 number deletion
-        const phoneNumber = await PhoneNumber.findByPk(identifier);
+        const phoneNumber = await PhoneNumber.findOne({ where: { number: identifier } });
         if (!phoneNumber) {
           return res.status(404).send({ error: 'Phone number not found' });
         }

--- a/tools/number.js
+++ b/tools/number.js
@@ -79,14 +79,19 @@ import('dotenv').then(dotenv => {
   })
   .then(({ PhoneNumber, stopDatabase }) => {
     logger.info({ options }, 'options');
-    (options.add ? PhoneNumber.upsert({
-      number: options.number.replace(/^0/, '44').replace(/^\+/, ''),
+    // Identity is (number, organisation) since schema 61, so an upsert on the
+    // primary key would create a second row rather than update the first.
+    const number = options.number.replace(/^0/, '44').replace(/^\+/, '');
+    const values = {
+      number,
       handler: options.handler,
       reservation: options.reservation,
-      organisationId: options.organisation,
+      organisationId: options.organisation ?? null,
       outbound: options.outbound,
       aplisayId: options.trunk
-    }) : PhoneNumber.destroy({
+    };
+    (options.add ? PhoneNumber.findOne({ where: { number, organisationId: options.organisation ?? null } })
+      .then((row) => (row ? row.update(values) : PhoneNumber.create(values))) : PhoneNumber.destroy({
       where: {
         number: options.number.replace(/^0/, '44').replace(/^\+/, ''),
         handler: options.handler,


### PR DESCRIPTION
Stacked on #270 (base branch `feat/trunk-qualified-inbound`); retarget to `next` once that merges.

`phone_numbers.number` was the primary key, so a number could exist once on the whole platform and whichever organisation created it first held it. Identity is now the pair (number, organisation), with a trunk carrying a number once.

**Schema 61**
- `phone_numbers.id` UUID becomes the primary key; `number` stays NOT NULL and stops being the key.
- `UNIQUE (number, organisation_id)`; `UNIQUE (number) WHERE organisation_id IS NULL` so the unallocated pool holds a number once (a plain unique index treats NULLs as distinct); `UNIQUE (number, aplisay_id)` so a trunk carries a number once.
- `migratePhoneNumbersIdentity()` runs in the gated upgrade chain **before** `PhoneNumber.sync({ alter })`, since sync will not move a primary key. Idempotent: adds the column, backfills with `gen_random_uuid()`, swaps the key only when it is not already on `id`, creates the indexes if missing. Index names match the model's `indexes` so a fresh database gets them from sync. Test image is PG 15, deployments are 16+.
- Rows with no organisation are left as they are: they are the unallocated pool that `linkNumber` and the list route expose to every organisation, not legacy data.

**Call sites** (the number is no longer enough to name a row)
- `POST /phone-endpoints`: duplicate check is per organisation and per trunk; the 409 says which.
- `GET/PUT/DELETE /phone-endpoints/{number}`: resolve the caller's own row, else the pool's. Another organisation's row for the same number is not found (404 where tests previously expected 403).
- `GET /agent-db/phone-endpoints?number=&trunkId=`: the trunk now selects the row rather than validating it afterwards; a number that exists but not on that trunk still answers "Trunk mismatch" 400. `callReceived` is stamped by id. The surrogate id is stripped from DDI payloads.
- `PATCH /agent-db/phone-endpoints/{number}`: stamps `provisioned` on every row carrying the number, since provisioning is a fact about the number at the carrier.
- `GET /agent-db/phone-numbers`: deterministic order, an organisation's row before the pool's.
- listen, originate, outbound-authorisation: qualified by the owner's organisation where it is known, own row before pool.
- `Agent.fromNumber` (jambonz, no trunk on the wire): prefers the row with an instance attached.
- `Instance.linkNumber`: own row before pool row for the same number.
- `tools/number.js`: find-then-update instead of an upsert on the old key.

**Tests**: `tests/phone-numbers-org-scoped.test.mjs` (two orgs holding one number; per-org and per-trunk 409s; index enforcement incl. the pool; own-row-else-pool resolution; worker lookup by (number, trunk); a real schema-60 table rebuilt and migrated; idempotent re-run). Existing `findByPk(number)` test sites moved to `findOne`. Full DB suite on a clean volume: 86 suites / 974 tests.

**Docs**: phone-endpoints-api.md, phone-numbers-api.md, livekit-agent-architecture.md §8.2.

Not in this PR: a carrier reservation reference on chargeable-trunk creates, and refusing an organisation change while a number is attached to an instance. Both are separate changes.
