### PR TITLE
Trace facade: pass debug through for a call's platform leg

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -2000,7 +2000,9 @@ components:
           description: For a call, which way it went
         callId:
           type: string
-          description: For a call, its SIP Call-ID
+          description: |-
+            For a call, the SIP Call-ID of its customer-facing leg — the one to look for in the
+            PBX's or carrier's own logs.
         startedAt:
           type: string
           format: date-time
@@ -2019,10 +2021,17 @@ components:
             known-good exchange.
         messages:
           type: integer
-          description: How many messages fetching this entry would return
+          description: |-
+            How many messages fetching this entry would return. For a call, that is its
+            customer-facing leg, which the detail route serves by default.
         bytes:
           type: integer
           description: Approximate size of that detail, in bytes
+        internalMessages:
+          type: integer
+          description: |-
+            For a call, how many more messages its platform leg holds — the same call between the
+            b2bua node and the platform. The detail route adds them under `debug=1`.
     SipTraceIndex:
       type: object
       description: |-
@@ -2071,6 +2080,13 @@ components:
           type: string
           enum: [in, out]
           description: Direction relative to the b2bua node
+        leg:
+          type: string
+          enum: [external, internal]
+          description: |-
+            For a message in a call, which leg of the bridge it was on: `external` between the node
+            and the customer's PBX or carrier, `internal` between the node and the platform. Absent
+            on a REGISTER, which has only one side.
         transport:
           type: string
           enum: [udp, tcp, tls]
@@ -2137,7 +2153,11 @@ components:
             $ref: '#/components/schemas/SipTraceMessage'
     SipTraceDialog:
       type: object
-      description: The signalling of one call dialog involving this registration.
+      description: |-
+        The signalling of one bridged call involving this registration. The b2bua node sits between
+        the customer's PBX or carrier and the platform, so a call has two legs; by default `messages`
+        is the customer-facing leg, and with `debug=1` both legs, interleaved by timestamp and each
+        message marked with its `leg`.
       properties:
         id:
           type: string
@@ -2145,6 +2165,12 @@ components:
           example: call-2
         callId:
           type: string
+          description: |-
+            SIP Call-ID of the customer-facing leg. A call refused before the customer side was
+            dialled has only a platform leg, and this is then that leg's Call-ID.
+        internalCallId:
+          type: string
+          description: SIP Call-ID of the platform leg, when the call has one
         direction:
           type: string
           enum: [inbound, outbound]
@@ -2330,6 +2356,11 @@ components:
               type: string
             dialog:
               type: string
+              description: For a packet in a call, the call's customer-facing Call-ID whichever leg the packet was on
+            leg:
+              type: string
+              enum: [external, internal]
+              description: For a packet in a call, which leg of the bridge it was on
     RegistrationProbeRequest:
       type: object
       description: Options for a live registration probe.

--- a/api/paths/phone-endpoints/{identifier}/trace.js
+++ b/api/paths/phone-endpoints/{identifier}/trace.js
@@ -7,6 +7,7 @@ import {
   describeNodeFailure,
   capabilityFromFailure,
   unsupportedNodeBody,
+  wantsDebugTrace,
   CAPABILITY_NONE
 } from '../../../../lib/regclient.js';
 
@@ -47,7 +48,7 @@ const getRegistrationTrace = async (req, res) => {
 
   const user = res.locals.user;
   const { identifier } = req.params;
-  const { format = 'json', since } = req.query;
+  const { format = 'json', since, debug } = req.query;
 
   try {
     if (!TRACE_INDEX_FORMATS.includes(format)) {
@@ -62,7 +63,9 @@ const getRegistrationTrace = async (req, res) => {
     const { node, config } = resolved;
 
     const address = await nodeDialAddress(node, config, { log: req.log });
-    const url = buildTraceUrl({ node: address, registrationId: identifier, format, since }, config);
+    const url = buildTraceUrl({
+      node: address, registrationId: identifier, format, since, debug: wantsDebugTrace(debug)
+    }, config);
     const wantsBinary = format === 'pcap';
 
     let response;
@@ -133,9 +136,16 @@ getRegistrationTrace.apiDoc = {
                 \`GET /phone-endpoints/{identifier}/trace/{transactionId}\`, which additionally
                 offers \`format=decode\` for parsed packets.
 
+                A bridged call is one entry. The node sits between the customer's PBX or carrier
+                and the platform, so every call has two legs; the entry describes the customer's
+                leg (\`messages\`, \`summary\`, \`callId\`) and says how many more messages the
+                platform leg holds (\`internalMessages\`), which the detail route adds under
+                \`debug=1\`.
+
                 \`format=pcap\` is available here and returns a capture of the **whole**
                 registration for Wireshark or sngrep — TLS legs included, exported decrypted, which
-                an on-wire capture can never show.
+                an on-wire capture can never show. It too is the customer's leg of each call
+                unless \`debug=1\` is given.
 
                 Traces live in a bounded in-memory buffer on the node, so they cover recent activity
                 rather than full history, and are lost if that node restarts. What has been
@@ -165,6 +175,13 @@ getRegistrationTrace.apiDoc = {
       required: false,
       schema: { type: 'string', format: 'date-time' },
       description: 'Only return messages captured at or after this time'
+    },
+    {
+      name: 'debug',
+      in: 'query',
+      required: false,
+      schema: { type: 'boolean', default: false },
+      description: 'With format=pcap, include the platform leg of each call as well as the customer leg'
     }
   ],
   responses: {

--- a/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
+++ b/api/paths/phone-endpoints/{identifier}/trace/{transactionId}.js
@@ -7,6 +7,7 @@ import {
   describeNodeFailure,
   capabilityFromFailure,
   unsupportedNodeBody,
+  wantsDebugTrace,
   CAPABILITY_NONE
 } from '../../../../../lib/regclient.js';
 
@@ -34,7 +35,7 @@ const getRegistrationTraceTransaction = async (req, res) => {
 
   const user = res.locals.user;
   const { identifier, transactionId } = req.params;
-  const { format = 'json', since } = req.query;
+  const { format = 'json', since, debug } = req.query;
 
   try {
     if (!TRACE_FORMATS.includes(format)) {
@@ -46,7 +47,9 @@ const getRegistrationTraceTransaction = async (req, res) => {
     const { node, config } = resolved;
 
     const address = await nodeDialAddress(node, config, { log: req.log });
-    const url = buildTraceUrl({ node: address, registrationId: identifier, transactionId, format, since }, config);
+    const url = buildTraceUrl({
+      node: address, registrationId: identifier, transactionId, format, since, debug: wantsDebugTrace(debug)
+    }, config);
     const wantsBinary = format === 'pcap';
 
     let response;
@@ -124,6 +127,13 @@ getRegistrationTraceTransaction.apiDoc = {
                     route sets survive the decode.
                   * \`pcap\` — this exchange as a capture file for Wireshark or sngrep.
 
+                A call dialog is served as its customer-facing leg: the messages between the
+                b2bua node and the customer's PBX or carrier, which is what a customer can compare
+                with their own logs. The node bridges every call to the platform on a second leg,
+                and \`debug=1\` adds that leg too, interleaved by timestamp, with every message
+                marked \`leg: external\` or \`leg: internal\`. Both legs' Call-IDs are on the
+                dialog (\`callId\`, \`internalCallId\`) and either addresses it here.
+
                 Digest credentials are always redacted. Trace entries rotate as new activity
                 arrives, so an id listed a few minutes ago may since have aged out; that is a 404.`,
   operationId: 'getPhoneEndpointTraceTransaction',
@@ -156,6 +166,13 @@ getRegistrationTraceTransaction.apiDoc = {
       required: false,
       schema: { type: 'string', format: 'date-time' },
       description: 'Only return messages captured at or after this time'
+    },
+    {
+      name: 'debug',
+      in: 'query',
+      required: false,
+      schema: { type: 'boolean', default: false },
+      description: 'For a call, include the platform leg interleaved with the customer leg'
     }
   ],
   responses: {

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -167,7 +167,7 @@ function isBlockedAddress(host, ipVersion, allowPrivateNodes) {
  * With no `transactionId` this addresses the listing; with one it addresses that
  * single exchange in full.
  */
-export function buildTraceUrl({ node, registrationId, transactionId, format = 'json', since }, config) {
+export function buildTraceUrl({ node, registrationId, transactionId, format = 'json', since, debug = false }, config) {
   const { scheme, port } = config;
   const host = net.isIP(node) === 6 ? `[${node}]` : node;
   const path = transactionId
@@ -176,7 +176,24 @@ export function buildTraceUrl({ node, registrationId, transactionId, format = 'j
   const url = new URL(`${scheme}://${host}:${port}${path}`);
   if (format && format !== 'json') url.searchParams.set('format', format);
   if (since) url.searchParams.set('since', String(since));
+  if (debug) url.searchParams.set('debug', '1');
   return url.toString();
+}
+
+/**
+ * Whether a trace request asked for the platform leg of each call.
+ *
+ * A bridged call has two legs: the customer's PBX or carrier on one side of
+ * the node and the platform on the other. The node serves the customer's leg
+ * by default — it is the one a customer can compare with their own logs, and
+ * the other, shown unasked, reads as a second call — and adds the platform
+ * leg, interleaved by timestamp, when `debug` is set. Query strings arrive as
+ * text, and the OpenAPI layer may or may not have coerced them, so accept the
+ * usual spellings of "yes".
+ */
+export function wantsDebugTrace(value) {
+  if (value === true) return true;
+  return ['1', 'true', 'yes', 'on'].includes(String(value ?? '').trim().toLowerCase());
 }
 
 /** URL of the probe collection, or of one probe / its event stream. */

--- a/tests/regclient-facade-routes.test.mjs
+++ b/tests/regclient-facade-routes.test.mjs
@@ -322,11 +322,37 @@ describe('GET /phone-endpoints/{identifier}/trace/{transactionId}', () => {
     expect(new URL(lastRequest.url).searchParams.get('format')).toBe('decode');
   });
 
+  // A call is two legs, and the node serves the customer's unless asked for
+  // the platform's as well. The flag passes through as the node spells it,
+  // and only when set — the default is the node's to choose.
+  it('passes debug through to the node for the platform leg', async () => {
+    makeReg();
+    nextResponse = { status: 200, data: { registrationId: REG, calls: [{ id: 'call-3', messages: [] }] } };
+    await callTraceTransaction({ transactionId: 'call-3', query: { debug: '1' } });
+    expect(new URL(lastRequest.url).searchParams.get('debug')).toBe('1');
+
+    await callTraceTransaction({ transactionId: 'call-3', query: { debug: 'false' } });
+    expect(new URL(lastRequest.url).searchParams.has('debug')).toBe(false);
+
+    await callTraceTransaction({ transactionId: 'call-3' });
+    expect(new URL(lastRequest.url).searchParams.has('debug')).toBe(false);
+  });
+
   it('names the exchange in the capture filename', async () => {
     makeReg();
     nextResponse = { status: 200, data: Buffer.from([0xd4, 0xc3, 0xb2, 0xa1]) };
     const res = await callTraceTransaction({ query: { format: 'pcap' } });
     expect(res._headers['Content-Disposition']).toContain(`${REG}-reg-8.pcap`);
+  });
+
+  // The whole-registration capture on the index route takes the same flag.
+  it('passes debug through on a whole-registration capture', async () => {
+    makeReg();
+    nextResponse = { status: 200, data: Buffer.from([0xd4, 0xc3, 0xb2, 0xa1]) };
+    await callTrace({ query: { format: 'pcap', debug: 'true' } });
+    const url = new URL(lastRequest.url);
+    expect(url.searchParams.get('format')).toBe('pcap');
+    expect(url.searchParams.get('debug')).toBe('1');
   });
 
   // Trace entries rotate. An id listed a few minutes ago may have aged out

--- a/tests/regclient-node-api.test.mjs
+++ b/tests/regclient-node-api.test.mjs
@@ -9,7 +9,8 @@ import {
   describeNodeFailure,
   selectProbeNode,
   TRACE_FORMATS,
-  TRACE_INDEX_FORMATS
+  TRACE_INDEX_FORMATS,
+  wantsDebugTrace
 } from '../lib/regclient.js';
 
 // The regclient node API client: URL construction, the guard on which node
@@ -167,6 +168,17 @@ describe('URL construction', () => {
     const url = new URL(buildTraceUrl({ node: '203.0.113.10', registrationId, format: 'decode', since: '2026-08-30T10:00:00Z' }, config));
     expect(url.searchParams.get('format')).toBe('decode');
     expect(url.searchParams.get('since')).toBe('2026-08-30T10:00:00Z');
+    expect(url.searchParams.has('debug')).toBe(false);
+  });
+
+  // The node serves a call's customer leg unless asked for the platform leg
+  // too; the flag is only sent when it is wanted, so the default stays the
+  // node's default.
+  it('asks for the platform leg only when debug is set', () => {
+    const url = new URL(buildTraceUrl({ node: '203.0.113.10', registrationId, transactionId: 'call-3', debug: true }, config));
+    expect(url.searchParams.get('debug')).toBe('1');
+    for (const value of ['1', 'true', 'YES', true]) expect(wantsDebugTrace(value)).toBe(true);
+    for (const value of ['0', 'false', '', undefined, null]) expect(wantsDebugTrace(value)).toBe(false);
   });
 
   it('brackets an IPv6 node address', () => {


### PR DESCRIPTION
Companion to the aplisay-b2bua change that traces a bridged call as one entry (both legs) and serves the customer-facing leg by default.

- Both trace routes accept `debug`; it is forwarded to the node as `debug=1` only when set.
- `wantsDebugTrace` accepts the usual spellings of yes, since the query arrives as text.
- OpenAPI: `leg` on messages, `internalCallId` on dialogs, `internalMessages` on index entries, `correlation.leg` on decoded packets; route descriptions explain the two legs.

Tests: `regclient-node-api` and `regclient-facade-routes` suites pass with new cases for the flag.
