### PR TITLE
Registration trunks: a registration may own a trunk that numbers attach to

### DIFF
--- a/agents/livekit/lib/sip-attributes.ts
+++ b/agents/livekit/lib/sip-attributes.ts
@@ -27,6 +27,10 @@ export const SIP_ATTRIBUTE_KEYS = {
   callerNumber: ["sip.phoneNumber", "sipPhoneNumber"],
   /** Aplisay trunk id stamped by the SBC. */
   aplisayTrunk: ["sip.h.x-aplisay-trunk", "sipHXAplisayTrunk"],
+  /** The number the caller dialled, when the B2BUA carries it in a header
+   *  rather than the Request-URI (a registration trunk: LiveKit admits the
+   *  call on the trunk's fixed number, so the DID rides here). */
+  aplisayCalled: ["sip.h.x-aplisay-called", "sipHXAplisayCalled"],
   /** Phone-registration endpoint id, when the leg came from a registration. */
   phoneRegistration: [
     "sip.h.x-aplisay-phoneregistration",

--- a/agents/livekit/lib/worker.ts
+++ b/agents/livekit/lib/worker.ts
@@ -1037,6 +1037,10 @@ async function getCallInfo(ctx: JobContext, room: Room): Promise<CallScenario> {
               );
 
               calledId = calledIdAttr;
+              // A registration trunk's INVITE reaches LiveKit on the trunk's
+              // fixed number; the dialled number rides in X-Aplisay-Called.
+              const aplisayCalledAttr = sipAttribute(attrs, "aplisayCalled");
+              if (aplisayCalledAttr) calledId = aplisayCalledAttr;
               callerId = callerIdAttr;
               aplisayId = aplisayIdAttr;
               phoneRegistration = phoneRegistrationAttr ?? null;
@@ -1139,7 +1143,11 @@ async function getCallInfo(ctx: JobContext, room: Room): Promise<CallScenario> {
                   );
                 }
               }
-            } else if (calledId) {
+            }
+            // A registration with no agent attached is a registration TRUNK:
+            // the call resolves by (dialled number, trunk) like any other
+            // trunk call. Same ladder as pipecat's _lookup_instance_for_inbound.
+            if (!instance && calledId) {
               logger.info(
                 { callerId, calledId, aplisayId },
                 "new Livekit inbound telephone call, looking up phone endpoint by number",

--- a/agents/pipecat/freeswitch/conf/dialplan/default.xml
+++ b/agents/pipecat/freeswitch/conf/dialplan/default.xml
@@ -37,6 +37,7 @@
              section 6 verbatim. -->
         <action application="set" data="aplisay_trunk=${sip_h_X-Aplisay-Trunk}"/>
         <action application="set" data="aplisay_phone_registration=${sip_h_X-Aplisay-PhoneRegistration}"/>
+        <action application="set" data="aplisay_called=${sip_h_X-Aplisay-Called}"/>
         <action application="set" data="aplisay_call_id=${sip_h_X-Aplisay-Call-Id}"/>
         <action application="set" data="aplisay_b2bua_ip=${sip_h_X-Lk-RealIp}"/>
         <action application="set" data="aplisay_b2bua_transport=${sip_h_X-Lk-Transport}"/>

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -336,7 +336,7 @@ async def _voiceblender_resolve_agent(
     ``_on_leg_ringing`` reads to build the ctx.
     """
     headers = event.get("sip_headers") or {}
-    to_number = event.get("to")
+    to_number = headers.get("X-Aplisay-Called") or event.get("to")
     aplisay_id = headers.get("X-Aplisay-Trunk")
     phone_registration = headers.get("X-Aplisay-PhoneRegistration")
 
@@ -446,7 +446,9 @@ async def _sipbridge_resolve_agent_from_headers(
         return s
 
     from_number = _user_of(from_uri)
-    to_number = _user_of(to_uri)
+    # A registration trunk's B2BUA puts the dialled number in X-Aplisay-Called
+    # as well as the Request-URI; the header wins when present.
+    to_number = h.get("x-aplisay-called") or _user_of(to_uri)
 
     instance, origin = await _lookup_instance_for_inbound(
         phone_registration=phone_registration,
@@ -673,6 +675,7 @@ async def daily_dialin(request: Request) -> dict:
     # SIP custom headers, if Daily surfaces them. The keys here mirror the
     # contract; degrade gracefully when missing.
     headers = body.get("sip_headers") or {}
+    to_number = headers.get("X-Aplisay-Called") or to_number
     aplisay_id = headers.get("X-Aplisay-Trunk")
     phone_registration = headers.get("X-Aplisay-PhoneRegistration")
 

--- a/agents/pipecat/tests/test_inbound_called_header.py
+++ b/agents/pipecat/tests/test_inbound_called_header.py
@@ -1,0 +1,42 @@
+"""X-Aplisay-Called carries the dialled number for a registration trunk.
+
+The B2BUA forwards a trunk's inbound call with the dialled number in
+X-Aplisay-Called (and, on this runtime, the Request-URI). The header wins
+over the event's own `to` when both are present, and the plain `to` still
+serves when it is absent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pipecat_aplisay import worker
+
+
+def _capture(monkeypatch):
+    captured: dict = {}
+
+    async def fake_lookup(*, phone_registration, to_number, aplisay_id):
+        captured.update(phone_registration=phone_registration, to_number=to_number, aplisay_id=aplisay_id)
+        return {"id": "i", "Agent": {"id": "a"}}, worker._InboundOrigin()
+
+    monkeypatch.setattr(worker, "_lookup_instance_for_inbound", fake_lookup)
+    return captured
+
+
+def test_voiceblender_prefers_the_called_header(monkeypatch):
+    captured = _capture(monkeypatch)
+    event = {
+        "to": "00000",
+        "sip_headers": {"X-Aplisay-Trunk": "reg-abc", "X-Aplisay-PhoneRegistration": "abc", "X-Aplisay-Called": "+442079460100"},
+    }
+    asyncio.run(worker._voiceblender_resolve_agent(event))
+    assert captured["to_number"] == "+442079460100"
+    assert captured["aplisay_id"] == "reg-abc"
+    assert captured["phone_registration"] == "abc"
+
+
+def test_voiceblender_falls_back_to_the_event_to(monkeypatch):
+    captured = _capture(monkeypatch)
+    asyncio.run(worker._voiceblender_resolve_agent({"to": "+445678", "sip_headers": {"X-Aplisay-Trunk": "tk"}}))
+    assert captured["to_number"] == "+445678"

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1833,6 +1833,26 @@ components:
                   description: Password for phone-registration type
                 options:
                   $ref: '#/components/schemas/PhoneRegistrationOptions'
+                trunk:
+                  type: boolean
+                  default: false
+                  description: |-
+                    Create this registration as a registration trunk: it owns a trunk that numbers attach to
+                    (POST /phone-endpoints type e164-ddi with the returned trunkId), and inbound calls resolve
+                    by (dialled number, trunk) rather than to one agent attached to the registration.
+                trunkId:
+                  type: string
+                  description: |-
+                    Name the trunk instead of the default `reg-<registration id>`. Requires trunk:create (a super
+                    migrating an existing trunk keeps its id, and with it its numbers). Only with trunk: true.
+                didSource:
+                  type: string
+                  description: |-
+                    Where the dialled number is found on an inbound INVITE for a trunk: `request-uri` (default),
+                    `to`, `header:<Header-Name>` (e.g. header:P-Called-Party-ID) or `none` (single-line behaviour).
+                didCountry:
+                  type: string
+                  description: ISO 3166-1 alpha-2 country used to normalise a national-format dialled number to E.164. Null = platform default.
     PhoneEndpointUpdateInput:
       description: |-
         Schema for updating a phone endpoint. All fields are optional.
@@ -1867,6 +1887,17 @@ components:
           description: Registration password (for registrations)
         options:
           $ref: '#/components/schemas/PhoneRegistrationOptions'
+        trunk:
+          type: boolean
+          description: |-
+            Registrations only. `true` turns a line into a registration trunk (creates its trunk and detaches it
+            from any agent); `false` turns a trunk back into a line, refused with 409 while numbers sit on it.
+        didSource:
+          type: string
+          description: Registration trunks — where the dialled number is found (see PhoneEndpointCreateInput).
+        didCountry:
+          type: string
+          description: Registration trunks — ISO 3166-1 alpha-2 for national-format dialled numbers.
     B2buaNodeHeartbeat:
       type: object
       description: A b2bua node announcing itself, about once a minute.

--- a/api/paths/agent-db/phone-endpoints.js
+++ b/api/paths/agent-db/phone-endpoints.js
@@ -181,6 +181,7 @@ const phoneEndpointsList = (async (req, res) => {
             id: registration.id,
             name: registration.name,
             handler: registration.handler,
+            trunkId: registration.trunkId || null,
             status: registration.status,
             state: registration.state,
             outbound: !!registration.outbound,

--- a/api/paths/phone-endpoints.js
+++ b/api/paths/phone-endpoints.js
@@ -1,8 +1,8 @@
 import { PhoneNumber, PhoneRegistration, Trunk, Organisation, Agent, Instance, Op } from '../../lib/database.js';
 import { getTelephonyHandler, HANDLER_NAMES, TELEPHONY_HANDLER_NAMES } from '../../lib/handlers/index.js';
-import { validateE164, normalizeE164, validateSipUri, validatePhoneRegistration, validateE164Ddi } from '../../lib/validation.js';
+import { validateE164, normalizeE164, validateSipUri, validatePhoneRegistration, validateE164Ddi, validateRegistrationTrunkFields } from '../../lib/validation.js';
 import { scopeWhereForOrganisation } from '../../lib/scope.js';
-import { requirePermission } from '../../lib/auth/permissions.js';
+import { requirePermission, can } from '../../lib/auth/permissions.js';
 
 let appParameters, log;
 
@@ -147,7 +147,9 @@ const phoneEndpointList = (async (req, res) => {
         status: r.status,
         state: r.state,
         handler: r.handler,
-        outbound: !!r.outbound
+        outbound: !!r.outbound,
+        trunkId: r.trunkId || null,
+        trunk: !!r.trunkId
       }));
       const nextOffset = rows.length === size ? startOffset + size : null;
       return res.send({ items, nextOffset });
@@ -183,7 +185,7 @@ const phoneEndpointList = (async (req, res) => {
       regWhere
         ? PhoneRegistration.findAll({
             where: regWhere,
-            attributes: ['id', 'name', 'registrar', 'username', 'b2buaId', 'status', 'state', 'handler', 'outbound', 'callReceived', 'createdAt'],
+            attributes: ['id', 'name', 'registrar', 'username', 'b2buaId', 'status', 'state', 'handler', 'outbound', 'callReceived', 'createdAt', 'trunkId'],
             limit: size,
             offset: startOffset
           })
@@ -212,6 +214,8 @@ const phoneEndpointList = (async (req, res) => {
       registrar: r.registrar,
       username: r.username,
       b2buaId: r.b2buaId || null,
+      trunkId: r.trunkId || null,
+      trunk: !!r.trunkId,
       status: r.status,
       state: r.state,
       handler: r.handler,
@@ -390,11 +394,29 @@ const createPhoneEndpoint = async (req, res) => {
       }
 
       const validation = validatePhoneRegistration(data);
-      if (!validation.isValid) {
+      const trunkErrors = validateRegistrationTrunkFields(data);
+      if (!validation.isValid || trunkErrors.length) {
         return res.status(400).send({
           error: 'Validation failed',
-          details: validation.errors
+          details: [...validation.errors, ...trunkErrors]
         });
+      }
+      // A registration trunk owns a trunks row. Its id defaults to reg-<uuid>;
+      // naming it is a super's privilege (an SBC trunk being migrated keeps its
+      // id, and with it its numbers).
+      const wantsTrunk = data.trunk === true;
+      const requestedTrunkId = typeof data.trunkId === 'string' ? data.trunkId.trim() : '';
+      if (requestedTrunkId && !wantsTrunk) {
+        return res.status(400).send({ error: 'trunkId is only meaningful with trunk: true' });
+      }
+      if (requestedTrunkId && !can(res.locals.user, 'trunk', 'create')) {
+        return res.status(403).send({ error: 'Naming the trunk requires trunk:create' });
+      }
+      if (requestedTrunkId && !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(requestedTrunkId)) {
+        return res.status(400).send({ error: 'trunkId must be 1–128 chars, letters/digits/._- and start alphanumeric' });
+      }
+      if (requestedTrunkId && (await Trunk.findByPk(requestedTrunkId))) {
+        return res.status(409).send({ error: `Trunk ${requestedTrunkId} already exists` });
       }
 
       // Strip sip:/sips: prefix from registrar if present before saving
@@ -415,21 +437,30 @@ const createPhoneEndpoint = async (req, res) => {
         });
       }
 
-      const record = await PhoneRegistration.create({
-        name: data.name,
-        handler: data.handler ?? 'livekit',
-        outbound: data.outbound ?? false,
-        registrar: normalizedRegistrar,
-        username: data.username,
-        password: data.password,
-        b2buaId: data.b2buaId != null && String(data.b2buaId).trim() ? String(data.b2buaId).trim() : null,
-        options: data.options || null,
-        organisationId,
-        status: 'disabled',
-        state: 'initial'
+      const record = await PhoneRegistration.sequelize.transaction(async (transaction) => {
+        const reg = await PhoneRegistration.create({
+          name: data.name,
+          handler: data.handler ?? 'livekit',
+          outbound: data.outbound ?? false,
+          registrar: normalizedRegistrar,
+          username: data.username,
+          password: data.password,
+          b2buaId: data.b2buaId != null && String(data.b2buaId).trim() ? String(data.b2buaId).trim() : null,
+          options: data.options || null,
+          organisationId,
+          status: 'disabled',
+          state: 'initial',
+          didSource: data.didSource ?? null,
+          didCountry: data.didCountry ? String(data.didCountry).toUpperCase() : null,
+        }, { transaction });
+        if (wantsTrunk) {
+          const trunk = await createRegistrationTrunk(reg, requestedTrunkId || null, organisationId, transaction);
+          await reg.update({ trunkId: trunk.id }, { transaction });
+        }
+        return reg;
       });
 
-      return res.status(201).send({ success: true, id: record.id });
+      return res.status(201).send({ success: true, id: record.id, trunkId: record.trunkId || null });
     }
   } catch (err) {
     req.log.error(err, 'Error creating phone endpoint');
@@ -438,6 +469,25 @@ const createPhoneEndpoint = async (req, res) => {
     });
   }
 };
+
+/**
+ * The trunks row a registration trunk owns: id reg-<uuid> unless named, the
+ * registration's handler and outbound, never chargeable, flagged so the
+ * reverse lookup (number → trunk → registration) works, and assigned to the
+ * organisation so the e164-ddi create path accepts numbers on it.
+ */
+export async function createRegistrationTrunk(registration, trunkId, organisationId, transaction) {
+  const trunk = await Trunk.create({
+    id: trunkId || `reg-${registration.id}`,
+    name: registration.name || registration.registrar,
+    handler: registration.handler,
+    outbound: !!registration.outbound,
+    chargeable: false,
+    flags: { provider: 'registration', registrationId: registration.id },
+  }, { transaction });
+  await trunk.addOrganisation(organisationId, { transaction });
+  return trunk;
+}
 
 phoneEndpointList.apiDoc = {
   summary: 'Returns a list of all phone endpoints for the organisation of the requestor. Optionally filter to only certain endpoint types.',

--- a/api/paths/phone-endpoints/{identifier}.js
+++ b/api/paths/phone-endpoints/{identifier}.js
@@ -1,5 +1,6 @@
-import { PhoneNumber, PhoneRegistration, Op } from '../../../lib/database.js';
-import { normalizeE164, validateSipUri, isPlausibleSipHost, hasRoutableRegisterProxy } from '../../../lib/validation.js';
+import { PhoneNumber, PhoneRegistration, Trunk, Op } from '../../../lib/database.js';
+import { normalizeE164, validateSipUri, isPlausibleSipHost, hasRoutableRegisterProxy, validateRegistrationTrunkFields } from '../../../lib/validation.js';
+import { createRegistrationTrunk } from '../phone-endpoints.js';
 import { TELEPHONY_HANDLER_NAMES } from '../../../lib/handlers/index.js';
 import { userOwnsRow } from '../../../lib/scope.js';
 import { requirePermission } from '../../../lib/auth/permissions.js';
@@ -74,7 +75,11 @@ const getPhoneEndpoint = async (req, res) => {
         handler: registration.handler,
         outbound: !!registration.outbound,
         callReceived: registration.callReceived ? registration.callReceived.toISOString() : null,
-        options: registration.options || null
+        options: registration.options || null,
+        trunkId: registration.trunkId || null,
+        trunk: !!registration.trunkId,
+        didSource: registration.didSource || null,
+        didCountry: registration.didCountry || null
       });
     }
 
@@ -245,7 +250,7 @@ const updatePhoneEndpoint = async (req, res) => {
       }
 
       // Update allowed fields for registrations
-      const allowedFields = ['outbound', 'handler', 'name', 'options', 'b2buaId'];
+      const allowedFields = ['outbound', 'handler', 'name', 'options', 'b2buaId', 'didSource', 'didCountry'];
       const credentialFields = ['registrar', 'username', 'password'];
       const updateFields = {};
       
@@ -267,6 +272,23 @@ const updatePhoneEndpoint = async (req, res) => {
       }
       if (updateFields.options !== undefined && typeof updateFields.options !== 'object') {
         return res.status(400).send({ error: 'options must be an object if provided' });
+      }
+      const trunkErrors = validateRegistrationTrunkFields(updateData);
+      if (trunkErrors.length) {
+        return res.status(400).send({ error: 'Validation failed', details: trunkErrors });
+      }
+      if (updateFields.didCountry) updateFields.didCountry = String(updateFields.didCountry).toUpperCase();
+      // Turning a line into a trunk creates its trunks row and detaches it
+      // from any single agent (a trunk's numbers are attached, not the trunk).
+      // Turning a trunk back into a line needs the trunk to be empty first.
+      let trunkChange = null;
+      if (updateData.trunk === true && !registration.trunkId) trunkChange = 'create';
+      if (updateData.trunk === false && registration.trunkId) {
+        const numbers = await PhoneNumber.count({ where: { aplisayId: registration.trunkId } });
+        if (numbers > 0) {
+          return res.status(409).send({ error: `This trunk still carries ${numbers} number${numbers === 1 ? '' : 's'}. Remove them before turning it back into a line.` });
+        }
+        trunkChange = 'remove';
       }
       if (updateFields.b2buaId !== undefined) {
         if (updateFields.b2buaId === null || updateFields.b2buaId === '') {
@@ -323,7 +345,43 @@ const updatePhoneEndpoint = async (req, res) => {
         updateFields.error = null;
       }
       
-      await registration.update(updateFields);
+      await PhoneRegistration.sequelize.transaction(async (transaction) => {
+      
+        if (trunkChange === 'create') {
+      
+          const trunk = await createRegistrationTrunk(registration, null, organisationId, transaction);
+      
+          updateFields.trunkId = trunk.id;
+      
+          updateFields.instanceId = null;
+      
+        }
+      
+        if (trunkChange === 'remove') {
+      
+          await Trunk.destroy({ where: { id: registration.trunkId }, transaction });
+      
+          updateFields.trunkId = null;
+      
+        }
+      
+        await registration.update(updateFields, { transaction });
+      
+        // The trunk mirrors the registration's handler and outbound.
+      
+        if (registration.trunkId && (updateFields.handler !== undefined || updateFields.outbound !== undefined)) {
+      
+          await Trunk.update(
+      
+            { ...(updateFields.handler !== undefined ? { handler: updateFields.handler } : {}), ...(updateFields.outbound !== undefined ? { outbound: updateFields.outbound } : {}) },
+      
+            { where: { id: registration.trunkId }, transaction },
+      
+          );
+      
+        }
+      
+      });
       
       // TODO: Emit worker signal for credential rotation if credentialsChanged
       
@@ -376,8 +434,19 @@ const deletePhoneEndpoint = async (req, res) => {
         return res.status(403).send({ error: 'Access denied' });
       }
 
-      // Hard delete the registration
-      await registration.destroy();
+      // A registration trunk goes with its registration, but not while
+      // numbers still sit on it: those would silently lose their trunk.
+      if (registration.trunkId) {
+        const numbers = await PhoneNumber.count({ where: { aplisayId: registration.trunkId } });
+        if (numbers > 0) {
+          return res.status(409).send({ error: `This trunk still carries ${numbers} number${numbers === 1 ? '' : 's'}. Remove them before deleting the connection.` });
+        }
+      }
+      // Hard delete the registration (and its trunk row)
+      await PhoneRegistration.sequelize.transaction(async (transaction) => {
+        if (registration.trunkId) await Trunk.destroy({ where: { id: registration.trunkId }, transaction });
+        await registration.destroy({ transaction });
+      });
       return res.send({
         success: true,
         message: 'Phone registration deleted successfully'

--- a/docs/livekit-agent-architecture.md
+++ b/docs/livekit-agent-architecture.md
@@ -384,7 +384,9 @@ On an inbound INVITE from the SBC, the contract is:
 - Request-URI — supplies the called number.
 - From header — supplies the caller number.
 
-Lookup chain: (called number, `aplisayId`) → PhoneEndpoint → Instance → Agent. The PhoneEndpoint record carries any per-trunk flags, notably `canRefer` (see 6.7). The pair is the whole key: there is no lookup by bare number behind it, so a number the trunk check refuses, or one with no instance, is "no agent for this call" rather than a second attempt without the trunk.
+Lookup chain: (called number, `aplisayId`) → PhoneEndpoint → Instance → Agent. The PhoneEndpoint record carries any per-trunk flags, notably `canRefer` (see 6.7).
+
+**Registration trunks.** A phone-registration created with `trunk: true` owns a trunk (`phone_registrations.trunk_id`, `trunks.flags.provider = "registration"`). The B2BUA forwards its inbound calls with BOTH `X-Aplisay-PhoneRegistration` and `X-Aplisay-Trunk`, and carries the dialled number (normalised to E.164 per `did_source` / `did_country`) in `X-Aplisay-Called` as well as, on the Pipecat runtime, the Request-URI. The registration has no instance of its own, so the lookup ladder falls through from the registration to (called number, `aplisayId`) and the number's agent answers. `X-Aplisay-Called` wins over the Request-URI / `sip.trunkPhoneNumber` wherever both are present. The pair is the whole key: there is no lookup by bare number behind it, so a number the trunk check refuses, or one with no instance, is "no agent for this call" rather than a second attempt without the trunk.
 
 Beyond routing, **all** `X-` headers on the inbound INVITE (including the routing ones above) are surfaced to the agent as `metadata.aplisay.sipHeaders` (a `{ "x-header-name": value }` map, keys lowercased) so agent logic and tools can read per-call context the SBC/carrier attached — see [`sip-headers.md`](sip-headers.md). LiveKit delivers them as `sip.h.x-*` participant attributes (the trunk is created with `includeHeaders = SIP_X_HEADERS`); on the Pipecat runtime the sipbridge and voiceblender gateways carry the same set.
 

--- a/docs/phone-endpoints-api.md
+++ b/docs/phone-endpoints-api.md
@@ -256,6 +256,17 @@ Trunks are a curated platform resource. Ordinary callers get the org-scoped list
 - **Multiple numbers**: The API creates one number per request. To add a range or list, your client can loop over normalized E.164 values and POST each (with optional client-side limit, e.g. max 40 per batch) and surface errors per number if needed.
 - **Validation**: Numbers are validated as E.164 (7–15 digits, optional leading `+`). A number is unique per organisation and per trunk, not platform-wide: creating one your organisation already holds, or one already on the same trunk, returns 409. Another organisation holding the same number on its own trunk is not a conflict.
 
+### Registration trunks
+
+A phone-registration created with `"trunk": true` is a **registration trunk**: it owns a trunk
+(`trunkId` in the response, `reg-<id>` unless a super names it with `trunkId`), numbers attach to
+that trunk with `POST /api/phone-endpoints` `type: e164-ddi`, and each number is given its own
+agent. The registration itself is never attached to an agent. `didSource` says where the dialled
+number is found on an inbound INVITE (`request-uri` default, `to`, `header:<Name>`, `none`), and
+`didCountry` normalises a national-format number. `PUT` with `trunk: true` turns a line into a
+trunk (detaching it from any agent); `trunk: false` and `DELETE` are refused with 409 while numbers
+still sit on the trunk.
+
 ### Agent assignment (inUse, agentId, agentName)
 
 - Numbers are linked to agents via **listeners** (agent instances). The API does not assign numbers to agents; that is done through the listener/agent configuration. The GET response only reports the current assignment.

--- a/lib/database-models/phone-registration.js
+++ b/lib/database-models/phone-registration.js
@@ -80,6 +80,24 @@ export function initPhoneRegistration(sequelize, types = DataTypes) {
         model: 'instances',
         key: 'id'
       }
+    },
+    // Registration trunk: the trunks row this registration owns, when it
+    // carries calls for several numbers. Null for a single line.
+    trunkId: {
+      type: types.STRING,
+      allowNull: true
+    },
+    // Where the regclient finds the dialled number on an inbound INVITE for a
+    // trunk: 'request-uri' (default), 'to', 'header:<Name>', or 'none'.
+    didSource: {
+      type: types.STRING,
+      allowNull: true
+    },
+    // ISO 3166-1 alpha-2, for normalising a national-format dialled number to
+    // E.164. Null = the platform default.
+    didCountry: {
+      type: types.STRING(2),
+      allowNull: true
     }
   }, {
     sequelize,

--- a/lib/database.js
+++ b/lib/database.js
@@ -17,7 +17,14 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 61;  // 61: phone_numbers identity — a surrogate `id` UUID becomes the primary key
+const schemaVersion = 62;  // 62: registration trunks — `phone_registrations.trunk_id` (FK trunks, SET NULL),
+                           //     `did_source`, `did_country`. A registration created with `trunk: true` owns
+                           //     a trunks row (`reg-<uuid>` unless a super names it, flags.provider =
+                           //     'registration', flags.registrationId) so numbers attach to it through the
+                           //     existing e164-ddi path and inbound calls resolve by (number, trunk). The
+                           //     regclient reads the three columns to decide how to forward. Design record
+                           //     lives in polite-ai docs/connection-setup-and-registration-trunks-design.md.
+                           // 61: phone_numbers identity — a surrogate `id` UUID becomes the primary key
                            //     and `number` stops being one. Uniqueness is now (number, organisation_id),
                            //     with a partial unique index on `number` where organisation_id IS NULL so the
                            //     unallocated pool still holds a number once, plus (number, aplisay_id) so a
@@ -2593,6 +2600,10 @@ Trunk.belongsToMany(Organisation, { through: TrunkOrganisation});
 // PhoneNumber to Trunk association (via aplisayId)
 PhoneNumber.belongsTo(Trunk, { foreignKey: 'aplisayId', targetKey: 'id', as: 'Trunk', onDelete: 'SET NULL' });
 Trunk.hasMany(PhoneNumber, { foreignKey: 'aplisayId', sourceKey: 'id', as: 'PhoneNumbers' });
+// A registration trunk: the registration owns a trunks row that numbers attach
+// to. Deleting the trunk row detaches the registration rather than deleting it.
+PhoneRegistration.belongsTo(Trunk, { foreignKey: 'trunkId', targetKey: 'id', as: 'Trunk', onDelete: 'SET NULL' });
+Trunk.hasOne(PhoneRegistration, { foreignKey: 'trunkId', sourceKey: 'id', as: 'Registration' });
 
 agentConcurrencyLimits = createAgentConcurrencyLimits({
   sequelize,

--- a/lib/schemas/phone-registration.ts
+++ b/lib/schemas/phone-registration.ts
@@ -31,6 +31,12 @@ export interface PhoneRegistrationSchema {
   error: string | null;
   lastSeenAt: Date | null;
   organisationId: string | null;
+  /** Registration trunk: the `trunks.id` this registration owns, null for a single line. */
+  trunkId?: string | null;
+  /** Where the regclient finds the dialled number on a trunk INVITE: 'request-uri' | 'to' | 'header:<Name>' | 'none'. */
+  didSource?: string | null;
+  /** ISO 3166-1 alpha-2 for national-format dialled numbers; null = platform default. */
+  didCountry?: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -39,5 +45,5 @@ export const PhoneRegistrationStatusValues: PhoneRegistrationStatus[] = ['active
 export const PhoneRegistrationStateValues: PhoneRegistrationState[] = ['initial', 'registering', 'registered', 'failed'];
 
 // Schema version for migration/validation tracking
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -230,3 +230,23 @@ export function validateE164Ddi(data) {
     errors
   };
 }
+
+
+const DID_SOURCE_RE = /^(request-uri|to|none|header:[A-Za-z][A-Za-z0-9-]{0,63})$/;
+
+/**
+ * Registration-trunk fields. `didSource` names where the regclient finds the
+ * dialled number on an inbound INVITE; `didCountry` is ISO 3166-1 alpha-2.
+ * Both optional; returns the list of problems (empty when fine).
+ */
+export function validateRegistrationTrunkFields(data = {}) {
+  const errors = [];
+  if (data.trunk !== undefined && typeof data.trunk !== 'boolean') errors.push('trunk must be a boolean');
+  if (data.didSource !== undefined && data.didSource !== null && !(typeof data.didSource === 'string' && DID_SOURCE_RE.test(data.didSource))) {
+    errors.push("didSource must be 'request-uri', 'to', 'none' or 'header:<Header-Name>'");
+  }
+  if (data.didCountry !== undefined && data.didCountry !== null && !(typeof data.didCountry === 'string' && /^[A-Za-z]{2}$/.test(data.didCountry))) {
+    errors.push('didCountry must be a two-letter ISO 3166-1 country code');
+  }
+  return errors;
+}

--- a/tests/registration-trunks.test.mjs
+++ b/tests/registration-trunks.test.mjs
@@ -1,0 +1,189 @@
+/**
+ * Schema 62: a phone-registration created with `trunk: true` owns a trunks
+ * row that numbers attach to. The registration is never attached to an agent
+ * itself; its numbers are. Turning a trunk back into a line, or deleting it,
+ * is refused while numbers still sit on it.
+ */
+import {
+  setupRealDatabase,
+  teardownRealDatabase,
+  PhoneNumber,
+  PhoneRegistration,
+  Organisation,
+  Trunk,
+  databaseStarted,
+} from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+describe('Registration trunks', () => {
+  let createEndpoint;
+  let getEndpoint;
+  let updateEndpoint;
+  let deleteEndpoint;
+  let agentDbList;
+  let orgId;
+
+  const mockLogger = { info() {}, error() {}, warn() {}, debug() {}, trace() {}, child: () => mockLogger };
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    await databaseStarted;
+    const collection = await import('../api/paths/phone-endpoints.js');
+    const item = await import('../api/paths/phone-endpoints/{identifier}.js');
+    const agentDb = await import('../api/paths/agent-db/phone-endpoints.js');
+    createEndpoint = collection.default(mockLogger, {}, {}).POST;
+    const handlers = item.default(mockLogger, {}, {});
+    getEndpoint = handlers.GET;
+    updateEndpoint = handlers.PUT;
+    deleteEndpoint = handlers.DELETE;
+    agentDbList = agentDb.default(mockLogger, {}, {}).GET;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 30000);
+
+  beforeEach(async () => {
+    orgId = randomUUID();
+    await Organisation.create({ id: orgId, name: 'Trunk org' });
+  });
+
+  afterEach(async () => {
+    const regs = await PhoneRegistration.findAll({ where: { organisationId: orgId } });
+    const trunkIds = regs.map((r) => r.trunkId).filter(Boolean);
+    await PhoneNumber.destroy({ where: { organisationId: orgId } });
+    await PhoneRegistration.destroy({ where: { organisationId: orgId } });
+    if (trunkIds.length) await Trunk.destroy({ where: { id: trunkIds } });
+    await Trunk.destroy({ where: { id: 'migrated-sbc-trunk' } });
+    await Organisation.destroy({ where: { id: orgId } });
+  });
+
+  const req = (extra = {}) => ({ params: {}, query: {}, body: {}, headers: {}, log: mockLogger, ...extra });
+  const res = (user) => ({
+    locals: { user },
+    _status: null,
+    _body: null,
+    status(code) { this._status = code; return this; },
+    send(body) { this._body = body; this._status = this._status || 200; return this; },
+    json(body) { return this.send(body); },
+    setHeader() { return this; },
+  });
+  const owner = () => ({ role: 'owner', organisationId: orgId });
+  const superUser = () => ({ role: 'superAdmin', organisationId: orgId });
+
+  const create = async (user, body) => {
+    const r = res(user);
+    await createEndpoint(
+      req({ body: { type: 'phone-registration', registrar: 'pbx.example.com', username: `u${Math.random().toString(36).slice(2, 8)}`, password: 'pw', handler: 'pipecat', ...body } }),
+      r,
+    );
+    return r;
+  };
+
+  test('a plain registration owns no trunk', async () => {
+    const r = await create(owner(), {});
+    expect(r._status).toBe(201);
+    expect(r._body.trunkId).toBeNull();
+    const g = res(owner());
+    await getEndpoint(req({ params: { identifier: r._body.id } }), g);
+    expect(g._body.trunk).toBe(false);
+  });
+
+  test('trunk: true creates the trunk, assigns it to the org and copies handler and outbound', async () => {
+    const r = await create(owner(), { trunk: true, outbound: true, didSource: 'header:P-Called-Party-ID', didCountry: 'gb' });
+    expect(r._status).toBe(201);
+    expect(r._body.trunkId).toBe(`reg-${r._body.id}`);
+    const trunk = await Trunk.findByPk(r._body.trunkId);
+    expect(trunk).toMatchObject({ handler: 'pipecat', outbound: true, chargeable: false });
+    expect(trunk.flags).toEqual({ provider: 'registration', registrationId: r._body.id });
+    expect(await trunk.hasOrganisation(orgId)).toBe(true);
+    const g = res(owner());
+    await getEndpoint(req({ params: { identifier: r._body.id } }), g);
+    expect(g._body).toMatchObject({ trunk: true, trunkId: r._body.trunkId, didSource: 'header:P-Called-Party-ID', didCountry: 'GB' });
+  });
+
+  test('numbers attach to the trunk through the ordinary e164-ddi path', async () => {
+    const r = await create(owner(), { trunk: true });
+    const n = res(owner());
+    await createEndpoint(req({ body: { type: 'e164-ddi', number: '+442079460100', trunkId: r._body.trunkId } }), n);
+    expect(n._status).toBe(201);
+    const row = await PhoneNumber.findOne({ where: { number: '442079460100', organisationId: orgId } });
+    expect(row.aplisayId).toBe(r._body.trunkId);
+    expect(row.handler).toBe('pipecat');
+    // The worker's lookup by (number, trunk) finds it.
+    const w = res();
+    await agentDbList(req({ query: { number: '442079460100', trunkId: r._body.trunkId } }), w);
+    expect(w._status).toBe(200);
+    expect(w._body.items[0].trunk.flags.registrationId).toBe(r._body.id);
+  });
+
+  test('naming the trunk needs trunk:create; a super migrating an SBC trunk keeps its id', async () => {
+    const denied = await create(owner(), { trunk: true, trunkId: 'migrated-sbc-trunk' });
+    expect(denied._status).toBe(403);
+    const named = await create(superUser(), { trunk: true, trunkId: 'migrated-sbc-trunk' });
+    expect(named._status).toBe(201);
+    expect(named._body.trunkId).toBe('migrated-sbc-trunk');
+    const again = await create(superUser(), { trunk: true, trunkId: 'migrated-sbc-trunk' });
+    expect(again._status).toBe(409);
+  });
+
+  test('trunkId without trunk: true, and a bad didSource, are rejected', async () => {
+    expect((await create(superUser(), { trunkId: 'x' }))._status).toBe(400);
+    expect((await create(owner(), { didSource: 'nonsense' }))._status).toBe(400);
+    expect((await create(owner(), { didCountry: 'GBR' }))._status).toBe(400);
+  });
+
+  test('a line becomes a trunk on PUT, and a trunk mirrors handler and outbound changes', async () => {
+    const r = await create(owner(), {});
+    const u = res(owner());
+    await updateEndpoint(req({ params: { identifier: r._body.id }, body: { trunk: true } }), u);
+    expect(u._status).toBe(200);
+    const reg = await PhoneRegistration.findByPk(r._body.id);
+    expect(reg.trunkId).toBe(`reg-${r._body.id}`);
+    const u2 = res(owner());
+    await updateEndpoint(req({ params: { identifier: r._body.id }, body: { outbound: true, handler: 'livekit' } }), u2);
+    expect(u2._status).toBe(200);
+    const trunk = await Trunk.findByPk(reg.trunkId);
+    expect(trunk).toMatchObject({ outbound: true, handler: 'livekit' });
+  });
+
+  test('a trunk with numbers cannot become a line or be deleted; an empty one can', async () => {
+    const r = await create(owner(), { trunk: true });
+    const n = res(owner());
+    await createEndpoint(req({ body: { type: 'e164-ddi', number: '+442079460101', trunkId: r._body.trunkId } }), n);
+    expect(n._status).toBe(201);
+
+    const off = res(owner());
+    await updateEndpoint(req({ params: { identifier: r._body.id }, body: { trunk: false } }), off);
+    expect(off._status).toBe(409);
+    const del = res(owner());
+    await deleteEndpoint(req({ params: { identifier: r._body.id } }), del);
+    expect(del._status).toBe(409);
+
+    await PhoneNumber.destroy({ where: { number: '442079460101', organisationId: orgId } });
+    const off2 = res(owner());
+    await updateEndpoint(req({ params: { identifier: r._body.id }, body: { trunk: false } }), off2);
+    expect(off2._status).toBe(200);
+    expect(await Trunk.findByPk(r._body.trunkId)).toBeNull();
+    expect((await PhoneRegistration.findByPk(r._body.id)).trunkId).toBeNull();
+  });
+
+  test('deleting an empty trunk registration removes its trunk row too', async () => {
+    const r = await create(owner(), { trunk: true });
+    const del = res(owner());
+    await deleteEndpoint(req({ params: { identifier: r._body.id } }), del);
+    expect(del._status).toBe(200);
+    expect(await Trunk.findByPk(r._body.trunkId)).toBeNull();
+    const [[joins]] = await Trunk.sequelize.query('SELECT count(*)::int AS n FROM trunk_organisations WHERE trunk_id = $1', { bind: [r._body.trunkId] });
+    expect(joins.n).toBe(0);
+  });
+
+  test('the worker lookup by registration id reports the trunk', async () => {
+    const r = await create(owner(), { trunk: true });
+    const w = res();
+    await agentDbList(req({ query: { id: r._body.id } }), w);
+    expect(w._status).toBe(200);
+    expect(w._body.items[0].trunkId).toBe(r._body.trunkId);
+    expect(w._body.items[0].instanceId ?? null).toBeNull();
+  });
+});


### PR DESCRIPTION
A phone-registration can now be a **registration trunk**: it owns a `trunks` row that numbers attach to through the ordinary `e164-ddi` path, and inbound calls on it resolve by (dialled number, trunk) to each number's agent rather than to one agent attached to the registration.

**Schema 62**
- `phone_registrations.trunk_id` (FK `trunks.id`, SET NULL), `did_source`, `did_country`. `PhoneRegistration.belongsTo(Trunk, as: 'Trunk')` / `Trunk.hasOne(PhoneRegistration, as: 'Registration')`. Plain columns, so the gated `sync({ alter })` carries them. `lib/schemas/phone-registration.ts` mirror updated.

**API**
- `POST /phone-endpoints` (`phone-registration`): `trunk: true` creates, in the same transaction, a trunk `reg-<registration id>` with the registration's handler and outbound, `chargeable: false`, `flags: { provider: 'registration', registrationId }`, assigned to the organisation. `trunkId` names it instead (requires `trunk:create`, 409 if taken, 400 without `trunk: true`). `didSource` (`request-uri` | `to` | `header:<Name>` | `none`) and `didCountry` (ISO 3166-1 alpha-2) validated.
- `GET /phone-endpoints/{id}` and both list projections expose `trunkId`, `trunk`, `didSource`, `didCountry`.
- `PUT`: `trunk: true` turns a line into a trunk (creates the row, clears `instanceId`); `trunk: false` turns it back, refused 409 while numbers sit on it. Handler/outbound changes mirror onto the trunk. `didSource`/`didCountry` updatable.
- `DELETE`: refused 409 while the trunk carries numbers; otherwise the trunk row goes with the registration.
- `GET /agent-db/phone-endpoints?id=` includes `trunkId`.

**Workers**
- LiveKit: a registration lookup that finds no `instanceId` now falls through to the (number, trunk) lookup, as pipecat's ladder already does. New attribute `aplisayCalled` (`sip.h.x-aplisay-called`): when present it is the called number, since a trunk's INVITE reaches LiveKit on the trunk's fixed number.
- Pipecat: `X-Aplisay-Called` wins over the Request-URI / event `to` on the sipbridge, voiceblender and dial-in paths; the FreeSWITCH dialplan sets `aplisay_called` from it (the serializer already read that variable).

**Docs**: `livekit-agent-architecture.md` §6.2 (registration trunks, `X-Aplisay-Called`), `phone-endpoints-api.md`.

**Tests**: `tests/registration-trunks.test.mjs` (9: create/expose, numbers attach and resolve by (number, trunk), naming needs `trunk:create` and keeps the id, validation, PUT toggle and mirroring, refusals while numbers exist, delete removes the trunk row and its org join, agent-db by id). `agents/pipecat/tests/test_inbound_called_header.py`. Full DB suite on a clean volume: 88 suites / 984 tests. LiveKit `tsc` shows only the pre-existing `livekit-model-registry.ts:99` error.

Not in this PR: the B2BUA side (forwarding trunk calls with both headers and the dialled number; source-host correlation for trunk rows) and outbound dialling from a number on a registration trunk.
