### PR TITLE
Probe an unclaimed registration on the least loaded live regclient node

### DIFF
--- a/docs/registration-trace-and-probe-api.md
+++ b/docs/registration-trace-and-probe-api.md
@@ -245,7 +245,7 @@ Both routes answer `503` unless the deployment is configured to reach nodes:
 | `REGCLIENT_API_PORT` | Node API port (default 8443) |
 | `REGCLIENT_CA_CERT` | Public certificate of the private CA that signs node certificates; PEM or base64 of a PEM |
 | `TRACE_PROXY_TIMEOUT_MS` | Hard per-request timeout, default 2000 ms. No retries |
-| `REGCLIENT_PROBE_NODES` | Nodes that may run a probe for a registration no node has claimed |
+| `REGCLIENT_PROBE_NODES` | Optional override: nodes that may run a probe for a registration no node has claimed. Unset by default — the least loaded regclient node that has heartbeated in the last three minutes is chosen from `b2bua_nodes` |
 | `REGCLIENT_NODE_ALLOWLIST` | Optional pin: only these node addresses may be contacted |
 | `REGCLIENT_ALLOW_PRIVATE_NODES` | Permit node addresses in private ranges (compose, kind). Off by default |
 | `REGCLIENT_API_INSECURE` | Development only: skip TLS verification |

--- a/environment-example
+++ b/environment-example
@@ -192,6 +192,8 @@ LIVEKIT_API_SECRET=<LIVEKIT API SECRET>
 # REGCLIENT_CAPABILITY_TTL_MS=600000    # how long "serves traces" is remembered
 # REGCLIENT_UNSUPPORTED_TTL_MS=60000    # how long "does not" is remembered
 # Nodes able to run a probe for a registration no node has claimed yet.
+# Optional override; by default an unclaimed registration is probed on the least loaded
+# regclient node that has heartbeated recently (b2bua_nodes).
 # REGCLIENT_PROBE_NODES=
 # Optional pin: only these node addresses may be contacted at all.
 # REGCLIENT_NODE_ALLOWLIST=

--- a/lib/regclient-facade.js
+++ b/lib/regclient-facade.js
@@ -11,9 +11,12 @@
  * `{ ok: true, registration, node, config }`.
  */
 
+import { Op } from 'sequelize';
 import { PhoneRegistration, B2buaNode } from './database.js';
 import { userOwnsRow } from './scope.js';
 import {
+  pickLeastLoadedNode,
+  HEARTBEAT_FRESH_MS,
   loadRegclientConfig,
   configurationProblem,
   assertNodeAddressAllowed,
@@ -37,7 +40,26 @@ import {
  * refusing its traces because we stopped hearing from it would be exactly
  * backwards: that is when somebody most wants to look.
  */
-const HEARTBEAT_FRESH_MS = 3 * 60 * 1000;
+
+/**
+ * The node to run a probe on for a registration nobody has claimed: the
+ * least loaded regclient node that is heartbeating. Nothing is configured for
+ * this — the registry is the fleet as it is — and a registry that cannot be
+ * read is an empty fleet, not an error.
+ */
+export async function probeNodeFromRegistry({ model = B2buaNode, now = Date.now } = {}) {
+  try {
+    const since = new Date(now() - HEARTBEAT_FRESH_MS);
+    const rows = await model.findAll({
+      where: { type: 'regclient', lastSeenAt: { [Op.gte]: since } },
+      attributes: ['nodeId', 'type', 'registrations', 'systemLoad', 'lastSeenAt'],
+    });
+    return pickLeastLoadedNode(rows.map((r) => (typeof r.get === 'function' ? r.get({ plain: true }) : r)), { now: now() });
+  }
+  catch (err) {
+    return null;
+  }
+}
 
 /**
  * What the node last told us about itself.
@@ -72,9 +94,13 @@ export async function resolveRegistrationNode({
   const { registration, config } = owned;
 
   const claimed = String(registration.b2buaId || '').trim();
-  const node = allowUnclaimed
-    ? selectProbeNode({ registrationId: identifier, claimedNode: claimed, env })
-    : claimed;
+  // A claimed row is probed by its owner. An unclaimed one goes to the
+  // env override when a deployment sets one, else to the least loaded live
+  // regclient node in the heartbeat registry.
+  let node = claimed;
+  if (!node && allowUnclaimed) {
+    node = selectProbeNode({ registrationId: identifier, claimedNode: '', env }) || (await probeNodeFromRegistry());
+  }
 
   if (!node) {
     return {
@@ -82,7 +108,7 @@ export async function resolveRegistrationNode({
       status: 409,
       body: {
         message: allowUnclaimed
-          ? 'Registration is not claimed by a b2bua node and no probe node pool is configured'
+          ? 'Registration is not claimed by a b2bua node and no regclient node has heartbeated recently to probe it'
           : 'Registration has not been claimed by a b2bua node, so no trace exists yet'
       }
     };

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -354,14 +354,47 @@ export function openNodeStream({ url, method = 'GET', config, requestImpl }) {
 }
 
 /**
+ * How long a node's heartbeat is treated as current: about three missed beats.
+ * Shared with the facade's capability check so "alive" means one thing.
+ */
+export const HEARTBEAT_FRESH_MS = 3 * 60 * 1000;
+
+/**
+ * The regclient node to probe an UNCLAIMED registration on, chosen from the
+ * heartbeat registry: the least loaded node that has heartbeated recently,
+ * ties broken by how many registrations it already holds, then by address so
+ * the choice is stable. Only regclient nodes qualify — the FreeSWITCH stack
+ * has no probe API — and a stale row says nothing about a node's health, so
+ * it is skipped rather than trusted.
+ *
+ * Pure: takes the rows, returns an address or null. `probeNodeFromRegistry`
+ * is the reading half.
+ */
+export function pickLeastLoadedNode(nodes, { now = Date.now() } = {}) {
+  const fresh = (nodes || []).filter((n) => {
+    if (!n || n.type !== 'regclient' || !n.nodeId || !n.lastSeenAt) return false;
+    return now - new Date(n.lastSeenAt).getTime() <= HEARTBEAT_FRESH_MS;
+  });
+  if (!fresh.length) return null;
+  const load = (n) => (typeof n.systemLoad === 'number' && Number.isFinite(n.systemLoad) ? n.systemLoad : Number.POSITIVE_INFINITY);
+  fresh.sort((a, b) =>
+    load(a) - load(b) ||
+    (Number(a.registrations) || 0) - (Number(b.registrations) || 0) ||
+    String(a.nodeId).localeCompare(String(b.nodeId)));
+  return String(fresh[0].nodeId);
+}
+
+/**
  * Which node should answer a probe for this registration?
  *
  * A claimed row must be probed by its owner — that node holds the live
  * registration and can therefore reuse its canonical Contact instead of
- * creating a second binding at the PBX. An unclaimed row has no owner, so any
- * node in `REGCLIENT_PROBE_NODES` will do; the choice is made deterministically
- * from the registration id so repeated calls about one row land on one node and
- * its probe ids stay resolvable.
+ * creating a second binding at the PBX. An unclaimed row has no owner, so it
+ * goes to the least loaded live regclient node in the heartbeat registry
+ * (`probeNodeFromRegistry`). `REGCLIENT_PROBE_NODES` remains as an optional
+ * OVERRIDE for deployments whose nodes cannot heartbeat — a compose or kind
+ * cluster with no route back to llm-agent — and, when set, is chosen from
+ * deterministically by registration id.
  */
 export function selectProbeNode({ registrationId, claimedNode, env = process.env }) {
   const claimed = String(claimedNode || '').trim();

--- a/tests/regclient-facade-routes.test.mjs
+++ b/tests/regclient-facade-routes.test.mjs
@@ -12,6 +12,7 @@ import { jest } from '@jest/globals';
  */
 
 const rows = new Map();
+let nodeRows = [];
 
 // The heartbeat registry is deliberately empty here: these tests exercise the
 // discovery path, which is what a node that has never announced itself falls
@@ -21,7 +22,8 @@ jest.unstable_mockModule('../lib/database.js', () => ({
     findByPk: async (id) => rows.get(id) || null
   },
   B2buaNode: {
-    findByPk: async () => null
+    findByPk: async () => null,
+    findAll: async () => nodeRows
   },
   B2BUA_NODE_TYPES: ['regclient', 'freeswitch']
 }));
@@ -397,13 +399,30 @@ describe('POST /phone-endpoints/{identifier}/probe', () => {
     expect(lastRequest.data).toEqual({ registrationId: REG, discover: true, apply: false });
   });
 
-  it('uses the probe node pool when no node has claimed the registration', async () => {
+  it('uses the probe node pool override when one is set and no node has claimed the registration', async () => {
     process.env.REGCLIENT_PROBE_NODES = '198.51.100.7';
     makeReg({ b2buaId: null });
     nextResponse = { status: 200, data: { probeId: 'p-2' } };
     const res = await callProbe();
     expect(res._status).toBe(202);
     expect(lastRequest.url).toBe('https://198.51.100.7:8443/probe');
+  });
+
+  it('otherwise probes an unclaimed registration on the least loaded live regclient node', async () => {
+    delete process.env.REGCLIENT_PROBE_NODES;
+    const fresh = new Date().toISOString();
+    nodeRows = [
+      { nodeId: '198.51.100.8', type: 'regclient', systemLoad: 1.4, registrations: 12, lastSeenAt: fresh },
+      { nodeId: '198.51.100.9', type: 'regclient', systemLoad: 0.3, registrations: 30, lastSeenAt: fresh },
+      { nodeId: '198.51.100.5', type: 'regclient', systemLoad: 0.0, registrations: 0, lastSeenAt: new Date(Date.now() - 20 * 60_000).toISOString() },
+    ];
+    makeReg({ b2buaId: null });
+    nextResponse = { status: 200, data: { probeId: 'p-3' } };
+    const res = await callProbe();
+    nodeRows = [];
+    expect(res._status).toBe(202);
+    expect(res._body.node).toBe('198.51.100.9');
+    expect(lastRequest.url).toBe('https://198.51.100.9:8443/probe');
   });
 
   it('says plainly when the node has no probe API either', async () => {

--- a/tests/regclient-node-api.test.mjs
+++ b/tests/regclient-node-api.test.mjs
@@ -8,6 +8,7 @@ import {
   nodeRequest,
   describeNodeFailure,
   selectProbeNode,
+  pickLeastLoadedNode,
   TRACE_FORMATS,
   TRACE_INDEX_FORMATS,
   wantsDebugTrace
@@ -258,5 +259,39 @@ describe('selectProbeNode', () => {
 
   it('returns null when nothing can run the probe', () => {
     expect(selectProbeNode({ registrationId: 'r1', claimedNode: '', env: {} })).toBeNull();
+  });
+});
+
+describe('pickLeastLoadedNode', () => {
+  const now = Date.parse('2026-09-02T12:00:00Z');
+  const fresh = new Date(now - 60_000).toISOString();
+  const stale = new Date(now - 10 * 60_000).toISOString();
+
+  it('prefers the least loaded live regclient node', () => {
+    expect(pickLeastLoadedNode([
+      { nodeId: '198.51.100.1', type: 'regclient', systemLoad: 0.9, registrations: 3, lastSeenAt: fresh },
+      { nodeId: '198.51.100.2', type: 'regclient', systemLoad: 0.2, registrations: 40, lastSeenAt: fresh },
+    ], { now })).toBe('198.51.100.2');
+  });
+
+  it('breaks a load tie on how many registrations the node already holds, then by address', () => {
+    expect(pickLeastLoadedNode([
+      { nodeId: '198.51.100.9', type: 'regclient', systemLoad: 0.5, registrations: 10, lastSeenAt: fresh },
+      { nodeId: '198.51.100.3', type: 'regclient', systemLoad: 0.5, registrations: 2, lastSeenAt: fresh },
+      { nodeId: '198.51.100.1', type: 'regclient', systemLoad: 0.5, registrations: 2, lastSeenAt: fresh },
+    ], { now })).toBe('198.51.100.1');
+  });
+
+  it('skips stale heartbeats and the FreeSWITCH stack, and treats an unknown load as worst', () => {
+    expect(pickLeastLoadedNode([
+      { nodeId: '198.51.100.1', type: 'regclient', systemLoad: 0.0, registrations: 0, lastSeenAt: stale },
+      { nodeId: '198.51.100.2', type: 'freeswitch', systemLoad: 0.0, registrations: 0, lastSeenAt: fresh },
+      { nodeId: '198.51.100.3', type: 'regclient', systemLoad: null, registrations: 0, lastSeenAt: fresh },
+      { nodeId: '198.51.100.4', type: 'regclient', systemLoad: 2.5, registrations: 0, lastSeenAt: fresh },
+    ], { now })).toBe('198.51.100.4');
+    expect(pickLeastLoadedNode([
+      { nodeId: '198.51.100.1', type: 'regclient', systemLoad: 0.0, registrations: 0, lastSeenAt: stale },
+    ], { now })).toBeNull();
+    expect(pickLeastLoadedNode([], { now })).toBeNull();
   });
 });


### PR DESCRIPTION
A probe for a registration no node has claimed used to need `REGCLIENT_PROBE_NODES`, a hand-maintained list of node addresses. The heartbeat registry already knows which regclient nodes are alive and how loaded they are, so the node is now chosen from there.

- `pickLeastLoadedNode(rows)` (`lib/regclient.js`, pure): among `b2bua_nodes` rows of type `regclient` whose `last_seen_at` is within `HEARTBEAT_FRESH_MS` (three minutes, now shared with the facade's capability check), the lowest `system_load` wins; ties go to the fewest `registrations`, then the lowest address, so the choice is stable. A null load sorts last; a stale row or a FreeSWITCH node never qualifies.
- `probeNodeFromRegistry()` (`lib/regclient-facade.js`) reads the fresh rows and applies it; a registry that cannot be read yields no node rather than an error.
- `resolveRegistrationNode`: a claimed row is still probed by its owner. An unclaimed one goes to the `REGCLIENT_PROBE_NODES` override when a deployment sets one (kept for compose and kind clusters where nodes cannot heartbeat), otherwise to the registry. The 409 when neither yields a node now says a regclient node has to have heartbeated recently.
- Docs and `environment-example` describe the variable as an optional override.

Tests: `pickLeastLoadedNode` cases (load, tie-breaks, stale, wrong stack, unknown load, empty) and a route test that an unclaimed registration is probed on the least loaded live node with no pool configured. Full DB suite on a clean volume: 86 suites / 979 tests.
