### PR TITLE
Carrier reservations for numbers claimed onto chargeable trunks

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1812,6 +1812,15 @@ components:
                 trunkId:
                   type: string
                   description: Trunk identifier for e164-ddi type. The handler and outbound capabilities for the created number are inherited from this trunk; callers cannot request a handler that is incompatible with the trunk.
+                reservationRef:
+                  type: string
+                  format: uuid
+                  description: >-
+                    Required when the trunk is chargeable, unless the caller holds trunk:create.
+                    The id of a reservation minted by POST /number-reservations for this same
+                    number, trunk and organisation; it is consumed by the claim. Missing gives
+                    403 code reservation_required; expired, used or mismatched gives 403 code
+                    reservation_invalid.
             - description: Phone registration endpoint
               type: object
               required:

--- a/api/paths/number-reservations.js
+++ b/api/paths/number-reservations.js
@@ -1,0 +1,128 @@
+import { NumberReservation, Trunk, Organisation, RESERVATION_TTL_MS } from '../../lib/database.js';
+import { requirePermission } from '../../lib/auth/permissions.js';
+import { validateE164, normalizeE164 } from '../../lib/validation.js';
+
+/**
+ * /api/number-reservations — mint the ticket a claim onto a CHARGEABLE trunk
+ * must present.
+ *
+ * Chargeable trunks are the platform's own carrier trunks: every number on
+ * one was bought from a carrier and every minute on it is paid for. The seam
+ * that does that buying holds a key with `phoneEndpoint:reserve`; it reserves
+ * here first, then the organisation's own key claims the number with the
+ * returned id as `reservationRef`. The claim checks the ticket names the same
+ * number, trunk and organisation, has not expired and has not been used, and
+ * consumes it in the same transaction that creates the number. Nothing here
+ * touches the carrier; it records that something which did has said yes.
+ */
+export default function (logger) {
+  const createReservation = async (req, res) => {
+    if (!requirePermission(res, 'phoneEndpoint', 'reserve')) return;
+    const { number, trunkId, organisationId, provider, carrierRef } = req.body || {};
+
+    if (!validateE164(number)) {
+      return res.status(400).send({ error: 'number must be a valid E.164 phone number' });
+    }
+    if (typeof trunkId !== 'string' || !trunkId.trim()) {
+      return res.status(400).send({ error: 'trunkId is required' });
+    }
+    if (typeof organisationId !== 'string' || !/^[0-9a-f-]{36}$/i.test(organisationId)) {
+      return res.status(400).send({ error: 'organisationId must be an organisation id' });
+    }
+    if (carrierRef !== undefined && carrierRef !== null && typeof carrierRef !== 'object') {
+      return res.status(400).send({ error: 'carrierRef must be an object' });
+    }
+
+    try {
+      const trunk = await Trunk.findByPk(trunkId, { attributes: ['id', 'chargeable'] });
+      if (!trunk) {
+        return res.status(400).send({ error: 'Trunk not found' });
+      }
+      if (!trunk.chargeable) {
+        // A reservation only means something where the platform pays; a
+        // customer's own trunk needs no ticket and would never check one.
+        return res.status(400).send({ error: 'Reservations apply only to chargeable trunks' });
+      }
+      const org = await Organisation.findByPk(organisationId, { attributes: ['id'] });
+      if (!org) {
+        return res.status(404).send({ error: 'Organisation not found' });
+      }
+
+      const reservation = await NumberReservation.create({
+        number: normalizeE164(number),
+        trunkId: trunk.id,
+        organisationId: org.id,
+        provider: typeof provider === 'string' && provider.trim() ? provider.trim() : null,
+        carrierRef: carrierRef ?? null,
+        expiresAt: new Date(Date.now() + RESERVATION_TTL_MS),
+        createdBy: res.locals.user?.id ?? null,
+      });
+      return res.status(201).send({
+        id: reservation.id,
+        number: reservation.number,
+        trunkId: reservation.trunkId,
+        organisationId: reservation.organisationId,
+        expiresAt: reservation.expiresAt.toISOString(),
+      });
+    } catch (err) {
+      req.log?.error(err, 'creating number reservation');
+      return res.status(500).send({ error: 'Internal server error' });
+    }
+  };
+
+  createReservation.apiDoc = {
+    summary: 'Reserve a number on a chargeable trunk ahead of the organisation claiming it.',
+    description: `Mints a short-lived reservation that a subsequent
+                  \`POST /phone-endpoints\` (type e164-ddi) onto a **chargeable** trunk must
+                  present as \`reservationRef\`. The reservation is bound to one number, one trunk
+                  and one organisation, expires after a few minutes, and is consumed by the claim
+                  that uses it. Requires \`phoneEndpoint:reserve\`, held by the platform's
+                  number-purchase seam and superAdmin; ordinary organisation roles cannot mint one.`,
+    operationId: 'createNumberReservation',
+    tags: ['Phone Endpoints'],
+    requestBody: {
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            required: ['number', 'trunkId', 'organisationId'],
+            properties: {
+              number: { type: 'string', description: 'E.164 phone number (with or without +)', pattern: '^\\+?[1-9]\\d{6,14}$' },
+              trunkId: { type: 'string', description: 'The chargeable trunk the number will be claimed onto' },
+              organisationId: { type: 'string', format: 'uuid', description: 'The organisation that will claim it' },
+              provider: { type: 'string', nullable: true, description: 'The numbering provider the number was reserved with' },
+              carrierRef: { type: 'object', nullable: true, additionalProperties: true, description: 'Whatever the carrier returned for the allocation; stored verbatim for audit' },
+            },
+          },
+        },
+      },
+    },
+    responses: {
+      201: {
+        description: 'The reservation',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              required: ['id', 'number', 'trunkId', 'organisationId', 'expiresAt'],
+              properties: {
+                id: { type: 'string', format: 'uuid', description: 'Pass as reservationRef when claiming the number' },
+                number: { type: 'string', description: 'Normalised number (without +)' },
+                trunkId: { type: 'string' },
+                organisationId: { type: 'string', format: 'uuid' },
+                expiresAt: { type: 'string', format: 'date-time' },
+              },
+            },
+          },
+        },
+      },
+      default: {
+        description: 'An error occurred',
+        content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } },
+      },
+    },
+  };
+
+  return { POST: createReservation };
+}

--- a/api/paths/phone-endpoints.js
+++ b/api/paths/phone-endpoints.js
@@ -1,4 +1,4 @@
-import { PhoneNumber, PhoneRegistration, Trunk, Organisation, Agent, Instance, Op } from '../../lib/database.js';
+import { PhoneNumber, PhoneRegistration, Trunk, Organisation, Agent, Instance, NumberReservation, Op } from '../../lib/database.js';
 import { getTelephonyHandler, HANDLER_NAMES, TELEPHONY_HANDLER_NAMES } from '../../lib/handlers/index.js';
 import { validateE164, normalizeE164, validateSipUri, validatePhoneRegistration, validateE164Ddi, validateRegistrationTrunkFields } from '../../lib/validation.js';
 import { scopeWhereForOrganisation } from '../../lib/scope.js';
@@ -314,6 +314,39 @@ const createPhoneEndpoint = async (req, res) => {
         });
       }
 
+      // A number on a chargeable trunk is one the platform pays the carrier
+      // for, so a claim must show that the carrier seam agreed to it: a
+      // reservation minted under phoneEndpoint:reserve for this exact number,
+      // trunk and organisation, still live and not yet used. Platform
+      // operators (trunk:create) may claim without one, which is how a
+      // number already routed at the carrier is attached by hand. A
+      // reservation that IS presented is always checked and consumed.
+      let reservation = null;
+      if (trunk.chargeable) {
+        const ref = typeof data.reservationRef === 'string' ? data.reservationRef.trim() : '';
+        if (!ref && !can(res.locals.user, 'trunk', 'create')) {
+          return res.status(403).send({
+            error: 'Claiming a number on a chargeable trunk requires a carrier reservation reference',
+            code: 'reservation_required'
+          });
+        }
+        if (ref) {
+          reservation = /^[0-9a-f-]{36}$/i.test(ref) ? await NumberReservation.findByPk(ref) : null;
+          const matches = reservation
+            && !reservation.consumedAt
+            && reservation.expiresAt > new Date()
+            && reservation.number === normalizedNumber
+            && reservation.trunkId === data.trunkId
+            && reservation.organisationId === (organisationId ?? null);
+          if (!matches) {
+            return res.status(403).send({
+              error: 'The carrier reservation reference is missing, expired, already used, or names a different number, trunk or organisation',
+              code: 'reservation_invalid'
+            });
+          }
+        }
+      }
+
       // Numbers on chargeable trunks (carrier trunks shared into the org, i.e.
       // not owned by it) are capped by Organisation.chargeableNumberLimit
       // (null = unlimited). Count + create share a transaction behind a FOR
@@ -350,7 +383,7 @@ const createPhoneEndpoint = async (req, res) => {
               }
             }
           }
-          return PhoneNumber.create({
+          const created = await PhoneNumber.create({
             number: normalizedNumber,
             // Handler is always derived from the trunk (or defaulted) and cannot be chosen by the caller for DDI endpoints
             handler: trunk.handler || 'livekit',
@@ -359,8 +392,29 @@ const createPhoneEndpoint = async (req, res) => {
             // Internally store the trunk association using the aplisayId foreign key
             aplisayId: data.trunkId
           }, { transaction });
+          if (reservation) {
+            // Consume it here, under the same transaction, with the liveness
+            // conditions repeated in the WHERE: two claims racing on one ticket
+            // both pass the read above, and only one of them updates a row.
+            const [consumed] = await NumberReservation.update(
+              { consumedAt: new Date(), phoneNumberId: created.id },
+              {
+                where: { id: reservation.id, consumedAt: null, expiresAt: { [Op.gt]: new Date() } },
+                transaction,
+              },
+            );
+            if (consumed !== 1) {
+              const err = new Error('The carrier reservation reference has already been used or has expired');
+              err.code = 'reservation_invalid';
+              throw err;
+            }
+          }
+          return created;
         });
       } catch (err) {
+        if (err.code === 'reservation_invalid') {
+          return res.status(403).send({ error: err.message, code: err.code });
+        }
         if (err.code === 'chargeable_number_limit') {
           return res.status(403).send({
             error: err.message,

--- a/docs/phone-endpoints-api.md
+++ b/docs/phone-endpoints-api.md
@@ -122,6 +122,17 @@ Creates a new phone endpoint. Supports E.164 DDI (number on a trunk) and phone-r
   limit returns `403 { "error": "…", "code": "chargeable_number_limit", "limit": n, "used": n }`.
   Numbers on the organisation's own (non-chargeable) trunks are never counted or limited.
   Current allowance is readable at [`GET /api/number-quota`](#get-apinumber-quota).
+- **Carrier reservation** (schema 63): a claim onto a chargeable trunk must also carry
+  `reservationRef`, the id of a reservation minted by
+  [`POST /api/number-reservations`](#post-apinumber-reservations) for the same number, trunk
+  and organisation. Chargeable numbers are ones the platform buys and pays for, so the claim
+  has to show that the seam which does the buying agreed to it. Missing returns
+  `403 { "code": "reservation_required" }`; expired, already used, or naming a different
+  number, trunk or organisation returns `403 { "code": "reservation_invalid" }`. The claim
+  consumes the reservation in its own transaction, so one reservation yields at most one
+  number. Callers holding `trunk:create` (platform operators) may claim without one, which is
+  how a number already routed at the carrier is attached by hand; a reference they do present
+  is still checked. Numbers on the organisation's own trunks never need one.
 - **Response (201)**: `{ "success": true, "number": "1234567890" }` (number without `+`).
 
 **Example:**
@@ -220,6 +231,24 @@ organisation membership.
 - The limit itself is `Organisation.chargeableNumberLimit` (default 3), editable via the
   organisations API under `organisation:setRate` (super admin billing policy — deliberately
   not orgAdmin's `setLimits`).
+
+---
+
+### POST /api/number-reservations
+
+Mint the reservation a claim onto a **chargeable** trunk must present. Requires
+`phoneEndpoint:reserve`, held by the platform's number-purchase seam (`billingService`) and
+super admins; organisation roles cannot mint one.
+
+- **Request body**: `number` (E.164), `trunkId` (must be a chargeable trunk), `organisationId`
+  (the organisation that will claim it), optionally `provider` and `carrierRef` (an object,
+  stored verbatim for audit).
+- **Response (201)**: `{ "id": "<uuid>", "number": "442079460100", "trunkId": "…",
+  "organisationId": "…", "expiresAt": "<ISO 8601>" }`. Pass `id` as `reservationRef` on the
+  claim within the expiry window (15 minutes).
+- A non-chargeable or unknown trunk returns `400`; an unknown organisation `404`.
+- Reservations are never deleted: a consumed one records when it was used and which number
+  row it produced.
 
 ---
 

--- a/lib/auth/permissions.js
+++ b/lib/auth/permissions.js
@@ -31,7 +31,10 @@ export const statements = {
   agentSet: ['create', 'read', 'update', 'delete'],
 
   // Telephony / calls / billing
-  phoneEndpoint: ['claim', 'read', 'update', 'release'],
+  // `reserve` mints a carrier reservation that a claim onto a CHARGEABLE
+  // trunk must present (see api/paths/number-reservations.js). Held by the
+  // seam that actually buys numbers at the carrier, never by an org role.
+  phoneEndpoint: ['claim', 'read', 'update', 'release', 'reserve'],
   trunk: ['read', 'assign', 'create'],
   // `prune` = bulk-delete stored call ARTIFACTS (recordings / transcripts /
   // invocation logs) past a retention horizon — the call rows themselves are
@@ -149,6 +152,7 @@ export const roles = {
       rate: ['read', 'readAll', 'create', 'update', 'delete'],
       tariff: ['read', 'readAll', 'create', 'update', 'delete'],
       trunk: ['read', 'assign', 'create'],
+      phoneEndpoint: [...OWNER_STATEMENTS.phoneEndpoint, 'reserve'],
       system: ['readConfig', 'manage'],
       user: ['create', 'read', 'readAll', 'update', 'delete', 'ban', 'setRole', 'setLimits', 'setPermissions', 'impersonate'],
       organisation: ['create', 'read', 'readAll', 'update', 'delete', 'verify', 'setLimits', 'setRate', 'credit', 'billing', 'setPermissions'],
@@ -186,6 +190,10 @@ export const roles = {
     statements: {
       organisation: ['read', 'readAll', 'setRate', 'credit', 'billing'],
       rate: ['read'],
+      // Number-purchase seam: the client mints a reservation for the number it
+      // has bought at the carrier before the user's own key claims it. Mint
+      // only — no claim, read, update or release of numbers.
+      phoneEndpoint: ['reserve'],
       // Retention seam: the client's billing service applies its own
       // call-artifact retention policies via POST /calls/prune. Artifact
       // deletion only — no call read/listen, no product access.

--- a/lib/database-models/number-reservation.js
+++ b/lib/database-models/number-reservation.js
@@ -1,0 +1,89 @@
+import { Model, DataTypes } from 'sequelize';
+
+/**
+ * A short-lived ticket that says "the platform's carrier seam has agreed this
+ * number may be claimed onto this chargeable trunk by this organisation".
+ *
+ * Numbers on chargeable trunks cost the platform money: the carrier bills for
+ * the allocation and for every minute that lands on it. Until now the only
+ * gate on `POST /phone-endpoints` for such a trunk was the organisation's
+ * number limit, so anything holding an ordinary org key could claim a
+ * carrier number that nobody had bought — a row the platform pays for, or a
+ * number the carrier never routed. A reservation closes that: the seam that
+ * actually talks to the carrier (holding a key with `phoneEndpoint:reserve`)
+ * mints one first, and the claim must present it. The claim consumes the
+ * reservation inside its own transaction, so a ticket is good for exactly one
+ * number, on one trunk, for one organisation, once, and only for a few
+ * minutes.
+ *
+ * `carrierRef` is whatever the carrier gave back for the allocation, kept
+ * verbatim for audit; the platform does not interpret it.
+ */
+class NumberReservation extends Model {}
+
+/** How long a fresh reservation stays claimable. Long enough to cover the carrier round trip, short enough that a stale ticket cannot be replayed later. */
+export const RESERVATION_TTL_MS = 15 * 60 * 1000;
+
+export function initNumberReservation(sequelize, types = DataTypes) {
+  NumberReservation.init({
+    id: {
+      type: types.UUID,
+      defaultValue: types.UUIDV4,
+      primaryKey: true
+    },
+    // Normalised E.164 without the leading +, the same shape as phone_numbers.number.
+    number: {
+      type: types.STRING,
+      allowNull: false
+    },
+    trunkId: {
+      type: types.STRING,
+      allowNull: false
+    },
+    organisationId: {
+      type: types.UUID,
+      allowNull: false
+    },
+    // The numbering provider the seam reserved with, when it says.
+    provider: {
+      type: types.STRING,
+      allowNull: true
+    },
+    carrierRef: {
+      type: types.JSONB,
+      allowNull: true
+    },
+    expiresAt: {
+      type: types.DATE,
+      allowNull: false
+    },
+    // Set, once, by the claim that used it. A consumed or expired reservation
+    // is refused; nothing is ever deleted, so the audit trail stays whole.
+    consumedAt: {
+      type: types.DATE,
+      allowNull: true
+    },
+    phoneNumberId: {
+      type: types.UUID,
+      allowNull: true
+    },
+    createdBy: {
+      type: types.STRING,
+      allowNull: true
+    }
+  }, {
+    sequelize,
+    timestamps: true,
+    underscored: true,
+    modelName: 'NumberReservation',
+    tableName: 'number_reservations',
+    indexes: [
+      { name: 'number_reservations_number_trunk', fields: ['number', 'trunk_id'] },
+      { name: 'number_reservations_organisation', fields: ['organisation_id'] }
+    ]
+  });
+
+  return NumberReservation;
+}
+
+export { NumberReservation };

--- a/lib/database.js
+++ b/lib/database.js
@@ -9,7 +9,9 @@ import { validateToolsCallsMetadataUsage } from './handlers/toolsCalls-metadata-
 import { validatePromptMetadata } from './prompt-metadata-validate.js';
 import { initPhoneRegistration } from './database-models/phone-registration.js';
 import { initB2buaNode } from './database-models/b2bua-node.js';
+import { initNumberReservation } from './database-models/number-reservation.js';
 export { B2BUA_NODE_TYPES } from './database-models/b2bua-node.js';
+export { RESERVATION_TTL_MS } from './database-models/number-reservation.js';
 import { encryptSecret, decryptSecret, credentialsEncryptionEnabled } from './utils/credentials.js';
 import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-limits.js';
 // Import-cycle note: lib/outbound-filter.js is deliberately dependency-free so the
@@ -17,7 +19,10 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 62;  // 62: registration trunks — `phone_registrations.trunk_id` (FK trunks, SET NULL),
+const schemaVersion = 63;  // 63: `number_reservations` — a claim onto a CHARGEABLE trunk must present a
+                           //     reservation minted by a key holding `phoneEndpoint:reserve` (the carrier
+                           //     seam) unless the caller holds `trunk:create`; the claim consumes it.
+                           // 62: registration trunks — `phone_registrations.trunk_id` (FK trunks, SET NULL),
                            //     `did_source`, `did_country`. A registration created with `trunk: true` owns
                            //     a trunks row (`reg-<uuid>` unless a super names it, flags.provider =
                            //     'registration', flags.registrationId) so numbers attach to it through the
@@ -2106,6 +2111,7 @@ Instance.hasOne(PhoneNumber, { foreignKey: 'instanceId', onDelete: 'SET NULL', a
 // Registration-based endpoints (non-DDI)
 const PhoneRegistration = initPhoneRegistration(sequelize, DataTypes);
 const B2buaNode = initB2buaNode(sequelize, DataTypes);
+const NumberReservation = initNumberReservation(sequelize, DataTypes);
 
 
 class User extends Model {
@@ -2858,6 +2864,7 @@ const databaseStarted = sequelize.authenticate()
     .then(() => migratePhoneNumbersIdentity())
     .then(() => PhoneNumber.sync({ alter: true }))
     .then(() => PhoneRegistration.sync({ alter: true }))
+    .then(() => NumberReservation.sync({ alter: true }))
     .then(() => TrunkOrganisation.sync({ alter: true }))
     .then(() => AuthKey.sync({ alter: true }))
     .then(() => {
@@ -2904,6 +2911,19 @@ const databaseStarted = sequelize.authenticate()
       logger.warn(
         { err: err.message },
         'could not ensure b2bua_nodes; node heartbeats will not be recorded and trace routing will discover each node instead',
+      );
+    }
+    // number_reservations likewise: a deployment nobody force-syncs must still
+    // get the table, or every carrier-backed number claim fails closed at the
+    // reservation gate. Loud rather than quiet, but still a table this boot
+    // should create for itself.
+    try {
+      await NumberReservation.sync();
+    }
+    catch (err) {
+      logger.warn(
+        { err: err.message },
+        'could not ensure number_reservations; claims onto chargeable trunks will be refused until it exists',
       );
     }
     // Columns added after first deploy: the unconditional sync above is
@@ -3080,6 +3100,7 @@ export {
   PhoneNumber,
   PhoneRegistration,
   B2buaNode,
+  NumberReservation,
   Call,
   TransactionLog,
   InvocationLog,

--- a/scripts/verify-billing-service.mjs
+++ b/scripts/verify-billing-service.mjs
@@ -56,6 +56,7 @@ const REQUIRED = [
   ['organisation', 'read', "read the org's rate-name timeline"],
   ['organisation', 'readAll', 'reach an org at all — this principal has no org of its own'],
   ['organisation', 'setRate', "write the org's rate-name timeline"],
+  ['phoneEndpoint', 'reserve', 'reserve a bought number before the org claims it (POST /number-reservations)'],
 ];
 
 const client = new pg.Client({

--- a/tests/chargeable-number-limit.test.mjs
+++ b/tests/chargeable-number-limit.test.mjs
@@ -1,4 +1,4 @@
-import { setupRealDatabase, teardownRealDatabase, PhoneNumber, Organisation, Trunk } from './setup/database-test-wrapper.js';
+import { setupRealDatabase, teardownRealDatabase, PhoneNumber, Organisation, Trunk, NumberReservation } from './setup/database-test-wrapper.js';
 import { randomUUID } from 'crypto';
 
 /**
@@ -49,10 +49,20 @@ describe('Chargeable number limit', () => {
   // Distinct E.164 numbers per test run (PhoneNumber PK is the number itself).
   const nextNumber = () => `+44${unique}${String(seq++).padStart(3, '0')}`;
 
+
+  // Claims onto a chargeable trunk must present a reservation minted by the
+  // carrier seam (schema 63); mint one per claim so these tests keep
+  // exercising the limit, not the gate.
+  const reserve = async (number, trunkId, organisationId) =>
+    NumberReservation.create({ number: number.replace(/^\+/, ''), trunkId, organisationId, expiresAt: new Date(Date.now() + 60000) });
+
   const claim = async (trunkId, { user, number } = {}) => {
-    const req = createMockRequest({ body: { type: 'e164-ddi', number: number || nextNumber(), trunkId } });
+    const n = number || nextNumber();
+    const u = user || { role: 'owner', organisationId: orgId };
+    const reservation = trunkId === chargeableTrunkId ? await reserve(n, trunkId, u.organisationId) : null;
+    const req = createMockRequest({ body: { type: 'e164-ddi', number: n, trunkId, ...(reservation ? { reservationRef: reservation.id } : {}) } });
     const res = createMockResponse();
-    res.locals.user = user || { role: 'owner', organisationId: orgId };
+    res.locals.user = u;
     await createPhoneEndpoint(req, res);
     return res;
   };

--- a/tests/chargeable-trunk-global.test.mjs
+++ b/tests/chargeable-trunk-global.test.mjs
@@ -1,4 +1,4 @@
-import { setupRealDatabase, teardownRealDatabase, PhoneNumber, Organisation, Trunk } from './setup/database-test-wrapper.js';
+import { setupRealDatabase, teardownRealDatabase, PhoneNumber, Organisation, Trunk, NumberReservation } from './setup/database-test-wrapper.js';
 import { randomUUID } from 'crypto';
 
 /**
@@ -37,10 +37,20 @@ describe('Chargeable trunks are global (not org-owned)', () => {
 
   const nextNumber = () => `+44${unique}${String(seq++).padStart(3, '0')}`;
 
+
+  // Claims onto a chargeable trunk must present a reservation minted by the
+  // carrier seam (schema 63); mint one per claim so these tests keep
+  // exercising the limit, not the gate.
+  const reserve = async (number, trunkId, organisationId) =>
+    NumberReservation.create({ number: number.replace(/^\+/, ''), trunkId, organisationId, expiresAt: new Date(Date.now() + 60000) });
+
   const claim = async (trunkId, { user, number } = {}) => {
-    const r = req({ body: { type: 'e164-ddi', number: number || nextNumber(), trunkId } });
+    const n = number || nextNumber();
+    const u = user || { role: 'owner', organisationId: orgId };
+    const reservation = trunkId === chargeableTrunkId && u.organisationId ? await reserve(n, trunkId, u.organisationId) : null;
+    const r = req({ body: { type: 'e164-ddi', number: n, trunkId, ...(reservation ? { reservationRef: reservation.id } : {}) } });
     const s = res();
-    s.locals.user = user || { role: 'owner', organisationId: orgId };
+    s.locals.user = u;
     await createPhoneEndpoint(r, s);
     return s;
   };

--- a/tests/number-reservations.test.mjs
+++ b/tests/number-reservations.test.mjs
@@ -1,0 +1,197 @@
+/**
+ * Schema 63: a number claimed onto a CHARGEABLE trunk must present a
+ * reservation minted under phoneEndpoint:reserve for that number, trunk and
+ * organisation. The claim consumes it; a used, expired, mismatched or made-up
+ * reference is refused. Operators holding trunk:create may claim without one.
+ * Numbers on an organisation's own trunk need nothing.
+ */
+import {
+  setupRealDatabase,
+  teardownRealDatabase,
+  PhoneNumber,
+  NumberReservation,
+  Organisation,
+  Trunk,
+  databaseStarted,
+} from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+describe('Number reservations', () => {
+  let createEndpoint;
+  let createReservation;
+  let orgId;
+  let otherOrgId;
+  let carrierId;
+  let ownTrunkId;
+  let seq = 0;
+
+  const mockLogger = { info() {}, error() {}, warn() {}, debug() {}, trace() {}, child: () => mockLogger };
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    await databaseStarted;
+    const collection = await import('../api/paths/phone-endpoints.js');
+    const reservations = await import('../api/paths/number-reservations.js');
+    createEndpoint = collection.default(mockLogger, {}, {}).POST;
+    createReservation = reservations.default(mockLogger).POST;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 30000);
+
+  beforeEach(async () => {
+    orgId = randomUUID();
+    otherOrgId = randomUUID();
+    await Organisation.create({ id: orgId, name: 'Buyer org', chargeableNumberLimit: null });
+    await Organisation.create({ id: otherOrgId, name: 'Other org', chargeableNumberLimit: null });
+    carrierId = `carrier-${orgId.slice(0, 8)}`;
+    await Trunk.create({ id: carrierId, name: 'Carrier', handler: 'livekit', outbound: true, chargeable: true });
+    ownTrunkId = `own-${orgId.slice(0, 8)}`;
+    const own = await Trunk.create({ id: ownTrunkId, name: 'Own', handler: 'livekit', chargeable: false });
+    await own.addOrganisation(orgId);
+  });
+
+  afterEach(async () => {
+    await PhoneNumber.destroy({ where: { aplisayId: [carrierId, ownTrunkId] } });
+    await NumberReservation.destroy({ where: { trunkId: carrierId } });
+    await Trunk.destroy({ where: { id: [carrierId, ownTrunkId] } });
+    await Organisation.destroy({ where: { id: [orgId, otherOrgId] } });
+  });
+
+  const req = (extra = {}) => ({ params: {}, query: {}, body: {}, headers: {}, log: mockLogger, ...extra });
+  const res = (user) => ({
+    locals: { user },
+    _status: null,
+    _body: null,
+    status(code) { this._status = code; return this; },
+    send(body) { this._body = body; this._status = this._status || 200; return this; },
+    json(body) { return this.send(body); },
+  });
+  const owner = (organisationId = orgId) => ({ role: 'owner', organisationId });
+  const seam = () => ({ role: 'billingService', id: 'billing-key' });
+  const superUser = () => ({ role: 'superAdmin' });
+  const nextNumber = () => `+4420795${String(10000 + seq++).slice(1)}`;
+
+  const reserve = async (body, user = seam()) => {
+    const r = res(user);
+    await createReservation(req({ body: { organisationId: orgId, trunkId: carrierId, ...body } }), r);
+    return r;
+  };
+  const claim = async (body, user = owner()) => {
+    const r = res(user);
+    await createEndpoint(req({ body: { type: 'e164-ddi', trunkId: carrierId, ...body } }), r);
+    return r;
+  };
+
+  test('the seam mints a reservation; an organisation role cannot', async () => {
+    const number = nextNumber();
+    const minted = await reserve({ number, provider: 'magrathea', carrierRef: { allocated: number } });
+    expect(minted._status).toBe(201);
+    expect(minted._body).toMatchObject({ number: number.slice(1), trunkId: carrierId, organisationId: orgId });
+    expect(new Date(minted._body.expiresAt).getTime()).toBeGreaterThan(Date.now() + 10 * 60 * 1000);
+    const row = await NumberReservation.findByPk(minted._body.id);
+    expect(row.carrierRef).toEqual({ allocated: number });
+    expect(row.createdBy).toBe('billing-key');
+
+    expect((await reserve({ number: nextNumber() }, owner()))._status).toBe(403);
+    expect((await reserve({ number: nextNumber() }, { role: 'orgAdmin', organisationId: orgId }))._status).toBe(403);
+    expect((await reserve({ number: nextNumber() }, superUser()))._status).toBe(201);
+  });
+
+  test('a reservation needs a chargeable trunk, a real organisation and a valid number', async () => {
+    expect((await reserve({ number: nextNumber(), trunkId: ownTrunkId }))._status).toBe(400);
+    expect((await reserve({ number: nextNumber(), trunkId: 'no-such-trunk' }))._status).toBe(400);
+    expect((await reserve({ number: nextNumber(), organisationId: randomUUID() }))._status).toBe(404);
+    expect((await reserve({ number: 'not-a-number' }))._status).toBe(400);
+    expect((await reserve({ number: nextNumber(), organisationId: 'nope' }))._status).toBe(400);
+  });
+
+  test('a claim onto a chargeable trunk without a reservation is refused; with one it succeeds and consumes it', async () => {
+    const number = nextNumber();
+    const bare = await claim({ number });
+    expect(bare._status).toBe(403);
+    expect(bare._body.code).toBe('reservation_required');
+    expect(await PhoneNumber.count({ where: { aplisayId: carrierId } })).toBe(0);
+
+    const minted = await reserve({ number });
+    const ok = await claim({ number, reservationRef: minted._body.id, outbound: true });
+    expect(ok._status).toBe(201);
+    const created = await PhoneNumber.findOne({ where: { number: number.slice(1), organisationId: orgId } });
+    expect(created.aplisayId).toBe(carrierId);
+    const row = await NumberReservation.findByPk(minted._body.id);
+    expect(row.consumedAt).toBeTruthy();
+    expect(row.phoneNumberId).toBe(created.id);
+
+    // Spent: the same reference cannot claim again (even after the number is released).
+    await PhoneNumber.destroy({ where: { id: created.id } });
+    const again = await claim({ number, reservationRef: minted._body.id });
+    expect(again._status).toBe(403);
+    expect(again._body.code).toBe('reservation_invalid');
+  });
+
+  test('a reservation is bound to its number, trunk and organisation', async () => {
+    const number = nextNumber();
+    const minted = await reserve({ number });
+    const other = nextNumber();
+
+    const wrongNumber = await claim({ number: other, reservationRef: minted._body.id });
+    expect(wrongNumber._status).toBe(403);
+    expect(wrongNumber._body.code).toBe('reservation_invalid');
+
+    const wrongOrg = await claim({ number, reservationRef: minted._body.id }, owner(otherOrgId));
+    expect(wrongOrg._status).toBe(403);
+    expect(wrongOrg._body.code).toBe('reservation_invalid');
+
+    const madeUp = await claim({ number, reservationRef: randomUUID() });
+    expect(madeUp._status).toBe(403);
+    expect(madeUp._body.code).toBe('reservation_invalid');
+
+    const garbage = await claim({ number, reservationRef: 'not-a-uuid' });
+    expect(garbage._status).toBe(403);
+    expect(garbage._body.code).toBe('reservation_invalid');
+
+    // Nothing above spent the ticket; the right claim still works.
+    expect((await claim({ number, reservationRef: minted._body.id }))._status).toBe(201);
+  });
+
+  test('an expired reservation is refused', async () => {
+    const number = nextNumber();
+    const stale = await NumberReservation.create({
+      number: number.slice(1), trunkId: carrierId, organisationId: orgId, expiresAt: new Date(Date.now() - 1000),
+    });
+    const r = await claim({ number, reservationRef: stale.id });
+    expect(r._status).toBe(403);
+    expect(r._body.code).toBe('reservation_invalid');
+  });
+
+  test('two claims racing on one reservation yield exactly one number', async () => {
+    const number = nextNumber();
+    const minted = await reserve({ number });
+    // Different organisations cannot share a ticket, so race the same org on
+    // the same number: the second claim is either the duplicate 409 or the
+    // consumed-ticket 403, never a second row.
+    const results = await Promise.all([
+      claim({ number, reservationRef: minted._body.id }),
+      claim({ number, reservationRef: minted._body.id }),
+    ]);
+    expect(results.filter((r) => r._status === 201)).toHaveLength(1);
+    expect(results.filter((r) => r._status !== 201).every((r) => [403, 409].includes(r._status))).toBe(true);
+    expect(await PhoneNumber.count({ where: { number: number.slice(1) } })).toBe(1);
+  });
+
+  test('operators may claim onto a chargeable trunk without a reservation; a presented one is still checked', async () => {
+    const number = nextNumber();
+    const byHand = await claim({ number }, { role: 'superAdmin', organisationId: orgId });
+    expect(byHand._status).toBe(201);
+
+    const bogus = await claim({ number: nextNumber(), reservationRef: randomUUID() }, { role: 'superAdmin', organisationId: orgId });
+    expect(bogus._status).toBe(403);
+    expect(bogus._body.code).toBe('reservation_invalid');
+  });
+
+  test("a number on the organisation's own trunk needs no reservation", async () => {
+    const r = await claim({ number: nextNumber(), trunkId: ownTrunkId });
+    expect(r._status).toBe(201);
+  });
+});

--- a/tests/phone-numbers-org-scoped.test.mjs
+++ b/tests/phone-numbers-org-scoped.test.mjs
@@ -9,6 +9,7 @@ import {
   setupRealDatabase,
   teardownRealDatabase,
   PhoneNumber,
+  NumberReservation,
   Organisation,
   Trunk,
   databaseStarted,
@@ -80,7 +81,11 @@ describe('Phone numbers are organisation-scoped', () => {
 
   const create = async (organisationId, trunkId) => {
     const r = res(organisationId);
-    await createEndpoint(req({ body: { type: 'e164-ddi', number: `+${NUMBER}`, trunkId } }), r);
+    // The shared carrier trunk is chargeable, so its claims carry a reservation.
+    const reservation = trunkId === carrier.id
+      ? await NumberReservation.create({ number: NUMBER, trunkId, organisationId, expiresAt: new Date(Date.now() + 60000) })
+      : null;
+    await createEndpoint(req({ body: { type: 'e164-ddi', number: `+${NUMBER}`, trunkId, ...(reservation ? { reservationRef: reservation.id } : {}) } }), r);
     return r;
   };
 

--- a/tests/rbac-permissions.test.mjs
+++ b/tests/rbac-permissions.test.mjs
@@ -69,6 +69,13 @@ describe('permissions — roles vocabulary', () => {
     // the cross-tenant capability targetInScope 404s every org it is asked about.
     expect(can({ role: 'billingService' }, 'organisation', 'readAll')).toBe(true);
     expect(targetInScope({ role: 'billingService' }, 'organisation', { id: 'org-1' })).toBe(true);
+    // Number purchases: it reserves the number it bought at the carrier so the
+    // org's own key can claim it, and holds nothing else over numbers.
+    expect(can({ role: 'billingService' }, 'phoneEndpoint', 'reserve')).toBe(true);
+    expect(can({ role: 'billingService' }, 'phoneEndpoint', 'claim')).toBe(false);
+    expect(can({ role: 'owner' }, 'phoneEndpoint', 'reserve')).toBe(false);
+    expect(can({ role: 'orgAdmin' }, 'phoneEndpoint', 'reserve')).toBe(false);
+    expect(can({ role: 'superAdmin' }, 'phoneEndpoint', 'reserve')).toBe(true);
   });
   test('billingService holds no product access and cannot administer rates or users', () => {
     // Still least-privilege: it prices ITS OWN tenants against cards someone

--- a/tests/setup/database-test-wrapper.js
+++ b/tests/setup/database-test-wrapper.js
@@ -73,6 +73,7 @@ export async function setupRealDatabase() {
       User: dbModule.User,
       PhoneNumber: dbModule.PhoneNumber,
       PhoneRegistration: dbModule.PhoneRegistration,
+      NumberReservation: dbModule.NumberReservation,
       Agent: dbModule.Agent,
       AgentSet: dbModule.AgentSet,
       Instance: dbModule.Instance,
@@ -99,6 +100,7 @@ export async function setupRealDatabase() {
   Instance = dbModule.Instance;
   PhoneNumber = dbModule.PhoneNumber;
   PhoneRegistration = dbModule.PhoneRegistration;
+  NumberReservation = dbModule.NumberReservation;
   Call = dbModule.Call;
   TransactionLog = dbModule.TransactionLog;
   InvocationLog = dbModule.InvocationLog;
@@ -135,6 +137,7 @@ export async function teardownRealDatabase() {
     Instance = undefined;
     PhoneNumber = undefined;
     PhoneRegistration = undefined;
+    NumberReservation = undefined;
     Call = undefined;
     TransactionLog = undefined;
     InvocationLog = undefined;
@@ -166,6 +169,6 @@ export function getRealDatabase() {
 
 // Export the same objects as database.js for drop-in replacement
 // These will be populated after setupRealDatabase() is called
-export let Metadata, Agent, AgentSet, Instance, PhoneNumber, PhoneRegistration, Call, TransactionLog, InvocationLog, UsageRecord, RateCard, BalanceCredit, Tariff, TariffPrefix, User, Organisation, AuthKey, Trunk;
+export let Metadata, Agent, AgentSet, Instance, PhoneNumber, PhoneRegistration, NumberReservation, Call, TransactionLog, InvocationLog, UsageRecord, RateCard, BalanceCredit, Tariff, TariffPrefix, User, Organisation, AuthKey, Trunk;
 export let Op, Sequelize;
 export let databaseStarted, stopDatabase;


### PR DESCRIPTION
## What

Numbers on a **chargeable** trunk are ones the platform buys and pays the carrier for, but the only gate on `POST /phone-endpoints` for such a trunk was the organisation's number limit. This adds a carrier reservation the claim must present.

- **Schema 63**: `number_reservations` (id, number, trunk_id, organisation_id, provider, carrier_ref, expires_at, consumed_at, phone_number_id, created_by). Ensured unconditionally at boot as well as in the gated alter chain.
- **New action** `phoneEndpoint:reserve`, granted to `billingService` and `superAdmin` only. `scripts/verify-billing-service.mjs` now requires it, so an existing billing key needs re-minting.
- **`POST /api/number-reservations`** mints a reservation bound to one number, one chargeable trunk and one organisation; 15 minute expiry.
- **`POST /api/phone-endpoints` (e164-ddi) onto a chargeable trunk** requires `reservationRef` unless the caller holds `trunk:create`. The reservation is validated (exists, live, unused, matches number + trunk + org) and consumed inside the create transaction, so a race on one reservation yields one number. A reference presented by an operator is still checked.
  - missing: `403 { code: "reservation_required" }`
  - expired / used / mismatched / malformed: `403 { code: "reservation_invalid" }`
- Numbers on an organisation's own (non-chargeable) trunks are unaffected.

## Tests

New `tests/number-reservations.test.mjs` (mint permissions, validation, required/consumed/bound/expired, race, operator bypass, own-trunk unaffected). Existing chargeable-trunk suites mint a reservation per claim. Full DB suite green on a clean volume: 83 suites, 921 tests.

## Deploy note

Clients that claim numbers onto chargeable trunks must mint a reservation first with a key holding `phoneEndpoint:reserve`; re-mint the billing key before deploying the client change.
