### PR TITLE
fix(sipbridge): G.711 A-law encoder doubled the level for PCMA-only peers

### DIFF
--- a/agents/pipecat/sipbridge/internal/codec/g711.go
+++ b/agents/pipecat/sipbridge/internal/codec/g711.go
@@ -124,53 +124,65 @@ func linearToPCMU(s int16) byte {
 	v += bias
 	// find segment
 	exp := byte(7)
-	for mask := 0x4000; (v & mask) == 0 && exp > 0; mask >>= 1 {
+	for mask := 0x4000; (v&mask) == 0 && exp > 0; mask >>= 1 {
 		exp--
 	}
 	mant := byte((v >> (int(exp) + 3)) & 0x0F)
 	return ^(sign | (exp << 4) | mant)
 }
 
+// -- A-law (ITU-T G.711 §A / RFC 3551 PCMA) -----------------------------
+//
+// A-law codes a 13-bit magnitude (s16 >> 3) in eight segments. Segment 0
+// is linear (mantissa is bits 4..1 of the 13-bit value), segments 1..7 are
+// 4-bit mantissas at successively coarser steps. The sign bit (0x80 after
+// the 0x55 mask) is SET for positive samples — the opposite of mu-law —
+// and every byte is XORed with 0x55 on the wire so runs of silence do not
+// look like an all-zeros/all-ones line. The step tables below are the
+// segment upper bounds of the 13-bit magnitude, as in the reference
+// implementation (Sun Microsystems g711.c, ITU-T G.711 Table 1a).
+var alawSegmentEnd = [8]int{0x1F, 0x3F, 0x7F, 0xFF, 0x1FF, 0x3FF, 0x7FF, 0xFFF}
+
 func alawDecodeByte(b byte) int16 {
 	b ^= 0x55
-	sign := b & 0x80
-	exp := (b >> 4) & 0x07
-	mant := b & 0x0F
-	var sample int16
-	if exp == 0 {
-		sample = int16(int(mant)<<4) + 8
-	} else {
-		sample = int16(((int(mant) << 4) + 0x108) << (exp - 1))
+	t := int(b&0x0F) << 4
+	seg := (b & 0x70) >> 4
+	switch seg {
+	case 0:
+		t += 8
+	case 1:
+		t += 0x108
+	default:
+		t += 0x108
+		t <<= seg - 1
 	}
-	if sign != 0 {
-		sample = -sample
+	if b&0x80 != 0 {
+		return int16(t)
 	}
-	return sample
+	return int16(-t)
 }
 
 func linearToPCMA(s int16) byte {
-	sign := byte(0x55) ^ 0x80
-	v := int(s)
-	if v >= 0 {
-		sign = 0x55
-	} else {
+	// Work on the 13-bit magnitude the codec is defined over.
+	v := int(s) >> 3
+	mask := byte(0xD5) // positive: sign bit set, then the 0x55 line mask
+	if v < 0 {
+		mask = 0x55
 		v = -v - 1
 	}
-	if v > 32635 {
-		v = 32635
+	seg := 0
+	for seg < 8 && v > alawSegmentEnd[seg] {
+		seg++
 	}
-	var exp byte
-	var mant byte
-	if v < 256 {
-		exp = 0
-		mant = byte((v >> 4) & 0x0F)
+	if seg >= 8 {
+		// Beyond the top segment: saturate to the largest code.
+		return 0x7F ^ mask
+	}
+	var mant int
+	if seg < 2 {
+		mant = (v >> 1) & 0x0F
 	} else {
-		exp = 1
-		seg := v
-		for seg >>= 8; seg > 0 && exp < 7; seg >>= 1 {
-			exp++
-		}
-		mant = byte((v >> (int(exp) + 3)) & 0x0F)
+		mant = (v >> seg) & 0x0F
 	}
-	return (exp<<4 | mant) ^ sign
+	return byte(seg<<4|mant) ^ mask
 }

--- a/agents/pipecat/sipbridge/internal/codec/g711_test.go
+++ b/agents/pipecat/sipbridge/internal/codec/g711_test.go
@@ -1,0 +1,160 @@
+package codec
+
+import "testing"
+
+// refAlawExpand is ITU-T G.711 Table 1a written out directly: the decoded
+// 13-bit magnitude for a (segment, mantissa) pair, independent of the
+// lookup-table construction in g711.go.
+func refAlawExpand(code byte) int {
+	c := code ^ 0x55
+	seg := int(c>>4) & 7
+	mant := int(c & 0x0F)
+	var mag int
+	if seg == 0 {
+		mag = 2*mant + 1
+	} else {
+		mag = (32 + 2*mant + 1) << (seg - 1)
+	}
+	if c&0x80 == 0 {
+		mag = -mag
+	}
+	return mag << 3 // back to the s16 scale
+}
+
+// refMulawExpand is G.711 Table 2a (mu-law, bias 33 on the 14-bit scale).
+func refMulawExpand(code byte) int {
+	c := ^code
+	seg := int(c>>4) & 7
+	mant := int(c & 0x0F)
+	mag := ((2*mant + 33) << seg) - 33
+	if c&0x80 != 0 {
+		mag = -mag
+	}
+	return mag << 2 // 14-bit → s16 scale
+}
+
+// G.711 is a truncating quantiser: each code owns a decision interval
+// centred on its expansion, half a segment step either side, and the
+// s16 input is first truncated to the codec's 13-bit (A-law) or 14-bit
+// (mu-law) scale. A correct encoder therefore emits a code whose
+// interval contains the input; picking the "nearest" expansion is NOT
+// the standard and differs at segment boundaries. These return the
+// half-step of a code's segment on the s16 scale, plus the truncation
+// slop, so the tests assert exactly the property the standard defines.
+func alawHalfStep(code byte) int {
+	seg := int((code^0x55)>>4) & 7
+	half := 1 // seg 0 and 1 both step by 2 on the 13-bit scale
+	if seg > 1 {
+		half = 1 << (seg - 1)
+	}
+	return half*8 + 7
+}
+
+func mulawHalfStep(code byte) int {
+	seg := int((^code)>>4) & 7
+	return (1<<seg)*4 + 3
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func TestAlawDecodeMatchesG711Table(t *testing.T) {
+	for c := 0; c < 256; c++ {
+		if got, want := int(alawDecodeByte(byte(c))), refAlawExpand(byte(c)); got != want {
+			t.Fatalf("alaw decode 0x%02x = %d, want %d", c, got, want)
+		}
+	}
+}
+
+func TestMulawDecodeMatchesG711Table(t *testing.T) {
+	for c := 0; c < 256; c++ {
+		if got, want := int(mulawDecodeByte(byte(c))), refMulawExpand(byte(c)); got != want {
+			t.Fatalf("mulaw decode 0x%02x = %d, want %d", c, got, want)
+		}
+	}
+}
+
+// Every s16 input must land inside the decision interval of the code the
+// encoder emits. This is the property the old A-law encoder broke: it
+// picked a segment one too high for everything between 256 and 16383,
+// doubling the level, then fell back to the right one above that.
+func TestAlawEncodeStaysInInterval(t *testing.T) {
+	for s := -32768; s <= 32767; s++ {
+		got := linearToPCMA(int16(s))
+		if got == 0xAA || got == 0x2A {
+			// Full-scale codes own everything beyond their expansion.
+			if abs(s) >= abs(refAlawExpand(got))-alawHalfStep(got) {
+				continue
+			}
+		}
+		if err := abs(refAlawExpand(got) - s); err > alawHalfStep(got) {
+			t.Fatalf("alaw encode %d = 0x%02x (decodes to %d, error %d): input outside the code's interval",
+				s, got, refAlawExpand(got), err)
+		}
+	}
+}
+
+func TestMulawEncodeStaysInInterval(t *testing.T) {
+	for s := -32768; s <= 32767; s++ {
+		got := linearToPCMU(int16(s))
+		if got == 0x00 || got == 0x80 {
+			// Full-scale codes own everything beyond their expansion.
+			if abs(s) >= abs(refMulawExpand(got))-mulawHalfStep(got) {
+				continue
+			}
+		}
+		if err := abs(refMulawExpand(got) - s); err > mulawHalfStep(got) {
+			t.Fatalf("mulaw encode %d = 0x%02x (decodes to %d, error %d): input outside the code's interval",
+				s, got, refMulawExpand(got), err)
+		}
+	}
+}
+
+func TestAlawKnownCodes(t *testing.T) {
+	cases := []struct {
+		in   int16
+		want byte
+	}{
+		{0, 0xD5},      // smallest positive step, line-masked
+		{-8, 0x55},     // smallest negative step
+		{32767, 0xAA},  // positive full scale
+		{-32768, 0x2A}, // negative full scale
+		{1000, 0xFA},   // 13-bit 125: seg 2, mant 15 → decodes to 1008
+	}
+	for _, c := range cases {
+		if got := linearToPCMA(c.in); got != c.want {
+			t.Errorf("alaw encode %d = 0x%02x, want 0x%02x", c.in, got, c.want)
+		}
+	}
+}
+
+// The decoded output must never move the other way from the input: a
+// non-monotonic codec turns loud peaks into sudden drops.
+func TestAlawRoundTripIsMonotonic(t *testing.T) {
+	prev := int(alawDecodeByte(linearToPCMA(-32768)))
+	for s := -32767; s <= 32767; s++ {
+		cur := int(alawDecodeByte(linearToPCMA(int16(s))))
+		if cur < prev {
+			t.Fatalf("alaw round trip not monotonic at %d: %d after %d", s, cur, prev)
+		}
+		prev = cur
+	}
+}
+
+func TestEncodeDecodeSlices(t *testing.T) {
+	in := []int16{0, 300, -300, 1000, -1000, 8000, -8000, 20000, -20000}
+	for i, s := range DecodePCMA(EncodePCMA(in)) {
+		if d := abs(int(s) - int(in[i])); d > abs(int(in[i]))/16+16 {
+			t.Errorf("PCMA round trip %d → %d", in[i], s)
+		}
+	}
+	for i, s := range DecodePCMU(EncodePCMU(in)) {
+		if d := abs(int(s) - int(in[i])); d > abs(int(in[i]))/16+16 {
+			t.Errorf("PCMU round trip %d → %d", in[i], s)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Calls where the far end negotiates **PCMA only** (no PCMU on offer) come out clipped with a noise overlay in the far end's ear, while the agent hears the caller perfectly. Peers that offer PCMU are unaffected because the bridge prefers mu-law whenever it is available.

## Cause

`linearToPCMA` in `agents/pipecat/sipbridge/internal/codec/g711.go` started its segment search one segment too high and then took the mantissa from the wrong bits. Checked against the ITU-T G.711 expansion tables:

| input | correct decode | old encoder decoded to |
|---|---|---|
| 300 | 296 | 816 |
| 1000 | 1008 | 2016 |
| 8000 | 8064 | 16128 |
| 16000 | 16128 | 32256 |
| 20000 | 19968 | 19968 |

Everything between 256 and 16383 encoded about 6 dB hot (nearly 9 dB in the 256 to 511 band) and everything above 16384 dropped back to the correct level, so the transfer curve was non-monotonic. All 65536 input values produced a different byte from the reference. `alawDecodeByte` also had the sign bit inverted, which is inaudible on its own but wrong. The mu-law encoder and decoder are correct. This code has been unchanged since the sipbridge was introduced and had no tests.

## Fix

Both A-law functions rewritten per ITU-T G.711: work on the 13-bit magnitude, choose the segment from the segment-end table, take the mantissa from the segment's bits, sign bit set for positive, 0x55 line mask, saturate to the top code.

## Tests

New `g711_test.go`:

- every one of the 256 codes decodes to the value in the G.711 expansion table, for A-law and mu-law
- every s16 input lands inside the decision interval of the code the encoder emits, for A-law and mu-law, with full-scale saturation handled
- known A-law vectors (0, -8, 1000, full scale both ways)
- the A-law round trip is monotonic across the whole input range
- slice encode/decode round trips

The old encoder fails five of the seven tests; `go test ./...` in the sipbridge module is green with the fix.
