### PR TITLE
Refuse moving a number between organisations while it is attached to an agent

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1865,7 +1865,9 @@ components:
     PhoneEndpointUpdateInput:
       description: |-
         Schema for updating a phone endpoint. All fields are optional.
-        For e164-ddi endpoints, only `outbound`, `handler` and `provisioned` can be updated.
+        For e164-ddi endpoints, only `outbound`, `handler` and `provisioned` can be updated;
+        `organisationId` (with `phoneEndpoint:assign`) moves the number to another organisation
+        or the unallocated pool and is refused with 409 code number_in_use while it is attached to an agent.
         For phone-registration endpoints, `name`, `outbound`, `handler`, `registrar`, `username`, `password`, and `options` can be updated.
         When credentials (registrar, username, password) are updated, the registration state is reset to initial.
       type: object
@@ -1879,6 +1881,21 @@ components:
         provisioned:
           type: boolean
           description: Carrier-side provisioning complete (e164-ddi only; set by the dashboard Buy-number flow)
+        organisationId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            e164-ddi only, requires phoneEndpoint:assign. The organisation to move the number to,
+            or null for the unallocated pool. Refused (409, code number_in_use) while the number is
+            attached to an agent; detach it first. The move is exclusive: no other field is applied.
+        fromOrganisationId:
+          type: string
+          format: uuid
+          nullable: true
+          description: >-
+            With organisationId: which row to move when the number is held by an organisation other
+            than the caller's (null names the pool). Defaults to the caller's own organisation.
         handler:
           type: string
           enum:

--- a/api/paths/phone-endpoints/{identifier}.js
+++ b/api/paths/phone-endpoints/{identifier}.js
@@ -1,9 +1,76 @@
-import { PhoneNumber, PhoneRegistration, Trunk, Op } from '../../../lib/database.js';
+import { PhoneNumber, PhoneRegistration, Trunk, Organisation, Op } from '../../../lib/database.js';
 import { normalizeE164, validateSipUri, isPlausibleSipHost, hasRoutableRegisterProxy, validateRegistrationTrunkFields } from '../../../lib/validation.js';
 import { createRegistrationTrunk } from '../phone-endpoints.js';
 import { TELEPHONY_HANDLER_NAMES } from '../../../lib/handlers/index.js';
 import { userOwnsRow } from '../../../lib/scope.js';
-import { requirePermission } from '../../../lib/auth/permissions.js';
+import { requirePermission, can } from '../../../lib/auth/permissions.js';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Move a number between organisations, or into and out of the unallocated
+ * pool (organisationId null). Platform operators only (phoneEndpoint:assign).
+ *
+ * Refused while the number is attached to an agent: the attachment belongs to
+ * the organisation that made it, and moving the row under it would leave one
+ * organisation's calls answered by another's agent. Detach first, then move.
+ * The source row is the caller's own organisation's (or the pool's) unless
+ * `fromOrganisationId` names another; a number is not unique on its own since
+ * schema 61, so the source has to be said.
+ */
+async function movePhoneNumber(req, res, normalizedNumber) {
+  if (!can(res.locals.user, 'phoneEndpoint', 'assign')) {
+    return res.status(403).send({ error: 'Moving a number between organisations requires phoneEndpoint:assign' });
+  }
+  const { organisationId: to, fromOrganisationId } = req.body;
+  const from = fromOrganisationId === undefined ? (res.locals.user.organisationId ?? null) : fromOrganisationId;
+  if (to !== null && !(typeof to === 'string' && UUID.test(to))) {
+    return res.status(400).send({ error: 'organisationId must be an organisation id, or null for the unallocated pool' });
+  }
+  if (from !== null && !(typeof from === 'string' && UUID.test(from))) {
+    return res.status(400).send({ error: 'fromOrganisationId must be an organisation id, or null for the unallocated pool' });
+  }
+
+  const row = await PhoneNumber.findOne({ where: { number: normalizedNumber, organisationId: from } });
+  if (!row) {
+    return res.status(404).send({ error: 'Phone endpoint not found' });
+  }
+  if (to === from) {
+    return res.send({ success: true, number: row.number, organisationId: to });
+  }
+  if (to && !(await Organisation.findByPk(to, { attributes: ['id'] }))) {
+    return res.status(404).send({ error: 'Organisation not found' });
+  }
+  if (row.instanceId) {
+    return res.status(409).send({
+      error: 'This number is attached to an agent; detach it before moving it to another organisation',
+      code: 'number_in_use',
+    });
+  }
+  if (await PhoneNumber.findOne({ where: { number: normalizedNumber, organisationId: to }, attributes: ['id'] })) {
+    return res.status(409).send({ error: 'The target organisation already holds this number' });
+  }
+  // A customer trunk (non-chargeable) is assigned to organisations; the
+  // number cannot outrun its trunk. Carrier trunks are shared, so no check.
+  if (to && row.aplisayId) {
+    const trunk = await Trunk.findByPk(row.aplisayId);
+    if (trunk && !trunk.chargeable && !(await trunk.hasOrganisation(to))) {
+      return res.status(409).send({ error: "The number's trunk is not assigned to the target organisation" });
+    }
+  }
+  try {
+    await row.update({ organisationId: to });
+  } catch (err) {
+    if (err.code === 'number_in_use') {
+      return res.status(409).send({ error: err.message, code: err.code });
+    }
+    if (err.name === 'SequelizeUniqueConstraintError') {
+      return res.status(409).send({ error: 'The target organisation already holds this number' });
+    }
+    throw err;
+  }
+  return res.send({ success: true, number: row.number, organisationId: to });
+}
 
 /**
  * A DDI addressed by number, as the caller sees it: their organisation's own
@@ -208,6 +275,9 @@ const updatePhoneEndpoint = async (req, res) => {
     // Check if identifier is a phone number (contains digits and possibly +)
     if (identifier.match(/^\+?[0-9]+$/)) {
       const normalizedNumber = normalizeE164(identifier);
+      if (updateData.organisationId !== undefined) {
+        return movePhoneNumber(req, res, normalizedNumber);
+      }
       const phoneNumber = await findOwnOrPoolNumber(normalizedNumber, organisationId);
       
       if (!phoneNumber) {

--- a/docs/phone-endpoints-api.md
+++ b/docs/phone-endpoints-api.md
@@ -202,6 +202,13 @@ Updates an existing phone endpoint.
   dashboard Buy-number flow sets it once the provider has activated the number and pointed it
   at the platform); for phone-registration, `name`, `outbound`, `handler`, `registrar`,
   `username`, `password`, and `options` can be updated. Updating credentials resets registration state.
+- **Moving a number** (`phoneEndpoint:assign`, platform operators): send `organisationId` (the
+  target organisation, or `null` for the unallocated pool), and `fromOrganisationId` when the
+  number is held by an organisation other than the caller's. The move is exclusive of the other
+  fields. It is **refused with `409 { "code": "number_in_use" }` while the number is attached to
+  an agent**: detach it first, then move it. Also `409` when the target already holds the number
+  or the number's customer trunk is not assigned to the target; `404` for an unknown source row
+  or organisation.
 - **Response (200)**: `{ "success": true }`.
 
 ---

--- a/lib/auth/permissions.js
+++ b/lib/auth/permissions.js
@@ -34,7 +34,9 @@ export const statements = {
   // `reserve` mints a carrier reservation that a claim onto a CHARGEABLE
   // trunk must present (see api/paths/number-reservations.js). Held by the
   // seam that actually buys numbers at the carrier, never by an org role.
-  phoneEndpoint: ['claim', 'read', 'update', 'release', 'reserve'],
+  // `assign` moves a number between organisations, or into and out of the
+  // unallocated pool. Platform operators only, like trunk:assign.
+  phoneEndpoint: ['claim', 'read', 'update', 'release', 'reserve', 'assign'],
   trunk: ['read', 'assign', 'create'],
   // `prune` = bulk-delete stored call ARTIFACTS (recordings / transcripts /
   // invocation logs) past a retention horizon — the call rows themselves are
@@ -152,7 +154,7 @@ export const roles = {
       rate: ['read', 'readAll', 'create', 'update', 'delete'],
       tariff: ['read', 'readAll', 'create', 'update', 'delete'],
       trunk: ['read', 'assign', 'create'],
-      phoneEndpoint: [...OWNER_STATEMENTS.phoneEndpoint, 'reserve'],
+      phoneEndpoint: [...OWNER_STATEMENTS.phoneEndpoint, 'reserve', 'assign'],
       system: ['readConfig', 'manage'],
       user: ['create', 'read', 'readAll', 'update', 'delete', 'ban', 'setRole', 'setLimits', 'setPermissions', 'impersonate'],
       organisation: ['create', 'read', 'readAll', 'update', 'delete', 'verify', 'setLimits', 'setRate', 'credit', 'billing', 'setPermissions'],

--- a/lib/database.js
+++ b/lib/database.js
@@ -2098,6 +2098,21 @@ PhoneNumber.init({
       // organisation index alone would let two orgs both hold a number there.
       { name: 'phone_numbers_number_trunk', unique: true, fields: ['number', 'aplisay_id'] },
     ],
+    hooks: {
+      // A number attached to an agent does not change hands. The attachment
+      // was made by the organisation that holds the number, and moving the
+      // row under it would leave one organisation's calls answered by
+      // another's agent. Every path that moves a number goes through an
+      // instance update (bulk updates skip instance hooks by design), so this
+      // is the backstop for the API's own check, not a replacement for it.
+      beforeUpdate(row) {
+        if (row.changed('organisationId') && (row.previous('instanceId') || row.instanceId)) {
+          const err = new Error('A number attached to an agent cannot move between organisations; detach it first');
+          err.code = 'number_in_use';
+          throw err;
+        }
+      },
+    },
   }
 );
 

--- a/tests/phone-number-org-move.test.mjs
+++ b/tests/phone-number-org-move.test.mjs
@@ -1,0 +1,169 @@
+/**
+ * Moving a number between organisations (PUT /phone-endpoints/{number} with
+ * organisationId) is platform administration, and it is refused while the
+ * number is attached to an agent: detach first, then move.
+ */
+import {
+  setupRealDatabase,
+  teardownRealDatabase,
+  PhoneNumber,
+  Organisation,
+  Trunk,
+  User,
+  Agent,
+  Instance,
+  databaseStarted,
+} from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+describe('Moving a number between organisations', () => {
+  let updateEndpoint;
+  let org1;
+  let org2;
+  let carrier;
+  let ownTrunk;
+  let userId;
+  let seq = 0;
+
+  const mockLogger = { info() {}, error() {}, warn() {}, debug() {}, trace() {}, child: () => mockLogger };
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    await databaseStarted;
+    const item = await import('../api/paths/phone-endpoints/{identifier}.js');
+    updateEndpoint = item.default(mockLogger, {}, {}).PUT;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 30000);
+
+  beforeEach(async () => {
+    org1 = randomUUID();
+    org2 = randomUUID();
+    await Organisation.create({ id: org1, name: 'From org' });
+    await Organisation.create({ id: org2, name: 'To org' });
+    carrier = await Trunk.create({ id: `carrier-${org1.slice(0, 8)}`, name: 'Carrier', handler: 'livekit', chargeable: true });
+    ownTrunk = await Trunk.create({ id: `own-${org1.slice(0, 8)}`, name: 'Own', handler: 'livekit', chargeable: false });
+    await ownTrunk.addOrganisation(org1);
+    userId = randomUUID();
+    await User.create({
+      id: userId, name: 'Mover', email: `mover-${userId.slice(0, 8)}@test.example.com`, emailVerified: true,
+      phone: '+10000000000', phoneVerified: true, picture: '', role: 'owner', organisationId: org1,
+    });
+  });
+
+  afterEach(async () => {
+    await PhoneNumber.destroy({ where: { aplisayId: [carrier.id, ownTrunk.id] } });
+    await Instance.destroy({ where: { organisationId: org1 } });
+    await Agent.destroy({ where: { organisationId: org1 } });
+    await User.destroy({ where: { id: userId } });
+    await Trunk.destroy({ where: { id: [carrier.id, ownTrunk.id] } });
+    await Organisation.destroy({ where: { id: [org1, org2] } });
+  });
+
+  const req = (extra = {}) => ({ params: {}, query: {}, body: {}, headers: {}, log: mockLogger, ...extra });
+  const res = (user) => ({
+    locals: { user },
+    _status: null,
+    _body: null,
+    status(code) { this._status = code; return this; },
+    send(body) { this._body = body; this._status = this._status || 200; return this; },
+    json(body) { return this.send(body); },
+  });
+  const superUser = () => ({ role: 'superAdmin' });
+  const nextNumber = () => `4420796${String(10000 + seq++).slice(1)}`;
+
+  const move = async (number, body, user = superUser()) => {
+    const r = res(user);
+    await updateEndpoint(req({ params: { identifier: `+${number}` }, body }), r);
+    return r;
+  };
+
+  const attach = async (row) => {
+    const agent = await Agent.create({
+      name: 'Holder', description: 't', modelName: 'livekit:ultravox/ultravox-v0.7', prompt: 'p',
+      options: {}, functions: {}, keys: [], userId, organisationId: org1,
+    });
+    const instance = await Instance.create({ agentId: agent.id, type: 'livekit', key: 'k', userId, organisationId: org1 });
+    await row.update({ instanceId: instance.id });
+    return instance;
+  };
+
+  test('an operator moves an unattached number to another organisation, and back to the pool', async () => {
+    const number = nextNumber();
+    await PhoneNumber.create({ number, handler: 'livekit', organisationId: org1, aplisayId: carrier.id });
+    const moved = await move(number, { organisationId: org2, fromOrganisationId: org1 });
+    expect(moved._status).toBe(200);
+    expect(moved._body).toMatchObject({ success: true, organisationId: org2 });
+    expect((await PhoneNumber.findOne({ where: { number } })).organisationId).toBe(org2);
+
+    const pooled = await move(number, { organisationId: null, fromOrganisationId: org2 });
+    expect(pooled._status).toBe(200);
+    expect((await PhoneNumber.findOne({ where: { number } })).organisationId).toBeNull();
+
+    // A pool row is the default source for an operator with no organisation.
+    const adopted = await move(number, { organisationId: org1 });
+    expect(adopted._status).toBe(200);
+    expect((await PhoneNumber.findOne({ where: { number } })).organisationId).toBe(org1);
+  });
+
+  test('a number attached to an agent does not move until it is detached', async () => {
+    const number = nextNumber();
+    const row = await PhoneNumber.create({ number, handler: 'livekit', organisationId: org1, aplisayId: carrier.id });
+    await attach(row);
+
+    const refused = await move(number, { organisationId: org2, fromOrganisationId: org1 });
+    expect(refused._status).toBe(409);
+    expect(refused._body.code).toBe('number_in_use');
+    expect((await PhoneNumber.findOne({ where: { number } })).organisationId).toBe(org1);
+
+    await row.update({ instanceId: null });
+    expect((await move(number, { organisationId: org2, fromOrganisationId: org1 }))._status).toBe(200);
+  });
+
+  test('the model refuses the move even when the API is bypassed', async () => {
+    const number = nextNumber();
+    const row = await PhoneNumber.create({ number, handler: 'livekit', organisationId: org1, aplisayId: carrier.id });
+    await attach(row);
+    await expect(row.update({ organisationId: org2 })).rejects.toMatchObject({ code: 'number_in_use' });
+    // Attaching and moving in one write is the same move.
+    const other = await PhoneNumber.create({ number: nextNumber(), handler: 'livekit', organisationId: org1, aplisayId: carrier.id });
+    await expect(other.update({ organisationId: org2, instanceId: row.instanceId })).rejects.toMatchObject({ code: 'number_in_use' });
+    // Changing something else on an attached number is fine. (Reload first:
+    // a rejected update leaves the refused value dirty on the instance.)
+    await row.reload();
+    await expect(row.update({ outbound: true })).resolves.toBeTruthy();
+  });
+
+  test('organisation roles cannot move numbers; the ordinary update path ignores nothing silently', async () => {
+    const number = nextNumber();
+    await PhoneNumber.create({ number, handler: 'livekit', organisationId: org1, aplisayId: carrier.id });
+    const owner = await move(number, { organisationId: org2 }, { role: 'owner', organisationId: org1 });
+    expect(owner._status).toBe(403);
+    const admin = await move(number, { organisationId: org2 }, { role: 'orgAdmin', organisationId: org1 });
+    expect(admin._status).toBe(403);
+    expect((await PhoneNumber.findOne({ where: { number } })).organisationId).toBe(org1);
+  });
+
+  test('the target must exist, must not already hold the number, and must be assigned the number’s customer trunk', async () => {
+    const number = nextNumber();
+    await PhoneNumber.create({ number, handler: 'livekit', organisationId: org1, aplisayId: carrier.id });
+    expect((await move(number, { organisationId: randomUUID(), fromOrganisationId: org1 }))._status).toBe(404);
+    expect((await move(number, { organisationId: 'nope', fromOrganisationId: org1 }))._status).toBe(400);
+    expect((await move(nextNumber(), { organisationId: org2, fromOrganisationId: org1 }))._status).toBe(404);
+
+    await PhoneNumber.create({ number, handler: 'livekit', organisationId: org2, aplisayId: ownTrunk.id });
+    const clash = await move(number, { organisationId: org2, fromOrganisationId: org1 });
+    expect(clash._status).toBe(409);
+    expect(clash._body.code).toBeUndefined();
+
+    const onOwn = nextNumber();
+    await PhoneNumber.create({ number: onOwn, handler: 'livekit', organisationId: org1, aplisayId: ownTrunk.id });
+    const outruns = await move(onOwn, { organisationId: org2, fromOrganisationId: org1 });
+    expect(outruns._status).toBe(409);
+    expect(outruns._body.error).toContain('trunk');
+    await ownTrunk.addOrganisation(org2);
+    expect((await move(onOwn, { organisationId: org2, fromOrganisationId: org1 }))._status).toBe(200);
+  });
+});

--- a/tests/rbac-permissions.test.mjs
+++ b/tests/rbac-permissions.test.mjs
@@ -76,6 +76,10 @@ describe('permissions — roles vocabulary', () => {
     expect(can({ role: 'owner' }, 'phoneEndpoint', 'reserve')).toBe(false);
     expect(can({ role: 'orgAdmin' }, 'phoneEndpoint', 'reserve')).toBe(false);
     expect(can({ role: 'superAdmin' }, 'phoneEndpoint', 'reserve')).toBe(true);
+    // Moving a number between organisations is platform administration.
+    expect(can({ role: 'superAdmin' }, 'phoneEndpoint', 'assign')).toBe(true);
+    expect(can({ role: 'owner' }, 'phoneEndpoint', 'assign')).toBe(false);
+    expect(can({ role: 'billingService' }, 'phoneEndpoint', 'assign')).toBe(false);
   });
   test('billingService holds no product access and cannot administer rates or users', () => {
     // Still least-privilege: it prices ITS OWN tenants against cards someone


### PR DESCRIPTION
## What

A number attached to an agent does not change hands. Moving it under a live attachment would leave one organisation's calls answered by another's agent.

- **`PUT /api/phone-endpoints/{number}`** accepts `organisationId` (target organisation, or `null` for the unallocated pool) and `fromOrganisationId` (the source row when it is not the caller's own; a number is not unique on its own since schema 61). Requires the new **`phoneEndpoint:assign`** action, held by `superAdmin` only. The move is exclusive of the other update fields.
- **Refused with `409 { code: "number_in_use" }`** while the number's `instanceId` is set. Detach first, then move.
- Also `409` when the target already holds the number or the number's customer (non-chargeable) trunk is not assigned to the target; `404` for an unknown source row or organisation.
- **Model backstop**: a `PhoneNumber` `beforeUpdate` hook refuses an `organisationId` change on an instance whose `instanceId` is set (bulk updates skip instance hooks by design; the API check is the primary gate).
- No schema change.

## Tests

New `tests/phone-number-org-move.test.mjs`: move org to org and to and from the pool, refused while attached then allowed once detached, model backstop with the API bypassed, organisation roles get 403, target validation and trunk-assignment rule. RBAC test extended for `assign`.
