### PR TITLE
Auxiliary "second opinion" STT: options.stt.aux → user-aux transcripts + stt-aux billing

### DIFF
--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -158,6 +158,17 @@ export interface Agent {
        * e.g. `deepgram/nova-3:en` (defaults to language derived from `stt.language`).
        */
       vendor?: string;
+      /**
+       * Auxiliary ("second opinion") STT: a second engine run over the caller's
+       * audio alongside the agent's own recognition, logged as `user-aux` and
+       * metered as `stt-aux`. Same shape as `stt`; `enabled: false` switches it
+       * off without removing the block. See lib/aux-stt.ts.
+       */
+      aux?: {
+        enabled?: boolean;
+        language?: string;
+        vendor?: string;
+      };
     };
     tts?: {
     

--- a/agents/livekit/lib/aux-stt.ts
+++ b/agents/livekit/lib/aux-stt.ts
@@ -1,0 +1,355 @@
+/**
+ * Auxiliary ("second opinion") speech recognition — `options.stt.aux`.
+ *
+ * Runs a second, independent STT engine over the caller's audio alongside the
+ * agent's own recognition (the pipeline STT, or a realtime model's built-in
+ * transcription) and logs each final transcript it produces as a `user-aux`
+ * transaction-log entry next to the primary `user` entry, so two recognitions
+ * of the same speech can be compared. The auxiliary engine never feeds the
+ * model — it is observation only.
+ *
+ * Mechanism: the worker already holds its own rtc-node connection to the room,
+ * so this opens one extra {@link AudioStream} on the caller participant's audio
+ * track — the technique bridge-transcription.ts uses for the bridged humans —
+ * and pumps it into a fresh STT stream. The AgentSession and this stream consume
+ * the same track independently; the session is untouched. STT vendor selection
+ * reuses the pipeline resolution with `options.stt.aux` standing in for
+ * `options.stt` (`inference.STT.fromModelString(resolvePipelineStt(...))`, or
+ * the direct Deepgram plugin under LIVEKIT_PIPELINE_USE_PROVIDER_KEYS), so the
+ * same vendor strings mean the same thing in both places.
+ *
+ * Metering: the audio streamed to the auxiliary engine is measured here in the
+ * pump (milliseconds, silence included — the basis streaming STT vendors bill
+ * on) and final transcripts are counted in characters. Both are reported through
+ * `onUsage` and land as `stt-aux` usage rows attributed to the agent call — its
+ * own technology, so the second engine's consumption is never merged with, or
+ * gated like, the primary `stt` meter (realtime models bundle their own
+ * recognition into the model charge; the auxiliary engine is a real extra cost).
+ *
+ * Everything here is best-effort: an auxiliary STT failure must never disturb
+ * the call. The stream self-disposes when the caller leaves or the room
+ * disconnects; the runtime disposes it on teardown, on a full agent handover
+ * (re-arming for the incoming agent's own configuration) and when the agent's
+ * media is detached after a bridged transfer.
+ */
+
+import { inference, stt } from "@livekit/agents";
+import { AudioStream, RoomEvent } from "@livekit/rtc-node";
+import type { AudioFrame, RemoteParticipant, Room, Track } from "@livekit/rtc-node";
+import logger from "./logger.js";
+import type { Agent } from "./api-client.js";
+import { resolvePipelineStt } from "./pipeline-inference-options.js";
+import {
+  buildProviderPipelineStt,
+  pipelineUsesProviderApiKeys,
+} from "./pipeline-provider-keys.js";
+import { fromServiceString, type VendorDetail } from "./usage-vendors.js";
+import { waitForAudioTrack, waitForRemoteParticipant } from "./bridge-transcription.js";
+
+/** Ledger technology for auxiliary-STT usage rows (distinct from the primary `stt`). */
+export const AUX_STT_TECHNOLOGY = "stt-aux";
+/** Transaction-log type for auxiliary transcripts (next to the primary `user`). */
+export const AUX_STT_LOG_TYPE = "user-aux";
+/** Sample rate the caller track is decoded at for the auxiliary stream. */
+const AUX_STT_SAMPLE_RATE = 16000;
+/** Report streamed-audio usage to the meter at least this often (ms of audio). */
+const AUDIO_USAGE_REPORT_INTERVAL_MS = 10_000;
+
+/** Normalised `options.stt.aux`: the same fields as `options.stt`. */
+export interface AuxSttConfig {
+  vendor?: string;
+  language?: string;
+}
+
+/**
+ * Normalise `options.stt.aux` to null (off) or `{vendor?, language?}`.
+ * Lenient — the server validated the shape at save time. Absent / `false` /
+ * `enabled: false` / malformed → off; `true` or `{}` → platform defaults.
+ */
+export function parseAuxSttOption(options: any): AuxSttConfig | null {
+  const raw = options?.stt?.aux;
+  if (raw === undefined || raw === null || raw === false) return null;
+  if (raw === true) return {};
+  if (typeof raw !== "object" || Array.isArray(raw) || raw.enabled === false) {
+    return null;
+  }
+  const vendor =
+    typeof raw.vendor === "string" && raw.vendor.trim() ? raw.vendor.trim() : undefined;
+  const language =
+    typeof raw.language === "string" && raw.language.trim()
+      ? raw.language.trim()
+      : undefined;
+  return { ...(vendor ? { vendor } : {}), ...(language ? { language } : {}) };
+}
+
+/**
+ * The agent with `options.stt.aux` standing in for `options.stt`, so the
+ * pipeline STT resolvers build the auxiliary engine exactly as they would the
+ * primary one. Language falls back to the agent's own `stt.language`, then
+ * `tts.language` (the platform's declare-once convention); the nested `aux`
+ * block itself is dropped.
+ */
+export function auxSttAgent(agent: Agent, config: AuxSttConfig): Agent {
+  const options: any = agent?.options || {};
+  const inherited =
+    (typeof options.stt?.language === "string" && options.stt.language.trim()) ||
+    (typeof options.tts?.language === "string" && options.tts.language.trim()) ||
+    undefined;
+  const language = config.language ?? inherited;
+  const sttBlock: Record<string, string> = {};
+  if (config.vendor) sttBlock.vendor = config.vendor;
+  if (language) sttBlock.language = language;
+  return { ...agent, options: { ...options, stt: sttBlock } } as Agent;
+}
+
+/** Canonical billing `{vendor, detail}` for the auxiliary engine. */
+export function resolveAuxSttVendor(agent: Agent, config: AuxSttConfig): VendorDetail {
+  try {
+    return fromServiceString(resolvePipelineStt(auxSttAgent(agent, config)));
+  } catch {
+    const vendor = config.vendor?.split("/")[0]?.split(":")[0]?.trim().toLowerCase();
+    return vendor ? { vendor } : {};
+  }
+}
+
+/**
+ * A fresh STT instance for the auxiliary engine — the pipeline's own
+ * resolution applied to `options.stt.aux`: LiveKit Inference by default, or
+ * the direct Deepgram plugin under LIVEKIT_PIPELINE_USE_PROVIDER_KEYS.
+ */
+export function buildAuxStt(agent: Agent, config: AuxSttConfig): stt.STT {
+  const effective = auxSttAgent(agent, config);
+  if (pipelineUsesProviderApiKeys()) {
+    return buildProviderPipelineStt(effective);
+  }
+  return inference.STT.fromModelString(resolvePipelineStt(effective));
+}
+
+/** Live auxiliary transcription: usage so far + teardown. */
+export interface AuxSttHandle {
+  /** Stop the audio pump and STT stream, reporting any unreported usage. Idempotent. */
+  dispose(): void;
+  /** Audio milliseconds streamed to the engine and characters it returned. */
+  readonly usage: { milliseconds: number; characters: number };
+}
+
+/** Anything the pump can iterate for caller audio (the rtc-node AudioStream, or a test fake). */
+export type AuxAudioSource = (AsyncIterable<AudioFrame> | { getReader(): any }) & {
+  cancel?: () => Promise<unknown>;
+};
+
+export interface ArmAuxSttParams {
+  /** The worker's connected RTC room (ctx.room). */
+  room: Room;
+  /** Server-side room name, for logging. */
+  roomName: string;
+  /** Identity of the caller participant whose audio is transcribed. */
+  callerIdentity: string;
+  /** The agent whose `options.stt.aux` (and language defaults) apply. */
+  agent: Agent;
+  config: AuxSttConfig;
+  /** A final transcript from the auxiliary engine, with the time it arrived. */
+  onTranscript: (text: string, at: Date) => void;
+  /** A usage delta for the aux meter. */
+  onUsage: (unit: "milliseconds" | "characters", quantity: number) => void;
+  /** Injection points (tests): engine construction, track resolution, audio source. */
+  deps?: {
+    buildStt?: (agent: Agent, config: AuxSttConfig) => stt.STT;
+    resolveTrack?: (room: Room, identity: string) => Promise<Track>;
+    openAudioStream?: (track: Track) => AuxAudioSource;
+  };
+}
+
+async function defaultResolveTrack(room: Room, identity: string): Promise<Track> {
+  const participant = await waitForRemoteParticipant(room, identity);
+  return waitForAudioTrack(room, participant);
+}
+
+function defaultOpenAudioStream(track: Track): AuxAudioSource {
+  return new AudioStream(track, {
+    sampleRate: AUX_STT_SAMPLE_RATE,
+    numChannels: 1,
+  }) as unknown as AuxAudioSource;
+}
+
+/** Iterate an audio source whether it is a web ReadableStream or a plain async iterable. */
+async function* frames(source: AuxAudioSource): AsyncGenerator<AudioFrame> {
+  if (typeof (source as any)[Symbol.asyncIterator] === "function") {
+    for await (const frame of source as AsyncIterable<AudioFrame>) yield frame;
+    return;
+  }
+  const reader = (source as { getReader(): any }).getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      yield value as AudioFrame;
+    }
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      /* already released */
+    }
+  }
+}
+
+/**
+ * Arm the auxiliary STT on the caller's audio track. Resolves the participant
+ * and track (waiting for them if needed), builds the engine, then pumps the
+ * decoded audio into its stream while forwarding final transcripts and usage.
+ * Never throws — transcription is best-effort.
+ */
+export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
+  const { room, roomName, callerIdentity, agent, config, onTranscript, onUsage } = params;
+  const buildStt = params.deps?.buildStt ?? buildAuxStt;
+  const resolveTrack = params.deps?.resolveTrack ?? defaultResolveTrack;
+  const openAudioStream = params.deps?.openAudioStream ?? defaultOpenAudioStream;
+
+  const usage = { milliseconds: 0, characters: 0 };
+  let reportedMs = 0;
+  let disposed = false;
+  const cleanups: Array<() => void> = [];
+
+  /** Report streamed audio not yet reported (whole milliseconds, no drift). */
+  const reportAudio = (): void => {
+    const delta = Math.floor(usage.milliseconds) - reportedMs;
+    if (delta <= 0) return;
+    reportedMs += delta;
+    try {
+      onUsage("milliseconds", delta);
+    } catch (e) {
+      logger.debug({ e, roomName }, "auxStt: usage report failed");
+    }
+  };
+
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    room.off(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
+    room.off(RoomEvent.Disconnected, onRoomDisconnected);
+    for (const fn of cleanups.splice(0)) {
+      try {
+        fn();
+      } catch (e) {
+        logger.debug({ e, roomName }, "auxStt: cleanup step failed");
+      }
+    }
+    reportAudio();
+    logger.info(
+      { roomName, callerIdentity, ...usage },
+      "auxStt: auxiliary transcription disposed",
+    );
+  };
+
+  const onParticipantDisconnected = (p: RemoteParticipant): void => {
+    const identity = p?.identity ?? (p as any)?.info?.identity;
+    if (identity === callerIdentity) dispose();
+  };
+  const onRoomDisconnected = (): void => {
+    dispose();
+  };
+  room.on(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
+  room.on(RoomEvent.Disconnected, onRoomDisconnected);
+
+  const run = async (): Promise<void> => {
+    try {
+      const track = await resolveTrack(room, callerIdentity);
+      if (disposed) return;
+
+      const sttInstance = buildStt(agent, config);
+      const sttStream = sttInstance.stream();
+      const audio = openAudioStream(track);
+      const stop = () => {
+        try {
+          sttStream.endInput();
+        } catch {
+          /* already ended */
+        }
+        try {
+          sttStream.close();
+        } catch {
+          /* already closed */
+        }
+        void sttInstance.close().catch(() => {});
+        void audio.cancel?.().catch?.(() => {});
+      };
+      cleanups.push(stop);
+      if (disposed) {
+        // dispose() ran between the awaits above and the push — unwind now.
+        stop();
+        return;
+      }
+
+      // Pump the caller's audio into the engine ourselves (rather than handing
+      // the stream over) so the audio actually streamed is what gets metered.
+      const pump = (async (): Promise<void> => {
+        try {
+          for await (const frame of frames(audio)) {
+            if (disposed) break;
+            const rate = frame.sampleRate || AUX_STT_SAMPLE_RATE;
+            usage.milliseconds += (frame.samplesPerChannel / rate) * 1000;
+            try {
+              sttStream.pushFrame(frame);
+            } catch {
+              break; // input ended underneath us (dispose / stream closed)
+            }
+            if (usage.milliseconds - reportedMs >= AUDIO_USAGE_REPORT_INTERVAL_MS) {
+              reportAudio();
+            }
+          }
+        } catch (e) {
+          if (!disposed) {
+            logger.warn({ e, roomName, callerIdentity }, "auxStt: audio pump failed");
+          }
+        } finally {
+          try {
+            sttStream.endInput();
+          } catch {
+            /* already ended */
+          }
+        }
+      })();
+
+      logger.info(
+        { roomName, callerIdentity, label: sttInstance.label, config },
+        "auxStt: auxiliary transcription armed on the caller track",
+      );
+
+      for await (const ev of sttStream) {
+        if (disposed) break;
+        if (ev.type !== stt.SpeechEventType.FINAL_TRANSCRIPT) continue;
+        const text = (ev.alternatives?.[0]?.text ?? "").trim();
+        if (!text) continue;
+        usage.characters += text.length;
+        try {
+          onUsage("characters", text.length);
+        } catch (e) {
+          logger.debug({ e, roomName }, "auxStt: usage report failed");
+        }
+        try {
+          onTranscript(text, new Date());
+        } catch (e) {
+          logger.warn({ e, roomName, callerIdentity }, "auxStt: transcript handler failed");
+        }
+      }
+      await pump.catch(() => {});
+    } catch (e) {
+      // Best-effort: the call carries on without the second opinion.
+      if (!disposed) {
+        logger.warn(
+          { e, roomName, callerIdentity },
+          "auxStt: auxiliary transcription failed (continuing without it)",
+        );
+      }
+    }
+  };
+  void run();
+
+  return {
+    dispose,
+    get usage() {
+      return usage;
+    },
+  };
+}

--- a/agents/livekit/lib/bridge-transcription.ts
+++ b/agents/livekit/lib/bridge-transcription.ts
@@ -204,7 +204,7 @@ function findRemoteParticipant(
 }
 
 /** Resolve a room participant by identity, waiting for it to join if needed. */
-function waitForRemoteParticipant(
+export function waitForRemoteParticipant(
   room: Room,
   identity: string,
   timeoutMs: number = TRACK_WAIT_TIMEOUT_MS,
@@ -253,7 +253,7 @@ function subscribedAudioTrack(
  * normally arrive subscribed; ask explicitly (setSubscribed) and wait on
  * RoomEvent.TrackSubscribed otherwise.
  */
-function waitForAudioTrack(
+export function waitForAudioTrack(
   room: Room,
   participant: RemoteParticipant,
   timeoutMs: number = TRACK_WAIT_TIMEOUT_MS,

--- a/agents/livekit/lib/bridged-transfer-to-agent.ts
+++ b/agents/livekit/lib/bridged-transfer-to-agent.ts
@@ -212,6 +212,15 @@ export interface BridgedTakeoverRuntime {
     /** Invoked once the continuation slot is reserved — drops the bridge. */
     onReserved: () => Promise<void>;
   }): Promise<void>;
+  /**
+   * Invoked when the primary agent's media is detached after a bridged
+   * transfer (the humans now talk directly). Anything the runtime was running
+   * over the caller's audio alongside the agent — the auxiliary STT
+   * (options.stt.aux) — stops here: there is no agent transcript left to
+   * second-guess, and the bridged segment has its own transcription option.
+   * A takeover that restarts an agent stack re-arms what it needs.
+   */
+  onPrimaryAgentDetached?(): void;
 }
 
 /**

--- a/agents/livekit/lib/transfer-handler.ts
+++ b/agents/livekit/lib/transfer-handler.ts
@@ -2223,6 +2223,15 @@ export async function handleTransfer(
   // Helper to finalize bridged call
   const finaliseBridgedCallFn = async (): Promise<Call | null> => {
     const session = sessionRef(null);
+    // The agent is leaving the conversation: let the runtime stop what it runs
+    // over the caller's audio alongside the agent (the auxiliary STT), so the
+    // human↔human segment is not transcribed onto the agent call —
+    // bridgedTransferTranscribe covers that segment on its own record.
+    try {
+      context.getBridgedTakeover?.()?.onPrimaryAgentDetached?.();
+    } catch (e) {
+      logger.debug({ e }, "onPrimaryAgentDetached hook failed");
+    }
     return finaliseBridgedCall(
       call,
       instance,

--- a/agents/livekit/lib/usage-vendors.ts
+++ b/agents/livekit/lib/usage-vendors.ts
@@ -27,7 +27,7 @@ export interface UsageVendors {
 }
 
 /** Split a "vendor/model:suffix" service string into {vendor, detail="vendor/model"}. */
-function fromServiceString(s: string | undefined): VendorDetail {
+export function fromServiceString(s: string | undefined): VendorDetail {
   if (!s) return {};
   const head = s.split(":")[0]!; // strip any :lang / :voice suffix
   const vendor = head.split("/")[0]!.trim().toLowerCase() || undefined;

--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -27,7 +27,15 @@ import {
   INACTIVITY_PROMPT_COUNT,
 } from "./voice-session-factory.js";
 import { resolveUsageVendors } from "./usage-vendors.js";
-import type { UsageVendors } from "./usage-vendors.js";
+import type { UsageVendors, VendorDetail } from "./usage-vendors.js";
+import {
+  armAuxStt,
+  parseAuxSttOption,
+  resolveAuxSttVendor,
+  AUX_STT_LOG_TYPE,
+  AUX_STT_TECHNOLOGY,
+  type AuxSttHandle,
+} from "./aux-stt.js";
 import type { BridgedTakeoverRuntime } from "./bridged-transfer-to-agent.js";
 
 export async function runAgentWorker({
@@ -236,6 +244,13 @@ export async function runAgentWorker({
   );
 
   let session: voice.AgentSession | null = null;
+  /**
+   * Auxiliary ("second opinion") STT over the caller's track (options.stt.aux).
+   * Independent of the AgentSession: armed once the session is up, re-armed
+   * with the incoming agent's configuration on a full handover, stopped when
+   * the agent's media is detached after a bridged transfer and on teardown.
+   */
+  let auxStt: AuxSttHandle | null = null;
   /** Recording + invocation logs must stay on the inbound agent call, not the bridged child call. */
   const primaryRecordingCallId = call.id;
   let maxDuration: number = 305000; // Default value
@@ -540,6 +555,21 @@ export async function runAgentWorker({
     meter.units[unit] = (meter.units[unit] || 0) + quantity;
     usageMeters.set(key, meter);
   };
+  // Auxiliary STT (options.stt.aux) meters: its own technology (`stt-aux`), so
+  // the second engine's consumption is priced by its own rate lines and is
+  // neither merged with nor gated like the primary `stt` meter above — a
+  // realtime model bundles its own recognition into the model charge, but the
+  // auxiliary engine is a real, separate cost on every voice mode.
+  const addAuxMeter = (vendor: VendorDetail, unit: string, quantity: number): void => {
+    if (!quantity || quantity <= 0) return;
+    const detail = vendor.detail || vendor.vendor || "aux";
+    const key = `${AUX_STT_TECHNOLOGY}|${detail}`;
+    const meter =
+      usageMeters.get(key) ||
+      { technology: AUX_STT_TECHNOLOGY, provider: vendor.vendor, detail, units: {} };
+    meter.units[unit] = (meter.units[unit] || 0) + quantity;
+    usageMeters.set(key, meter);
+  };
   const onMetrics = (m: any): void => {
     try {
       switch (m?.type) {
@@ -616,6 +646,49 @@ export async function runAgentWorker({
     } catch (e) {
       logger.warn({ e }, "failed to flush usage to ledger");
     }
+  };
+
+  /**
+   * (Re)arm the auxiliary STT for `agentDef` on the caller's track: dispose any
+   * running instance (reporting its usage), then start one if the agent asks
+   * for it. Final transcripts are logged as `user-aux` through the same
+   * sendMessage path as the primary `user` entries (so they follow the active
+   * call record and the streamLog/batch convention), and are suppressed while
+   * a consultation has the caller on hold, exactly like the primary transcript.
+   */
+  const armAuxSttFor = (agentDef: Agent): void => {
+    if (auxStt) {
+      auxStt.dispose();
+      auxStt = null;
+    }
+    const config = parseAuxSttOption(agentDef?.options);
+    if (!config) return;
+    const callerIdentity = participant?.identity;
+    if (!callerIdentity || !ctx.room) {
+      logger.warn(
+        { callId: call.id, hasParticipant: Boolean(participant), hasRoom: Boolean(ctx.room) },
+        "auxStt: options.stt.aux set but no caller participant/room to tap; skipping",
+      );
+      return;
+    }
+    const vendor = resolveAuxSttVendor(agentDef, config);
+    auxStt = armAuxStt({
+      room: ctx.room,
+      roomName: room.name,
+      callerIdentity,
+      agent: agentDef,
+      config,
+      onTranscript: (text, at) => {
+        if (getConsultInProgress()) return;
+        sendMessage({ [AUX_STT_LOG_TYPE]: text }, at);
+      },
+      onUsage: (unit, quantity) => addAuxMeter(vendor, unit, quantity),
+    });
+  };
+  const disposeAuxStt = (): void => {
+    if (!auxStt) return;
+    auxStt.dispose();
+    auxStt = null;
   };
 
   const cleanupAndClose = async (
@@ -695,6 +768,10 @@ export async function runAgentWorker({
         }
       }
 
+
+      // Stop the auxiliary STT first so its final audio/character counts are
+      // in the meters the flush below writes.
+      disposeAuxStt();
 
       // Flush accumulated usage (tokens / characters / audio) to the ledger
       // before ending the call so it lands as the finalised session total.
@@ -1219,6 +1296,9 @@ export async function runAgentWorker({
         record: false,
         inputOptions: { closeOnDisconnect: true },
       });
+      // The incoming agent's own options.stt.aux applies from here (a takeover
+      // also re-arms it: the caller is talking to an agent again).
+      armAuxSttFor(newAgentDef);
 
       // The incoming agent speaks next. Ultravox realtime greets natively via
       // firstSpeakerSettings; other stacks need an explicit first turn.
@@ -1447,6 +1527,10 @@ export async function runAgentWorker({
           }`,
         },
       }),
+    // The agent has left the conversation (bridged transfer): stop the
+    // auxiliary STT rather than transcribe the human↔human segment onto the
+    // agent call. A takeover re-arms it via restartWithAgent.
+    onPrimaryAgentDetached: disposeAuxStt,
   });
 
   try {
@@ -1805,6 +1889,9 @@ export async function runAgentWorker({
           "timing: session.start done",
         );
         logger.info({ callId: call.id }, "session started");
+
+        // Auxiliary ("second opinion") STT on the caller's track, if configured.
+        armAuxSttFor(agent);
 
         // ---- Inactivity "kick" ----
         // When options.inactivity is configured, the session was built with

--- a/agents/livekit/test/aux-stt.test.ts
+++ b/agents/livekit/test/aux-stt.test.ts
@@ -1,0 +1,295 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stt } from "@livekit/agents";
+import {
+  AUX_STT_LOG_TYPE,
+  AUX_STT_TECHNOLOGY,
+  armAuxStt,
+  auxSttAgent,
+  parseAuxSttOption,
+  resolveAuxSttVendor,
+} from "../lib/aux-stt.js";
+
+// Option parser, vendor resolution and the arm/pump loop for options.stt.aux,
+// driven with a fake room, track, audio source and STT (no SDK connections).
+// run: tsx --test test/aux-stt.test.ts
+
+test("constants match the platform contract", () => {
+  assert.equal(AUX_STT_LOG_TYPE, "user-aux");
+  assert.equal(AUX_STT_TECHNOLOGY, "stt-aux");
+});
+
+test("parseAuxSttOption: absent/false/disabled/malformed give null", () => {
+  assert.equal(parseAuxSttOption(undefined), null);
+  assert.equal(parseAuxSttOption({}), null);
+  assert.equal(parseAuxSttOption({ stt: {} }), null);
+  assert.equal(parseAuxSttOption({ stt: { aux: false } }), null);
+  assert.equal(parseAuxSttOption({ stt: { aux: null } }), null);
+  assert.equal(parseAuxSttOption({ stt: { aux: { enabled: false, vendor: "assemblyai" } } }), null);
+  // Malformed shapes are off, not errors (the server validates at save time).
+  assert.equal(parseAuxSttOption({ stt: { aux: "yes" } }), null);
+  assert.equal(parseAuxSttOption({ stt: { aux: ["deepgram"] } }), null);
+});
+
+test("parseAuxSttOption: true / {} / object normalise", () => {
+  assert.deepEqual(parseAuxSttOption({ stt: { aux: true } }), {});
+  assert.deepEqual(parseAuxSttOption({ stt: { aux: {} } }), {});
+  assert.deepEqual(parseAuxSttOption({ stt: { aux: { enabled: true } } }), {});
+  assert.deepEqual(
+    parseAuxSttOption({ stt: { aux: { vendor: " assemblyai ", language: "en-GB" } } }),
+    { vendor: "assemblyai", language: "en-GB" },
+  );
+  // Blank strings are "unset".
+  assert.deepEqual(parseAuxSttOption({ stt: { aux: { vendor: "  ", language: "" } } }), {});
+});
+
+test("auxSttAgent: aux block stands in for stt; language inherits stt then tts; nested aux dropped", () => {
+  const agent = {
+    id: "a",
+    options: {
+      stt: { vendor: "deepgram", language: "en-US", aux: { vendor: "assemblyai" } },
+      tts: { vendor: "cartesia", language: "fr-FR", voice: "v" },
+    },
+  } as any;
+  const a = auxSttAgent(agent, { vendor: "assemblyai" });
+  assert.deepEqual(a.options.stt, { vendor: "assemblyai", language: "en-US" });
+  // Untouched elsewhere.
+  assert.deepEqual(a.options.tts, agent.options.tts);
+  assert.equal(agent.options.stt.aux.vendor, "assemblyai"); // input not mutated
+
+  // No stt.language → tts.language; explicit aux language wins over both.
+  const b = auxSttAgent({ id: "b", options: { tts: { language: "de-DE" } } } as any, {});
+  assert.deepEqual(b.options.stt, { language: "de-DE" });
+  const c = auxSttAgent(agent, { vendor: "cartesia", language: "es" });
+  assert.deepEqual(c.options.stt, { vendor: "cartesia", language: "es" });
+  // Nothing declared anywhere → empty block (platform defaults).
+  assert.deepEqual(auxSttAgent({ id: "d" } as any, {}).options.stt, {});
+});
+
+test("resolveAuxSttVendor: canonical {vendor, detail} via the pipeline STT resolution", () => {
+  const agent = { id: "a", options: {} } as any;
+  assert.deepEqual(resolveAuxSttVendor(agent, {}), { vendor: "deepgram", detail: "deepgram/nova-3" });
+  assert.deepEqual(resolveAuxSttVendor(agent, { vendor: "assemblyai" }), {
+    vendor: "assemblyai",
+    detail: "assemblyai/universal-streaming",
+  });
+  assert.deepEqual(resolveAuxSttVendor(agent, { vendor: "cartesia" }), {
+    vendor: "cartesia",
+    detail: "cartesia/ink-whisper",
+  });
+  // A scoped vendor string keeps its model; the :lang suffix is not part of detail.
+  assert.deepEqual(resolveAuxSttVendor(agent, { vendor: "deepgram/nova-2:en" }), {
+    vendor: "deepgram",
+    detail: "deepgram/nova-2",
+  });
+});
+
+// ---- arm/pump loop with fakes ---------------------------------------------
+
+function fakeRoom() {
+  const handlers = new Map<any, (...a: any[]) => void>();
+  return {
+    on(evt: any, cb: (...a: any[]) => void) {
+      handlers.set(evt, cb);
+    },
+    off(evt: any) {
+      handlers.delete(evt);
+    },
+    emit(evt: any, ...args: any[]) {
+      handlers.get(evt)?.(...args);
+    },
+    handlerCount: () => handlers.size,
+  } as any;
+}
+
+/** Minimal stand-in for stt.SpeechStream: emits a FINAL after N pushed frames. */
+class FakeSpeechStream {
+  pushed: any[] = [];
+  private queue: any[] = [];
+  private waiters: Array<(r: IteratorResult<any>) => void> = [];
+  private ended = false;
+  constructor(private readonly finalAfterFrames: number, private readonly text: string) {}
+  pushFrame(frame: any) {
+    if (this.ended) throw new Error("input ended");
+    this.pushed.push(frame);
+    if (this.pushed.length === this.finalAfterFrames) {
+      this.put({ type: stt.SpeechEventType.INTERIM_TRANSCRIPT, alternatives: [{ text: "hel" }] });
+      this.put({ type: stt.SpeechEventType.FINAL_TRANSCRIPT, alternatives: [{ text: this.text }] });
+      this.put({ type: stt.SpeechEventType.END_OF_SPEECH });
+    }
+  }
+  private put(ev: any) {
+    const w = this.waiters.shift();
+    if (w) w({ value: ev, done: false });
+    else this.queue.push(ev);
+  }
+  endInput() {
+    this.ended = true;
+    for (const w of this.waiters.splice(0)) w({ value: undefined, done: true });
+  }
+  close() {
+    this.endInput();
+  }
+  next(): Promise<IteratorResult<any>> {
+    if (this.queue.length) return Promise.resolve({ value: this.queue.shift(), done: false });
+    if (this.ended) return Promise.resolve({ value: undefined, done: true });
+    return new Promise((r) => this.waiters.push(r));
+  }
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+}
+
+const fakeStt = (stream: FakeSpeechStream, closed: { n: number }) =>
+  ({ label: "fake.STT", stream: () => stream, close: async () => void closed.n++ }) as any;
+
+/** `n` 20 ms frames at 16 kHz (320 samples each). */
+async function* audioFrames(n: number) {
+  for (let i = 0; i < n; i++) {
+    await new Promise((r) => setImmediate(r));
+    yield { sampleRate: 16000, samplesPerChannel: 320, channels: 1 } as any;
+  }
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 30));
+
+test("armAuxStt: pumps the caller track, logs finals, meters audio ms + characters", async () => {
+  const room = fakeRoom();
+  const stream = new FakeSpeechStream(3, "  hello there ");
+  const closed = { n: 0 };
+  const transcripts: Array<{ text: string; at: Date }> = [];
+  const usage: Record<string, number> = { milliseconds: 0, characters: 0 };
+  let cancelled = 0;
+  const source = Object.assign(audioFrames(5), { cancel: async () => void cancelled++ });
+
+  const handle = armAuxStt({
+    room,
+    roomName: "r",
+    callerIdentity: "caller",
+    agent: { id: "a", options: {} } as any,
+    config: {},
+    onTranscript: (text, at) => transcripts.push({ text, at }),
+    onUsage: (unit, q) => (usage[unit] += q),
+    deps: {
+      buildStt: () => fakeStt(stream, closed),
+      resolveTrack: async () => ({ sid: "track" }) as any,
+      openAudioStream: () => source,
+    },
+  });
+  assert.equal(room.handlerCount(), 2, "listens for caller leave + room disconnect");
+
+  await settle();
+  assert.deepEqual(
+    transcripts.map((t) => t.text),
+    ["hello there"],
+    "only FINAL events are logged, trimmed",
+  );
+  assert.ok(transcripts[0].at instanceof Date);
+  assert.equal(stream.pushed.length, 5, "every frame reached the engine");
+  assert.equal(usage.characters, "hello there".length);
+  assert.equal(handle.usage.characters, "hello there".length);
+  // 5 × 20 ms of audio streamed; reported in full once disposed.
+  handle.dispose();
+  assert.equal(usage.milliseconds, 100);
+  assert.equal(Math.round(handle.usage.milliseconds), 100);
+  assert.equal(closed.n, 1, "engine closed on dispose");
+  assert.equal(room.handlerCount(), 0, "room listeners removed");
+  // Idempotent: a second dispose reports nothing more.
+  handle.dispose();
+  assert.equal(usage.milliseconds, 100);
+  assert.equal(closed.n, 1);
+});
+
+test("armAuxStt: self-disposes when the caller leaves (not on another participant)", async () => {
+  const room = fakeRoom();
+  const stream = new FakeSpeechStream(99, "never");
+  const closed = { n: 0 };
+  const usage: Record<string, number> = { milliseconds: 0, characters: 0 };
+  // A source that never ends on its own.
+  async function* endless() {
+    for (;;) {
+      await new Promise((r) => setTimeout(r, 5));
+      yield { sampleRate: 16000, samplesPerChannel: 160, channels: 1 } as any;
+    }
+  }
+  armAuxStt({
+    room,
+    roomName: "r",
+    callerIdentity: "caller",
+    agent: { id: "a", options: {} } as any,
+    config: {},
+    onTranscript: () => assert.fail("no transcript expected"),
+    onUsage: (unit, q) => (usage[unit] += q),
+    deps: {
+      buildStt: () => fakeStt(stream, closed),
+      resolveTrack: async () => ({}) as any,
+      openAudioStream: () => Object.assign(endless(), { cancel: async () => {} }),
+    },
+  });
+  await settle();
+  const { RoomEvent } = await import("@livekit/rtc-node");
+  room.emit(RoomEvent.ParticipantDisconnected, { identity: "someone-else" });
+  assert.equal(closed.n, 0, "another participant leaving does not stop it");
+  room.emit(RoomEvent.ParticipantDisconnected, { info: { identity: "caller" } });
+  assert.equal(closed.n, 1, "caller leaving disposes");
+  assert.ok(usage.milliseconds > 0, "streamed audio reported on dispose");
+  const pushedAtDispose = stream.pushed.length;
+  await settle();
+  assert.equal(stream.pushed.length, pushedAtDispose, "pump stopped");
+});
+
+test("armAuxStt: an engine that fails to build is contained; dispose still safe", async () => {
+  const room = fakeRoom();
+  const transcripts: string[] = [];
+  const handle = armAuxStt({
+    room,
+    roomName: "r",
+    callerIdentity: "caller",
+    agent: { id: "a", options: {} } as any,
+    config: { vendor: "nope" },
+    onTranscript: (t) => transcripts.push(t),
+    onUsage: () => assert.fail("no usage expected"),
+    deps: {
+      buildStt: () => {
+        throw new Error("no such vendor");
+      },
+      resolveTrack: async () => ({}) as any,
+      openAudioStream: () => audioFrames(1),
+    },
+  });
+  await settle();
+  assert.deepEqual(transcripts, []);
+  handle.dispose();
+  assert.deepEqual(handle.usage, { milliseconds: 0, characters: 0 });
+});
+
+test("armAuxStt: disposing before the track resolves never starts the engine", async () => {
+  const room = fakeRoom();
+  let built = 0;
+  let release: () => void = () => {};
+  const gate = new Promise<void>((r) => (release = r));
+  const handle = armAuxStt({
+    room,
+    roomName: "r",
+    callerIdentity: "caller",
+    agent: { id: "a", options: {} } as any,
+    config: {},
+    onTranscript: () => {},
+    onUsage: () => {},
+    deps: {
+      buildStt: () => {
+        built++;
+        return fakeStt(new FakeSpeechStream(99, ""), { n: 0 });
+      },
+      resolveTrack: async () => {
+        await gate;
+        return {} as any;
+      },
+      openAudioStream: () => audioFrames(1),
+    },
+  });
+  handle.dispose();
+  release();
+  await settle();
+  assert.equal(built, 0);
+});

--- a/agents/pipecat/pipecat_aplisay/aux_stt.py
+++ b/agents/pipecat/pipecat_aplisay/aux_stt.py
@@ -1,0 +1,248 @@
+"""Auxiliary ("second opinion") speech recognition — ``options.stt.aux``.
+
+Runs a second, independent STT engine over the caller's audio alongside the
+agent's own recognition (the pipeline STT, or a realtime model's built-in
+transcription) and logs each final transcript it produces as a ``user-aux``
+transaction-log entry next to the primary ``user`` entry, so two recognitions
+of the same speech can be compared. The auxiliary engine never feeds the model
+— it is observation only.
+
+Mechanism: an :class:`AuxSttTap` sits right after ``transport.input()`` (behind
+the WebRTC relay tap, so an engaged relay silences it too). It passes every
+frame through untouched and copies each ``InputAudioRawFrame`` into a side
+STT-only pipeline (:class:`~pipecat_aplisay.bridge_transcript.SttStream` — the
+same helper the bridged-segment transcription uses), so the auxiliary service
+never sits in the main chain: none of its transcription, metrics or settings
+frames can reach the context aggregator or the primary STT, and an STT control
+frame aimed at the primary engine is never swallowed by the wrong service.
+
+The engine is built by ``voice_session.build_stt_service`` with
+``options.stt.aux`` standing in for ``options.stt`` (:func:`aux_stt_agent`), so
+the same vendor strings mean the same thing in both places.
+
+Metering: the audio streamed to the auxiliary engine is measured at the tap
+(milliseconds, silence included — the basis streaming STT vendors bill on) and
+final transcripts are counted in characters. Both are reported through
+``on_usage`` and land as ``stt-aux`` usage rows — their own technology, so the
+second engine's consumption is neither merged with nor gated like the primary
+``stt`` meter (a realtime model bundles its own recognition into the model
+charge; the auxiliary engine is a real extra cost on every voice mode).
+
+Everything here is best-effort: an auxiliary STT failure must never disturb
+the call. See docs/auxiliary-stt.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, Optional
+
+from loguru import logger
+from pipecat.frames.frames import CancelFrame, EndFrame, InputAudioRawFrame
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from .bridge_transcript import SttStream
+
+#: Ledger technology for auxiliary-STT usage rows (distinct from the primary ``stt``).
+AUX_STT_TECHNOLOGY = "stt-aux"
+#: Transaction-log type for auxiliary transcripts (next to the primary ``user``).
+AUX_STT_LOG_TYPE = "user-aux"
+#: Default engine when ``options.stt.aux.vendor`` is unset — the pipeline default.
+DEFAULT_AUX_STT_VENDOR = "deepgram"
+
+
+def parse_aux_stt_option(options: Optional[dict]) -> Optional[dict]:
+    """Normalise ``options.stt.aux`` to ``None`` (off) or
+    ``{"vendor": Optional[str], "language": Optional[str]}``. Lenient — the
+    server validated the shape at save time: absent / ``False`` /
+    ``enabled: False`` / malformed → off; ``True`` or ``{}`` → defaults."""
+    stt_opts = (options or {}).get("stt")
+    if not isinstance(stt_opts, dict):
+        return None
+    raw = stt_opts.get("aux")
+    if raw is None or raw is False:
+        return None
+    if raw is True:
+        return {"vendor": None, "language": None}
+    if not isinstance(raw, dict) or raw.get("enabled") is False:
+        return None
+    vendor = raw.get("vendor")
+    language = raw.get("language")
+    return {
+        "vendor": vendor.strip() if isinstance(vendor, str) and vendor.strip() else None,
+        "language": language.strip() if isinstance(language, str) and language.strip() else None,
+    }
+
+
+def aux_stt_agent(agent: dict, config: dict) -> dict:
+    """The agent with ``options.stt.aux`` standing in for ``options.stt``, so
+    ``build_stt_service`` constructs the auxiliary engine exactly as it would
+    the primary one. Language falls back to the agent's own ``stt.language``,
+    then ``tts.language`` (the platform's declare-once convention); the nested
+    ``aux`` block itself is dropped."""
+    options = dict(agent.get("options") or {})
+    stt_opts = options.get("stt") or {}
+    tts_opts = options.get("tts") or {}
+    language = (
+        config.get("language")
+        or (stt_opts.get("language") if isinstance(stt_opts, dict) else None)
+        or (tts_opts.get("language") if isinstance(tts_opts, dict) else None)
+    )
+    block: dict = {}
+    if config.get("vendor"):
+        block["vendor"] = config["vendor"]
+    if language:
+        block["language"] = language
+    options["stt"] = block
+    return {**agent, "options": options}
+
+
+def aux_stt_vendor(agent: dict, config: dict) -> dict:
+    """Canonical ``{vendor, model}`` for the auxiliary engine's usage rows:
+    ``vendor`` is the bare engine name (what the rate lines match on);
+    ``model`` is ``vendor/model`` when the vendor string was scoped
+    (``deepgram/nova-3``), else ``None``."""
+    stt_opts = (aux_stt_agent(agent, config).get("options") or {}).get("stt") or {}
+    raw = str(stt_opts.get("vendor") or DEFAULT_AUX_STT_VENDOR)
+    head = raw.split(":", 1)[0]
+    vendor = head.split("/", 1)[0].strip().lower()
+    model = head.split("/", 1)[1].strip() if "/" in head else None
+    return {"vendor": vendor, "model": f"{vendor}/{model}" if model else None}
+
+
+OnFinal = Callable[[str], Awaitable[None]]
+OnUsage = Callable[[str, int], None]
+
+
+class AuxSttTap(FrameProcessor):
+    """Pass-through processor that copies caller audio into a side STT-only
+    pipeline and forwards its final transcripts + usage.
+
+    Args:
+        stt_factory: builds the auxiliary STT service (called once, lazily, on
+            the first audio frame so a build failure only costs the second
+            opinion, never the call).
+        on_final: awaited with each non-empty final transcript.
+        on_usage: called with ``("milliseconds", n)`` as audio is streamed to
+            the engine and ``("characters", n)`` per final transcript.
+        stream_factory: test seam — builds the side pipeline; defaults to
+            :class:`SttStream`.
+    """
+
+    def __init__(
+        self,
+        *,
+        stt_factory: Callable[[], Any],
+        on_final: OnFinal,
+        on_usage: Optional[OnUsage] = None,
+        stream_factory: Optional[Callable[..., Any]] = None,
+        name: Optional[str] = None,
+    ) -> None:
+        super().__init__(name=name or "AuxSttTap")
+        self._stt_factory = stt_factory
+        self._on_final = on_final
+        self._on_usage: OnUsage = on_usage or (lambda _unit, _qty: None)
+        self._stream_factory = stream_factory or SttStream
+        self._stream: Optional[Any] = None
+        self._sample_rate: Optional[int] = None
+        self._num_channels: Optional[int] = None
+        self._failed = False
+        self._rate_warned = False
+        self._milliseconds: float = 0.0
+        self._reported_ms = 0
+        self._characters = 0
+        self._stop_task: Optional[asyncio.Task] = None
+
+    @property
+    def usage(self) -> dict:
+        """Audio milliseconds streamed to the engine and characters it returned."""
+        return {"milliseconds": int(self._milliseconds), "characters": self._characters}
+
+    async def process_frame(self, frame, direction: FrameDirection):  # noqa: ANN001
+        await super().process_frame(frame, direction)
+        if isinstance(frame, InputAudioRawFrame) and direction == FrameDirection.DOWNSTREAM:
+            await self._tap_audio(frame)
+        elif isinstance(frame, (EndFrame, CancelFrame)):
+            self._schedule_stop()
+        await self.push_frame(frame, direction)
+
+    async def _tap_audio(self, frame: InputAudioRawFrame) -> None:
+        if self._failed:
+            return
+        try:
+            if self._stream is None:
+                self._sample_rate = frame.sample_rate
+                self._num_channels = frame.num_channels
+                self._stream = self._stream_factory(
+                    self._stt_factory(),
+                    self._collect_final,
+                    sample_rate=frame.sample_rate,
+                    num_channels=frame.num_channels,
+                )
+                await self._stream.start()
+                logger.info(
+                    f"auxStt: auxiliary transcription armed "
+                    f"({frame.sample_rate} Hz, {frame.num_channels} ch)"
+                )
+            if frame.sample_rate != self._sample_rate or frame.num_channels != self._num_channels:
+                # The side pipeline was started at the first frame's format;
+                # a mid-call change would need a rebuild — drop rather than
+                # feed the engine audio it will mis-decode.
+                if not self._rate_warned:
+                    self._rate_warned = True
+                    logger.warning(
+                        "auxStt: input audio format changed mid-call; dropping mismatched frames"
+                    )
+                return
+            await self._stream.feed(frame.audio)
+            self._milliseconds += frame.num_frames / frame.sample_rate * 1000.0
+            self._report_audio()
+        except Exception as e:  # noqa: BLE001
+            # Best-effort: the call carries on without the second opinion.
+            self._failed = True
+            logger.warning(f"auxStt: auxiliary transcription failed (continuing without it): {e}")
+            self._schedule_stop()
+
+    def _report_audio(self) -> None:
+        """Report streamed audio not yet reported (whole milliseconds, no drift)."""
+        delta = int(self._milliseconds) - self._reported_ms
+        if delta <= 0:
+            return
+        self._reported_ms += delta
+        try:
+            self._on_usage("milliseconds", delta)
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"auxStt: usage report failed: {e}")
+
+    async def _collect_final(self, text: str) -> None:
+        text = (text or "").strip()
+        if not text:
+            return
+        self._characters += len(text)
+        try:
+            self._on_usage("characters", len(text))
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"auxStt: usage report failed: {e}")
+        try:
+            await self._on_final(text)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"auxStt: transcript handler failed: {e}")
+
+    def _schedule_stop(self) -> None:
+        """Tear the side pipeline down without holding up the main chain's own
+        End/Cancel processing (its stop waits on the runner, bounded)."""
+        stream, self._stream = self._stream, None
+        if stream is None:
+            return
+        self._report_audio()
+        self._stop_task = asyncio.create_task(self._stop_stream(stream))
+
+    async def _stop_stream(self, stream: Any) -> None:
+        try:
+            await stream.stop()
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"auxStt: side pipeline stop raised: {e}")
+        logger.info(
+            f"auxStt: auxiliary transcription stopped "
+            f"({int(self._milliseconds)} ms streamed, {self._characters} chars)"
+        )

--- a/agents/pipecat/pipecat_aplisay/bridge_transcript.py
+++ b/agents/pipecat/pipecat_aplisay/bridge_transcript.py
@@ -126,13 +126,24 @@ class _TranscriptionCollector:
 
 
 class SttStream:
-    """A minimal STT-only Pipecat pipeline: feed mono 16 kHz PCM in, get
-    final transcription text out via ``on_final``. One instance per
-    bridged leg on the sipbridge topology."""
+    """A minimal STT-only Pipecat pipeline: feed PCM16 in, get final
+    transcription text out via ``on_final``. One instance per bridged leg on
+    the sipbridge topology (mono 16 kHz, the tap contract), and the side
+    pipeline behind the auxiliary STT tap (``aux_stt.py``), which starts it at
+    the call's own input format."""
 
-    def __init__(self, stt_service: Any, on_final: Callable[[str], Awaitable[None]]) -> None:
+    def __init__(
+        self,
+        stt_service: Any,
+        on_final: Callable[[str], Awaitable[None]],
+        *,
+        sample_rate: int = 16000,
+        num_channels: int = 1,
+    ) -> None:
         self._stt = stt_service
         self._collector = _TranscriptionCollector(on_final)
+        self._sample_rate = sample_rate
+        self._num_channels = num_channels
         self._task: Optional[Any] = None
         self._runner_task: Optional[asyncio.Task] = None
 
@@ -145,8 +156,8 @@ class SttStream:
         self._task = PipelineTask(
             pipeline,
             params=PipelineParams(
-                audio_in_sample_rate=16000,
-                audio_out_sample_rate=16000,
+                audio_in_sample_rate=self._sample_rate,
+                audio_out_sample_rate=self._sample_rate,
             ),
         )
         runner = PipelineRunner(handle_sigint=False)
@@ -158,7 +169,13 @@ class SttStream:
         from pipecat.frames.frames import InputAudioRawFrame
 
         await self._task.queue_frames(
-            [InputAudioRawFrame(audio=pcm16, sample_rate=16000, num_channels=1)]
+            [
+                InputAudioRawFrame(
+                    audio=pcm16,
+                    sample_rate=self._sample_rate,
+                    num_channels=self._num_channels,
+                )
+            ]
         )
 
     async def stop(self) -> None:

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -523,6 +523,8 @@ class CallSession:
             relay_endpoint=self.relay_endpoint,
             tone_injector=self._tone_injector,
             on_inactivity_hangup=self._on_inactivity_hangup,
+            on_aux_transcript=self._on_aux_transcript,
+            on_aux_usage=self._on_aux_usage,
         )
         # Stash the context handle so ``get_parent_transcript`` (used by
         # the consultative-transfer flow) can walk the chat history.
@@ -979,6 +981,32 @@ class CallSession:
                 logger.warning(f"transaction log post failed: {e}")
         else:
             self.call.batched_transaction_logs.append(entry)
+
+    async def _on_aux_transcript(self, text: str) -> None:
+        """A final transcript from the auxiliary STT (``options.stt.aux``),
+        logged as ``user-aux`` next to the primary ``user`` entry through the
+        same transaction-log path (streamLog/batch convention included)."""
+        from .aux_stt import AUX_STT_LOG_TYPE
+
+        await self._send_message({AUX_STT_LOG_TYPE: text}, is_final=True)
+
+    def _on_aux_usage(self, unit: str, quantity: int, vendor: dict) -> None:
+        """Auxiliary STT usage (audio ms streamed / transcript chars) into the
+        call's usage observer as ``stt-aux`` rows, so it flushes with every
+        other meter at ``_end``. The engine runs in a side pipeline the
+        observer cannot see, hence the explicit hand-off."""
+        from .aux_stt import AUX_STT_TECHNOLOGY
+
+        observer = getattr(self, "_usage_observer", None)
+        if observer is None:
+            return
+        observer.add_meter(
+            AUX_STT_TECHNOLOGY,
+            unit,
+            quantity,
+            provider=vendor.get("vendor"),
+            detail=vendor.get("model"),
+        )
 
     async def _on_hangup(self) -> None:
         self._wants_hangup = True

--- a/agents/pipecat/pipecat_aplisay/usage.py
+++ b/agents/pipecat/pipecat_aplisay/usage.py
@@ -30,6 +30,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.metrics.metrics import LLMUsageMetricsData, TTSUsageMetricsData
 from pipecat.observers.base_observer import BaseObserver, FramePushed
+from pipecat.services.stt_service import STTService
 
 from . import api_client
 from .voice_mode import model_id_from_name
@@ -103,6 +104,15 @@ class UsageMeteringObserver(BaseObserver):
             provider = model.split("/", 1)[0]
         return provider, detail
 
+    def add_meter(
+        self, technology: str, unit: str, qty: Any, *, provider: str | None = None, detail: str | None = None
+    ) -> None:
+        """Accumulate usage produced outside the observed pipeline — e.g. the
+        auxiliary STT tap (``aux_stt.py``), whose engine runs in a side
+        pipeline this observer never sees — so every meter for the call still
+        flushes through the one ledger writer."""
+        self._add(technology, unit, qty, provider=provider, detail=detail)
+
     def _add(self, technology: str, unit: str, qty: Any, *, provider: str | None, detail: str | None) -> None:
         try:
             quantity = int(qty or 0)
@@ -147,9 +157,15 @@ class UsageMeteringObserver(BaseObserver):
             return
 
         # STT characters — the final transcript text length (Pipecat has no
-        # STTUsageMetricsData). Gate on `finalized` so interims don't double-count.
+        # STTUsageMetricsData). A TranscriptionFrame is by definition final
+        # (interims are InterimTranscriptionFrame), so every one counts — its
+        # `finalized` flag only records a commit/finalize handshake, which the
+        # Deepgram service never sets in normal streaming (gating on it counted
+        # nothing). Count only frames an STT *service* originated: a realtime
+        # model's own transcripts (source = the LLM service) are bundled into
+        # its charge, and the auxiliary engine meters itself (``stt-aux``).
         if isinstance(frame, TranscriptionFrame):
-            if not getattr(frame, "finalized", True):
+            if not isinstance(data.source, STTService):
                 return
             if self._seen(frame_id):
                 return

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -922,8 +922,15 @@ async def build_voice_session(
     relay_endpoint: "Optional[Any]" = None,
     tone_injector: "Optional[Any]" = None,
     on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
+    on_aux_transcript: "Optional[Callable[[str], Awaitable[None]]]" = None,
+    on_aux_usage: "Optional[Callable[[str, int, dict], None]]" = None,
 ) -> tuple[PipelineTask, Optional[AudioBufferProcessor], LLMContext, Any]:
     """Construct a configured ``PipelineTask`` for the call.
+
+    ``on_aux_transcript`` / ``on_aux_usage`` receive the auxiliary STT's final
+    transcripts and usage deltas (``unit, quantity, {vendor, model}``) when the
+    agent sets ``options.stt.aux`` — see aux_stt.py. Without a transcript
+    callback the option is ignored.
 
     When ``enable_recording`` is true the returned ``AudioBufferProcessor``
     is appended to the pipeline (stereo, user-left/bot-right per
@@ -951,17 +958,49 @@ async def build_voice_session(
         # right" layout — matches LiveKit's RecorderIO output exactly.
         audio_buffer = AudioBufferProcessor(num_channels=2)
 
+    aux_tap = _aux_stt_tap_for(agent, on_aux_transcript, on_aux_usage)
+
     if mode == "realtime":
         task, context, llm = await _build_realtime(
             transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector,
-            on_inactivity_hangup,
+            on_inactivity_hangup, aux_tap=aux_tap,
         )
     else:
         task, context, llm = await _build_pipeline(
             transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector,
-            on_inactivity_hangup,
+            on_inactivity_hangup, aux_tap=aux_tap,
         )
     return task, audio_buffer, context, llm
+
+
+def _aux_stt_tap_for(
+    agent: dict,
+    on_transcript: "Optional[Callable[[str], Awaitable[None]]]",
+    on_usage: "Optional[Callable[[str, int, dict], None]]",
+) -> "Optional[Any]":
+    """The auxiliary STT tap for ``options.stt.aux`` (see aux_stt.py), or
+    ``None`` when the option is off. The engine is built lazily by the tap
+    through :func:`build_stt_service` with the aux block standing in for
+    ``options.stt`` — an unsupported vendor therefore costs only the second
+    opinion (logged), never the call."""
+    from .aux_stt import AuxSttTap, aux_stt_agent, aux_stt_vendor, parse_aux_stt_option
+
+    config = parse_aux_stt_option(agent.get("options"))
+    if config is None or on_transcript is None:
+        return None
+    effective_agent = aux_stt_agent(agent, config)
+    vendor = aux_stt_vendor(agent, config)
+    logger.bind(vendor=vendor).info("auxiliary STT configured (options.stt.aux)")
+
+    def _report(unit: str, quantity: int) -> None:
+        if on_usage is not None:
+            on_usage(unit, quantity, vendor)
+
+    return AuxSttTap(
+        stt_factory=lambda: build_stt_service(effective_agent),
+        on_final=on_transcript,
+        on_usage=_report,
+    )
 
 
 async def _build_realtime(
@@ -975,6 +1014,7 @@ async def _build_realtime(
     relay_endpoint: "Optional[Any]" = None,
     tone_injector: "Optional[Any]" = None,
     on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
+    aux_tap: "Optional[Any]" = None,
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
@@ -1254,9 +1294,15 @@ async def _build_realtime(
     # aggregator (see _dtmf_aggregator_for). Without this, InputDTMFFrames are
     # never consumed and digits are dropped.
     dtmf_aggregator = _dtmf_aggregator_for(agent)
+    # Auxiliary STT tap (options.stt.aux) right behind the relay tap: an
+    # engaged relay silences the caller's audio for the aux engine too, and the
+    # tap copies audio out to a side pipeline — nothing of the second engine
+    # enters this chain (see aux_stt.py).
+    aux = [aux_tap] if aux_tap is not None else []
     processors: list = [
         transport.input(),
         *relay_tap,
+        *aux,
         dtmf_aggregator,
         user_aggregator,
         llm,
@@ -1304,6 +1350,7 @@ async def _build_pipeline(
     relay_endpoint: "Optional[Any]" = None,
     tone_injector: "Optional[Any]" = None,
     on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
+    aux_tap: "Optional[Any]" = None,
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
@@ -1375,9 +1422,14 @@ async def _build_pipeline(
     # aggregator (see _dtmf_aggregator_for). Sits after STT — STT only consumes
     # audio frames, so ordering relative to it is immaterial.
     dtmf_aggregator = _dtmf_aggregator_for(agent)
+    # Auxiliary STT tap (options.stt.aux) between the relay tap and the primary
+    # STT: the tap only copies audio out to a side pipeline, so the primary STT
+    # sees exactly the frames it always did (see aux_stt.py).
+    aux = [aux_tap] if aux_tap is not None else []
     processors: list = [
         transport.input(),
         *relay_tap,
+        *aux,
         stt,
         dtmf_aggregator,
         user_aggregator,

--- a/agents/pipecat/tests/test_aux_stt.py
+++ b/agents/pipecat/tests/test_aux_stt.py
@@ -1,0 +1,325 @@
+"""Auxiliary ("second opinion") STT — ``options.stt.aux`` (aux_stt.py).
+
+Option parsing, the agent/vendor stand-in, and the tap's behaviour driven
+through a real Pipecat pipeline (``pipecat.tests.utils.run_test``) with the
+side STT pipeline replaced by a fake: frames pass through untouched, audio is
+copied out and metered, finals are forwarded and counted, End/Cancel stop the
+side pipeline, and an engine failure is contained.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pipecat.frames.frames import (
+    CancelFrame,
+    EndFrame,
+    InputAudioRawFrame,
+    TextFrame,
+)
+from pipecat.tests.utils import run_test
+
+from pipecat_aplisay.aux_stt import (
+    AUX_STT_LOG_TYPE,
+    AUX_STT_TECHNOLOGY,
+    AuxSttTap,
+    aux_stt_agent,
+    aux_stt_vendor,
+    parse_aux_stt_option,
+)
+
+
+def test_constants_match_platform_contract():
+    assert AUX_STT_LOG_TYPE == "user-aux"
+    assert AUX_STT_TECHNOLOGY == "stt-aux"
+
+
+class TestParseAuxSttOption:
+    def test_off_shapes(self):
+        assert parse_aux_stt_option(None) is None
+        assert parse_aux_stt_option({}) is None
+        assert parse_aux_stt_option({"stt": {}}) is None
+        assert parse_aux_stt_option({"stt": {"aux": False}}) is None
+        assert parse_aux_stt_option({"stt": {"aux": None}}) is None
+        assert parse_aux_stt_option({"stt": {"aux": {"enabled": False, "vendor": "google"}}}) is None
+        # Malformed shapes are off, not errors (the server validates at save time).
+        assert parse_aux_stt_option({"stt": {"aux": "yes"}}) is None
+        assert parse_aux_stt_option({"stt": {"aux": ["google"]}}) is None
+        assert parse_aux_stt_option({"stt": "deepgram"}) is None
+
+    def test_on_shapes_normalise(self):
+        assert parse_aux_stt_option({"stt": {"aux": True}}) == {"vendor": None, "language": None}
+        assert parse_aux_stt_option({"stt": {"aux": {}}}) == {"vendor": None, "language": None}
+        assert parse_aux_stt_option({"stt": {"aux": {"enabled": True}}}) == {
+            "vendor": None,
+            "language": None,
+        }
+        assert parse_aux_stt_option(
+            {"stt": {"aux": {"vendor": " google ", "language": "en-GB"}}}
+        ) == {"vendor": "google", "language": "en-GB"}
+        # Blank strings are "unset".
+        assert parse_aux_stt_option({"stt": {"aux": {"vendor": "  ", "language": ""}}}) == {
+            "vendor": None,
+            "language": None,
+        }
+
+
+class TestAuxSttAgent:
+    AGENT = {
+        "id": "a",
+        "options": {
+            "stt": {"vendor": "deepgram", "language": "en-US", "aux": {"vendor": "google"}},
+            "tts": {"vendor": "cartesia", "language": "fr-FR", "voice": "v"},
+        },
+    }
+
+    def test_aux_block_stands_in_for_stt_and_inherits_language(self):
+        a = aux_stt_agent(self.AGENT, {"vendor": "google", "language": None})
+        assert a["options"]["stt"] == {"vendor": "google", "language": "en-US"}
+        assert a["options"]["tts"] == self.AGENT["options"]["tts"]
+        # Input untouched.
+        assert self.AGENT["options"]["stt"]["aux"] == {"vendor": "google"}
+
+    def test_language_fallbacks(self):
+        b = aux_stt_agent({"options": {"tts": {"language": "de-DE"}}}, {"vendor": None, "language": None})
+        assert b["options"]["stt"] == {"language": "de-DE"}
+        c = aux_stt_agent(self.AGENT, {"vendor": "google", "language": "es"})
+        assert c["options"]["stt"] == {"vendor": "google", "language": "es"}
+        assert aux_stt_agent({}, {"vendor": None, "language": None})["options"]["stt"] == {}
+
+    def test_vendor_resolution(self):
+        assert aux_stt_vendor({}, {"vendor": None, "language": None}) == {"vendor": "deepgram", "model": None}
+        assert aux_stt_vendor({}, {"vendor": "Google", "language": None}) == {"vendor": "google", "model": None}
+        assert aux_stt_vendor({}, {"vendor": "deepgram/nova-2:en", "language": None}) == {
+            "vendor": "deepgram",
+            "model": "deepgram/nova-2",
+        }
+
+
+# ---- the tap, through a real pipeline ---------------------------------------
+
+
+class _FakeStream:
+    """Stand-in for SttStream: records what it is fed and emits a final
+    transcript through ``on_final`` after ``final_after`` feeds."""
+
+    instances: list["_FakeStream"] = []
+
+    def __init__(self, stt_service, on_final, *, sample_rate, num_channels, final_after=2, text=" hello there "):
+        self.stt_service = stt_service
+        self.on_final = on_final
+        self.sample_rate = sample_rate
+        self.num_channels = num_channels
+        self.final_after = final_after
+        self.text = text
+        self.fed: list[bytes] = []
+        self.started = False
+        self.stopped = False
+        _FakeStream.instances.append(self)
+
+    async def start(self):
+        self.started = True
+
+    async def feed(self, pcm16: bytes):
+        self.fed.append(pcm16)
+        if len(self.fed) == self.final_after:
+            await self.on_final(self.text)
+
+    async def stop(self):
+        self.stopped = True
+
+
+def _audio(ms: int, rate: int = 8000) -> InputAudioRawFrame:
+    """`ms` of s16le mono silence at `rate`."""
+    return InputAudioRawFrame(audio=b"\x00\x00" * (rate * ms // 1000), sample_rate=rate, num_channels=1)
+
+
+def _tap(**kw) -> tuple[AuxSttTap, list, list]:
+    finals: list[str] = []
+    usage: list[tuple[str, int]] = []
+
+    async def on_final(text):
+        finals.append(text)
+
+    tap = AuxSttTap(
+        stt_factory=kw.pop("stt_factory", lambda: "fake-stt"),
+        on_final=on_final,
+        on_usage=lambda unit, qty: usage.append((unit, qty)),
+        stream_factory=kw.pop("stream_factory", _FakeStream),
+        **kw,
+    )
+    return tap, finals, usage
+
+
+class TestAuxSttTap:
+    def setup_method(self):
+        _FakeStream.instances.clear()
+
+    def test_passthrough_copy_meter_and_finals(self):
+        async def run():
+            tap, finals, usage = _tap()
+            f1, f2, f3 = _audio(20), _audio(20), _audio(10)
+            text = TextFrame("not audio")
+            # Input audio is a system frame (processed immediately) while the
+            # TextFrame is a data frame (queued), so it arrives after the audio.
+            down, _up = await run_test(
+                tap,
+                frames_to_send=[f1, text, f2, f3],
+                expected_down_frames=[InputAudioRawFrame, InputAudioRawFrame, InputAudioRawFrame, TextFrame],
+            )
+            # Every frame passed through untouched (same objects, same bytes).
+            assert [d for d in down if isinstance(d, InputAudioRawFrame)] == [f1, f2, f3]
+            assert [d for d in down if isinstance(d, TextFrame)] == [text]
+            assert f1.audio == b"\x00\x00" * 160
+
+            # One side pipeline, started lazily at the call's own input format,
+            # fed a copy of each audio frame in order.
+            assert len(_FakeStream.instances) == 1
+            side = _FakeStream.instances[0]
+            assert side.started and side.stopped, "started on first audio, stopped on EndFrame"
+            assert side.stt_service == "fake-stt"
+            assert (side.sample_rate, side.num_channels) == (8000, 1)
+            assert side.fed == [f1.audio, f2.audio, f3.audio]
+
+            # The final was forwarded, trimmed, and counted in characters.
+            assert finals == ["hello there"]
+            assert ("characters", len("hello there")) in usage
+            # Audio streamed = 50 ms, reported in whole milliseconds, no drift.
+            assert sum(q for u, q in usage if u == "milliseconds") == 50
+            assert tap.usage == {"milliseconds": 50, "characters": len("hello there")}
+
+        asyncio.run(run())
+
+    def test_cancel_stops_side_pipeline(self):
+        async def run():
+            tap, _finals, _usage = _tap()
+            await run_test(
+                tap,
+                frames_to_send=[_audio(20), CancelFrame()],
+                expected_down_frames=[InputAudioRawFrame, CancelFrame],
+                send_end_frame=False,
+            )
+            await asyncio.sleep(0)  # let the scheduled stop run
+            assert _FakeStream.instances[0].stopped
+
+        asyncio.run(run())
+
+    def test_engine_build_failure_is_contained(self):
+        async def run():
+            def boom():
+                raise RuntimeError("Unsupported STT vendor 'nope' for pipeline mode")
+
+            tap, finals, usage = _tap(stt_factory=boom)
+            f1, f2 = _audio(20), _audio(20)
+            down, _ = await run_test(
+                tap,
+                frames_to_send=[f1, f2],
+                expected_down_frames=[InputAudioRawFrame, InputAudioRawFrame],
+            )
+            # The call carries on: audio still flows, nothing metered, no finals.
+            assert [d for d in down if isinstance(d, InputAudioRawFrame)] == [f1, f2]
+            assert finals == [] and usage == []
+            assert _FakeStream.instances == []
+
+        asyncio.run(run())
+
+    def test_format_change_mid_call_drops_mismatched_frames(self):
+        async def run():
+            tap, _finals, usage = _tap()
+            await run_test(
+                tap,
+                frames_to_send=[_audio(20, 8000), _audio(20, 16000), _audio(20, 8000)],
+                expected_down_frames=[InputAudioRawFrame] * 3,
+            )
+            side = _FakeStream.instances[0]
+            assert len(side.fed) == 2, "the 16 kHz frame was not fed to an 8 kHz engine"
+            assert sum(q for u, q in usage if u == "milliseconds") == 40
+
+        asyncio.run(run())
+
+    def test_transcript_handler_errors_do_not_stop_the_tap(self):
+        async def run():
+            calls = []
+
+            async def failing_on_final(text):
+                calls.append(text)
+                raise RuntimeError("log post failed")
+
+            tap = AuxSttTap(
+                stt_factory=lambda: "fake",
+                on_final=failing_on_final,
+                on_usage=lambda *_: None,
+                stream_factory=lambda *a, **k: _FakeStream(*a, final_after=1, **k),
+            )
+            await run_test(
+                tap,
+                frames_to_send=[_audio(20), _audio(20), _audio(20)],
+                expected_down_frames=[InputAudioRawFrame] * 3,
+            )
+            assert calls == [" hello there ".strip()]
+            assert len(_FakeStream.instances[0].fed) == 3
+
+        asyncio.run(run())
+
+
+class TestVoiceSessionWiring:
+    def test_tap_built_only_when_configured_and_callback_present(self):
+        from pipecat_aplisay.voice_session import _aux_stt_tap_for
+
+        async def on_transcript(_text):
+            pass
+
+        assert _aux_stt_tap_for({"options": {}}, on_transcript, None) is None
+        assert _aux_stt_tap_for({"options": {"stt": {"aux": {}}}}, None, None) is None
+        tap = _aux_stt_tap_for({"options": {"stt": {"aux": {"vendor": "google"}}}}, on_transcript, None)
+        assert isinstance(tap, AuxSttTap)
+
+    def test_usage_callback_carries_the_aux_vendor(self):
+        from pipecat_aplisay.voice_session import _aux_stt_tap_for
+
+        seen = []
+
+        async def on_transcript(_text):
+            pass
+
+        tap = _aux_stt_tap_for(
+            {"options": {"stt": {"vendor": "deepgram", "aux": {"vendor": "google"}}}},
+            on_transcript,
+            lambda unit, qty, vendor: seen.append((unit, qty, vendor)),
+        )
+        tap._on_usage("milliseconds", 20)
+        assert seen == [("milliseconds", 20, {"vendor": "google", "model": None})]
+
+
+class TestCallSessionHandoff:
+    def test_aux_usage_lands_on_the_usage_observer_as_stt_aux(self):
+        from pipecat_aplisay.call_session import CallSession
+        from pipecat_aplisay.usage import UsageMeteringObserver
+
+        session = CallSession.__new__(CallSession)
+        session._usage_observer = UsageMeteringObserver(services={})
+        CallSession._on_aux_usage(session, "milliseconds", 1500, {"vendor": "google", "model": None})
+        CallSession._on_aux_usage(session, "characters", 11, {"vendor": "google", "model": None})
+        rows = {(m["technology"], m["unit"]): m for m in session._usage_observer._meters.values()}
+        assert rows[("stt-aux", "milliseconds")]["quantity"] == 1500
+        assert rows[("stt-aux", "milliseconds")]["provider"] == "google"
+        assert rows[("stt-aux", "characters")]["quantity"] == 11
+
+    def test_aux_usage_before_observer_exists_is_ignored(self):
+        from pipecat_aplisay.call_session import CallSession
+
+        session = CallSession.__new__(CallSession)
+        CallSession._on_aux_usage(session, "milliseconds", 1, {"vendor": "google", "model": None})
+
+    def test_aux_transcript_logs_user_aux_final(self):
+        from pipecat_aplisay.call_session import CallSession
+
+        sent = []
+
+        async def _send_message(message, *, is_final=True):
+            sent.append((message, is_final))
+
+        session = CallSession.__new__(CallSession)
+        session._send_message = _send_message
+        asyncio.run(CallSession._on_aux_transcript(session, "hello there"))
+        assert sent == [({"user-aux": "hello there"}, True)]

--- a/agents/pipecat/tests/test_usage.py
+++ b/agents/pipecat/tests/test_usage.py
@@ -22,17 +22,34 @@ from pipecat.frames.frames import (
 from pipecat.metrics.metrics import LLMTokenUsage, LLMUsageMetricsData, TTSUsageMetricsData
 from pipecat.observers.base_observer import FramePushed
 from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.llm_service import LLMService
+from pipecat.services.stt_service import STTService
 
 from pipecat_aplisay import api_client
 from pipecat_aplisay.usage import UsageMeteringObserver, usage_vendors
 
 
-def _push(observer: UsageMeteringObserver, *frames) -> None:
+class _FakeSTT(STTService):
+    """A concrete STTService so a frame can be attributed to an STT source."""
+
+    async def run_stt(self, audio: bytes):  # pragma: no cover - never driven
+        if False:
+            yield None
+
+
+class _FakeLLM(LLMService):
+    """A realtime-style LLM source (it transcribes internally)."""
+
+    def create_context_aggregator(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _push(observer: UsageMeteringObserver, *frames, source=None) -> None:
     async def run():
         for fr in frames:
             await observer.on_push_frame(
                 FramePushed(
-                    source=None, destination=None, frame=fr,
+                    source=source, destination=None, frame=fr,
                     direction=FrameDirection.DOWNSTREAM, timestamp=0,
                 )
             )
@@ -107,16 +124,42 @@ def test_tts_milliseconds_from_audio_frame_duration():
 
 # --- STT characters + milliseconds (new) -------------------------------------
 
-def test_stt_characters_from_final_transcript_only():
+def test_stt_characters_from_every_stt_transcription_frame():
+    # A TranscriptionFrame is final by definition (interims are
+    # InterimTranscriptionFrame); the Deepgram service never sets `finalized`
+    # in normal streaming, so gating on it counted nothing. Both count.
     obs = UsageMeteringObserver(services={"stt": {"vendor": "deepgram", "model": None}})
     _push(
         obs,
-        TranscriptionFrame(user_id="u", text="ignored interim", timestamp="", finalized=False),
-        TranscriptionFrame(user_id="u", text="hello there", timestamp="", finalized=True),
+        TranscriptionFrame(user_id="u", text="hello", timestamp=""),
+        TranscriptionFrame(user_id="u", text="there", timestamp="", finalized=True),
+        source=_FakeSTT(),
     )
     chars = _meter(obs, "stt", "characters")
-    assert chars["quantity"] == len("hello there")
+    assert chars["quantity"] == len("hello") + len("there")
     assert chars["provider"] == "deepgram"
+
+
+def test_stt_characters_only_from_an_stt_service_source():
+    # A realtime model's own transcripts (source = the LLM service) are bundled
+    # into its charge; an unattributed frame is not STT usage either.
+    obs = UsageMeteringObserver(services={"stt": {"vendor": "deepgram", "model": None}})
+    _push(obs, TranscriptionFrame(user_id="u", text="from the model", timestamp=""), source=_FakeLLM())
+    _push(obs, TranscriptionFrame(user_id="u", text="from nowhere", timestamp=""), source=None)
+    assert _meter(obs, "stt", "characters") is None
+
+
+def test_add_meter_accumulates_external_usage_for_flush():
+    # The auxiliary STT runs in a side pipeline the observer never sees, so it
+    # hands its meters in through add_meter and they flush with the rest.
+    obs = UsageMeteringObserver(services={})
+    obs.add_meter("stt-aux", "milliseconds", 1200, provider="google", detail=None)
+    obs.add_meter("stt-aux", "milliseconds", 300, provider="google", detail=None)
+    obs.add_meter("stt-aux", "characters", 11, provider="google", detail=None)
+    obs.add_meter("stt-aux", "characters", 0, provider="google", detail=None)  # no-op
+    assert _meter(obs, "stt-aux", "milliseconds")["quantity"] == 1500
+    assert _meter(obs, "stt-aux", "milliseconds")["provider"] == "google"
+    assert _meter(obs, "stt-aux", "characters")["quantity"] == 11
 
 
 def test_stt_milliseconds_from_vad_window():

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -494,6 +494,40 @@ components:
               description: |-
                 STT provider for pipeline models (e.g. deepgram, assemblyai, cartesia).
                 You may optionally scope the inference model (and suffix) using `vendor/model[:lang]`, e.g. `deepgram/nova-3:en`.
+            aux:
+              type: object
+              description: |-
+                Auxiliary ("second opinion") speech recognition. When set, the worker runs a second,
+                independent STT engine over the caller's audio alongside the agent's own recognition —
+                the pipeline STT, or a realtime model's built-in transcription — and logs each final
+                transcript it produces as a `user-aux` transaction-log entry next to the primary `user`
+                entry, so two recognitions of the same speech can be compared. The auxiliary engine
+                never feeds the model; it is observation only.
+
+                Same shape as `stt` (`vendor`, `language`), plus `enabled`. `vendor` defaults to the
+                platform's default STT engine; `language` defaults to `stt.language`, then `tts.language`.
+
+                Its consumption is metered separately as `stt-aux` usage — the audio streamed to the
+                auxiliary engine (milliseconds, silence included) and the transcript characters it
+                returned — and priced by that component's own rate lines. Supported on `livekit:` and
+                `pipecat:` models, in both realtime and pipeline modes; rejected on other models.
+                See docs/auxiliary-stt.md.
+              properties:
+                enabled:
+                  type: boolean
+                  default: true
+                  description: Set `false` to switch the auxiliary engine off without removing the object.
+                language:
+                  $ref: "#/components/schemas/Language"
+                vendor:
+                  type: string
+                  description: |-
+                    Auxiliary STT provider, with the same semantics as `stt.vendor` (e.g. `deepgram`,
+                    `assemblyai`, `cartesia` on LiveKit; `deepgram`, `google` on Pipecat), optionally
+                    scoped as `vendor/model[:lang]`.
+              example:
+                vendor: assemblyai
+                language: en-GB
         fallback:
           type: object
           description: |-

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Index of the docs in this directory. Start with the first table if you're new; t
 | [tool-call-chaining-metadata-priming.md](tool-call-chaining-metadata-priming.md) | Static/metadata parameter sourcing and chained tool calls |
 | [prompt-metadata.md](prompt-metadata.md) | Stating call facts (date/time, caller number, seeded data) in the agent's prompt |
 | [uninterruptible-greetings.md](uninterruptible-greetings.md) | Barge-in control for opening prompts |
+| [auxiliary-stt.md](auxiliary-stt.md) | `options.stt.aux`: a second STT engine's transcript of the caller logged as `user-aux`, metered as `stt-aux` |
 | [ultravox-vendor-specific-options.md](ultravox-vendor-specific-options.md) | Ultravox model variants and tuning options |
 | [agent-concurrency-limits.md](agent-concurrency-limits.md) | Per-agent/user/organisation concurrency caps |
 | [agent-failover.md](agent-failover.md) | Automatic fallback agents and numbers |

--- a/docs/auxiliary-stt.md
+++ b/docs/auxiliary-stt.md
@@ -1,0 +1,70 @@
+# Auxiliary ("second opinion") STT — `options.stt.aux`
+
+An agent can run a **second, independent speech-recognition engine over the caller's audio** alongside its own recognition. Every final transcript the auxiliary engine produces is logged in the call's transaction log as a `user-aux` entry, next to the primary `user` entry for the same speech, and its consumption is metered as its own `stt-aux` usage component.
+
+The auxiliary engine is **observation only**: nothing it produces reaches the model. It exists so two recognitions of the same audio can be compared — for evaluating an STT vendor before switching to it, for measuring how well a realtime model's built-in transcription holds up against a dedicated engine, or for keeping an independent record of what the caller said.
+
+It works on both voice workers and in both voice modes:
+
+| Model family | Realtime (speech-to-speech) | Pipeline (STT → LLM → TTS) |
+|---|---|---|
+| `livekit:` | ✅ second engine next to the model's own transcription | ✅ second engine next to the pipeline STT |
+| `pipecat:` | ✅ | ✅ |
+| `ultravox:` (native driver), `jambonz:`, `text:` | ❌ rejected at save time (`Model … does not support auxiliary STT`) | — |
+
+## Configuration
+
+`options.stt.aux` has the **same shape as `options.stt`** (`vendor`, `language`), plus `enabled`:
+
+```json
+{
+  "modelName": "livekit:ultravox/ultravox-v0.7",
+  "options": {
+    "stt": {
+      "language": "en-GB",
+      "aux": { "vendor": "assemblyai" }
+    }
+  }
+}
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `true` | Set `false` to switch the auxiliary engine off without removing the block. |
+| `vendor` | the platform's default STT engine (Deepgram) | Same semantics as `stt.vendor`: a vendor name, optionally scoped as `vendor/model[:lang]` (e.g. `deepgram/nova-2:en`). LiveKit offers `deepgram`, `assemblyai`, `cartesia` (via LiveKit Inference; Deepgram only under `LIVEKIT_PIPELINE_USE_PROVIDER_KEYS`); Pipecat offers `deepgram` and `google`. |
+| `language` | `stt.language`, then `tts.language` | Language hint for the auxiliary engine (`Language` schema). The "no fixed language" sentinels (`any`, `multi`, …) are accepted and mean "let the engine decide", as for `stt.language`. |
+
+`{}` (or `true`) enables the engine with defaults. The block is validated when the agent is saved: unknown fields, a nested `aux`, a non-boolean `enabled`, a malformed vendor string or a non-BCP-47 language are rejected with a 400. A vendor the *worker* cannot build (say `google` on LiveKit) is not caught at save time: the worker logs a warning and the call runs without the second opinion.
+
+## What gets logged
+
+- Each **final** transcript segment from the auxiliary engine becomes one transaction-log entry of type **`user-aux`** with `isFinal: true` and `data` = the text, timestamped when the segment arrived. Interim results are not logged.
+- The primary `user` entries are unchanged. Consumers that compare the two should align them by `createdAt`: an auxiliary engine finalises per speech segment, whereas a realtime model or the pipeline STT may log one entry per turn, so one `user` entry can correspond to several `user-aux` entries.
+- The entries follow the same path as every other transcript entry — streamed live when the listener sets `streamLog`, otherwise batched onto the call record at the end — and the live progress socket carries them as `{ "user-aux": "<text>", isFinal, callId, timestamp }`. Front-ends that render transcripts by type should decide how (or whether) to show the new type; the platform does not merge it into `user`.
+
+## Lifecycle
+
+- The engine is armed once the agent session is up, on the caller's audio only (never the agent's).
+- **Agent handover** (`transfer_agent`, or a hand-back after a bridged transfer): the auxiliary engine is re-armed with the *incoming* agent's own `options.stt.aux` — an agent without the option switches it off for the rest of the call.
+- **Consultative transfer** (LiveKit): while the caller is on hold during the consultation, auxiliary transcripts are suppressed, matching the primary transcript.
+- **Bridged transfer**: when the agent's media is detached and the caller talks to a human, the auxiliary engine is stopped — there is no agent transcript left to second-guess, and the human↔human segment has its own option, [`bridgedTransferTranscribe`](./call-transfers.md#transcribing-the-bridged-segment-bridgedtransfertranscribe). A WebRTC-origin transfer relay on Pipecat silences the auxiliary engine in the same way.
+- The engine stops when the caller leaves or the call ends. A failure inside it (vendor error, unsupported vendor, no audio track) is logged and never affects the call.
+
+## Billing
+
+The auxiliary engine is a real cost on every voice mode — including realtime models, whose *own* recognition is bundled into the model charge — so it is metered as its **own technology, `stt-aux`**, never folded into the primary `stt` meter:
+
+| Row | `technology` | `provider` | `detail` | `unit` | What is counted |
+|---|---|---|---|---|---|
+| audio | `stt-aux` | the aux vendor (e.g. `assemblyai`) | `vendor/model` where known | `milliseconds` | Audio actually streamed to the auxiliary engine, silence included — the basis streaming STT vendors bill on. Measured by the worker at the point it hands audio to the engine. |
+| text | `stt-aux` | as above | as above | `characters` | Characters in the final transcripts the engine returned. |
+
+Rows are attributed to the agent call (the session's own call record, like the model's token and TTS meters) and finalised when it ends; a handover carries the running totals onto the continuation call.
+
+**Rate cards must price the component explicitly.** `GET /api/rate-components` advertises one `stt-aux:<engine>` component per STT engine (dimension `stt`, units `minute` | `character`) alongside the primary `stt:<engine>` components; a line keyed on `{ technology: "stt", provider }` does *not* match `stt-aux` rows, and a card with no `stt-aux` line leaves them uncosted (`no_line`), visible as `uncostedMeters` in `GET /api/usage`. This is deliberate: an operator decides whether the second opinion is priced like primary STT, at a premium, or given away, and the usage report shows it as its own line either way. Filter with `GET /api/usage?technology=stt-aux`.
+
+## Implementation notes
+
+- **LiveKit worker** — [`agents/livekit/lib/aux-stt.ts`](../agents/livekit/lib/aux-stt.ts). The worker already holds its own connection to the room, so it opens one extra `AudioStream` on the caller participant's audio track (the technique the bridged-segment transcription uses) and pumps it into a fresh STT stream built by the pipeline's own resolution with `options.stt.aux` standing in for `options.stt`. The `AgentSession` is untouched.
+- **Pipecat worker** — [`agents/pipecat/pipecat_aplisay/aux_stt.py`](../agents/pipecat/pipecat_aplisay/aux_stt.py). An `AuxSttTap` sits right after `transport.input()` (behind the WebRTC relay tap). It passes every frame through untouched and copies each input audio frame into a side STT-only pipeline (`SttStream`, shared with the bridged-segment transcription), so nothing the auxiliary service emits — transcripts, metrics, settings — can enter the main chain or be mistaken for the primary STT's.
+- Transaction-log type: `user-aux` is a new value of `transaction_logs.type` (schema version 64; a `DB_FORCE_SYNC` boot adds it).

--- a/docs/livekit-agent-architecture.md
+++ b/docs/livekit-agent-architecture.md
@@ -731,6 +731,7 @@ The catalog below covers every option that affects runtime behavior. The "Level"
 |---|---|---|---|
 | `voiceMode` | Agent | Override mode selection (pipeline / realtime) | 4.1 |
 | `stt` | Agent | STT configuration (vendor, language) | 4.3, 4.4 |
+| `stt.aux` | Agent | Auxiliary ("second opinion") STT over the caller's audio, logged as `user-aux` and metered as `stt-aux` (vendor, language, enabled) | [auxiliary-stt.md](auxiliary-stt.md) |
 | `tts` | Agent | TTS configuration (vendor, voice, language) | 4.3, 4.4 |
 | `vendorSpecific` | Agent | Free-form provider passthrough | 4.6 |
 | `greeting` | Agent | Uninterruptible opening greeting (text or instructions) | 4.5 |

--- a/docs/livekit-pipeline-api-implications.md
+++ b/docs/livekit-pipeline-api-implications.md
@@ -71,6 +71,7 @@ Supported shape:
 Notes:
 
 - If you omit `options.stt.vendor`, the default is at this time `deepgram` → `deepgram/nova-3:<derivedLang>`.
+- `options.stt.aux` (same shape: `vendor`, `language`, plus `enabled`) runs a *second* STT engine over the caller's audio purely for comparison — on realtime models too — logging `user-aux` transcript entries and `stt-aux` usage. See [`docs/auxiliary-stt.md`](./auxiliary-stt.md).
 
 #### `options.tts`
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -19,7 +19,10 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 63;  // 63: `number_reservations` — a claim onto a CHARGEABLE trunk must present a
+const schemaVersion = 64;  // 64: transaction_logs.type gains 'user-aux' — the auxiliary ("second opinion")
+                           //     STT transcript of the caller's speech (options.stt.aux), logged next to
+                           //     the primary 'user' entry. See docs/auxiliary-stt.md.
+                           // 63: `number_reservations` — a claim onto a CHARGEABLE trunk must present a
                            //     reservation minted by a key holding `phoneEndpoint:reserve` (the carrier
                            //     seam) unless the caller holds `trunk:create`; the claim consumes it.
                            // 62: registration trunks — `phone_registrations.trunk_id` (FK trunks, SET NULL),
@@ -650,6 +653,18 @@ Agent.init({
           //  agent's configured STT). See docs/call-transfers.md.
           validateBridgedTransferTranscribeShape(this.options.bridgedTransferTranscribe, {
             hasTransfer: Handler.hasTransfer,
+            modelName: this.modelName,
+          });
+        }
+        if (this.options?.stt?.aux !== undefined && this.options?.stt?.aux !== null) {
+          // Auxiliary ("second opinion") STT: a second, independent recognition of
+          //  the caller's speech, logged as `user-aux` transaction-log entries next
+          //  to the primary `user` ones and metered as `stt-aux` usage. Same shape
+          //  as options.stt. Only the workers that can tap the caller's audio
+          //  alongside the primary stack (LiveKit, Pipecat) implement it — see
+          //  docs/auxiliary-stt.md.
+          validateAuxSttShape(this.options.stt.aux, {
+            hasAuxStt: Handler.hasAuxStt,
             modelName: this.modelName,
           });
         }
@@ -1394,7 +1409,7 @@ TransactionLog.init({
   },
   type: {
     type: DataTypes.ENUM,
-    values: ['start', 'hangup', 'goodbye', 'answer', 'inject', 'call', 'call_failed', 'agent', 'user', 'function_calls', 'rest_callout', 'function_results', 'error'],
+    values: ['start', 'hangup', 'goodbye', 'answer', 'inject', 'call', 'call_failed', 'agent', 'user', 'user-aux', 'function_calls', 'rest_callout', 'function_results', 'error'],
     required: true
   },
   data: {
@@ -3104,6 +3119,54 @@ function validateBridgedTransferTranscribeShape(transcribe, { hasTransfer, model
   }
 }
 
+/**
+ * UI / legacy `language` values that mean "no fixed language" rather than a tag.
+ * Accepted wherever a BCP-47 tag is, since both voice workers already treat them
+ * as "unspecified" (see NON_SPECIFIC_STT_LANGUAGES in the LiveKit worker).
+ */
+const NON_SPECIFIC_LANGUAGE_VALUES = ['any', 'multi', '*', 'auto', 'all', 'global'];
+
+/**
+ * Structural validation of an `options.stt.aux` value — the auxiliary ("second
+ * opinion") STT configuration. An object of the same shape as `options.stt`
+ * ({ vendor?, language? }) plus `enabled?`; nothing else, and never nested.
+ * Shared between Agent.validate and any future listener-level override path.
+ *
+ * @param {object} aux the candidate value
+ * @param {object} flags { hasAuxStt, modelName, context }
+ * @throws {Error} (status 400) on any shape violation
+ */
+function validateAuxSttShape(aux, { hasAuxStt, modelName, context = 'options.stt.aux' } = {}) {
+  const fail = (message) => {
+    const err = new Error(message);
+    err.status = 400;
+    throw err;
+  };
+  if (aux === null || typeof aux !== 'object' || Array.isArray(aux)) {
+    fail(`${context} must be an object of the same shape as options.stt ({ vendor, language })`);
+  }
+  if (!hasAuxStt) {
+    fail(`Model ${modelName} does not support auxiliary STT, but ${context} is set`);
+  }
+  const allowedFields = ['enabled', 'vendor', 'language'];
+  const unknown = Object.keys(aux).filter((field) => !allowedFields.includes(field));
+  if (unknown.length) {
+    fail(`${context} has unknown field(s) ${unknown.join(', ')} (allowed: ${allowedFields.join(', ')})`);
+  }
+  if (aux.enabled !== undefined && typeof aux.enabled !== 'boolean') {
+    fail(`${context}.enabled must be a boolean`);
+  }
+  if (aux.vendor !== undefined
+    && (typeof aux.vendor !== 'string' || !/^[a-z0-9][a-z0-9_.-]*(\/[^\s:]+)?(:[^\s]+)?$/i.test(aux.vendor))) {
+    fail(`${context}.vendor must be an STT vendor name, optionally scoped as vendor/model[:lang] (e.g. "deepgram", "deepgram/nova-3:en")`);
+  }
+  if (aux.language !== undefined
+    && !NON_SPECIFIC_LANGUAGE_VALUES.includes(`${aux.language}`.toLowerCase())
+    && !/^[a-z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(`${aux.language}`)) {
+    fail(`${context}.language must be a BCP-47 language tag (e.g. "en", "en-US")`);
+  }
+}
+
 
 export {
   Metadata,
@@ -3112,6 +3175,7 @@ export {
   Instance,
   validateBridgedTransferToAgentShape,
   validateBridgedTransferTranscribeShape,
+  validateAuxSttShape,
   PhoneNumber,
   PhoneRegistration,
   B2buaNode,

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -37,6 +37,10 @@ export default class Handler {
   static hasSubagent = false;
   // Supports the send_dtmf builtin: play RFC 4733 (out-of-band) DTMF digits over a SIP call
   static hasDtmf = false;
+  // Supports options.stt.aux: an auxiliary ("second opinion") STT run over the caller's
+  // audio alongside the primary stack, logged as `user-aux` and metered as `stt-aux`.
+  // Needs a worker that owns the caller's media independently of the model stack.
+  static hasAuxStt = false;
   // The Agent.type implemented by this handler: 'interactive-audio' (default) or 'text'
   static agentType = 'interactive-audio';
 

--- a/lib/handlers/livekit.js
+++ b/lib/handlers/livekit.js
@@ -20,6 +20,9 @@ class Livekit extends Handler {
   static hasSubagent = true;
   // Send out-of-band (RFC 4733) DTMF via localParticipant.publishDtmf — SIP calls only.
   static hasDtmf = true;
+  // Auxiliary STT (options.stt.aux): a second STT stream on the caller's room track,
+  // alongside the AgentSession — see agents/livekit/lib/aux-stt.ts.
+  static hasAuxStt = true;
 
   static get models() {
     return [LiveKitModel];

--- a/lib/handlers/pipecat.js
+++ b/lib/handlers/pipecat.js
@@ -40,6 +40,9 @@ class Pipecat extends Handler {
   // Send out-of-band (RFC 4733) DTMF over the SIP leg — the gateway (sipbridge /
   // voiceblender) synthesises telephone-event RTP; browser/WebRTC sessions error.
   static hasDtmf = true;
+  // Auxiliary STT (options.stt.aux): an audio tap after transport.input() feeds a
+  // side STT-only pipeline — see pipecat_aplisay/aux_stt.py.
+  static hasAuxStt = true;
 
   static get models() {
     return [PipecatModel];

--- a/lib/rate-components.js
+++ b/lib/rate-components.js
@@ -21,8 +21,13 @@
 
 /** TTS engines and the billing units each can be metered on (characters + audio ms). */
 export const TTS_ENGINES = ['elevenlabs', 'cartesia', 'deepgram', 'google'];
-/** STT engines and their metered billing units (audio ms + transcript characters). */
-export const STT_ENGINES = ['deepgram'];
+/**
+ * STT engines and their metered billing units (audio ms + transcript characters).
+ * Every vendor either worker can be pointed at for the primary pipeline STT or the
+ * auxiliary STT (options.stt.aux): assemblyai/cartesia via LiveKit Inference,
+ * google via the Pipecat worker, deepgram on both.
+ */
+export const STT_ENGINES = ['deepgram', 'assemblyai', 'cartesia', 'google'];
 
 /** Split `<handler>:<vendor>/<model>` into its parts; `detail` is the post-handler id. */
 function parseModelName(name) {
@@ -112,6 +117,18 @@ export function buildRateComponents({ implementations = [], models = [] } = {}) 
     components.push({
       dim: 'stt', key: `stt:${provider}`, label: `STT · ${provider}`,
       match: { technology: 'stt', provider }, units: ['minute', 'character'], available: true,
+    });
+  }
+  // stt-aux: the auxiliary ("second opinion") STT (options.stt.aux) runs a second
+  // engine over the caller's audio alongside the primary stack — on realtime
+  // models too, whose own recognition is bundled into the model charge. It is a
+  // real, separate cost, so it is metered as its own technology rather than
+  // folded into `stt`, and priced by its own lines (same engines, same units).
+  // A card that carries no stt-aux line leaves those rows uncosted (no_line).
+  for (const provider of STT_ENGINES) {
+    components.push({
+      dim: 'stt', key: `stt-aux:${provider}`, label: `Auxiliary STT · ${provider}`,
+      match: { technology: 'stt-aux', provider }, units: ['minute', 'character'], available: true,
     });
   }
 

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -35,7 +35,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * @param {string} [params.organisationId]
  * @param {string} [params.userId]
  * @param {string} [params.agentId]
- * @param {string} params.technology broad category ('llm'|'tts'|'stt'|'voice'|'function'|…)
+ * @param {string} params.technology broad category ('llm'|'tts'|'stt'|'stt-aux'|'voice'|'function'|…)
  * @param {string} [params.provider] vendor ('anthropic'|'elevenlabs'|…)
  * @param {string} [params.detail] detailed model/tech name
  * @param {string} params.unit unit of measure ('input_tokens'|'characters'|'milliseconds'|…)

--- a/tests/agent-aux-stt-options.test.mjs
+++ b/tests/agent-aux-stt-options.test.mjs
@@ -1,0 +1,159 @@
+import {
+  setupRealDatabase, teardownRealDatabase,
+  Agent, TransactionLog, User, Organisation,
+} from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+import { validateAuxSttShape } from '../lib/database.js';
+
+/**
+ * options.stt.aux — the auxiliary ("second opinion") STT: shape validation at
+ * agent save time, handler gating, round-trip of the stored block, the new
+ * `user-aux` transaction-log type, and the pure validator's error texts.
+ * See docs/auxiliary-stt.md.
+ */
+
+const mockLogger = {
+  info: () => { }, warn: () => { }, error: () => { }, debug: () => { }, child: () => mockLogger,
+};
+
+function makeReq(body = {}, params = {}, query = {}) {
+  return { body, params, query, log: mockLogger };
+}
+
+function makeRes(user) {
+  return {
+    locals: { user },
+    statusCode: 200,
+    body: undefined,
+    status(code) { this.statusCode = code; return this; },
+    send(payload) { this.body = payload; return this; },
+    json(payload) { this.body = payload; return this; },
+  };
+}
+
+const LIVEKIT_MODEL = 'livekit:ultravox/ultravox-70b';
+const PIPECAT_MODEL = 'pipecat:openai/gpt-4o';
+const TEXT_MODEL = 'text:openai/gpt-4o';
+
+describe('options.stt.aux (auxiliary STT)', () => {
+  let createAgent, getAgent;
+  let user, org;
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    const agents = (await import('../api/paths/agents.js')).default(mockLogger, {}, {});
+    createAgent = agents.POST;
+    const item = (await import('../api/paths/agents/{agentId}.js')).default(mockLogger, {}, {});
+    getAgent = item.GET;
+
+    org = await Organisation.create({ id: randomUUID(), name: 'Aux STT Test Org' });
+    const dbUser = await User.create({
+      id: randomUUID(),
+      name: 'Aux STT Tester',
+      email: `aux-stt-${randomUUID()}@example.com`,
+      emailVerified: true,
+      phone: '',
+      phoneVerified: false,
+      picture: '',
+      role: 'owner',
+      organisationId: org.id,
+    });
+    user = { id: dbUser.id, organisationId: org.id, role: 'owner' };
+  }, 60000);
+
+  afterAll(async () => {
+    await Agent.destroy({ where: { organisationId: org.id } });
+    await User.destroy({ where: { organisationId: org.id } });
+    await Organisation.destroy({ where: { id: org.id } });
+    await teardownRealDatabase();
+  }, 60000);
+
+  const create = async (body) => {
+    const res = makeRes(user);
+    await createAgent(makeReq(body), res);
+    return res;
+  };
+
+  test('accepts the documented shapes on LiveKit and Pipecat models', async () => {
+    for (const [modelName, aux] of [
+      [LIVEKIT_MODEL, {}],
+      [LIVEKIT_MODEL, { vendor: 'assemblyai', language: 'en-GB' }],
+      [LIVEKIT_MODEL, { vendor: 'deepgram/nova-2:en' }],
+      [LIVEKIT_MODEL, { enabled: false }],
+      [LIVEKIT_MODEL, { language: 'any' }], // "no fixed language" sentinel, as options.stt allows
+      [PIPECAT_MODEL, { vendor: 'google', language: 'fr-FR' }],
+    ]) {
+      const res = await create({ modelName, prompt: 'front desk', options: { stt: { aux } } });
+      expect([res.statusCode, JSON.stringify(res.body)]).toEqual([200, expect.any(String)]);
+    }
+  });
+
+  test('round-trips the stored block next to the primary stt options', async () => {
+    const options = {
+      stt: { vendor: 'deepgram', language: 'en-US', aux: { vendor: 'assemblyai', language: 'en-GB' } },
+    };
+    const res = await create({ modelName: LIVEKIT_MODEL, prompt: 'front desk', options });
+    expect(res.statusCode).toBe(200);
+    const got = makeRes(user);
+    await getAgent(makeReq({}, { agentId: res.body.id }), got);
+    expect(got.statusCode).toBe(200);
+    expect(got.body.options.stt).toEqual(options.stt);
+  });
+
+  test('rejects malformed shapes with a 400 that names the problem', async () => {
+    for (const [aux, pattern] of [
+      [true, /same shape as options\.stt/],
+      ['assemblyai', /same shape as options\.stt/],
+      [['assemblyai'], /same shape as options\.stt/],
+      [{ provider: 'assemblyai' }, /unknown field/],
+      [{ aux: {} }, /unknown field/], // never nested
+      [{ enabled: 'yes' }, /enabled must be a boolean/],
+      [{ vendor: 'bad vendor!' }, /vendor must be an STT vendor name/],
+      [{ vendor: 42 }, /vendor must be an STT vendor name/],
+      [{ language: 'English!' }, /BCP-47/],
+    ]) {
+      const res = await create({ modelName: LIVEKIT_MODEL, prompt: 'front desk', options: { stt: { aux } } });
+      expect([res.statusCode, JSON.stringify(res.body)]).toEqual([400, expect.stringMatching(pattern)]);
+    }
+  });
+
+  test('rejects the option on a model whose handler cannot tap the caller audio', async () => {
+    const res = await create({
+      modelName: TEXT_MODEL, type: 'text', prompt: 'writer', options: { stt: { aux: {} } },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/does not support auxiliary STT/);
+  });
+
+  test('transaction_logs.type carries user-aux, in the model and in the live enum (schema v64)', async () => {
+    expect(TransactionLog.rawAttributes.type.values).toContain('user-aux');
+    // The forced sync the test wrapper runs must have added the value to the
+    // Postgres enum itself — that is what a DB_FORCE_SYNC deploy relies on.
+    const [labels] = await TransactionLog.sequelize.query(
+      `SELECT e.enumlabel FROM pg_enum e JOIN pg_type t ON e.enumtypid = t.oid
+        WHERE t.typname = 'enum_transaction_logs_type' ORDER BY e.enumsortorder`,
+    );
+    expect(labels.map((l) => l.enumlabel)).toEqual(expect.arrayContaining(['user', 'user-aux', 'agent']));
+  });
+
+  test('validateAuxSttShape: pure validator contract', () => {
+    const ok = (aux) => expect(() => validateAuxSttShape(aux, { hasAuxStt: true, modelName: 'm' })).not.toThrow();
+    const bad = (aux, pattern, flags = { hasAuxStt: true, modelName: 'm' }) => {
+      let err;
+      try { validateAuxSttShape(aux, flags); } catch (e) { err = e; }
+      expect(err).toBeTruthy();
+      expect(err.status).toBe(400);
+      expect(err.message).toMatch(pattern);
+    };
+    ok({});
+    ok({ vendor: 'deepgram', language: 'en', enabled: true });
+    ok({ vendor: 'deepgram/nova-3:en' });
+    ok({ language: 'multi' });
+    bad(null, /must be an object/);
+    bad({}, /Model m does not support auxiliary STT/, { hasAuxStt: false, modelName: 'm' });
+    bad({ bogus: 1 }, /unknown field\(s\) bogus/);
+    bad({ language: 'en_GB' }, /BCP-47/);
+    // The context label is threaded into every message (listener-override reuse).
+    bad({ bogus: 1 }, /^listener\.stt\.aux has unknown/, { hasAuxStt: true, modelName: 'm', context: 'listener.stt.aux' });
+  });
+});

--- a/tests/rate-components.test.mjs
+++ b/tests/rate-components.test.mjs
@@ -1,5 +1,5 @@
 import { setupRealDatabase, teardownRealDatabase, databaseStarted } from './setup/database-test-wrapper.js';
-import { buildRateComponents, TTS_ENGINES } from '../lib/rate-components.js';
+import { buildRateComponents, STT_ENGINES, TTS_ENGINES } from '../lib/rate-components.js';
 import { resolveRowCost } from '../lib/rates.js';
 
 // Phase-3 catalogue: the priceable-component roster /api/rate-components advertises,
@@ -47,6 +47,36 @@ describe('rate-components catalogue', () => {
     expect(comps.filter((c) => c.dim === 'tts').map((c) => c.match.provider).sort()).toEqual([...TTS_ENGINES].sort());
     expect(byKey('tts:elevenlabs').units).toEqual(['character', 'minute']);
     expect(byKey('stt:deepgram').units).toEqual(['minute', 'character']);
+    // Every STT engine either worker can be pointed at, primary or auxiliary.
+    expect(comps.filter((c) => c.key.startsWith('stt:')).map((c) => c.match.provider).sort()).toEqual([...STT_ENGINES].sort());
+  });
+
+  it('advertises the auxiliary STT (options.stt.aux) as its own stt-aux component per engine', () => {
+    const aux = comps.filter((c) => c.key.startsWith('stt-aux:'));
+    expect(aux.map((c) => c.match.provider).sort()).toEqual([...STT_ENGINES].sort());
+    expect(byKey('stt-aux:deepgram')).toEqual({
+      dim: 'stt', key: 'stt-aux:deepgram', label: 'Auxiliary STT · deepgram',
+      match: { technology: 'stt-aux', provider: 'deepgram' }, units: ['minute', 'character'], available: true,
+    });
+  });
+
+  it('an stt-aux row is priced only by an stt-aux line, never by the primary stt line', () => {
+    const line = (comp, unit, priceMicros) => ({ dim: comp.dim, match: comp.match, unit, priceMicros });
+    const auxRow = { technology: 'stt-aux', provider: 'deepgram', detail: 'deepgram/nova-3', unit: 'milliseconds', quantity: 60000 };
+    const primaryOnly = { detail: { lines: [line(byKey('stt:deepgram'), 'minute', 100000)] } };
+    expect(resolveRowCost(auxRow, primaryOnly)).toEqual({ costMicros: null, status: 'no_line', breakdown: [] });
+    const both = { detail: { lines: [
+      line(byKey('stt:deepgram'), 'minute', 100000),
+      line(byKey('stt-aux:deepgram'), 'minute', 70000),
+    ] } };
+    const { costMicros, status, breakdown } = resolveRowCost(auxRow, both);
+    expect(status).toBe('matched');
+    expect(costMicros).toBe(70000);
+    expect(breakdown).toHaveLength(1);
+    expect(breakdown[0].match).toEqual({ technology: 'stt-aux', provider: 'deepgram' });
+    // …and the primary row is untouched by the aux line.
+    const primaryRow = { ...auxRow, technology: 'stt' };
+    expect(resolveRowCost(primaryRow, both).costMicros).toBe(100000);
   });
 
   it('the catalogue match templates resolve a real Ultravox voice row on BOTH dimensions', () => {


### PR DESCRIPTION
## Summary

An agent can run a **second, independent STT engine over the caller's audio** alongside its own recognition, on both voice workers and in both voice modes. Every final transcript it produces is logged as a new transaction-log type, **`user-aux`**, next to the primary `user` entry, and its consumption is metered as its own usage technology, **`stt-aux`**. Observation only — nothing it produces reaches the model.

```json
"stt": { "language": "en-GB", "aux": { "vendor": "assemblyai" } }
```

Same shape as `options.stt` (`vendor`, `language`) plus `enabled`. Validated at save time; rejected (400) on models whose handler cannot tap the caller audio (native Ultravox, Jambonz, text). Full write-up: `docs/auxiliary-stt.md`.

## Design points

- **`stt-aux` is its own technology, not folded into `stt`.** Realtime agents suppress primary STT rows because that recognition is bundled into the model charge, but the auxiliary engine is a real extra cost; merging would also collide meter keys when both engines share a vendor. A rate card therefore needs an `stt-aux:<engine>` line (now advertised by `/api/rate-components`) or the rows stay uncosted (`no_line`).
- **Units:** milliseconds of audio actually streamed to the auxiliary engine (silence included, measured by the worker at the hand-off point) + characters of final text. Finals only; no interim rows.
- **Lifecycle:** re-armed with the incoming agent's config on a `transfer_agent` handover / bridged takeover; stopped when the agent's media is detached after a bridged transfer (new `onPrimaryAgentDetached` hook) and on teardown; suppressed during a LiveKit consultation like the primary transcript.
- **LiveKit:** extra rtc-node `AudioStream` on the caller track, own pump (so ms are measured), vendor via the pipeline resolution with the aux block standing in for `options.stt`.
- **Pipecat:** pass-through `AuxSttTap` after the relay tap feeding a side STT-only pipeline (`SttStream`, generalised to the call's input format); nothing of the aux engine enters the main chain.

## Also fixed

Pipecat 1.6 primary STT character metering counted **nothing**: the Deepgram service never sets `TranscriptionFrame.finalized`, which the old gate required. Every STT-service-sourced `TranscriptionFrame` now counts; realtime-model transcripts are excluded (they are bundled into the model charge).

## Deploy notes

- **Schema v64** (`DB_FORCE_SYNC` adds the enum value). Workers logging `user-aux` before the enum exists get a 500 from the transaction-log ingest.
- Front-ends that render transcripts by type need to learn `user-aux` (polite-ai / llm-frontend changes in progress separately).

## Tests

| Suite | Result |
|---|---|
| Server jest, 10 relevant DB suites (incl. new `agent-aux-stt-options`, extended `rate-components`) | 101 passed |
| Pipecat pytest, full suite (incl. new `test_aux_stt.py`, updated `test_usage.py`) | 457 passed |
| LiveKit node tests (new `test/aux-stt.test.ts`, 9 cases) | all pass; the 1 failure in `voice-session-factory` is pre-existing on `next` |
| LiveKit `tsc --noEmit` / `tsup` build | clean for touched files |

Not yet live-verified on a real call.
