### PR TITLE
Advertise hasAuxStt on the model roster

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -115,6 +115,14 @@ components:
           description: This model supports audio input via WebRTC
           type: boolean
           example: true
+        hasAuxStt:
+          description: |-
+            This model accepts `options.stt.aux` — an auxiliary ("second opinion") STT run over the
+            caller's audio alongside the model's own recognition, logged as `user-aux` transcript
+            entries and metered as `stt-aux` usage (see docs/auxiliary-stt.md). True for the
+            LiveKit and Pipecat voice workers; the option is rejected on other models.
+          type: boolean
+          example: true
       required:
         - name
         - description

--- a/api/paths/models.js
+++ b/api/paths/models.js
@@ -28,6 +28,7 @@ const modelList = async (req, res) => {
         implementation,
         hasTelephony,
         hasWebRTC,
+        hasAuxStt,
         audioModel,
         voiceStack,
         requiresSttTts,
@@ -40,6 +41,7 @@ const modelList = async (req, res) => {
           audioModel: audioModel ?? implementation.audioModel,
           hasTelephony,
           hasWebRTC,
+          hasAuxStt: hasAuxStt === true,
           ...(voiceStack != null ? { voiceStack } : {}),
           ...(requiresSttTts != null ? { requiresSttTts } : {}),
         }

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -102,6 +102,7 @@ export default class Handler {
               supportsMcp: implementation.supportsMcp(name),
               hasTelephony: this.hasTelephony,
               hasWebRTC: this.hasWebRTC,
+              hasAuxStt: this.hasAuxStt,
               description,
               implementation,
               audioModel: flags.audioModel ?? implementation.audioModel,

--- a/tests/models-endpoint.test.mjs
+++ b/tests/models-endpoint.test.mjs
@@ -132,7 +132,7 @@ describe('Models Endpoint Test', () => {
     
     // All models should have the same structure
     for (const [modelName, modelInfo] of modelEntries) {
-      const requiredKeys = ['description', 'supportsFunctions', 'audioModel', 'hasTelephony', 'hasWebRTC'];
+      const requiredKeys = ['description', 'supportsFunctions', 'audioModel', 'hasTelephony', 'hasWebRTC', 'hasAuxStt'];
       
       for (const key of requiredKeys) {
         expect(modelInfo).toHaveProperty(key);


### PR DESCRIPTION
Follow-up to #279: `GET /models` now carries `hasAuxStt` per model (true for `livekit:` and `pipecat:` models, false elsewhere), so the dashboards can gate the auxiliary-transcription toggle on models that accept `options.stt.aux` rather than discovering it from a 400 at save time. Documented in the OpenAPI model schema; `models-endpoint` test asserts the key.