### PR TITLE
fix(livekit): ship agent-lib/fallback-message as a real copy — the symlink dangles in the image

### DIFF
--- a/agents/livekit/agent-lib/fallback-message
+++ b/agents/livekit/agent-lib/fallback-message
@@ -1,1 +1,0 @@
-../../../lib/fallback-message/

--- a/agents/livekit/agent-lib/fallback-message/CONTRACT.md
+++ b/agents/livekit/agent-lib/fallback-message/CONTRACT.md
@@ -1,0 +1,140 @@
+# Fixed fallback message — shared contract
+
+This document is the single source of truth for the cache layout and audio
+format used by the fixed-message failover path (`options.fallback.message`).
+Two implementations follow it:
+
+- **JS** — this directory (`lib/fallback-message/`), consumed by the LiveKit
+  agent via the `agent-lib/` symlink.
+- **Python** — `agents/pipecat/pipecat_aplisay/fallback_message/`, a sibling
+  implementation. Different language, same contract.
+
+Both runtimes read and write the *same* objects. A change made on one side and
+not the other does not corrupt anything — it splits the cache in two, so each
+runtime silently re-synthesises what the other already paid for. If you change
+anything here, change both sides and update
+`tests/lib/fallback-message.test.mjs` and
+`agents/pipecat/tests/test_fallback_message.py`.
+
+## Why there is a cache at all
+
+The announcement never varies for a given configuration, so it is synthesised
+once and replayed thereafter. That is not only a latency and cost win: it is
+what keeps the playout path free of any billing interaction. A cache hit makes
+no vendor call, so it meters nothing, so it needs no `Call` record, so it never
+touches the concurrency limiter — which matters because the single most useful
+time to play a fixed message is when that limiter is the thing rejecting the
+call. See `docs/agent-failover.md` for the full argument.
+
+## Cache key
+
+Content-addressed. The key is the first 32 hex characters (128 bits) of
+`sha256(canonical)` where `canonical` is the UTF-8 JSON encoding of exactly:
+
+```json
+["<text>", "<vendor>", "<voice>", "<language>"]
+```
+
+Absent fields are the empty string, never `null` or omitted. Fields are hashed
+as a JSON array rather than a delimited string so a value containing the
+delimiter cannot collide with a different field split.
+
+`options.fallback.message` is always an object — there is no bare-string
+shorthand, and both runtimes resolve a string to `null` rather than treating it
+as `{ text }`.
+
+`text` is whitespace-trimmed. `vendor`, `voice`, and `language` are resolved
+against the agent's own `options.tts` before hashing, so an agent that states
+only `text` hashes with its normal TTS settings filled in.
+
+### Inheritance is conditional, and both runtimes must agree
+
+`vendor` and `voice` are inherited from `options.tts` **only when the agent has
+a discrete TTS** — that is, when its voice mode is `pipeline`. A realtime
+speech-to-speech agent's `options.tts.voice` names a timbre of the *model*
+(`"Svetlana"` on Ultravox), which no TTS can render; inheriting it would hand
+the TTS builder a vendor of `ultravox`, which raises rather than degrading. So
+for realtime agents those two fields resolve to empty and the worker's default
+TTS is used unless the message states its own.
+
+`language` is inherited either way — a BCP-47 tag means the same thing to a
+model and to a TTS.
+
+Each runtime derives this from its own voice-mode resolver
+(`resolveVoiceMode` / `resolve_voice_mode`, both of which honour
+`options.voiceMode`). **This decision feeds the key**, so a runtime that decided
+it differently would split the cache exactly as a hashing difference would. The
+cross-language test pins realtime cases for this reason.
+
+Consequences, both intended:
+
+- Editing any of the four inputs changes the key, so invalidation is automatic.
+  There is no cache to bust and no way to serve stale audio for edited text.
+- Two agents with an identical announcement in an identical voice share one
+  object. Safe: the content is fully determined by the key, so computing the
+  key requires already holding the plaintext, and the bucket is platform-private.
+
+## Storage layout
+
+Base URL resolution, in order:
+
+1. `FALLBACK_MESSAGE_STORAGE_PATH` if set.
+2. The bucket from `RECORDING_STORAGE_PATH` (if set) with prefix
+   `<NODE_ENV>-fallback-messages` — so a deployment that has already moved
+   recordings to its own bucket does not keep writing announcements to the
+   default one.
+3. `gs://llm-voice/<NODE_ENV>-fallback-messages`.
+
+Object name: `<prefix><key>.wav`.
+
+Objects are stored **unencrypted**, unlike recordings, and deliberately so.
+
+There is nothing to protect: a recording is customer conversation audio, held
+under a key the platform sometimes does not have, whereas an announcement is
+rendered from an agent's own `options.fallback.message.text`, which sits in
+clear in the database. Encrypting a rendering of plaintext we already hold
+buys no confidentiality.
+
+More importantly it would cost CPU in the worst possible place. This path runs
+when an agent session has failed, and one of the likelier reasons for that is
+that the system is under load — so the playout path is disproportionately
+likely to execute exactly when there are no cycles to spare. It must be as
+cheap as we can make it. That is the same reasoning behind storing PCM rather
+than a compressed codec: playing a cached announcement should be a download, a
+resample, and a write to the transport, with no decrypt and no decode in the
+way.
+
+The bucket is platform-private and is never exposed to tenants.
+
+## Audio format
+
+- Container: **WAV** (RIFF/WAVE), codec **PCM**, signed 16-bit little-endian.
+- Channels: **mono**.
+- Sample rate: **whatever the synthesising TTS emitted** — readers must take
+  the rate from the WAV header and resample to their transport's rate. It is
+  deliberately not pinned: the two runtimes synthesise through different vendor
+  stacks, and forcing a rate would mean an extra resample on the write path for
+  no benefit.
+
+WAV rather than raw PCM so the rate travels with the samples, and so a cached
+object can be pulled from the bucket and played in any audio tool during
+diagnosis.
+
+Readers must walk the RIFF chunks rather than assuming `data` at offset 36:
+some vendors emit a `LIST` or `fact` chunk first, and a fixed-offset reader
+turns such a payload into noise.
+
+## Write concurrency
+
+Uploads use `ifGenerationMatch: 0` (create-only). When an outage fails many
+calls at once, every worker misses and synthesises concurrently; the first to
+finish publishes and the rest receive a precondition failure, which both
+implementations report to their caller as success — the cache does now hold the
+object. The losers play the copy they synthesised for their own call.
+
+## Failure behaviour
+
+Every cache operation is never-throw in both implementations. A read failure is
+a miss (synthesise it again this call); a write failure is a no-op (re-synthesise
+next time). This path only ever runs when something else has already broken, so
+it must not add a second failure of its own.

--- a/agents/livekit/agent-lib/fallback-message/cache-key.js
+++ b/agents/livekit/agent-lib/fallback-message/cache-key.js
@@ -1,0 +1,124 @@
+/**
+ * Cache-key derivation for synthesised fallback messages.
+ *
+ * The fixed-message failover path (`options.fallback.message`) plays a
+ * pre-synthesised announcement at the caller when agent setup has failed. The
+ * audio never varies for a given configuration, so it is synthesised once and
+ * cached in GCS; every later playout is a byte-for-byte replay.
+ *
+ * The cache is **content-addressed**: the object name is a digest of exactly
+ * those inputs that change the audio. Two consequences follow, and both are
+ * deliberate:
+ *
+ *   - Editing the message text (or the voice, vendor, or language) yields a
+ *     different key, so the next playout misses, re-synthesises, and writes a
+ *     new object. Invalidation is therefore automatic — there is no cache to
+ *     explicitly bust and no way to serve stale audio for edited text.
+ *   - Two agents configured with the same announcement in the same voice share
+ *     one object. That is a dedupe win rather than a leak: the object's content
+ *     is fully determined by the key, so a reader who can compute the key
+ *     already holds the plaintext that produced it, and the bucket itself is
+ *     platform-private (workers read it with platform credentials; it is never
+ *     exposed to tenants).
+ *
+ * Mirrored by `agents/pipecat/pipecat_aplisay/fallback_message/cache_key.py`.
+ * The digest formula is a cross-runtime contract: a change on one side that is
+ * not made on the other silently splits the cache in two (correct audio, wasted
+ * synthesis). See CONTRACT.md.
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Digest length in hex characters. 32 hex chars = 128 bits, ample for a CAS. */
+export const KEY_LENGTH = 32;
+
+/**
+ * @typedef {Object} ResolvedFallbackMessage
+ * @property {string} text The words to speak.
+ * @property {string=} vendor TTS provider, e.g. `elevenlabs` or `deepgram/aura-2`.
+ * @property {string=} voice Voice specifier as understood by `vendor`.
+ * @property {string=} language BCP-47 language tag.
+ */
+
+/**
+ * Resolve `options.fallback.message` against the agent's own `options.tts`.
+ *
+ * The message may name its own vendor/voice/language — the point of the feature
+ * is that the announcement can be spoken by a TTS that is known-good even when
+ * the agent's configured stack is what just failed. Anything the message does
+ * not state falls back to the agent's normal TTS settings, so the common case
+ * ("say this, in my usual voice") needs only `text`.
+ *
+ * `inheritAgentTts` is the exception, and it matters: a realtime
+ * speech-to-speech agent (Ultravox, OpenAI Realtime, Gemini Live) has no
+ * discrete TTS, and its `options.tts.voice` names a timbre of the *model*.
+ * The announcement is always spoken by a real TTS — it plays because the model
+ * could not be started, so the model cannot be what speaks it — and handing a
+ * TTS service a vendor of `ultravox` does not degrade, it throws. So for those
+ * agents the vendor and voice are NOT inherited, leaving the worker to use its
+ * default TTS unless the message names one explicitly.
+ *
+ * `language` is inherited either way: it is a portable BCP-47 tag that means
+ * the same thing to a model and to a TTS, and an announcement in the wrong
+ * language would be worse than one in an unfamiliar voice.
+ *
+ * @param {unknown} message Raw `options.fallback.message`. Must be an object
+ *   with `text`; a bare string is not accepted (see below).
+ * @param {{ tts?: { vendor?: string, voice?: string, language?: string } }=} agentOptions
+ * @param {{ inheritAgentTts?: boolean }=} opts `inheritAgentTts` defaults to
+ *   true (a pipeline agent, whose `options.tts` describes a real TTS). Pass
+ *   false for a realtime agent. Callers must agree on this: it feeds the cache
+ *   key, so the two runtimes deciding differently would split the cache.
+ * @returns {ResolvedFallbackMessage | null} `null` when no usable text is configured.
+ */
+export function resolveFallbackMessage(message, agentOptions = {}, { inheritAgentTts = true } = {}) {
+  // Deliberately NOT accepting a bare string as shorthand for `{ text }`. The
+  // option always takes an object, so there is one shape to document, one to
+  // validate, and one to read — worth a few extra characters in the common
+  // case. Anything else resolves to null here, but the write-time validation in
+  // lib/database.js rejects it outright, so a bad shape is a save error rather
+  // than an announcement that silently never plays.
+  const raw = message;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+  const text = typeof raw.text === 'string' ? raw.text.trim() : '';
+  if (!text) {
+    return null;
+  }
+  const tts = agentOptions?.tts || {};
+  const pick = (a, b) => {
+    const v = typeof a === 'string' && a.trim() ? a : b;
+    return typeof v === 'string' && v.trim() ? v.trim() : undefined;
+  };
+  return {
+    text,
+    vendor: pick(raw.vendor, inheritAgentTts ? tts.vendor : undefined),
+    voice: pick(raw.voice, inheritAgentTts ? tts.voice : undefined),
+    // Always inherited — a language tag is portable across model and TTS.
+    language: pick(raw.language, tts.language),
+  };
+}
+
+/**
+ * Derive the content-addressed cache key for a resolved message.
+ *
+ * Fields are hashed as a canonical JSON array rather than a concatenated string
+ * so that a value containing the separator cannot collide with a different
+ * field split (`{voice: 'a|b'}` vs `{voice: 'a', language: 'b'}`).
+ *
+ * @param {ResolvedFallbackMessage} resolved Output of {@link resolveFallbackMessage}.
+ * @returns {string} Lowercase hex digest, {@link KEY_LENGTH} characters.
+ */
+export function fallbackMessageKey(resolved) {
+  if (!resolved?.text) {
+    throw new Error('fallbackMessageKey: resolved message must have text');
+  }
+  const canonical = JSON.stringify([
+    resolved.text,
+    resolved.vendor || '',
+    resolved.voice || '',
+    resolved.language || '',
+  ]);
+  return createHash('sha256').update(canonical, 'utf8').digest('hex').slice(0, KEY_LENGTH);
+}

--- a/agents/livekit/agent-lib/fallback-message/gcs-path.js
+++ b/agents/livekit/agent-lib/fallback-message/gcs-path.js
@@ -1,0 +1,66 @@
+/**
+ * GCS path helpers for the fallback-message cache.
+ *
+ * Sibling of `lib/recording/gcs-path.js` and deliberately shaped the same way:
+ * exactly one formula for where a cached announcement lands, shared by every
+ * runtime that reads or writes one.
+ *
+ * The cache lives in the same platform-owned bucket as call recordings, under
+ * its own prefix. That bucket is already provisioned, credentialed, and
+ * lifecycle-managed on every deployment, so the cache inherits all of it
+ * without new infrastructure.
+ *
+ * Unlike recordings, cached announcements are stored unencrypted. A recording
+ * is customer conversation audio, sometimes under a key we do not hold; an
+ * announcement is a rendering of `options.fallback.message.text`, which sits
+ * in clear in the database, so encrypting it would protect nothing. It would
+ * also cost CPU precisely where we can least afford it — this path runs after
+ * an agent session has failed, and heavy load is one of the likelier reasons
+ * for that, so playout is disproportionately likely to happen when the machine
+ * is already struggling. Keep it a download, a resample, and a write.
+ */
+
+/**
+ * @typedef {Object} GcsPath
+ * @property {string} bucket
+ * @property {string} prefix Always empty or ending with a single trailing slash.
+ */
+
+export { parseGcsPath } from '../recording/gcs-path.js';
+
+/**
+ * Default base URL for the fallback-message cache.
+ *
+ * Derived from `RECORDING_STORAGE_PATH`'s bucket when set so that a deployment
+ * which has already pointed recordings at its own bucket does not silently
+ * keep writing announcements to the default one. Falls back to the same
+ * `gs://llm-voice` default the recording path uses.
+ *
+ * @returns {string}
+ */
+export function defaultFallbackMessageBaseUrl() {
+  const { FALLBACK_MESSAGE_STORAGE_PATH, RECORDING_STORAGE_PATH, NODE_ENV } = process.env;
+  if (FALLBACK_MESSAGE_STORAGE_PATH) {
+    return FALLBACK_MESSAGE_STORAGE_PATH;
+  }
+  const env = NODE_ENV || 'development';
+  if (RECORDING_STORAGE_PATH) {
+    // Reuse the configured bucket, but never the recordings prefix itself.
+    const withoutScheme = RECORDING_STORAGE_PATH.slice('gs://'.length);
+    const bucket = withoutScheme.split('/')[0];
+    return `gs://${bucket}/${env}-fallback-messages`;
+  }
+  return `gs://llm-voice/${env}-fallback-messages`;
+}
+
+/**
+ * Build the GCS object name for a cache key. Cached announcements are always
+ * mono 16 kHz PCM in a WAV container — see `wav.js`.
+ *
+ * @param {string} prefix Empty string or trailing-slash prefix from `parseGcsPath`.
+ * @param {string} key Digest from `fallbackMessageKey`.
+ * @returns {string}
+ */
+export function objectNameForKey(prefix, key) {
+  return `${prefix}${key}.wav`;
+}

--- a/agents/livekit/agent-lib/fallback-message/index.d.ts
+++ b/agents/livekit/agent-lib/fallback-message/index.d.ts
@@ -1,0 +1,64 @@
+/**
+ * Type declarations for the shared fallback-message cache, consumed by the
+ * LiveKit agent through the `agent-lib/` symlink. The implementation is plain
+ * JS (see `index.js`); this file exists so the TypeScript side gets real types
+ * instead of `any`. Keep it in step with the JSDoc on the modules themselves.
+ */
+
+export const KEY_LENGTH: number;
+export const DEFAULT_TIMEOUT_MS: number;
+
+export interface ResolvedFallbackMessage {
+  text: string;
+  vendor?: string;
+  voice?: string;
+  language?: string;
+}
+
+export interface GcsPath {
+  bucket: string;
+  prefix: string;
+}
+
+export interface CacheLogger {
+  debug?: (meta: unknown, message: string) => void;
+  info?: (meta: unknown, message: string) => void;
+  warn?: (meta: unknown, message: string) => void;
+}
+
+export function resolveFallbackMessage(
+  message: unknown,
+  agentOptions?: { tts?: { vendor?: string; voice?: string; language?: string } },
+  opts?: {
+    /**
+     * Whether the agent's `options.tts` describes a real TTS whose vendor/voice
+     * may be inherited. False for realtime speech-to-speech agents, whose
+     * `options.tts` names a timbre of the model. Defaults to true.
+     */
+    inheritAgentTts?: boolean;
+  },
+): ResolvedFallbackMessage | null;
+
+export function fallbackMessageKey(resolved: ResolvedFallbackMessage): string;
+
+export function parseGcsPath(baseUrl: string): GcsPath;
+export function defaultFallbackMessageBaseUrl(): string;
+export function objectNameForKey(prefix: string, key: string): string;
+
+export function encodeWav(pcm: Buffer, sampleRate: number): Buffer;
+export function decodeWav(buffer: Buffer): { pcm: Buffer; sampleRate: number };
+
+export function fetchCachedMessage(options: {
+  key: string;
+  baseUrl?: string;
+  timeoutMs?: number;
+  logger?: CacheLogger;
+}): Promise<Buffer | null>;
+
+export function storeCachedMessage(options: {
+  key: string;
+  wav: Buffer;
+  baseUrl?: string;
+  timeoutMs?: number;
+  logger?: CacheLogger;
+}): Promise<boolean>;

--- a/agents/livekit/agent-lib/fallback-message/index.js
+++ b/agents/livekit/agent-lib/fallback-message/index.js
@@ -1,0 +1,16 @@
+export {
+  KEY_LENGTH,
+  resolveFallbackMessage,
+  fallbackMessageKey,
+} from './cache-key.js';
+export {
+  parseGcsPath,
+  defaultFallbackMessageBaseUrl,
+  objectNameForKey,
+} from './gcs-path.js';
+export { encodeWav, decodeWav } from './wav.js';
+export {
+  DEFAULT_TIMEOUT_MS,
+  fetchCachedMessage,
+  storeCachedMessage,
+} from './store.js';

--- a/agents/livekit/agent-lib/fallback-message/store.js
+++ b/agents/livekit/agent-lib/fallback-message/store.js
@@ -1,0 +1,118 @@
+/**
+ * GCS read/write for the fallback-message cache.
+ *
+ * Every function here is **never-throw**. This code runs only when agent setup
+ * has already failed, and the caller's remaining options are to play the
+ * announcement or drop to `fallback.number`; a bucket outage must degrade to
+ * "synthesise it again this call", never to an exception that costs the caller
+ * the announcement as well as the agent.
+ *
+ * Mirrored by `agents/pipecat/pipecat_aplisay/fallback_message/store.py`.
+ */
+
+import { Storage } from '@google-cloud/storage';
+import { parseGcsPath, defaultFallbackMessageBaseUrl, objectNameForKey } from './gcs-path.js';
+
+const NOOP_LOGGER = { debug() {}, info() {}, warn() {} };
+
+/** Default deadline for either direction. Short: the caller is on the line. */
+export const DEFAULT_TIMEOUT_MS = 5000;
+
+let sharedStorage;
+/** Lazily constructed so importing this module never touches credentials. */
+function storage() {
+  if (!sharedStorage) {
+    sharedStorage = new Storage();
+  }
+  return sharedStorage;
+}
+
+/** @param {Promise<any>} promise @param {number} ms @param {string} what */
+function withTimeout(promise, ms, what) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`${what} timed out after ${ms}ms`)), ms).unref?.(),
+    ),
+  ]);
+}
+
+/**
+ * Read a cached announcement.
+ *
+ * @param {Object} options
+ * @param {string} options.key Digest from `fallbackMessageKey`.
+ * @param {string=} options.baseUrl Defaults to {@link defaultFallbackMessageBaseUrl}.
+ * @param {number=} options.timeoutMs
+ * @param {{debug?:Function,info?:Function,warn?:Function}=} options.logger
+ * @returns {Promise<Buffer|null>} WAV bytes, or `null` on a miss or any failure.
+ */
+export async function fetchCachedMessage({ key, baseUrl, timeoutMs = DEFAULT_TIMEOUT_MS, logger = NOOP_LOGGER }) {
+  const { bucket, prefix } = parseGcsPath(baseUrl || defaultFallbackMessageBaseUrl());
+  const gcsObject = objectNameForKey(prefix, key);
+  try {
+    const [contents] = await withTimeout(
+      storage().bucket(bucket).file(gcsObject).download(),
+      timeoutMs,
+      'fallback message download',
+    );
+    logger.debug?.({ key, bucket, gcsObject, bytes: contents.length }, 'fallback message cache hit');
+    return contents;
+  } catch (e) {
+    // 404 is the ordinary first-use miss and is not worth a warning; anything
+    // else is worth seeing, but is still only a miss as far as the caller goes.
+    if (e?.code === 404) {
+      logger.debug?.({ key, bucket, gcsObject }, 'fallback message cache miss');
+    } else {
+      logger.warn?.({ e, key, bucket, gcsObject }, 'fallback message cache read failed; will synthesise');
+    }
+    return null;
+  }
+}
+
+/**
+ * Write a freshly synthesised announcement into the cache.
+ *
+ * Written with `ifGenerationMatch: 0`, which makes the upload succeed only if
+ * the object does not yet exist. When a model outage fails many calls at once
+ * every worker misses the cache and synthesises concurrently; this way the
+ * first to finish publishes and the rest get a precondition failure, which is
+ * reported here as success because the cache does now hold the object. Without
+ * it the losers would overwrite a perfectly good object with an identical one,
+ * burning writes and briefly exposing readers to a partial overwrite.
+ *
+ * @param {Object} options
+ * @param {string} options.key
+ * @param {Buffer} options.wav Complete WAV payload from `encodeWav`.
+ * @param {string=} options.baseUrl
+ * @param {number=} options.timeoutMs
+ * @param {{debug?:Function,info?:Function,warn?:Function}=} options.logger
+ * @returns {Promise<boolean>} True when the cache holds the object afterwards.
+ */
+export async function storeCachedMessage({ key, wav, baseUrl, timeoutMs = DEFAULT_TIMEOUT_MS, logger = NOOP_LOGGER }) {
+  const { bucket, prefix } = parseGcsPath(baseUrl || defaultFallbackMessageBaseUrl());
+  const gcsObject = objectNameForKey(prefix, key);
+  try {
+    await withTimeout(
+      storage()
+        .bucket(bucket)
+        .file(gcsObject)
+        .save(wav, {
+          resumable: false,
+          contentType: 'audio/wav',
+          preconditionOpts: { ifGenerationMatch: 0 },
+        }),
+      timeoutMs,
+      'fallback message upload',
+    );
+    logger.info?.({ key, bucket, gcsObject, bytes: wav.length }, 'cached synthesised fallback message');
+    return true;
+  } catch (e) {
+    if (e?.code === 412) {
+      logger.debug?.({ key, bucket, gcsObject }, 'fallback message already cached by a concurrent writer');
+      return true;
+    }
+    logger.warn?.({ e, key, bucket, gcsObject }, 'failed to cache fallback message; will re-synthesise next time');
+    return false;
+  }
+}

--- a/agents/livekit/agent-lib/fallback-message/wav.js
+++ b/agents/livekit/agent-lib/fallback-message/wav.js
@@ -1,0 +1,111 @@
+/**
+ * Minimal mono PCM WAV reader/writer for the fallback-message cache.
+ *
+ * Cached announcements are stored as 16-bit signed little-endian PCM in a WAV
+ * container. WAV rather than raw PCM because the container carries the sample
+ * rate with the samples: the two runtimes synthesise through different TTS
+ * stacks at whatever rate the vendor emits, and the reader must resample to
+ * the transport's rate without being told out of band what it started from. It
+ * also means a cached object can be pulled out of the bucket and played in any
+ * audio tool when someone is working out why an announcement sounds wrong.
+ *
+ * Only the subset needed here is implemented: PCM (format 1), mono, 16-bit.
+ * Mirrored by `agents/pipecat/pipecat_aplisay/fallback_message/wav.py`.
+ */
+
+const RIFF = 0x46464952; // 'RIFF' little-endian
+const WAVE = 0x45564157; // 'WAVE'
+const FMT_ = 0x20746d66; // 'fmt '
+const DATA = 0x61746164; // 'data'
+
+const HEADER_BYTES = 44;
+const PCM_FORMAT = 1;
+const BITS_PER_SAMPLE = 16;
+const CHANNELS = 1;
+
+/**
+ * @typedef {Object} DecodedWav
+ * @property {Buffer} pcm Raw 16-bit little-endian mono samples.
+ * @property {number} sampleRate
+ */
+
+/**
+ * Wrap mono 16-bit PCM in a WAV container.
+ *
+ * @param {Buffer} pcm Raw 16-bit little-endian mono samples.
+ * @param {number} sampleRate
+ * @returns {Buffer}
+ */
+export function encodeWav(pcm, sampleRate) {
+  if (!Buffer.isBuffer(pcm)) {
+    throw new Error('encodeWav: pcm must be a Buffer');
+  }
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+    throw new Error(`encodeWav: invalid sampleRate ${sampleRate}`);
+  }
+  const byteRate = sampleRate * CHANNELS * (BITS_PER_SAMPLE / 8);
+  const blockAlign = CHANNELS * (BITS_PER_SAMPLE / 8);
+  const header = Buffer.alloc(HEADER_BYTES);
+  header.writeUInt32LE(RIFF, 0);
+  header.writeUInt32LE(HEADER_BYTES - 8 + pcm.length, 4); // RIFF chunk size
+  header.writeUInt32LE(WAVE, 8);
+  header.writeUInt32LE(FMT_, 12);
+  header.writeUInt32LE(16, 16); // fmt chunk size
+  header.writeUInt16LE(PCM_FORMAT, 20);
+  header.writeUInt16LE(CHANNELS, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(BITS_PER_SAMPLE, 34);
+  header.writeUInt32LE(DATA, 36);
+  header.writeUInt32LE(pcm.length, 40);
+  return Buffer.concat([header, pcm]);
+}
+
+/**
+ * Read a mono 16-bit PCM WAV produced by {@link encodeWav}.
+ *
+ * Chunks are walked rather than assumed at fixed offsets: some TTS vendors
+ * return WAV with a `LIST`/`fact` chunk ahead of `data`, and a cached object
+ * written from such a payload would otherwise decode as noise.
+ *
+ * @param {Buffer} buffer
+ * @returns {DecodedWav}
+ */
+export function decodeWav(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 12) {
+    throw new Error('decodeWav: buffer too short to be a WAV');
+  }
+  if (buffer.readUInt32LE(0) !== RIFF || buffer.readUInt32LE(8) !== WAVE) {
+    throw new Error('decodeWav: not a RIFF/WAVE payload');
+  }
+  let sampleRate = 0;
+  let offset = 12;
+  while (offset + 8 <= buffer.length) {
+    const chunkId = buffer.readUInt32LE(offset);
+    const chunkSize = buffer.readUInt32LE(offset + 4);
+    const body = offset + 8;
+    if (chunkId === FMT_) {
+      const format = buffer.readUInt16LE(body);
+      const channels = buffer.readUInt16LE(body + 2);
+      const bits = buffer.readUInt16LE(body + 14);
+      if (format !== PCM_FORMAT || channels !== CHANNELS || bits !== BITS_PER_SAMPLE) {
+        throw new Error(
+          `decodeWav: expected mono 16-bit PCM, got format=${format} channels=${channels} bits=${bits}`,
+        );
+      }
+      sampleRate = buffer.readUInt32LE(body + 4);
+    } else if (chunkId === DATA) {
+      if (!sampleRate) {
+        throw new Error('decodeWav: data chunk before fmt chunk');
+      }
+      // Trust the buffer over the declared size: a truncated upload would
+      // otherwise hand callers a Buffer slice shorter than they expect.
+      const end = Math.min(body + chunkSize, buffer.length);
+      return { pcm: buffer.subarray(body, end), sampleRate };
+    }
+    // Chunks are word-aligned: an odd size carries a trailing pad byte.
+    offset = body + chunkSize + (chunkSize % 2);
+  }
+  throw new Error('decodeWav: no data chunk found');
+}

--- a/tests/livekit-agent-lib-copies.test.mjs
+++ b/tests/livekit-agent-lib-copies.test.mjs
@@ -1,0 +1,61 @@
+/**
+ * The LiveKit worker reaches shared `lib/` code through `agents/livekit/agent-lib/`. Single files
+ * there may be symlinks: the image build (`agents/livekit/Dockerfile`) does `COPY lib/* ./agent-lib/`,
+ * which lands a real file over each of them. A shared DIRECTORY cannot be a symlink, though: that COPY
+ * flattens a directory's contents into `agent-lib/` and leaves the directory symlink dangling, GNU
+ * `cp -rp` in the tsup `onSuccess` step copies it into `dist/` still dangling, and the worker then
+ * crash-loops at module load (`ERR_MODULE_NOT_FOUND …/dist/agent-lib/<dir>/index.js`) — exactly what
+ * took out the staging runner on 2026-09-03 with `agent-lib/fallback-message`. macOS `cp` follows the
+ * link, so a local build never shows it. Shared directories are therefore committed as real copies
+ * (the `recording/` precedent) and this test keeps them byte-identical to their `lib/` source.
+ */
+import { describe, expect, test } from '@jest/globals';
+import { lstatSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const LIB = new URL('../lib/', import.meta.url).pathname;
+const LIVEKIT = new URL('../agents/livekit/', import.meta.url).pathname;
+const AGENT_LIB = join(LIVEKIT, 'agent-lib');
+
+/** Every `agent-lib/<dir>/…` directory the worker's own sources import (TypeScript under agents/livekit). */
+function importedAgentLibDirectories() {
+  const dirs = new Set();
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'agent-lib') continue;
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) walk(path);
+      else if (/\.ts$/.test(entry.name)) {
+        for (const m of readFileSync(path, 'utf8').matchAll(/agent-lib\/([A-Za-z0-9_.-]+)\//g)) dirs.add(m[1]);
+      }
+    }
+  };
+  walk(LIVEKIT);
+  return [...dirs].sort();
+}
+
+const imported = importedAgentLibDirectories();
+
+describe('agents/livekit/agent-lib shared directories the worker imports', () => {
+  test('the known ones are still imported (guards the test itself)', () => {
+    expect(imported).toEqual(expect.arrayContaining(['recording', 'fallback-message']));
+  });
+
+  test.each(imported)('agent-lib/%s is a real directory, not a symlink (the image build cannot follow one)', (name) => {
+    expect(lstatSync(join(AGENT_LIB, name)).isSymbolicLink()).toBe(false);
+    expect(statSync(join(AGENT_LIB, name)).isDirectory()).toBe(true);
+  });
+
+  test.each(imported)('agent-lib/%s is a byte-identical copy of lib/%s (code files)', (name) => {
+    const codeFiles = (dir) =>
+      readdirSync(dir)
+        .filter((f) => /\.(js|d\.ts)$/.test(f))
+        .sort();
+    const source = codeFiles(join(LIB, name));
+    const copy = codeFiles(join(AGENT_LIB, name));
+    expect(copy).toEqual(source);
+    for (const file of source) {
+      expect(readFileSync(join(AGENT_LIB, name, file), 'utf8')).toBe(readFileSync(join(LIB, name, file), 'utf8'));
+    }
+  });
+});


### PR DESCRIPTION
## What broke

The staging LiveKit runner has crash-looped on every start since the first image built after the fallback-message change (#236):

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/usr/src/app/dist/agent-lib/fallback-message/index.js'
imported from /usr/src/app/dist/lib/fallback-message.js
```

`agents/livekit/agent-lib/fallback-message` was a git **symlink** to `../../../lib/fallback-message/`. The Dockerfile does `COPY lib/* ./agent-lib/`, which flattens each lib directory's files into `agent-lib/` and leaves a *directory* symlink dangling (single-file symlinks are fine, the COPY lands a real file over them); GNU `cp -rp` in tsup's `onSuccess` then copies it into `dist/` still dangling. macOS `cp` follows the link, so a local `yarn build` never reproduces it. Production still runs the pre-#236 `:latest`, but the next release cut from `next` would carry this.

## Fix

- `agent-lib/fallback-message` is now a real copy of `lib/fallback-message/` (the `agent-lib/recording` precedent).
- New no-DB guard `tests/livekit-agent-lib-copies.test.mjs`: finds every `agent-lib/<dir>/` the worker's TypeScript imports and asserts it is a real directory that is byte-identical to its `lib/` source. Proven to fail on the symlink.

## Verification

Built the image from a clean export of this branch with `agents/livekit/Dockerfile`, then inside it:
`node -e "import('/usr/src/app/dist/lib/fallback-message.js'); import('/usr/src/app/dist/lib/voice-agent-runtime.js')"` → both load. Guard + fallback-message shared-lib tests: 28 passed.
