### PR TITLE
fix(aux-stt): meter what the engine accepted, surface engine errors, arm on outbound legs

### DIFF
--- a/agents/livekit/lib/aux-stt.ts
+++ b/agents/livekit/lib/aux-stt.ts
@@ -18,13 +18,17 @@
  * the direct Deepgram plugin under LIVEKIT_PIPELINE_USE_PROVIDER_KEYS), so the
  * same vendor strings mean the same thing in both places.
  *
- * Metering: the audio streamed to the auxiliary engine is measured here in the
- * pump (milliseconds, silence included — the basis streaming STT vendors bill
- * on) and final transcripts are counted in characters. Both are reported through
- * `onUsage` and land as `stt-aux` usage rows attributed to the agent call — its
- * own technology, so the second engine's consumption is never merged with, or
- * gated like, the primary `stt` meter (realtime models bundle their own
- * recognition into the model charge; the auxiliary engine is a real extra cost).
+ * Metering: milliseconds come from the engine's own usage report
+ * (`metrics_collected` → `audioDurationMs`, the same event the primary STT
+ * meter reads as `stt_metrics`), which both the LiveKit Inference stream and the
+ * Deepgram plugin derive from the audio they actually SENT to the vendor — so
+ * an engine that never connects (bad credentials, say) meters nothing, however
+ * much audio we pumped at it. Final transcripts are counted in characters. Both
+ * are reported through `onUsage` and land as `stt-aux` usage rows attributed to
+ * the agent call — its own technology, so the second engine's consumption is
+ * never merged with, or gated like, the primary `stt` meter (realtime models
+ * bundle their own recognition into the model charge; the auxiliary engine is a
+ * real extra cost). The audio we streamed is kept separately for diagnostics.
  *
  * Everything here is best-effort: an auxiliary STT failure must never disturb
  * the call. The stream self-disposes when the caller leaves or the room
@@ -52,8 +56,13 @@ export const AUX_STT_TECHNOLOGY = "stt-aux";
 export const AUX_STT_LOG_TYPE = "user-aux";
 /** Sample rate the caller track is decoded at for the auxiliary stream. */
 const AUX_STT_SAMPLE_RATE = 16000;
-/** Report streamed-audio usage to the meter at least this often (ms of audio). */
-const AUDIO_USAGE_REPORT_INTERVAL_MS = 10_000;
+/**
+ * On dispose, how long to give the engine to report its last partial usage
+ * interval after we ask it to flush, before the stream is closed for good.
+ */
+const USAGE_FLUSH_GRACE_MS = 300;
+/** Streamed audio below which "the engine returned nothing" is not worth a warning. */
+const SILENT_ENGINE_WARN_MS = 3000;
 
 /** Normalised `options.stt.aux`: the same fields as `options.stt`. */
 export interface AuxSttConfig {
@@ -127,10 +136,19 @@ export function buildAuxStt(agent: Agent, config: AuxSttConfig): stt.STT {
 
 /** Live auxiliary transcription: usage so far + teardown. */
 export interface AuxSttHandle {
-  /** Stop the audio pump and STT stream, reporting any unreported usage. Idempotent. */
-  dispose(): void;
-  /** Audio milliseconds streamed to the engine and characters it returned. */
-  readonly usage: { milliseconds: number; characters: number };
+  /**
+   * Stop the audio pump, ask the engine to report its last usage interval, then
+   * close it. Resolves once that report had its chance to land (bounded by
+   * {@link USAGE_FLUSH_GRACE_MS}), so a caller that flushes meters right after
+   * can await it. Idempotent.
+   */
+  dispose(): Promise<void>;
+  /**
+   * `milliseconds` = audio the engine reported accepting (what is metered);
+   * `characters` = final transcript text; `streamedMilliseconds` = audio we
+   * pumped at it (diagnostic only — it is not billed).
+   */
+  readonly usage: { milliseconds: number; characters: number; streamedMilliseconds: number };
 }
 
 /** Anything the pump can iterate for caller audio (the rtc-node AudioStream, or a test fake). */
@@ -206,48 +224,58 @@ export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
   const resolveTrack = params.deps?.resolveTrack ?? defaultResolveTrack;
   const openAudioStream = params.deps?.openAudioStream ?? defaultOpenAudioStream;
 
-  const usage = { milliseconds: 0, characters: 0 };
-  let reportedMs = 0;
+  const usage = { milliseconds: 0, characters: 0, streamedMilliseconds: 0 };
   let disposed = false;
+  let disposing: Promise<void> | null = null;
   const cleanups: Array<() => void> = [];
+  /** Asks the live engine to report its last partial usage interval (set once the stream exists). */
+  let flushUsageReport: (() => Promise<void>) | null = null;
 
-  /** Report streamed audio not yet reported (whole milliseconds, no drift). */
-  const reportAudio = (): void => {
-    const delta = Math.floor(usage.milliseconds) - reportedMs;
-    if (delta <= 0) return;
-    reportedMs += delta;
-    try {
-      onUsage("milliseconds", delta);
-    } catch (e) {
-      logger.debug({ e, roomName }, "auxStt: usage report failed");
-    }
-  };
-
-  const dispose = (): void => {
-    if (disposed) return;
-    disposed = true;
-    room.off(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
-    room.off(RoomEvent.Disconnected, onRoomDisconnected);
-    for (const fn of cleanups.splice(0)) {
-      try {
-        fn();
-      } catch (e) {
-        logger.debug({ e, roomName }, "auxStt: cleanup step failed");
+  const dispose = (): Promise<void> => {
+    if (disposing) return disposing;
+    disposing = (async () => {
+      disposed = true;
+      room.off(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
+      room.off(RoomEvent.Disconnected, onRoomDisconnected);
+      if (flushUsageReport) {
+        try {
+          await flushUsageReport();
+        } catch {
+          /* engine already gone */
+        }
       }
-    }
-    reportAudio();
-    logger.info(
-      { roomName, callerIdentity, ...usage },
-      "auxStt: auxiliary transcription disposed",
-    );
+      for (const fn of cleanups.splice(0)) {
+        try {
+          fn();
+        } catch (e) {
+          logger.debug({ e, roomName }, "auxStt: cleanup step failed");
+        }
+      }
+      if (usage.streamedMilliseconds > 0 && usage.milliseconds === 0) {
+        logger.warn(
+          { roomName, callerIdentity, ...usage },
+          "auxStt: the engine accepted none of the streamed audio (connection or credentials failure?); nothing metered",
+        );
+      } else if (usage.streamedMilliseconds >= SILENT_ENGINE_WARN_MS && usage.characters === 0) {
+        logger.warn(
+          { roomName, callerIdentity, ...usage },
+          "auxStt: the engine returned no transcript for the streamed audio",
+        );
+      }
+      logger.info(
+        { roomName, callerIdentity, ...usage },
+        "auxStt: auxiliary transcription disposed",
+      );
+    })();
+    return disposing;
   };
 
   const onParticipantDisconnected = (p: RemoteParticipant): void => {
     const identity = p?.identity ?? (p as any)?.info?.identity;
-    if (identity === callerIdentity) dispose();
+    if (identity === callerIdentity) void dispose();
   };
   const onRoomDisconnected = (): void => {
-    dispose();
+    void dispose();
   };
   room.on(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
   room.on(RoomEvent.Disconnected, onRoomDisconnected);
@@ -260,7 +288,48 @@ export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
       const sttInstance = buildStt(agent, config);
       const sttStream = sttInstance.stream();
       const audio = openAudioStream(track);
+
+      // Meter what the ENGINE says it accepted, not what we pumped: both the
+      // Inference stream and the Deepgram plugin report audio they actually sent
+      // to the vendor (the plugin every 5 s, flushed on demand), and report
+      // nothing while a connection is failing — so a 401 from the vendor cannot
+      // become a bill for the caller.
+      const onMetrics = (m: any): void => {
+        const ms = Math.round(Number(m?.audioDurationMs) || 0);
+        if (ms <= 0) return;
+        usage.milliseconds += ms;
+        try {
+          onUsage("milliseconds", ms);
+        } catch (e) {
+          logger.debug({ e, roomName }, "auxStt: usage report failed");
+        }
+      };
+      // The SDK surfaces engine failures as events, not throws (a failing
+      // connection retries quietly for minutes): log them, and stop on a
+      // non-recoverable one rather than keep pumping into a dead stream.
+      const onEngineError = (ev: any): void => {
+        const recoverable = ev?.recoverable !== false;
+        logger.warn(
+          { roomName, callerIdentity, label: ev?.label, recoverable, err: ev?.error?.message ?? String(ev?.error) },
+          recoverable
+            ? "auxStt: engine error (recoverable)"
+            : "auxStt: engine failed (not recoverable); stopping the auxiliary transcription",
+        );
+        if (!recoverable) void dispose();
+      };
+      sttInstance.on("metrics_collected", onMetrics);
+      sttInstance.on("error", onEngineError);
+      flushUsageReport = async () => {
+        sttStream.flush(); // FLUSH_SENTINEL → the engine reports its last partial usage interval
+        await new Promise((resolve) => setTimeout(resolve, USAGE_FLUSH_GRACE_MS));
+      };
       const stop = () => {
+        try {
+          sttInstance.off("metrics_collected", onMetrics);
+          sttInstance.off("error", onEngineError);
+        } catch {
+          /* not an emitter (tests) */
+        }
         try {
           sttStream.endInput();
         } catch {
@@ -282,20 +351,18 @@ export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
       }
 
       // Pump the caller's audio into the engine ourselves (rather than handing
-      // the stream over) so the audio actually streamed is what gets metered.
+      // the stream over) so we know how much we streamed — a diagnostic only;
+      // the meter is the engine's own report above.
       const pump = (async (): Promise<void> => {
         try {
           for await (const frame of frames(audio)) {
             if (disposed) break;
             const rate = frame.sampleRate || AUX_STT_SAMPLE_RATE;
-            usage.milliseconds += (frame.samplesPerChannel / rate) * 1000;
+            usage.streamedMilliseconds += (frame.samplesPerChannel / rate) * 1000;
             try {
               sttStream.pushFrame(frame);
             } catch {
               break; // input ended underneath us (dispose / stream closed)
-            }
-            if (usage.milliseconds - reportedMs >= AUDIO_USAGE_REPORT_INTERVAL_MS) {
-              reportAudio();
             }
           }
         } catch (e) {

--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -658,12 +658,15 @@ export async function runAgentWorker({
    */
   const armAuxSttFor = (agentDef: Agent): void => {
     if (auxStt) {
-      auxStt.dispose();
+      void auxStt.dispose();
       auxStt = null;
     }
     const config = parseAuxSttOption(agentDef?.options);
     if (!config) return;
-    const callerIdentity = participant?.identity;
+    // Inbound legs carry a ParticipantInfo (`identity`); an outbound leg's
+    // participant is the SipParticipant the worker dialled (`participantIdentity`).
+    const callerIdentity =
+      participant?.identity || (participant as unknown as { participantIdentity?: string })?.participantIdentity;
     if (!callerIdentity || !ctx.room) {
       logger.warn(
         { callId: call.id, hasParticipant: Boolean(participant), hasRoom: Boolean(ctx.room) },
@@ -685,10 +688,12 @@ export async function runAgentWorker({
       onUsage: (unit, quantity) => addAuxMeter(vendor, unit, quantity),
     });
   };
-  const disposeAuxStt = (): void => {
-    if (!auxStt) return;
-    auxStt.dispose();
+  /** Resolves once the engine's last usage report had its chance to land (see AuxSttHandle.dispose). */
+  const disposeAuxStt = (): Promise<void> => {
+    if (!auxStt) return Promise.resolve();
+    const handle = auxStt;
     auxStt = null;
+    return handle.dispose();
   };
 
   const cleanupAndClose = async (
@@ -769,9 +774,9 @@ export async function runAgentWorker({
       }
 
 
-      // Stop the auxiliary STT first so its final audio/character counts are
-      // in the meters the flush below writes.
-      disposeAuxStt();
+      // Stop the auxiliary STT first — and wait for the engine's last usage
+      // report — so its final counts are in the meters the flush below writes.
+      await disposeAuxStt();
 
       // Flush accumulated usage (tokens / characters / audio) to the ledger
       // before ending the call so it lands as the finalised session total.
@@ -1530,7 +1535,9 @@ export async function runAgentWorker({
     // The agent has left the conversation (bridged transfer): stop the
     // auxiliary STT rather than transcribe the human↔human segment onto the
     // agent call. A takeover re-arms it via restartWithAgent.
-    onPrimaryAgentDetached: disposeAuxStt,
+    onPrimaryAgentDetached: () => {
+      void disposeAuxStt();
+    },
   });
 
   try {

--- a/agents/livekit/test/aux-stt.test.ts
+++ b/agents/livekit/test/aux-stt.test.ts
@@ -105,6 +105,10 @@ function fakeRoom() {
 /** Minimal stand-in for stt.SpeechStream: emits a FINAL after N pushed frames. */
 class FakeSpeechStream {
   pushed: any[] = [];
+  flushes = 0;
+  flush() {
+    this.flushes += 1;
+  }
   private queue: any[] = [];
   private waiters: Array<(r: IteratorResult<any>) => void> = [];
   private ended = false;
@@ -140,8 +144,24 @@ class FakeSpeechStream {
   }
 }
 
-const fakeStt = (stream: FakeSpeechStream, closed: { n: number }) =>
-  ({ label: "fake.STT", stream: () => stream, close: async () => void closed.n++ }) as any;
+/** Fake stt.STT: an emitter (metrics_collected / error) around one stream. */
+function fakeStt(stream: FakeSpeechStream, closed: { n: number }) {
+  const handlers = new Map<string, Set<(ev: any) => void>>();
+  return {
+    label: "fake.STT",
+    stream: () => stream,
+    close: async () => void closed.n++,
+    on(evt: string, cb: (ev: any) => void) {
+      (handlers.get(evt) ?? handlers.set(evt, new Set()).get(evt)!).add(cb);
+    },
+    off(evt: string, cb: (ev: any) => void) {
+      handlers.get(evt)?.delete(cb);
+    },
+    emit(evt: string, ev: any) {
+      for (const cb of handlers.get(evt) ?? []) cb(ev);
+    },
+  } as any;
+}
 
 /** `n` 20 ms frames at 16 kHz (320 samples each). */
 async function* audioFrames(n: number) {
@@ -153,7 +173,7 @@ async function* audioFrames(n: number) {
 
 const settle = () => new Promise((r) => setTimeout(r, 30));
 
-test("armAuxStt: pumps the caller track, logs finals, meters audio ms + characters", async () => {
+test("armAuxStt: pumps the caller track, logs finals, meters the engine's own audio report + characters", async () => {
   const room = fakeRoom();
   const stream = new FakeSpeechStream(3, "  hello there ");
   const closed = { n: 0 };
@@ -161,6 +181,7 @@ test("armAuxStt: pumps the caller track, logs finals, meters audio ms + characte
   const usage: Record<string, number> = { milliseconds: 0, characters: 0 };
   let cancelled = 0;
   const source = Object.assign(audioFrames(5), { cancel: async () => void cancelled++ });
+  const engine = fakeStt(stream, closed);
 
   const handle = armAuxStt({
     room,
@@ -171,7 +192,7 @@ test("armAuxStt: pumps the caller track, logs finals, meters audio ms + characte
     onTranscript: (text, at) => transcripts.push({ text, at }),
     onUsage: (unit, q) => (usage[unit] += q),
     deps: {
-      buildStt: () => fakeStt(stream, closed),
+      buildStt: () => engine,
       resolveTrack: async () => ({ sid: "track" }) as any,
       openAudioStream: () => source,
     },
@@ -188,16 +209,87 @@ test("armAuxStt: pumps the caller track, logs finals, meters audio ms + characte
   assert.equal(stream.pushed.length, 5, "every frame reached the engine");
   assert.equal(usage.characters, "hello there".length);
   assert.equal(handle.usage.characters, "hello there".length);
-  // 5 × 20 ms of audio streamed; reported in full once disposed.
-  handle.dispose();
-  assert.equal(usage.milliseconds, 100);
-  assert.equal(Math.round(handle.usage.milliseconds), 100);
+  // 5 × 20 ms were pumped (diagnostic), but the METER is what the engine reports.
+  assert.equal(Math.round(handle.usage.streamedMilliseconds), 100);
+  assert.equal(usage.milliseconds, 0, "nothing metered until the engine reports");
+  engine.emit("metrics_collected", { type: "stt_metrics", audioDurationMs: 4800 });
+  engine.emit("metrics_collected", { type: "stt_metrics", audioDurationMs: 0 }); // ignored
+  assert.equal(usage.milliseconds, 4800);
+  assert.equal(handle.usage.milliseconds, 4800);
+  await handle.dispose();
+  assert.equal(stream.flushes, 1, "dispose asks the engine to report its last interval");
+  assert.equal(usage.milliseconds, 4800, "streamed audio is never billed on its own");
   assert.equal(closed.n, 1, "engine closed on dispose");
   assert.equal(room.handlerCount(), 0, "room listeners removed");
-  // Idempotent: a second dispose reports nothing more.
-  handle.dispose();
-  assert.equal(usage.milliseconds, 100);
+  // Idempotent.
+  await handle.dispose();
   assert.equal(closed.n, 1);
+  assert.equal(stream.flushes, 1);
+});
+
+test("armAuxStt: an engine that accepts nothing (e.g. rejected credentials) meters nothing", async () => {
+  const room = fakeRoom();
+  const stream = new FakeSpeechStream(99, "never");
+  const closed = { n: 0 };
+  const usage: Record<string, number> = { milliseconds: 0, characters: 0 };
+  const engine = fakeStt(stream, closed);
+  const handle = armAuxStt({
+    room,
+    roomName: "r",
+    callerIdentity: "caller",
+    agent: { id: "a", options: {} } as any,
+    config: {},
+    onTranscript: () => assert.fail("no transcript expected"),
+    onUsage: (unit, q) => (usage[unit] += q),
+    deps: {
+      buildStt: () => engine,
+      resolveTrack: async () => ({}) as any,
+      openAudioStream: () => audioFrames(10),
+    },
+  });
+  await settle();
+  // The SDK reports a failing connection as recoverable error events while it retries.
+  engine.emit("error", { type: "stt_error", label: "deepgram.STT", recoverable: true, error: new Error("401") });
+  assert.equal(closed.n, 0, "a recoverable error keeps the stream up");
+  await handle.dispose();
+  assert.equal(Math.round(handle.usage.streamedMilliseconds), 200, "audio was pumped");
+  assert.equal(usage.milliseconds, 0, "none of it is metered");
+  assert.equal(handle.usage.milliseconds, 0);
+});
+
+test("armAuxStt: a non-recoverable engine error stops the auxiliary transcription", async () => {
+  const room = fakeRoom();
+  const stream = new FakeSpeechStream(99, "never");
+  const closed = { n: 0 };
+  const engine = fakeStt(stream, closed);
+  async function* endless() {
+    for (;;) {
+      await new Promise((r) => setTimeout(r, 5));
+      yield { sampleRate: 16000, samplesPerChannel: 160, channels: 1 } as any;
+    }
+  }
+  armAuxStt({
+    room,
+    roomName: "r",
+    callerIdentity: "caller",
+    agent: { id: "a", options: {} } as any,
+    config: {},
+    onTranscript: () => {},
+    onUsage: () => {},
+    deps: {
+      buildStt: () => engine,
+      resolveTrack: async () => ({}) as any,
+      openAudioStream: () => Object.assign(endless(), { cancel: async () => {} }),
+    },
+  });
+  await settle();
+  engine.emit("error", { type: "stt_error", label: "deepgram.STT", recoverable: false, error: new Error("gave up") });
+  await new Promise((r) => setTimeout(r, 400));
+  assert.equal(closed.n, 1, "engine closed");
+  const pushedAtStop = stream.pushed.length;
+  await settle();
+  assert.equal(stream.pushed.length, pushedAtStop, "pump stopped");
+  assert.equal(room.handlerCount(), 0);
 });
 
 test("armAuxStt: self-disposes when the caller leaves (not on another participant)", async () => {
@@ -231,8 +323,9 @@ test("armAuxStt: self-disposes when the caller leaves (not on another participan
   room.emit(RoomEvent.ParticipantDisconnected, { identity: "someone-else" });
   assert.equal(closed.n, 0, "another participant leaving does not stop it");
   room.emit(RoomEvent.ParticipantDisconnected, { info: { identity: "caller" } });
+  await new Promise((r) => setTimeout(r, 400)); // dispose gives the engine a grace period to report
   assert.equal(closed.n, 1, "caller leaving disposes");
-  assert.ok(usage.milliseconds > 0, "streamed audio reported on dispose");
+  assert.equal(usage.milliseconds, 0, "no engine report, nothing metered");
   const pushedAtDispose = stream.pushed.length;
   await settle();
   assert.equal(stream.pushed.length, pushedAtDispose, "pump stopped");
@@ -259,8 +352,8 @@ test("armAuxStt: an engine that fails to build is contained; dispose still safe"
   });
   await settle();
   assert.deepEqual(transcripts, []);
-  handle.dispose();
-  assert.deepEqual(handle.usage, { milliseconds: 0, characters: 0 });
+  await handle.dispose();
+  assert.deepEqual(handle.usage, { milliseconds: 0, characters: 0, streamedMilliseconds: 0 });
 });
 
 test("armAuxStt: disposing before the track resolves never starts the engine", async () => {
@@ -288,7 +381,7 @@ test("armAuxStt: disposing before the track resolves never starts the engine", a
       openAudioStream: () => audioFrames(1),
     },
   });
-  handle.dispose();
+  await handle.dispose();
   release();
   await settle();
   assert.equal(built, 0);

--- a/agents/pipecat/pipecat_aplisay/aux_stt.py
+++ b/agents/pipecat/pipecat_aplisay/aux_stt.py
@@ -22,7 +22,12 @@ the same vendor strings mean the same thing in both places.
 
 Metering: the audio streamed to the auxiliary engine is measured at the tap
 (milliseconds, silence included — the basis streaming STT vendors bill on) and
-final transcripts are counted in characters. Both are reported through
+final transcripts are counted in characters. Pipecat's STT services expose no
+"audio the vendor accepted" figure, so streamed audio is metered only once the
+engine has proved itself by returning a transcript in this call: until then the
+milliseconds are held back, and an engine that never produces one (rejected
+credentials, a dead connection) meters nothing rather than billing the caller
+for a service that delivered nothing. Both meters are reported through
 ``on_usage`` and land as ``stt-aux`` usage rows — their own technology, so the
 second engine's consumption is neither merged with nor gated like the primary
 ``stt`` meter (a realtime model bundles its own recognition into the model
@@ -151,6 +156,10 @@ class AuxSttTap(FrameProcessor):
         self._milliseconds: float = 0.0
         self._reported_ms = 0
         self._characters = 0
+        # Streamed milliseconds held back until the engine returns its first
+        # transcript (see module docstring); dropped if it never does.
+        self._pending_ms = 0
+        self._proven = False
         self._stop_task: Optional[asyncio.Task] = None
 
     @property
@@ -204,13 +213,21 @@ class AuxSttTap(FrameProcessor):
             self._schedule_stop()
 
     def _report_audio(self) -> None:
-        """Report streamed audio not yet reported (whole milliseconds, no drift)."""
+        """Account for streamed audio not yet accounted for (whole milliseconds, no
+        drift): metered straight away once the engine has proved itself, held
+        back until then."""
         delta = int(self._milliseconds) - self._reported_ms
         if delta <= 0:
             return
         self._reported_ms += delta
+        if not self._proven:
+            self._pending_ms += delta
+            return
+        self._emit_usage("milliseconds", delta)
+
+    def _emit_usage(self, unit: str, quantity: int) -> None:
         try:
-            self._on_usage("milliseconds", delta)
+            self._on_usage(unit, quantity)
         except Exception as e:  # noqa: BLE001
             logger.debug(f"auxStt: usage report failed: {e}")
 
@@ -218,11 +235,14 @@ class AuxSttTap(FrameProcessor):
         text = (text or "").strip()
         if not text:
             return
+        if not self._proven:
+            # The engine works: meter what was streamed before this first transcript too.
+            self._proven = True
+            pending, self._pending_ms = self._pending_ms, 0
+            if pending:
+                self._emit_usage("milliseconds", pending)
         self._characters += len(text)
-        try:
-            self._on_usage("characters", len(text))
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"auxStt: usage report failed: {e}")
+        self._emit_usage("characters", len(text))
         try:
             await self._on_final(text)
         except Exception as e:  # noqa: BLE001
@@ -242,6 +262,11 @@ class AuxSttTap(FrameProcessor):
             await stream.stop()
         except Exception as e:  # noqa: BLE001
             logger.debug(f"auxStt: side pipeline stop raised: {e}")
+        if not self._proven and self._pending_ms:
+            logger.warning(
+                f"auxStt: the engine returned no transcript for {self._pending_ms} ms of "
+                "streamed audio (connection or credentials failure?); nothing metered"
+            )
         logger.info(
             f"auxStt: auxiliary transcription stopped "
             f"({int(self._milliseconds)} ms streamed, {self._characters} chars)"

--- a/agents/pipecat/tests/test_aux_stt.py
+++ b/agents/pipecat/tests/test_aux_stt.py
@@ -185,7 +185,10 @@ class TestAuxSttTap:
             assert finals == ["hello there"]
             assert ("characters", len("hello there")) in usage
             # Audio streamed = 50 ms, reported in whole milliseconds, no drift.
-            assert sum(q for u, q in usage if u == "milliseconds") == 50
+            # The fake returns its first transcript while the 2nd frame is being
+            # fed, so: frame 1 (20 ms) was held back and released with that
+            # transcript, then frames 2 and 3 (20 + 10 ms) reported directly.
+            assert [q for u, q in usage if u == "milliseconds"] == [20, 20, 10]
             assert tap.usage == {"milliseconds": 50, "characters": len("hello there")}
 
         asyncio.run(run())
@@ -201,6 +204,22 @@ class TestAuxSttTap:
             )
             await asyncio.sleep(0)  # let the scheduled stop run
             assert _FakeStream.instances[0].stopped
+
+        asyncio.run(run())
+
+    def test_engine_that_never_transcribes_is_not_metered(self):
+        async def run():
+            # e.g. rejected credentials: audio streams into the side pipeline, nothing comes back.
+            tap, finals, usage = _tap(stream_factory=lambda *a, **k: _FakeStream(*a, final_after=99, **k))
+            await run_test(
+                tap,
+                frames_to_send=[_audio(20), _audio(20), _audio(20)],
+                expected_down_frames=[InputAudioRawFrame] * 3,
+            )
+            await asyncio.sleep(0)
+            assert finals == []
+            assert usage == [], "streamed audio the engine never turned into a transcript is not billed"
+            assert tap.usage["milliseconds"] == 60, "…but it is still visible as streamed audio"
 
         asyncio.run(run())
 

--- a/docs/auxiliary-stt.md
+++ b/docs/auxiliary-stt.md
@@ -56,7 +56,7 @@ The auxiliary engine is a real cost on every voice mode — including realtime m
 
 | Row | `technology` | `provider` | `detail` | `unit` | What is counted |
 |---|---|---|---|---|---|
-| audio | `stt-aux` | the aux vendor (e.g. `assemblyai`) | `vendor/model` where known | `milliseconds` | Audio actually streamed to the auxiliary engine, silence included — the basis streaming STT vendors bill on. Measured by the worker at the point it hands audio to the engine. |
+| audio | `stt-aux` | the aux vendor (e.g. `assemblyai`) | `vendor/model` where known | `milliseconds` | Audio the auxiliary engine accepted, silence included — the basis streaming STT vendors bill on. On LiveKit this is the engine's own usage report (the same `metrics_collected` event the primary STT meter reads), which counts only audio actually sent to the vendor, so an engine that never connects meters nothing. On Pipecat, whose STT services report no such figure, it is the audio streamed to the engine, metered only once the engine has returned its first transcript in the call; an engine that never does meters nothing. |
 | text | `stt-aux` | as above | as above | `characters` | Characters in the final transcripts the engine returned. |
 
 Rows are attributed to the agent call (the session's own call record, like the model's token and TTS meters) and finalised when it ends; a handover carries the running totals onto the continuation call.


### PR DESCRIPTION
## What staging showed

First LiveKit run of `options.stt.aux` (#279) on staging: the auxiliary Deepgram stream armed on both inbound legs and was fed 25 s / 11 s of audio, but the plugin logged `failed to connect to Deepgram … Unexpected server response: 401` on every retry (the LiveKit staging runner's `DEEPGRAM_API_KEY` is rejected — an env fix, separate from this PR) and never accepted a byte. Three code defects fell out of that call.

## Fixes

- **Meter what the engine accepted, not what we pumped.** The LiveKit meter would have billed 36 s of `stt-aux` the vendor never received. It now meters the engine's own usage report (`metrics_collected` → `audioDurationMs`, the same event the primary STT meter reads): both the Inference stream and the Deepgram plugin derive it only from audio actually sent to the vendor, so an engine that never connects meters nothing. `dispose()` is now async (flush the engine's last interval → 300 ms grace → close) and `cleanupAndClose` awaits it before `flushUsage`. **Pipecat** exposes no such figure, so its tap holds streamed milliseconds back until the engine's first transcript in the call; a dead engine meters nothing.
- **Engine errors surfaced.** The SDK reports failures as `error` events, not throws. They are now logged; a non-recoverable one stops the auxiliary stream; a warning fires when streamed audio produced nothing.
- **Outbound legs arm.** The caller leg logged "no caller participant/room to tap": an outbound leg's participant is the dialled `SipParticipant` (`participantIdentity`, not `identity`). The runtime falls back to it.

Docs updated to describe the two metering bases.

## Tests

- LiveKit `test/aux-stt.test.ts`: 11 passing (new: engine-accepts-nothing → nothing metered; non-recoverable error stops the stream; metering from the engine report; dispose flush). `tsc --noEmit` clean apart from the pre-existing `livekit-model-registry` error.
- Pipecat suite: 458 passing (new: never-transcribes → not metered; pins the held-back release order).
