### PR TITLE
Output audit STT: options.tts.output → agent-speech transcripts + stt-output billing

### DIFF
--- a/agents/livekit/lib/api-client.ts
+++ b/agents/livekit/lib/api-client.ts
@@ -174,6 +174,16 @@ export interface Agent {
     
       language?: string;
       /**
+       * Output audit STT: an independent engine run over the agent's OWN audio,
+       * logged as `agent-speech` and metered as `stt-output`. Same shape as
+       * `stt`; `enabled: false` switches it off. See lib/output-stt.ts.
+       */
+      output?: {
+        enabled?: boolean;
+        language?: string;
+        vendor?: string;
+      };
+      /**
        * TTS vendor for LiveKit pipeline (e.g. cartesia, google, elevenlabs).
        * `google` uses Gemini TTS on Node (`@livekit/agents-plugin-google`), not Google Cloud
        * voice ids (`en-GB-Standard-O`). Map timbre with `LIVEKIT_PIPELINE_GEMINI_TTS_VOICE`

--- a/agents/livekit/lib/aux-stt.ts
+++ b/agents/livekit/lib/aux-stt.ts
@@ -1,5 +1,7 @@
 /**
- * Auxiliary ("second opinion") speech recognition — `options.stt.aux`.
+ * Side STT engines: the auxiliary ("second opinion") recognition of the CALLER
+ * (`options.stt.aux`, armed here) and the shared engine machinery the output
+ * audit of the AGENT (`options.tts.output`, see output-stt.ts) also runs on.
  *
  * Runs a second, independent STT engine over the caller's audio alongside the
  * agent's own recognition (the pipeline STT, or a realtime model's built-in
@@ -64,91 +66,303 @@ const USAGE_FLUSH_GRACE_MS = 300;
 /** Streamed audio below which "the engine returned nothing" is not worth a warning. */
 const SILENT_ENGINE_WARN_MS = 3000;
 
-/** Normalised `options.stt.aux`: the same fields as `options.stt`. */
-export interface AuxSttConfig {
+/** Normalised side-STT block: the same fields as `options.stt`. */
+export interface SideSttConfig {
   vendor?: string;
   language?: string;
 }
+/** @deprecated alias — the caller-side name. */
+export type AuxSttConfig = SideSttConfig;
+
+/** Which of the agent's own language declarations a side engine inherits, in order. */
+export type LanguageSource = "stt" | "tts";
+/** The caller side speaks the language the agent listens for. */
+const AUX_LANGUAGE_ORDER: LanguageSource[] = ["stt", "tts"];
+/** The agent side speaks in its TTS language. */
+const OUTPUT_LANGUAGE_ORDER: LanguageSource[] = ["tts", "stt"];
 
 /**
- * Normalise `options.stt.aux` to null (off) or `{vendor?, language?}`.
+ * Normalise one side-STT block to null (off) or `{vendor?, language?}`.
  * Lenient — the server validated the shape at save time. Absent / `false` /
  * `enabled: false` / malformed → off; `true` or `{}` → platform defaults.
  */
-export function parseAuxSttOption(options: any): AuxSttConfig | null {
-  const raw = options?.stt?.aux;
+export function parseSideSttBlock(raw: unknown): SideSttConfig | null {
   if (raw === undefined || raw === null || raw === false) return null;
   if (raw === true) return {};
-  if (typeof raw !== "object" || Array.isArray(raw) || raw.enabled === false) {
+  if (typeof raw !== "object" || Array.isArray(raw) || (raw as any).enabled === false) {
     return null;
   }
+  const block = raw as Record<string, unknown>;
   const vendor =
-    typeof raw.vendor === "string" && raw.vendor.trim() ? raw.vendor.trim() : undefined;
+    typeof block.vendor === "string" && block.vendor.trim() ? block.vendor.trim() : undefined;
   const language =
-    typeof raw.language === "string" && raw.language.trim()
-      ? raw.language.trim()
+    typeof block.language === "string" && block.language.trim()
+      ? block.language.trim()
       : undefined;
   return { ...(vendor ? { vendor } : {}), ...(language ? { language } : {}) };
 }
 
+/** `options.stt.aux` → config or null (off). */
+export function parseAuxSttOption(options: any): SideSttConfig | null {
+  return parseSideSttBlock(options?.stt?.aux);
+}
+
+/** `options.tts.output` → config or null (off). */
+export function parseOutputSttOption(options: any): SideSttConfig | null {
+  return parseSideSttBlock(options?.tts?.output);
+}
+
 /**
- * The agent with `options.stt.aux` standing in for `options.stt`, so the
- * pipeline STT resolvers build the auxiliary engine exactly as they would the
- * primary one. Language falls back to the agent's own `stt.language`, then
- * `tts.language` (the platform's declare-once convention); the nested `aux`
- * block itself is dropped.
+ * The agent with a side block standing in for `options.stt`, so the pipeline
+ * STT resolvers build the side engine exactly as they would the primary one.
+ * Language falls back through `order` (the platform's declare-once
+ * convention); the nested side blocks themselves are dropped.
  */
-export function auxSttAgent(agent: Agent, config: AuxSttConfig): Agent {
+export function sideSttAgent(agent: Agent, config: SideSttConfig, order: LanguageSource[]): Agent {
   const options: any = agent?.options || {};
-  const inherited =
-    (typeof options.stt?.language === "string" && options.stt.language.trim()) ||
-    (typeof options.tts?.language === "string" && options.tts.language.trim()) ||
-    undefined;
-  const language = config.language ?? inherited;
+  let language = config.language;
+  for (const source of order) {
+    if (language) break;
+    const declared = options[source]?.language;
+    language = typeof declared === "string" && declared.trim() ? declared.trim() : undefined;
+  }
   const sttBlock: Record<string, string> = {};
   if (config.vendor) sttBlock.vendor = config.vendor;
   if (language) sttBlock.language = language;
   return { ...agent, options: { ...options, stt: sttBlock } } as Agent;
 }
 
-/** Canonical billing `{vendor, detail}` for the auxiliary engine. */
-export function resolveAuxSttVendor(agent: Agent, config: AuxSttConfig): VendorDetail {
+export function auxSttAgent(agent: Agent, config: SideSttConfig): Agent {
+  return sideSttAgent(agent, config, AUX_LANGUAGE_ORDER);
+}
+
+export function outputSttAgent(agent: Agent, config: SideSttConfig): Agent {
+  return sideSttAgent(agent, config, OUTPUT_LANGUAGE_ORDER);
+}
+
+/** Canonical billing `{vendor, detail}` for a side engine. */
+export function resolveSideSttVendor(
+  agent: Agent,
+  config: SideSttConfig,
+  order: LanguageSource[],
+): VendorDetail {
   try {
-    return fromServiceString(resolvePipelineStt(auxSttAgent(agent, config)));
+    return fromServiceString(resolvePipelineStt(sideSttAgent(agent, config, order)));
   } catch {
     const vendor = config.vendor?.split("/")[0]?.split(":")[0]?.trim().toLowerCase();
     return vendor ? { vendor } : {};
   }
 }
 
+export function resolveAuxSttVendor(agent: Agent, config: SideSttConfig): VendorDetail {
+  return resolveSideSttVendor(agent, config, AUX_LANGUAGE_ORDER);
+}
+
+export function resolveOutputSttVendor(agent: Agent, config: SideSttConfig): VendorDetail {
+  return resolveSideSttVendor(agent, config, OUTPUT_LANGUAGE_ORDER);
+}
+
 /**
- * A fresh STT instance for the auxiliary engine — the pipeline's own
- * resolution applied to `options.stt.aux`: LiveKit Inference by default, or
- * the direct Deepgram plugin under LIVEKIT_PIPELINE_USE_PROVIDER_KEYS.
+ * A fresh STT instance for a side engine — the pipeline's own resolution
+ * applied to the side block: LiveKit Inference by default, or the direct
+ * Deepgram plugin under LIVEKIT_PIPELINE_USE_PROVIDER_KEYS.
  */
-export function buildAuxStt(agent: Agent, config: AuxSttConfig): stt.STT {
-  const effective = auxSttAgent(agent, config);
+export function buildSideStt(agent: Agent, config: SideSttConfig, order: LanguageSource[]): stt.STT {
+  const effective = sideSttAgent(agent, config, order);
   if (pipelineUsesProviderApiKeys()) {
     return buildProviderPipelineStt(effective);
   }
   return inference.STT.fromModelString(resolvePipelineStt(effective));
 }
 
-/** Live auxiliary transcription: usage so far + teardown. */
-export interface AuxSttHandle {
+export function buildAuxStt(agent: Agent, config: SideSttConfig): stt.STT {
+  return buildSideStt(agent, config, AUX_LANGUAGE_ORDER);
+}
+
+export function buildOutputStt(agent: Agent, config: SideSttConfig): stt.STT {
+  return buildSideStt(agent, config, OUTPUT_LANGUAGE_ORDER);
+}
+
+/** Usage counters shared by both sides. */
+export interface SideSttUsage {
+  /** Audio the engine reported accepting — what is metered. */
+  milliseconds: number;
+  /** Final transcript text the engine returned. */
+  characters: number;
+  /** Audio we handed to the engine (diagnostic only — never billed). */
+  streamedMilliseconds: number;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** A running side STT engine fed frame by frame. */
+export interface SideSttEngine {
+  /** Feed one audio frame; a no-op once the engine is disposed or has failed. */
+  push(frame: AudioFrame): void;
   /**
-   * Stop the audio pump, ask the engine to report its last usage interval, then
-   * close it. Resolves once that report had its chance to land (bounded by
-   * {@link USAGE_FLUSH_GRACE_MS}), so a caller that flushes meters right after
-   * can await it. Idempotent.
+   * Ask the engine to report its last usage interval, then close it. Resolves
+   * once that report had its chance to land (bounded by
+   * {@link USAGE_FLUSH_GRACE_MS}). Idempotent.
    */
   dispose(): Promise<void>;
-  /**
-   * `milliseconds` = audio the engine reported accepting (what is metered);
-   * `characters` = final transcript text; `streamedMilliseconds` = audio we
-   * pumped at it (diagnostic only — it is not billed).
-   */
-  readonly usage: { milliseconds: number; characters: number; streamedMilliseconds: number };
+  readonly usage: SideSttUsage;
+}
+
+export interface StartSideSttEngineParams {
+  /** Log prefix: `auxStt` (caller side) or `outputStt` (agent side). */
+  label: string;
+  roomName: string;
+  /** What is being transcribed, for logs (a caller identity, "agent output"). */
+  subject: string;
+  /** The engine, already built (so a build failure is the caller's to handle). */
+  stt: stt.STT;
+  /** A final transcript, with the time it arrived. */
+  onTranscript: (text: string, at: Date) => void;
+  /** A usage delta for the side meter. */
+  onUsage: (unit: "milliseconds" | "characters", quantity: number) => void;
+  /** Invoked when the engine stops itself on a non-recoverable error. */
+  onEngineStopped?: () => void;
+}
+
+/**
+ * Run a side STT engine: consume its stream (finals → `onTranscript`, the
+ * engine's own audio-usage reports → `onUsage`, errors → logged; a
+ * non-recoverable one stops the engine), and expose `push` for whoever holds
+ * the audio — the caller-track pump below, or the output tee. Both sides meter
+ * what the ENGINE says it accepted, never what was pushed: the Inference
+ * stream and the Deepgram plugin report audio they actually sent to the vendor
+ * (the plugin every 5 s, flushed on demand) and nothing while a connection is
+ * failing, so a rejected credential cannot become a bill.
+ */
+export function startSideSttEngine(params: StartSideSttEngineParams): SideSttEngine {
+  const { label, roomName, subject, stt: sttInstance, onTranscript, onUsage, onEngineStopped } = params;
+  const usage: SideSttUsage = { milliseconds: 0, characters: 0, streamedMilliseconds: 0 };
+  let disposed = false;
+  let disposing: Promise<void> | null = null;
+  const sttStream = sttInstance.stream();
+
+  const onMetrics = (m: any): void => {
+    const ms = Math.round(Number(m?.audioDurationMs) || 0);
+    if (ms <= 0) return;
+    usage.milliseconds += ms;
+    try {
+      onUsage("milliseconds", ms);
+    } catch (e) {
+      logger.debug({ e, roomName }, `${label}: usage report failed`);
+    }
+  };
+  const onEngineError = (ev: any): void => {
+    const recoverable = ev?.recoverable !== false;
+    logger.warn(
+      { roomName, subject, label: ev?.label, recoverable, err: ev?.error?.message ?? String(ev?.error) },
+      recoverable
+        ? `${label}: engine error (recoverable)`
+        : `${label}: engine failed (not recoverable); stopping the side transcription`,
+    );
+    if (!recoverable) {
+      void dispose();
+      try {
+        onEngineStopped?.();
+      } catch {
+        /* best-effort */
+      }
+    }
+  };
+  sttInstance.on("metrics_collected", onMetrics);
+  sttInstance.on("error", onEngineError);
+
+  const consumer = (async (): Promise<void> => {
+    try {
+      for await (const ev of sttStream) {
+        if (disposed) break;
+        if (ev.type !== stt.SpeechEventType.FINAL_TRANSCRIPT) continue;
+        const text = (ev.alternatives?.[0]?.text ?? "").trim();
+        if (!text) continue;
+        usage.characters += text.length;
+        try {
+          onUsage("characters", text.length);
+        } catch (e) {
+          logger.debug({ e, roomName }, `${label}: usage report failed`);
+        }
+        try {
+          onTranscript(text, new Date());
+        } catch (e) {
+          logger.warn({ e, roomName, subject }, `${label}: transcript handler failed`);
+        }
+      }
+    } catch (e) {
+      if (!disposed) {
+        logger.warn({ e, roomName, subject }, `${label}: side transcription failed (continuing without it)`);
+      }
+    }
+  })();
+
+  const push = (frame: AudioFrame): void => {
+    if (disposed) return;
+    const rate = frame.sampleRate || AUX_STT_SAMPLE_RATE;
+    usage.streamedMilliseconds += (frame.samplesPerChannel / rate) * 1000;
+    try {
+      sttStream.pushFrame(frame);
+    } catch {
+      /* input ended underneath us (dispose / stream closed) */
+    }
+  };
+
+  const dispose = (): Promise<void> => {
+    if (disposing) return disposing;
+    disposing = (async () => {
+      disposed = true;
+      try {
+        sttStream.flush(); // FLUSH_SENTINEL → the engine reports its last partial usage interval
+        await sleep(USAGE_FLUSH_GRACE_MS);
+      } catch {
+        /* engine already gone */
+      }
+      try {
+        sttInstance.off("metrics_collected", onMetrics);
+        sttInstance.off("error", onEngineError);
+      } catch {
+        /* not an emitter (tests) */
+      }
+      try {
+        sttStream.endInput();
+      } catch {
+        /* already ended */
+      }
+      try {
+        sttStream.close();
+      } catch {
+        /* already closed */
+      }
+      void sttInstance.close().catch(() => {});
+      await consumer.catch(() => {});
+      if (usage.streamedMilliseconds > 0 && usage.milliseconds === 0) {
+        logger.warn(
+          { roomName, subject, ...usage },
+          `${label}: the engine accepted none of the streamed audio (connection or credentials failure?); nothing metered`,
+        );
+      } else if (usage.streamedMilliseconds >= SILENT_ENGINE_WARN_MS && usage.characters === 0) {
+        logger.warn({ roomName, subject, ...usage }, `${label}: the engine returned no transcript for the streamed audio`);
+      }
+      logger.info({ roomName, subject, ...usage }, `${label}: side transcription disposed`);
+    })();
+    return disposing;
+  };
+
+  return {
+    push,
+    dispose,
+    get usage() {
+      return usage;
+    },
+  };
+}
+
+/** Live auxiliary (caller-side) transcription: usage so far + teardown. */
+export interface AuxSttHandle {
+  /** Stop the pump, let the engine report its last usage interval, close it. Idempotent. */
+  dispose(): Promise<void>;
+  readonly usage: SideSttUsage;
 }
 
 /** Anything the pump can iterate for caller audio (the rtc-node AudioStream, or a test fake). */
@@ -165,14 +379,14 @@ export interface ArmAuxSttParams {
   callerIdentity: string;
   /** The agent whose `options.stt.aux` (and language defaults) apply. */
   agent: Agent;
-  config: AuxSttConfig;
+  config: SideSttConfig;
   /** A final transcript from the auxiliary engine, with the time it arrived. */
   onTranscript: (text: string, at: Date) => void;
   /** A usage delta for the aux meter. */
   onUsage: (unit: "milliseconds" | "characters", quantity: number) => void;
   /** Injection points (tests): engine construction, track resolution, audio source. */
   deps?: {
-    buildStt?: (agent: Agent, config: AuxSttConfig) => stt.STT;
+    buildStt?: (agent: Agent, config: SideSttConfig) => stt.STT;
     resolveTrack?: (room: Room, identity: string) => Promise<Track>;
     openAudioStream?: (track: Track) => AuxAudioSource;
   };
@@ -212,11 +426,14 @@ async function* frames(source: AuxAudioSource): AsyncGenerator<AudioFrame> {
   }
 }
 
+const NO_USAGE: SideSttUsage = { milliseconds: 0, characters: 0, streamedMilliseconds: 0 };
+
 /**
  * Arm the auxiliary STT on the caller's audio track. Resolves the participant
- * and track (waiting for them if needed), builds the engine, then pumps the
- * decoded audio into its stream while forwarding final transcripts and usage.
- * Never throws — transcription is best-effort.
+ * and track (waiting for them if needed), opens one more in-process sink on
+ * the track the session already receives (an rtc-node AudioStream — at the
+ * FFI layer a sink on the one decoded WebRTC track, not a new subscription),
+ * builds the engine and pumps the decoded audio into it. Never throws.
  */
 export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
   const { room, roomName, callerIdentity, agent, config, onTranscript, onUsage } = params;
@@ -224,12 +441,10 @@ export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
   const resolveTrack = params.deps?.resolveTrack ?? defaultResolveTrack;
   const openAudioStream = params.deps?.openAudioStream ?? defaultOpenAudioStream;
 
-  const usage = { milliseconds: 0, characters: 0, streamedMilliseconds: 0 };
+  let engine: SideSttEngine | null = null;
   let disposed = false;
   let disposing: Promise<void> | null = null;
   const cleanups: Array<() => void> = [];
-  /** Asks the live engine to report its last partial usage interval (set once the stream exists). */
-  let flushUsageReport: (() => Promise<void>) | null = null;
 
   const dispose = (): Promise<void> => {
     if (disposing) return disposing;
@@ -237,13 +452,6 @@ export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
       disposed = true;
       room.off(RoomEvent.ParticipantDisconnected, onParticipantDisconnected);
       room.off(RoomEvent.Disconnected, onRoomDisconnected);
-      if (flushUsageReport) {
-        try {
-          await flushUsageReport();
-        } catch {
-          /* engine already gone */
-        }
-      }
       for (const fn of cleanups.splice(0)) {
         try {
           fn();
@@ -251,21 +459,8 @@ export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
           logger.debug({ e, roomName }, "auxStt: cleanup step failed");
         }
       }
-      if (usage.streamedMilliseconds > 0 && usage.milliseconds === 0) {
-        logger.warn(
-          { roomName, callerIdentity, ...usage },
-          "auxStt: the engine accepted none of the streamed audio (connection or credentials failure?); nothing metered",
-        );
-      } else if (usage.streamedMilliseconds >= SILENT_ENGINE_WARN_MS && usage.characters === 0) {
-        logger.warn(
-          { roomName, callerIdentity, ...usage },
-          "auxStt: the engine returned no transcript for the streamed audio",
-        );
-      }
-      logger.info(
-        { roomName, callerIdentity, ...usage },
-        "auxStt: auxiliary transcription disposed",
-      );
+      if (engine) await engine.dispose();
+      logger.info({ roomName, callerIdentity, ...(engine?.usage ?? NO_USAGE) }, "auxStt: auxiliary transcription disposed");
     })();
     return disposing;
   };
@@ -284,123 +479,35 @@ export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
     try {
       const track = await resolveTrack(room, callerIdentity);
       if (disposed) return;
-
       const sttInstance = buildStt(agent, config);
-      const sttStream = sttInstance.stream();
+      engine = startSideSttEngine({
+        label: "auxStt",
+        roomName,
+        subject: callerIdentity,
+        stt: sttInstance,
+        onTranscript,
+        onUsage,
+        onEngineStopped: () => void dispose(),
+      });
       const audio = openAudioStream(track);
-
-      // Meter what the ENGINE says it accepted, not what we pumped: both the
-      // Inference stream and the Deepgram plugin report audio they actually sent
-      // to the vendor (the plugin every 5 s, flushed on demand), and report
-      // nothing while a connection is failing — so a 401 from the vendor cannot
-      // become a bill for the caller.
-      const onMetrics = (m: any): void => {
-        const ms = Math.round(Number(m?.audioDurationMs) || 0);
-        if (ms <= 0) return;
-        usage.milliseconds += ms;
-        try {
-          onUsage("milliseconds", ms);
-        } catch (e) {
-          logger.debug({ e, roomName }, "auxStt: usage report failed");
-        }
-      };
-      // The SDK surfaces engine failures as events, not throws (a failing
-      // connection retries quietly for minutes): log them, and stop on a
-      // non-recoverable one rather than keep pumping into a dead stream.
-      const onEngineError = (ev: any): void => {
-        const recoverable = ev?.recoverable !== false;
-        logger.warn(
-          { roomName, callerIdentity, label: ev?.label, recoverable, err: ev?.error?.message ?? String(ev?.error) },
-          recoverable
-            ? "auxStt: engine error (recoverable)"
-            : "auxStt: engine failed (not recoverable); stopping the auxiliary transcription",
-        );
-        if (!recoverable) void dispose();
-      };
-      sttInstance.on("metrics_collected", onMetrics);
-      sttInstance.on("error", onEngineError);
-      flushUsageReport = async () => {
-        sttStream.flush(); // FLUSH_SENTINEL → the engine reports its last partial usage interval
-        await new Promise((resolve) => setTimeout(resolve, USAGE_FLUSH_GRACE_MS));
-      };
-      const stop = () => {
-        try {
-          sttInstance.off("metrics_collected", onMetrics);
-          sttInstance.off("error", onEngineError);
-        } catch {
-          /* not an emitter (tests) */
-        }
-        try {
-          sttStream.endInput();
-        } catch {
-          /* already ended */
-        }
-        try {
-          sttStream.close();
-        } catch {
-          /* already closed */
-        }
-        void sttInstance.close().catch(() => {});
+      cleanups.push(() => {
         void audio.cancel?.().catch?.(() => {});
-      };
-      cleanups.push(stop);
+      });
       if (disposed) {
         // dispose() ran between the awaits above and the push — unwind now.
-        stop();
+        await engine.dispose();
         return;
       }
-
-      // Pump the caller's audio into the engine ourselves (rather than handing
-      // the stream over) so we know how much we streamed — a diagnostic only;
-      // the meter is the engine's own report above.
-      const pump = (async (): Promise<void> => {
-        try {
-          for await (const frame of frames(audio)) {
-            if (disposed) break;
-            const rate = frame.sampleRate || AUX_STT_SAMPLE_RATE;
-            usage.streamedMilliseconds += (frame.samplesPerChannel / rate) * 1000;
-            try {
-              sttStream.pushFrame(frame);
-            } catch {
-              break; // input ended underneath us (dispose / stream closed)
-            }
-          }
-        } catch (e) {
-          if (!disposed) {
-            logger.warn({ e, roomName, callerIdentity }, "auxStt: audio pump failed");
-          }
-        } finally {
-          try {
-            sttStream.endInput();
-          } catch {
-            /* already ended */
-          }
-        }
-      })();
-
       logger.info(
         { roomName, callerIdentity, label: sttInstance.label, config },
         "auxStt: auxiliary transcription armed on the caller track",
       );
-
-      for await (const ev of sttStream) {
+      // Pump the caller's audio into the engine ourselves (rather than handing
+      // the stream over) so we know how much we streamed — a diagnostic only.
+      for await (const frame of frames(audio)) {
         if (disposed) break;
-        if (ev.type !== stt.SpeechEventType.FINAL_TRANSCRIPT) continue;
-        const text = (ev.alternatives?.[0]?.text ?? "").trim();
-        if (!text) continue;
-        usage.characters += text.length;
-        try {
-          onUsage("characters", text.length);
-        } catch (e) {
-          logger.debug({ e, roomName }, "auxStt: usage report failed");
-        }
-        try {
-          onTranscript(text, new Date());
-        } catch (e) {
-          logger.warn({ e, roomName, callerIdentity }, "auxStt: transcript handler failed");
-        }
+        engine.push(frame);
       }
-      await pump.catch(() => {});
     } catch (e) {
       // Best-effort: the call carries on without the second opinion.
       if (!disposed) {
@@ -416,7 +523,7 @@ export function armAuxStt(params: ArmAuxSttParams): AuxSttHandle {
   return {
     dispose,
     get usage() {
-      return usage;
+      return engine?.usage ?? NO_USAGE;
     },
   };
 }

--- a/agents/livekit/lib/output-stt.ts
+++ b/agents/livekit/lib/output-stt.ts
@@ -1,0 +1,165 @@
+/**
+ * Output audit speech recognition — `options.tts.output`.
+ *
+ * Runs an independent STT engine over the AGENT's own audio — what the caller
+ * actually hears, whether synthesised by the pipeline TTS or produced by a
+ * realtime model — and logs each final transcript it produces as an
+ * `agent-speech` transaction-log entry beside the `agent` entry the model
+ * produced: an audit of what the agent said against what it thought it said.
+ * Observation only; nothing here can affect the call.
+ *
+ * Mechanism: the agent's outbound audio is a stream of frames this process
+ * itself produces and hands to the session's audio output, so the audit is a
+ * tee at that point — the same construction the SDK's own RecorderIO uses to
+ * record the agent. `session.output.audio` is replaced by a Proxy over the
+ * live output object that intercepts ONLY `captureFrame` (copying each frame
+ * to the side engine before forwarding it) and leaves every other member —
+ * flush/clearBuffer/pause/resume, playback events, waitForPlayout — bound to
+ * the original. Nothing touches the room: no subscription, no second media
+ * stream, no FFI sink. (The SDK does not export its AudioOutput base class at
+ * runtime, which is why this wraps an instance rather than subclassing.)
+ *
+ * Nothing is installed on a call unless `options.tts.output` is set — see the
+ * runtime's armOutputSttFor, which returns before touching the session when the
+ * option is absent. Metering is the engine's own audio-usage report, exactly as
+ * for the caller side (see aux-stt.ts startSideSttEngine).
+ */
+
+import type { stt } from "@livekit/agents";
+import type { AudioFrame } from "@livekit/rtc-node";
+import logger from "./logger.js";
+import type { Agent } from "./api-client.js";
+import {
+  buildOutputStt,
+  startSideSttEngine,
+  type SideSttConfig,
+  type SideSttEngine,
+  type SideSttUsage,
+} from "./aux-stt.js";
+
+/** Ledger technology for output-audit usage rows. */
+export const OUTPUT_STT_TECHNOLOGY = "stt-output";
+/** Transaction-log type for the output audit's transcripts (next to `agent`). */
+export const OUTPUT_STT_LOG_TYPE = "agent-speech";
+
+/** The one member of the SDK's AudioOutput the tee intercepts; the rest pass through. */
+export interface TeeableAudioOutput {
+  captureFrame(frame: AudioFrame): Promise<void>;
+}
+
+/** The slice of voice.AgentSession the tee needs (structural, so tests can fake it). */
+export interface TeeableSession {
+  output: { audio: TeeableAudioOutput | null };
+}
+
+export interface OutputSttHandle {
+  /** Uninstall the tee (restoring the original output if still ours) and dispose the engine. Idempotent. */
+  dispose(): Promise<void>;
+  readonly usage: SideSttUsage;
+  /** Whether a tee was actually installed (false when the session had no audio output or the engine could not be built). */
+  readonly installed: boolean;
+}
+
+export interface ArmOutputSttParams {
+  session: TeeableSession;
+  roomName: string;
+  agent: Agent;
+  config: SideSttConfig;
+  onTranscript: (text: string, at: Date) => void;
+  onUsage: (unit: "milliseconds" | "characters", quantity: number) => void;
+  deps?: {
+    buildStt?: (agent: Agent, config: SideSttConfig) => stt.STT;
+  };
+}
+
+const NO_USAGE: SideSttUsage = { milliseconds: 0, characters: 0, streamedMilliseconds: 0 };
+const NOOP_HANDLE: OutputSttHandle = { dispose: async () => {}, usage: NO_USAGE, installed: false };
+
+/**
+ * Wrap a live audio output so every captured frame is also pushed to `engine`.
+ * Exported for tests. Everything but `captureFrame` is the original's own
+ * member, bound to the original, so the session cannot tell the difference.
+ */
+export function teeAudioOutput<T extends TeeableAudioOutput>(original: T, engine: SideSttEngine): T {
+  return new Proxy(original, {
+    get(target, prop) {
+      if (prop === "captureFrame") {
+        return async (frame: AudioFrame): Promise<void> => {
+          engine.push(frame);
+          return target.captureFrame(frame);
+        };
+      }
+      const value = Reflect.get(target, prop, target);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    set(target, prop, value) {
+      return Reflect.set(target, prop, value, target);
+    },
+  });
+}
+
+/**
+ * Arm the output audit on a started session. Builds the engine, installs the
+ * tee as `session.output.audio`, and returns a handle that restores the
+ * original output on dispose. Never throws: a session without an audio
+ * output, or an engine that cannot be built, leaves the session untouched.
+ */
+export function armOutputStt(params: ArmOutputSttParams): OutputSttHandle {
+  const { session, roomName, agent, config, onTranscript, onUsage } = params;
+  const buildStt = params.deps?.buildStt ?? buildOutputStt;
+
+  const original = session.output.audio;
+  if (!original) {
+    logger.warn({ roomName }, "outputStt: session has no audio output to tee; skipping the output audit");
+    return NOOP_HANDLE;
+  }
+  let sttInstance: stt.STT;
+  try {
+    sttInstance = buildStt(agent, config);
+  } catch (e) {
+    logger.warn({ e, roomName, config }, "outputStt: could not build the audit engine (continuing without it)");
+    return NOOP_HANDLE;
+  }
+
+  let disposing: Promise<void> | null = null;
+  let tee: TeeableAudioOutput | null = null;
+  const dispose = (): Promise<void> => {
+    if (disposing) return disposing;
+    disposing = (async () => {
+      if (tee && session.output.audio === tee) {
+        try {
+          session.output.audio = original;
+        } catch (e) {
+          logger.debug({ e, roomName }, "outputStt: could not restore the original audio output");
+        }
+      }
+      await engine.dispose();
+      logger.info({ roomName, ...engine.usage }, "outputStt: output audit disposed");
+    })();
+    return disposing;
+  };
+
+  const engine = startSideSttEngine({
+    label: "outputStt",
+    roomName,
+    subject: "agent output",
+    stt: sttInstance,
+    onTranscript,
+    onUsage,
+    onEngineStopped: () => void dispose(),
+  });
+  tee = teeAudioOutput(original, engine);
+  session.output.audio = tee;
+  logger.info(
+    { roomName, label: sttInstance.label, config, output: (original as any)?.constructor?.name },
+    "outputStt: output audit armed on the session's audio output",
+  );
+
+  return {
+    dispose,
+    get usage() {
+      return engine.usage;
+    },
+    installed: true,
+  };
+}

--- a/agents/livekit/lib/voice-agent-runtime.ts
+++ b/agents/livekit/lib/voice-agent-runtime.ts
@@ -31,11 +31,19 @@ import type { UsageVendors, VendorDetail } from "./usage-vendors.js";
 import {
   armAuxStt,
   parseAuxSttOption,
+  parseOutputSttOption,
   resolveAuxSttVendor,
+  resolveOutputSttVendor,
   AUX_STT_LOG_TYPE,
   AUX_STT_TECHNOLOGY,
   type AuxSttHandle,
 } from "./aux-stt.js";
+import {
+  armOutputStt,
+  OUTPUT_STT_LOG_TYPE,
+  OUTPUT_STT_TECHNOLOGY,
+  type OutputSttHandle,
+} from "./output-stt.js";
 import type { BridgedTakeoverRuntime } from "./bridged-transfer-to-agent.js";
 
 export async function runAgentWorker({
@@ -251,6 +259,11 @@ export async function runAgentWorker({
    * the agent's media is detached after a bridged transfer and on teardown.
    */
   let auxStt: AuxSttHandle | null = null;
+  /**
+   * Output audit STT over the agent's own audio (options.tts.output): a tee on
+   * the session's audio output, same lifecycle as the caller-side aux STT.
+   */
+  let outputStt: OutputSttHandle | null = null;
   /** Recording + invocation logs must stay on the inbound agent call, not the bridged child call. */
   const primaryRecordingCallId = call.id;
   let maxDuration: number = 305000; // Default value
@@ -560,13 +573,17 @@ export async function runAgentWorker({
   // neither merged with nor gated like the primary `stt` meter above — a
   // realtime model bundles its own recognition into the model charge, but the
   // auxiliary engine is a real, separate cost on every voice mode.
-  const addAuxMeter = (vendor: VendorDetail, unit: string, quantity: number): void => {
+  const addSideMeter = (
+    technology: string,
+    vendor: VendorDetail,
+    unit: string,
+    quantity: number,
+  ): void => {
     if (!quantity || quantity <= 0) return;
-    const detail = vendor.detail || vendor.vendor || "aux";
-    const key = `${AUX_STT_TECHNOLOGY}|${detail}`;
+    const detail = vendor.detail || vendor.vendor || technology;
+    const key = `${technology}|${detail}`;
     const meter =
-      usageMeters.get(key) ||
-      { technology: AUX_STT_TECHNOLOGY, provider: vendor.vendor, detail, units: {} };
+      usageMeters.get(key) || { technology, provider: vendor.vendor, detail, units: {} };
     meter.units[unit] = (meter.units[unit] || 0) + quantity;
     usageMeters.set(key, meter);
   };
@@ -685,7 +702,7 @@ export async function runAgentWorker({
         if (getConsultInProgress()) return;
         sendMessage({ [AUX_STT_LOG_TYPE]: text }, at);
       },
-      onUsage: (unit, quantity) => addAuxMeter(vendor, unit, quantity),
+      onUsage: (unit, quantity) => addSideMeter(AUX_STT_TECHNOLOGY, vendor, unit, quantity),
     });
   };
   /** Resolves once the engine's last usage report had its chance to land (see AuxSttHandle.dispose). */
@@ -693,6 +710,37 @@ export async function runAgentWorker({
     if (!auxStt) return Promise.resolve();
     const handle = auxStt;
     auxStt = null;
+    return handle.dispose();
+  };
+
+  /**
+   * (Re)arm the output audit for `agentDef` on a started session: a tee on the
+   * session's audio output (see output-stt.ts) — installed only when
+   * options.tts.output is set; the session is untouched otherwise. Finals are
+   * logged as `agent-speech` through sendMessage, like every other transcript
+   * entry, and metered as `stt-output`.
+   */
+  const armOutputSttFor = (agentDef: Agent, s: voice.AgentSession | null): void => {
+    if (outputStt) {
+      void outputStt.dispose();
+      outputStt = null;
+    }
+    const config = parseOutputSttOption(agentDef?.options);
+    if (!config || !s) return;
+    const vendor = resolveOutputSttVendor(agentDef, config);
+    outputStt = armOutputStt({
+      session: s as any,
+      roomName: room.name,
+      agent: agentDef,
+      config,
+      onTranscript: (text, at) => sendMessage({ [OUTPUT_STT_LOG_TYPE]: text }, at),
+      onUsage: (unit, quantity) => addSideMeter(OUTPUT_STT_TECHNOLOGY, vendor, unit, quantity),
+    });
+  };
+  const disposeOutputStt = (): Promise<void> => {
+    if (!outputStt) return Promise.resolve();
+    const handle = outputStt;
+    outputStt = null;
     return handle.dispose();
   };
 
@@ -774,9 +822,9 @@ export async function runAgentWorker({
       }
 
 
-      // Stop the auxiliary STT first — and wait for the engine's last usage
-      // report — so its final counts are in the meters the flush below writes.
-      await disposeAuxStt();
+      // Stop the side STTs first — and wait for each engine's last usage
+      // report — so their final counts are in the meters the flush below writes.
+      await Promise.all([disposeAuxStt(), disposeOutputStt()]);
 
       // Flush accumulated usage (tokens / characters / audio) to the ledger
       // before ending the call so it lands as the finalised session total.
@@ -1301,9 +1349,10 @@ export async function runAgentWorker({
         record: false,
         inputOptions: { closeOnDisconnect: true },
       });
-      // The incoming agent's own options.stt.aux applies from here (a takeover
-      // also re-arms it: the caller is talking to an agent again).
+      // The incoming agent's own side-STT options apply from here (a takeover
+      // also re-arms them: the caller is talking to an agent again).
       armAuxSttFor(newAgentDef);
+      armOutputSttFor(newAgentDef, newSession);
 
       // The incoming agent speaks next. Ultravox realtime greets natively via
       // firstSpeakerSettings; other stacks need an explicit first turn.
@@ -1537,6 +1586,7 @@ export async function runAgentWorker({
     // agent call. A takeover re-arms it via restartWithAgent.
     onPrimaryAgentDetached: () => {
       void disposeAuxStt();
+      void disposeOutputStt();
     },
   });
 
@@ -1897,8 +1947,10 @@ export async function runAgentWorker({
         );
         logger.info({ callId: call.id }, "session started");
 
-        // Auxiliary ("second opinion") STT on the caller's track, if configured.
+        // Side STTs, each only if configured: the auxiliary ("second opinion")
+        // STT on the caller's track, and the output audit on the session's output.
         armAuxSttFor(agent);
+        armOutputSttFor(agent, session);
 
         // ---- Inactivity "kick" ----
         // When options.inactivity is configured, the session was built with

--- a/agents/livekit/test/aux-stt.test.ts
+++ b/agents/livekit/test/aux-stt.test.ts
@@ -43,6 +43,15 @@ test("parseAuxSttOption: true / {} / object normalise", () => {
   assert.deepEqual(parseAuxSttOption({ stt: { aux: { vendor: "  ", language: "" } } }), {});
 });
 
+test("parseOutputSttOption / parseAuxSttOption share one normaliser but read different blocks", async () => {
+  const { parseOutputSttOption } = await import("../lib/aux-stt.js");
+  const options = { stt: { aux: { vendor: "assemblyai" } }, tts: { output: { vendor: "deepgram" } } };
+  assert.deepEqual(parseAuxSttOption(options), { vendor: "assemblyai" });
+  assert.deepEqual(parseOutputSttOption(options), { vendor: "deepgram" });
+  assert.equal(parseOutputSttOption({ stt: { aux: {} } }), null);
+  assert.equal(parseAuxSttOption({ tts: { output: {} } }), null);
+});
+
 test("auxSttAgent: aux block stands in for stt; language inherits stt then tts; nested aux dropped", () => {
   const agent = {
     id: "a",

--- a/agents/livekit/test/output-stt.test.ts
+++ b/agents/livekit/test/output-stt.test.ts
@@ -1,0 +1,242 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { stt } from "@livekit/agents";
+import { OUTPUT_STT_LOG_TYPE, OUTPUT_STT_TECHNOLOGY, armOutputStt, teeAudioOutput } from "../lib/output-stt.js";
+import { outputSttAgent, parseOutputSttOption, resolveOutputSttVendor, startSideSttEngine } from "../lib/aux-stt.js";
+
+// The output audit: option parsing, the agent-side language order, and the
+// AudioOutput tee driven with a fake session output and a fake STT engine.
+// run: tsx --test test/output-stt.test.ts
+
+test("constants match the platform contract", () => {
+  assert.equal(OUTPUT_STT_LOG_TYPE, "agent-speech");
+  assert.equal(OUTPUT_STT_TECHNOLOGY, "stt-output");
+});
+
+test("parseOutputSttOption reads options.tts.output with the shared leniency", () => {
+  assert.equal(parseOutputSttOption(undefined), null);
+  assert.equal(parseOutputSttOption({ tts: { voice: "Ciara" } }), null);
+  assert.equal(parseOutputSttOption({ tts: { output: false } }), null);
+  assert.equal(parseOutputSttOption({ tts: { output: { enabled: false } } }), null);
+  assert.deepEqual(parseOutputSttOption({ tts: { output: true } }), {});
+  assert.deepEqual(parseOutputSttOption({ tts: { output: { vendor: " deepgram ", language: "en-GB" } } }), {
+    vendor: "deepgram",
+    language: "en-GB",
+  });
+});
+
+test("outputSttAgent: the agent speaks in its TTS language, so tts.language wins", () => {
+  const agent = { id: "a", options: { tts: { voice: "Ciara", language: "en-GB", output: {} }, stt: { language: "fr" } } } as any;
+  assert.deepEqual(outputSttAgent(agent, { vendor: "deepgram" }).options.stt, { vendor: "deepgram", language: "en-GB" });
+  assert.deepEqual(outputSttAgent({ id: "b", options: { stt: { language: "fr" } } } as any, {}).options.stt, { language: "fr" });
+  assert.deepEqual(resolveOutputSttVendor(agent, {}), { vendor: "deepgram", detail: "deepgram/nova-3" });
+});
+
+// ---- fakes ----------------------------------------------------------------
+
+class FakeSpeechStream {
+  pushed: any[] = [];
+  flushes = 0;
+  private queue: any[] = [];
+  private waiters: Array<(r: IteratorResult<any>) => void> = [];
+  private ended = false;
+  constructor(private readonly finalAfterFrames: number, private readonly text: string) {}
+  flush() {
+    this.flushes += 1;
+  }
+  pushFrame(frame: any) {
+    if (this.ended) throw new Error("input ended");
+    this.pushed.push(frame);
+    if (this.pushed.length === this.finalAfterFrames) {
+      this.put({ type: stt.SpeechEventType.FINAL_TRANSCRIPT, alternatives: [{ text: this.text }] });
+    }
+  }
+  private put(ev: any) {
+    const w = this.waiters.shift();
+    if (w) w({ value: ev, done: false });
+    else this.queue.push(ev);
+  }
+  endInput() {
+    this.ended = true;
+    for (const w of this.waiters.splice(0)) w({ value: undefined, done: true });
+  }
+  close() {
+    this.endInput();
+  }
+  next(): Promise<IteratorResult<any>> {
+    if (this.queue.length) return Promise.resolve({ value: this.queue.shift(), done: false });
+    if (this.ended) return Promise.resolve({ value: undefined, done: true });
+    return new Promise((r) => this.waiters.push(r));
+  }
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+}
+
+function fakeStt(stream: FakeSpeechStream, closed: { n: number }) {
+  const handlers = new Map<string, Set<(ev: any) => void>>();
+  return {
+    label: "fake.STT",
+    stream: () => stream,
+    close: async () => void closed.n++,
+    on(evt: string, cb: (ev: any) => void) {
+      (handlers.get(evt) ?? handlers.set(evt, new Set()).get(evt)!).add(cb);
+    },
+    off(evt: string, cb: (ev: any) => void) {
+      handlers.get(evt)?.delete(cb);
+    },
+    emit(evt: string, ev: any) {
+      for (const cb of handlers.get(evt) ?? []) cb(ev);
+    },
+  } as any;
+}
+
+/** A stand-in for the SDK's ParticipantAudioOutput: records frames, has a getter, a method and events. */
+class FakeParticipantOutput {
+  frames: any[] = [];
+  flushed = 0;
+  listeners: string[] = [];
+  private readonly _rate = 24000;
+  get sampleRate() {
+    return this._rate;
+  }
+  async captureFrame(frame: any) {
+    this.frames.push(frame);
+  }
+  flush() {
+    this.flushed += 1;
+  }
+  waitForPlayout() {
+    return "played";
+  }
+  on(evt: string) {
+    this.listeners.push(evt);
+    return this;
+  }
+}
+
+const frame = (n: number) => ({ sampleRate: 16000, samplesPerChannel: 320, channels: 1, n }) as any;
+const settle = () => new Promise((r) => setTimeout(r, 30));
+
+test("teeAudioOutput: intercepts captureFrame only; everything else is the original's, bound", async () => {
+  const original = new FakeParticipantOutput();
+  const stream = new FakeSpeechStream(2, " thank you for calling ");
+  const closed = { n: 0 };
+  const transcripts: string[] = [];
+  const engine = startSideSttEngine({
+    label: "outputStt",
+    roomName: "r",
+    subject: "agent output",
+    stt: fakeStt(stream, closed),
+    onTranscript: (t) => transcripts.push(t),
+    onUsage: () => {},
+  });
+  const tee = teeAudioOutput(original as any, engine) as any;
+  await tee.captureFrame(frame(1));
+  await tee.captureFrame(frame(2));
+  await settle();
+  assert.deepEqual(original.frames.map((f) => f.n), [1, 2], "frames reach the real output, in order");
+  assert.deepEqual(stream.pushed.map((f) => f.n), [1, 2], "…and the engine");
+  assert.deepEqual(transcripts, ["thank you for calling"]);
+  assert.equal(tee.sampleRate, 24000, "getters read through");
+  assert.equal(tee.waitForPlayout(), "played", "methods bound to the original");
+  tee.flush();
+  assert.equal(original.flushed, 1);
+  tee.on("playbackFinished");
+  assert.deepEqual(original.listeners, ["playbackFinished"], "event registration lands on the original");
+  assert.ok(tee instanceof FakeParticipantOutput, "instanceof still holds");
+  await engine.dispose();
+  assert.equal(closed.n, 1);
+});
+
+test("armOutputStt: installs the tee, logs finals, meters the engine's report, restores on dispose", async () => {
+  const original = new FakeParticipantOutput();
+  const session = { output: { audio: original as any } };
+  const stream = new FakeSpeechStream(3, "hello, this is the agent");
+  const closed = { n: 0 };
+  const engineStt = fakeStt(stream, closed);
+  const transcripts: string[] = [];
+  const usage: Record<string, number> = { milliseconds: 0, characters: 0 };
+  const handle = armOutputStt({
+    session,
+    roomName: "r",
+    agent: { id: "a", options: {} } as any,
+    config: {},
+    onTranscript: (t) => transcripts.push(t),
+    onUsage: (unit, q) => (usage[unit] += q),
+    deps: { buildStt: () => engineStt },
+  });
+  assert.equal(handle.installed, true);
+  assert.notEqual(session.output.audio, original, "the tee is now the session's output");
+  for (let i = 1; i <= 3; i++) await (session.output.audio as any).captureFrame(frame(i));
+  await settle();
+  assert.equal(original.frames.length, 3, "playout unaffected");
+  assert.deepEqual(transcripts, ["hello, this is the agent"]);
+  assert.equal(usage.characters, "hello, this is the agent".length);
+  assert.equal(Math.round(handle.usage.streamedMilliseconds), 60);
+  assert.equal(usage.milliseconds, 0, "nothing metered until the engine reports");
+  engineStt.emit("metrics_collected", { type: "stt_metrics", audioDurationMs: 1200 });
+  assert.equal(usage.milliseconds, 1200);
+  await handle.dispose();
+  assert.equal(session.output.audio, original, "original output restored");
+  assert.equal(stream.flushes, 1, "engine asked for its last usage interval");
+  assert.equal(closed.n, 1);
+  await handle.dispose();
+  assert.equal(closed.n, 1, "idempotent");
+});
+
+test("armOutputStt: leaves the session untouched when there is no output or the engine cannot be built", async () => {
+  const none = { output: { audio: null } };
+  const h1 = armOutputStt({
+    session: none,
+    roomName: "r",
+    agent: { id: "a", options: {} } as any,
+    config: {},
+    onTranscript: () => assert.fail("no transcript"),
+    onUsage: () => assert.fail("no usage"),
+    deps: { buildStt: () => assert.fail("must not build without an output") },
+  });
+  assert.equal(h1.installed, false);
+  assert.equal(none.output.audio, null);
+  await h1.dispose();
+
+  const original = new FakeParticipantOutput();
+  const session = { output: { audio: original as any } };
+  const h2 = armOutputStt({
+    session,
+    roomName: "r",
+    agent: { id: "a", options: {} } as any,
+    config: { vendor: "nope" },
+    onTranscript: () => {},
+    onUsage: () => {},
+    deps: {
+      buildStt: () => {
+        throw new Error("no such vendor");
+      },
+    },
+  });
+  assert.equal(h2.installed, false);
+  assert.equal(session.output.audio, original, "no tee installed");
+  await h2.dispose();
+});
+
+test("armOutputStt: a non-recoverable engine error uninstalls the tee", async () => {
+  const original = new FakeParticipantOutput();
+  const session = { output: { audio: original as any } };
+  const closed = { n: 0 };
+  const engineStt = fakeStt(new FakeSpeechStream(99, "never"), closed);
+  armOutputStt({
+    session,
+    roomName: "r",
+    agent: { id: "a", options: {} } as any,
+    config: {},
+    onTranscript: () => {},
+    onUsage: () => {},
+    deps: { buildStt: () => engineStt },
+  });
+  assert.notEqual(session.output.audio, original);
+  engineStt.emit("error", { type: "stt_error", label: "deepgram.STT", recoverable: false, error: new Error("gave up") });
+  await new Promise((r) => setTimeout(r, 400));
+  assert.equal(session.output.audio, original, "original restored after the engine stopped itself");
+  assert.equal(closed.n, 1);
+});

--- a/agents/pipecat/pipecat_aplisay/aux_stt.py
+++ b/agents/pipecat/pipecat_aplisay/aux_stt.py
@@ -1,4 +1,6 @@
-"""Auxiliary ("second opinion") speech recognition — ``options.stt.aux``.
+"""Side STT taps: the auxiliary ("second opinion") recognition of the CALLER
+(``options.stt.aux``) and the output audit recognition of the AGENT
+(``options.tts.output``).
 
 Runs a second, independent STT engine over the caller's audio alongside the
 agent's own recognition (the pipeline STT, or a realtime model's built-in
@@ -33,8 +35,20 @@ second engine's consumption is neither merged with nor gated like the primary
 ``stt`` meter (a realtime model bundles its own recognition into the model
 charge; the auxiliary engine is a real extra cost on every voice mode).
 
-Everything here is best-effort: an auxiliary STT failure must never disturb
-the call. See docs/auxiliary-stt.md.
+Output audit (``options.tts.output``): the same tap class, pointed at the
+agent's own ``TTSAudioRawFrame``s immediately before ``transport.output()`` —
+the synthesised (pipeline) or model-produced (realtime) audio the caller
+actually hears. Its finals are logged as ``agent-speech`` beside the ``agent``
+turn the model produced, and metered as ``stt-output``. Only TTS audio is
+tapped: the confidence tone, a fixed fallback message and relayed peer audio are
+plain ``OutputAudioRawFrame``s and are ignored.
+
+Neither tap exists on a call unless its option is set: ``voice_session`` builds
+a tap only for a configured option, and the engine is built lazily on the first
+audio frame inside it.
+
+Everything here is best-effort: a side STT failure must never disturb the call.
+See docs/auxiliary-stt.md.
 """
 
 from __future__ import annotations
@@ -43,7 +57,7 @@ import asyncio
 from typing import Any, Awaitable, Callable, Optional
 
 from loguru import logger
-from pipecat.frames.frames import CancelFrame, EndFrame, InputAudioRawFrame
+from pipecat.frames.frames import CancelFrame, EndFrame, InputAudioRawFrame, TTSAudioRawFrame
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 from .bridge_transcript import SttStream
@@ -52,19 +66,19 @@ from .bridge_transcript import SttStream
 AUX_STT_TECHNOLOGY = "stt-aux"
 #: Transaction-log type for auxiliary transcripts (next to the primary ``user``).
 AUX_STT_LOG_TYPE = "user-aux"
-#: Default engine when ``options.stt.aux.vendor`` is unset — the pipeline default.
+#: Ledger technology for the output audit's usage rows.
+OUTPUT_STT_TECHNOLOGY = "stt-output"
+#: Transaction-log type for the output audit's transcripts (next to ``agent``).
+OUTPUT_STT_LOG_TYPE = "agent-speech"
+#: Default engine when a side option's ``vendor`` is unset — the pipeline default.
 DEFAULT_AUX_STT_VENDOR = "deepgram"
 
 
-def parse_aux_stt_option(options: Optional[dict]) -> Optional[dict]:
-    """Normalise ``options.stt.aux`` to ``None`` (off) or
+def _parse_side_stt_block(raw: Any) -> Optional[dict]:
+    """Normalise one side-STT block to ``None`` (off) or
     ``{"vendor": Optional[str], "language": Optional[str]}``. Lenient — the
     server validated the shape at save time: absent / ``False`` /
     ``enabled: False`` / malformed → off; ``True`` or ``{}`` → defaults."""
-    stt_opts = (options or {}).get("stt")
-    if not isinstance(stt_opts, dict):
-        return None
-    raw = stt_opts.get("aux")
     if raw is None or raw is False:
         return None
     if raw is True:
@@ -79,20 +93,34 @@ def parse_aux_stt_option(options: Optional[dict]) -> Optional[dict]:
     }
 
 
-def aux_stt_agent(agent: dict, config: dict) -> dict:
-    """The agent with ``options.stt.aux`` standing in for ``options.stt``, so
-    ``build_stt_service`` constructs the auxiliary engine exactly as it would
-    the primary one. Language falls back to the agent's own ``stt.language``,
-    then ``tts.language`` (the platform's declare-once convention); the nested
-    ``aux`` block itself is dropped."""
+def parse_aux_stt_option(options: Optional[dict]) -> Optional[dict]:
+    """``options.stt.aux`` → side-STT config or ``None`` (off)."""
+    stt_opts = (options or {}).get("stt")
+    if not isinstance(stt_opts, dict):
+        return None
+    return _parse_side_stt_block(stt_opts.get("aux"))
+
+
+def parse_output_stt_option(options: Optional[dict]) -> Optional[dict]:
+    """``options.tts.output`` → side-STT config or ``None`` (off)."""
+    tts_opts = (options or {}).get("tts")
+    if not isinstance(tts_opts, dict):
+        return None
+    return _parse_side_stt_block(tts_opts.get("output"))
+
+
+def _side_stt_agent(agent: dict, config: dict, language_order: tuple[str, ...]) -> dict:
+    """The agent with the side block standing in for ``options.stt``, so
+    ``build_stt_service`` constructs the side engine exactly as it would the
+    primary one. Language falls back through ``language_order`` (the
+    platform's declare-once convention); nested side blocks are dropped."""
     options = dict(agent.get("options") or {})
-    stt_opts = options.get("stt") or {}
-    tts_opts = options.get("tts") or {}
-    language = (
-        config.get("language")
-        or (stt_opts.get("language") if isinstance(stt_opts, dict) else None)
-        or (tts_opts.get("language") if isinstance(tts_opts, dict) else None)
-    )
+    language = config.get("language")
+    for key in language_order:
+        if language:
+            break
+        block = options.get(key)
+        language = block.get("language") if isinstance(block, dict) else None
     block: dict = {}
     if config.get("vendor"):
         block["vendor"] = config["vendor"]
@@ -102,12 +130,22 @@ def aux_stt_agent(agent: dict, config: dict) -> dict:
     return {**agent, "options": options}
 
 
-def aux_stt_vendor(agent: dict, config: dict) -> dict:
-    """Canonical ``{vendor, model}`` for the auxiliary engine's usage rows:
-    ``vendor`` is the bare engine name (what the rate lines match on);
-    ``model`` is ``vendor/model`` when the vendor string was scoped
-    (``deepgram/nova-3``), else ``None``."""
-    stt_opts = (aux_stt_agent(agent, config).get("options") or {}).get("stt") or {}
+def aux_stt_agent(agent: dict, config: dict) -> dict:
+    """Caller side: language falls back to ``stt.language`` then ``tts.language``."""
+    return _side_stt_agent(agent, config, ("stt", "tts"))
+
+
+def output_stt_agent(agent: dict, config: dict) -> dict:
+    """Agent side: the agent speaks in its TTS language, so ``tts.language`` first."""
+    return _side_stt_agent(agent, config, ("tts", "stt"))
+
+
+def _side_stt_vendor(effective_agent: dict) -> dict:
+    """Canonical ``{vendor, model}`` for a side engine's usage rows: ``vendor``
+    is the bare engine name (what the rate lines match on); ``model`` is
+    ``vendor/model`` when the vendor string was scoped (``deepgram/nova-3``),
+    else ``None``."""
+    stt_opts = (effective_agent.get("options") or {}).get("stt") or {}
     raw = str(stt_opts.get("vendor") or DEFAULT_AUX_STT_VENDOR)
     head = raw.split(":", 1)[0]
     vendor = head.split("/", 1)[0].strip().lower()
@@ -115,21 +153,33 @@ def aux_stt_vendor(agent: dict, config: dict) -> dict:
     return {"vendor": vendor, "model": f"{vendor}/{model}" if model else None}
 
 
+def aux_stt_vendor(agent: dict, config: dict) -> dict:
+    return _side_stt_vendor(aux_stt_agent(agent, config))
+
+
+def output_stt_vendor(agent: dict, config: dict) -> dict:
+    return _side_stt_vendor(output_stt_agent(agent, config))
+
+
 OnFinal = Callable[[str], Awaitable[None]]
 OnUsage = Callable[[str, int], None]
 
 
 class AuxSttTap(FrameProcessor):
-    """Pass-through processor that copies caller audio into a side STT-only
-    pipeline and forwards its final transcripts + usage.
+    """Pass-through processor that copies one class of audio frame into a side
+    STT-only pipeline and forwards its final transcripts + usage. Instantiated
+    twice over: on the caller's ``InputAudioRawFrame``s (the auxiliary STT) and
+    on the agent's ``TTSAudioRawFrame``s (the output audit).
 
     Args:
-        stt_factory: builds the auxiliary STT service (called once, lazily, on
-            the first audio frame so a build failure only costs the second
-            opinion, never the call).
+        stt_factory: builds the side STT service (called once, lazily, on the
+            first audio frame so a build failure only costs the side transcript,
+            never the call).
         on_final: awaited with each non-empty final transcript.
         on_usage: called with ``("milliseconds", n)`` as audio is streamed to
             the engine and ``("characters", n)`` per final transcript.
+        frame_cls: the audio frame class to tap (default: the caller's input).
+        label: log prefix (``auxStt`` / ``outputStt``).
         stream_factory: test seam — builds the side pipeline; defaults to
             :class:`SttStream`.
     """
@@ -140,10 +190,14 @@ class AuxSttTap(FrameProcessor):
         stt_factory: Callable[[], Any],
         on_final: OnFinal,
         on_usage: Optional[OnUsage] = None,
+        frame_cls: type = InputAudioRawFrame,
+        label: str = "auxStt",
         stream_factory: Optional[Callable[..., Any]] = None,
         name: Optional[str] = None,
     ) -> None:
-        super().__init__(name=name or "AuxSttTap")
+        super().__init__(name=name or f"{label}Tap")
+        self._frame_cls = frame_cls
+        self._label = label
         self._stt_factory = stt_factory
         self._on_final = on_final
         self._on_usage: OnUsage = on_usage or (lambda _unit, _qty: None)
@@ -169,7 +223,7 @@ class AuxSttTap(FrameProcessor):
 
     async def process_frame(self, frame, direction: FrameDirection):  # noqa: ANN001
         await super().process_frame(frame, direction)
-        if isinstance(frame, InputAudioRawFrame) and direction == FrameDirection.DOWNSTREAM:
+        if isinstance(frame, self._frame_cls) and direction == FrameDirection.DOWNSTREAM:
             await self._tap_audio(frame)
         elif isinstance(frame, (EndFrame, CancelFrame)):
             self._schedule_stop()
@@ -190,7 +244,7 @@ class AuxSttTap(FrameProcessor):
                 )
                 await self._stream.start()
                 logger.info(
-                    f"auxStt: auxiliary transcription armed "
+                    f"{self._label}: side transcription armed "
                     f"({frame.sample_rate} Hz, {frame.num_channels} ch)"
                 )
             if frame.sample_rate != self._sample_rate or frame.num_channels != self._num_channels:
@@ -200,7 +254,7 @@ class AuxSttTap(FrameProcessor):
                 if not self._rate_warned:
                     self._rate_warned = True
                     logger.warning(
-                        "auxStt: input audio format changed mid-call; dropping mismatched frames"
+                        f"{self._label}: audio format changed mid-call; dropping mismatched frames"
                     )
                 return
             await self._stream.feed(frame.audio)
@@ -209,7 +263,7 @@ class AuxSttTap(FrameProcessor):
         except Exception as e:  # noqa: BLE001
             # Best-effort: the call carries on without the second opinion.
             self._failed = True
-            logger.warning(f"auxStt: auxiliary transcription failed (continuing without it): {e}")
+            logger.warning(f"{self._label}: side transcription failed (continuing without it): {e}")
             self._schedule_stop()
 
     def _report_audio(self) -> None:
@@ -229,7 +283,7 @@ class AuxSttTap(FrameProcessor):
         try:
             self._on_usage(unit, quantity)
         except Exception as e:  # noqa: BLE001
-            logger.debug(f"auxStt: usage report failed: {e}")
+            logger.debug(f"{self._label}: usage report failed: {e}")
 
     async def _collect_final(self, text: str) -> None:
         text = (text or "").strip()
@@ -246,7 +300,7 @@ class AuxSttTap(FrameProcessor):
         try:
             await self._on_final(text)
         except Exception as e:  # noqa: BLE001
-            logger.warning(f"auxStt: transcript handler failed: {e}")
+            logger.warning(f"{self._label}: transcript handler failed: {e}")
 
     def _schedule_stop(self) -> None:
         """Tear the side pipeline down without holding up the main chain's own
@@ -261,13 +315,13 @@ class AuxSttTap(FrameProcessor):
         try:
             await stream.stop()
         except Exception as e:  # noqa: BLE001
-            logger.debug(f"auxStt: side pipeline stop raised: {e}")
+            logger.debug(f"{self._label}: side pipeline stop raised: {e}")
         if not self._proven and self._pending_ms:
             logger.warning(
-                f"auxStt: the engine returned no transcript for {self._pending_ms} ms of "
+                f"{self._label}: the engine returned no transcript for {self._pending_ms} ms of "
                 "streamed audio (connection or credentials failure?); nothing metered"
             )
         logger.info(
-            f"auxStt: auxiliary transcription stopped "
+            f"{self._label}: side transcription stopped "
             f"({int(self._milliseconds)} ms streamed, {self._characters} chars)"
         )

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -525,6 +525,8 @@ class CallSession:
             on_inactivity_hangup=self._on_inactivity_hangup,
             on_aux_transcript=self._on_aux_transcript,
             on_aux_usage=self._on_aux_usage,
+            on_output_transcript=self._on_output_transcript,
+            on_output_usage=self._on_output_usage,
         )
         # Stash the context handle so ``get_parent_transcript`` (used by
         # the consultative-transfer flow) can walk the chat history.
@@ -1002,6 +1004,30 @@ class CallSession:
             return
         observer.add_meter(
             AUX_STT_TECHNOLOGY,
+            unit,
+            quantity,
+            provider=vendor.get("vendor"),
+            detail=vendor.get("model"),
+        )
+
+    async def _on_output_transcript(self, text: str) -> None:
+        """A final transcript from the output audit STT (``options.tts.output``)
+        — what the agent's audio actually said — logged as ``agent-speech``
+        next to the ``agent`` turn the model produced."""
+        from .aux_stt import OUTPUT_STT_LOG_TYPE
+
+        await self._send_message({OUTPUT_STT_LOG_TYPE: text}, is_final=True)
+
+    def _on_output_usage(self, unit: str, quantity: int, vendor: dict) -> None:
+        """Output audit STT usage into the call's usage observer as
+        ``stt-output`` rows (see ``_on_aux_usage``)."""
+        from .aux_stt import OUTPUT_STT_TECHNOLOGY
+
+        observer = getattr(self, "_usage_observer", None)
+        if observer is None:
+            return
+        observer.add_meter(
+            OUTPUT_STT_TECHNOLOGY,
             unit,
             quantity,
             provider=vendor.get("vendor"),

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -924,13 +924,18 @@ async def build_voice_session(
     on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
     on_aux_transcript: "Optional[Callable[[str], Awaitable[None]]]" = None,
     on_aux_usage: "Optional[Callable[[str, int, dict], None]]" = None,
+    on_output_transcript: "Optional[Callable[[str], Awaitable[None]]]" = None,
+    on_output_usage: "Optional[Callable[[str, int, dict], None]]" = None,
 ) -> tuple[PipelineTask, Optional[AudioBufferProcessor], LLMContext, Any]:
     """Construct a configured ``PipelineTask`` for the call.
 
     ``on_aux_transcript`` / ``on_aux_usage`` receive the auxiliary STT's final
     transcripts and usage deltas (``unit, quantity, {vendor, model}``) when the
-    agent sets ``options.stt.aux`` — see aux_stt.py. Without a transcript
-    callback the option is ignored.
+    agent sets ``options.stt.aux``; ``on_output_transcript`` /
+    ``on_output_usage`` likewise for the output audit STT when the agent sets
+    ``options.tts.output`` — see aux_stt.py. Neither tap exists on a call
+    unless its option is set; without a transcript callback an option is
+    ignored.
 
     When ``enable_recording`` is true the returned ``AudioBufferProcessor``
     is appended to the pipeline (stereo, user-left/bot-right per
@@ -959,16 +964,17 @@ async def build_voice_session(
         audio_buffer = AudioBufferProcessor(num_channels=2)
 
     aux_tap = _aux_stt_tap_for(agent, on_aux_transcript, on_aux_usage)
+    output_tap = _output_stt_tap_for(agent, on_output_transcript, on_output_usage)
 
     if mode == "realtime":
         task, context, llm = await _build_realtime(
             transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector,
-            on_inactivity_hangup, aux_tap=aux_tap,
+            on_inactivity_hangup, aux_tap=aux_tap, output_tap=output_tap,
         )
     else:
         task, context, llm = await _build_pipeline(
             transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector,
-            on_inactivity_hangup, aux_tap=aux_tap,
+            on_inactivity_hangup, aux_tap=aux_tap, output_tap=output_tap,
         )
     return task, audio_buffer, context, llm
 
@@ -1003,6 +1009,38 @@ def _aux_stt_tap_for(
     )
 
 
+def _output_stt_tap_for(
+    agent: dict,
+    on_transcript: "Optional[Callable[[str], Awaitable[None]]]",
+    on_usage: "Optional[Callable[[str, int, dict], None]]",
+) -> "Optional[Any]":
+    """The output audit tap for ``options.tts.output`` (see aux_stt.py), or
+    ``None`` when the option is off — in which case nothing is inserted into
+    the chain. Taps the agent's ``TTSAudioRawFrame``s only."""
+    from pipecat.frames.frames import TTSAudioRawFrame
+
+    from .aux_stt import AuxSttTap, output_stt_agent, output_stt_vendor, parse_output_stt_option
+
+    config = parse_output_stt_option(agent.get("options"))
+    if config is None or on_transcript is None:
+        return None
+    effective_agent = output_stt_agent(agent, config)
+    vendor = output_stt_vendor(agent, config)
+    logger.bind(vendor=vendor).info("output audit STT configured (options.tts.output)")
+
+    def _report(unit: str, quantity: int) -> None:
+        if on_usage is not None:
+            on_usage(unit, quantity, vendor)
+
+    return AuxSttTap(
+        stt_factory=lambda: build_stt_service(effective_agent),
+        on_final=on_transcript,
+        on_usage=_report,
+        frame_cls=TTSAudioRawFrame,
+        label="outputStt",
+    )
+
+
 async def _build_realtime(
     transport: BaseTransport,
     model_name: str,
@@ -1015,6 +1053,7 @@ async def _build_realtime(
     tone_injector: "Optional[Any]" = None,
     on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
     aux_tap: "Optional[Any]" = None,
+    output_tap: "Optional[Any]" = None,
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
@@ -1299,6 +1338,10 @@ async def _build_realtime(
     # tap copies audio out to a side pipeline — nothing of the second engine
     # enters this chain (see aux_stt.py).
     aux = [aux_tap] if aux_tap is not None else []
+    # Output audit tap (options.tts.output) immediately before transport.output():
+    # after the rate guard, so it sees the agent's TTS audio at the transport's
+    # own rate; TTS frames only, so the tone and relayed audio never reach it.
+    output = [output_tap] if output_tap is not None else []
     processors: list = [
         transport.input(),
         *relay_tap,
@@ -1310,6 +1353,7 @@ async def _build_realtime(
         *relay_inject,
         rate_guard,
         cushion_interrupt,
+        *output,
         transport.output(),
     ]
     # The recording docs require ``AudioBufferProcessor`` to sit AFTER
@@ -1351,6 +1395,7 @@ async def _build_pipeline(
     tone_injector: "Optional[Any]" = None,
     on_inactivity_hangup: "Optional[Callable[[], Awaitable[None]]]" = None,
     aux_tap: "Optional[Any]" = None,
+    output_tap: "Optional[Any]" = None,
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
@@ -1426,6 +1471,9 @@ async def _build_pipeline(
     # STT: the tap only copies audio out to a side pipeline, so the primary STT
     # sees exactly the frames it always did (see aux_stt.py).
     aux = [aux_tap] if aux_tap is not None else []
+    # Output audit tap (options.tts.output) immediately before transport.output()
+    # — see _build_realtime.
+    output = [output_tap] if output_tap is not None else []
     processors: list = [
         transport.input(),
         *relay_tap,
@@ -1438,6 +1486,7 @@ async def _build_pipeline(
         *tone,
         *relay_inject,
         rate_guard,
+        *output,
         transport.output(),
     ]
     if audio_buffer is not None:

--- a/agents/pipecat/tests/test_aux_stt.py
+++ b/agents/pipecat/tests/test_aux_stt.py
@@ -15,17 +15,24 @@ from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
     InputAudioRawFrame,
+    OutputAudioRawFrame,
     TextFrame,
+    TTSAudioRawFrame,
 )
 from pipecat.tests.utils import run_test
 
 from pipecat_aplisay.aux_stt import (
     AUX_STT_LOG_TYPE,
     AUX_STT_TECHNOLOGY,
+    OUTPUT_STT_LOG_TYPE,
+    OUTPUT_STT_TECHNOLOGY,
     AuxSttTap,
     aux_stt_agent,
     aux_stt_vendor,
+    output_stt_agent,
+    output_stt_vendor,
     parse_aux_stt_option,
+    parse_output_stt_option,
 )
 
 
@@ -342,3 +349,102 @@ class TestCallSessionHandoff:
         session._send_message = _send_message
         asyncio.run(CallSession._on_aux_transcript(session, "hello there"))
         assert sent == [({"user-aux": "hello there"}, True)]
+
+
+# ---- the output audit (options.tts.output) -----------------------------------
+
+
+def test_output_constants_match_platform_contract():
+    assert OUTPUT_STT_LOG_TYPE == "agent-speech"
+    assert OUTPUT_STT_TECHNOLOGY == "stt-output"
+
+
+class TestParseOutputSttOption:
+    def test_shapes(self):
+        assert parse_output_stt_option(None) is None
+        assert parse_output_stt_option({"tts": {"voice": "Ciara"}}) is None
+        assert parse_output_stt_option({"tts": {"output": False}}) is None
+        assert parse_output_stt_option({"tts": {"output": {"enabled": False}}}) is None
+        assert parse_output_stt_option({"tts": "cartesia"}) is None
+        assert parse_output_stt_option({"tts": {"output": True}}) == {"vendor": None, "language": None}
+        assert parse_output_stt_option({"tts": {"output": {"vendor": " deepgram ", "language": "en-GB"}}}) == {
+            "vendor": "deepgram",
+            "language": "en-GB",
+        }
+
+    def test_agent_stand_in_prefers_the_tts_language(self):
+        agent = {"options": {"tts": {"voice": "Ciara", "language": "en-GB", "output": {}}, "stt": {"language": "fr"}}}
+        out = output_stt_agent(agent, {"vendor": "deepgram", "language": None})
+        assert out["options"]["stt"] == {"vendor": "deepgram", "language": "en-GB"}
+        assert out["options"]["tts"] == agent["options"]["tts"]  # untouched
+        assert output_stt_agent({"options": {"stt": {"language": "fr"}}}, {"vendor": None, "language": None})["options"]["stt"] == {"language": "fr"}
+        assert output_stt_vendor({}, {"vendor": "deepgram/nova-3:en", "language": None}) == {
+            "vendor": "deepgram",
+            "model": "deepgram/nova-3",
+        }
+
+
+def _tts(ms: int, rate: int = 16000) -> TTSAudioRawFrame:
+    return TTSAudioRawFrame(audio=b"\x00\x00" * (rate * ms // 1000), sample_rate=rate, num_channels=1)
+
+
+class TestOutputTap:
+    def setup_method(self):
+        _FakeStream.instances.clear()
+
+    def test_taps_only_the_agents_tts_audio(self):
+        async def run():
+            tap, finals, usage = _tap(frame_cls=TTSAudioRawFrame, label="outputStt")
+            tts1, tts2 = _tts(20), _tts(20)
+            tone = OutputAudioRawFrame(audio=b"\x00\x00" * 320, sample_rate=16000, num_channels=1)
+            caller = _audio(20, 16000)
+            down, _ = await run_test(
+                tap,
+                frames_to_send=[caller, tts1, tone, tts2],
+                expected_down_frames=[InputAudioRawFrame, TTSAudioRawFrame, OutputAudioRawFrame, TTSAudioRawFrame],
+            )
+            # Everything passed through untouched…
+            assert [type(d).__name__ for d in down] == [
+                "InputAudioRawFrame", "TTSAudioRawFrame", "OutputAudioRawFrame", "TTSAudioRawFrame",
+            ]
+            # …but only the two TTS frames reached the engine: not the caller's audio,
+            # not a plain OutputAudioRawFrame (tone / fixed message / relayed peer).
+            side = _FakeStream.instances[0]
+            assert side.fed == [tts1.audio, tts2.audio]
+            assert finals == ["hello there"]
+            assert sum(q for u, q in usage if u == "milliseconds") == 40
+
+        asyncio.run(run())
+
+
+class TestOutputWiring:
+    def test_tap_built_only_when_configured(self):
+        from pipecat_aplisay.voice_session import _output_stt_tap_for
+
+        async def on_transcript(_text):
+            pass
+
+        assert _output_stt_tap_for({"options": {}}, on_transcript, None) is None
+        assert _output_stt_tap_for({"options": {"tts": {"output": {}}}}, None, None) is None
+        tap = _output_stt_tap_for({"options": {"tts": {"output": {"vendor": "deepgram"}}}}, on_transcript, None)
+        assert isinstance(tap, AuxSttTap)
+        assert tap._frame_cls is TTSAudioRawFrame
+
+    def test_usage_lands_as_stt_output_and_transcript_as_agent_speech(self):
+        from pipecat_aplisay.call_session import CallSession
+        from pipecat_aplisay.usage import UsageMeteringObserver
+
+        session = CallSession.__new__(CallSession)
+        session._usage_observer = UsageMeteringObserver(services={})
+        CallSession._on_output_usage(session, "milliseconds", 900, {"vendor": "deepgram", "model": None})
+        rows = {(m["technology"], m["unit"]): m for m in session._usage_observer._meters.values()}
+        assert rows[("stt-output", "milliseconds")]["quantity"] == 900
+
+        sent = []
+
+        async def _send_message(message, *, is_final=True):
+            sent.append((message, is_final))
+
+        session._send_message = _send_message
+        asyncio.run(CallSession._on_output_transcript(session, "thank you for calling"))
+        assert sent == [({"agent-speech": "thank you for calling"}, True)]

--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -123,6 +123,14 @@ components:
             LiveKit and Pipecat voice workers; the option is rejected on other models.
           type: boolean
           example: true
+        hasOutputStt:
+          description: |-
+            This model accepts `options.tts.output` — an output audit STT run over the agent's own audio,
+            logged as `agent-speech` transcript entries beside the `agent` turns the model produced and
+            metered as `stt-output` usage (see docs/auxiliary-stt.md). True for the LiveKit and Pipecat
+            voice workers; the option is rejected on other models.
+          type: boolean
+          example: true
       required:
         - name
         - description
@@ -492,6 +500,36 @@ components:
                 Must be a supported voice language as returned from a get on the `voices` api
               type: string
               example: en-GB-Wavenet-A
+            output:
+              type: object
+              description: |-
+                Output audit speech recognition. When set, the worker runs an independent STT engine over the
+                agent's OWN audio — what the caller actually hears, whether synthesised by the pipeline TTS
+                or produced by a realtime model — and logs each final transcript it produces as an
+                `agent-speech` transaction-log entry beside the `agent` entry, so what the agent said can be
+                compared with what the model thought it said. Observation only: it never affects the call.
+
+                Same shape as `stt` (`vendor`, `language`), plus `enabled`. `vendor` defaults to the platform's
+                default STT engine; `language` defaults to `tts.language`, then `stt.language`.
+
+                Its consumption is metered separately as `stt-output` usage (audio the engine accepted, and
+                transcript characters) and priced by that component's own rate lines. Supported on
+                `livekit:` and `pipecat:` models, in both realtime and pipeline modes; rejected on other models.
+                Nothing is installed on a call unless this option is set. See docs/auxiliary-stt.md.
+              properties:
+                enabled:
+                  type: boolean
+                  default: true
+                  description: Set `false` to switch the audit engine off without removing the object.
+                language:
+                  $ref: "#/components/schemas/Language"
+                vendor:
+                  type: string
+                  description: |-
+                    Audit STT provider, with the same semantics as `stt.vendor` (e.g. `deepgram`, `assemblyai`,
+                    `cartesia` on LiveKit; `deepgram`, `google` on Pipecat), optionally scoped as `vendor/model[:lang]`.
+              example:
+                vendor: deepgram
         stt:
           type: object
           properties:

--- a/api/paths/models.js
+++ b/api/paths/models.js
@@ -29,6 +29,7 @@ const modelList = async (req, res) => {
         hasTelephony,
         hasWebRTC,
         hasAuxStt,
+        hasOutputStt,
         audioModel,
         voiceStack,
         requiresSttTts,
@@ -42,6 +43,7 @@ const modelList = async (req, res) => {
           hasTelephony,
           hasWebRTC,
           hasAuxStt: hasAuxStt === true,
+          hasOutputStt: hasOutputStt === true,
           ...(voiceStack != null ? { voiceStack } : {}),
           ...(requiresSttTts != null ? { requiresSttTts } : {}),
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Index of the docs in this directory. Start with the first table if you're new; t
 | [tool-call-chaining-metadata-priming.md](tool-call-chaining-metadata-priming.md) | Static/metadata parameter sourcing and chained tool calls |
 | [prompt-metadata.md](prompt-metadata.md) | Stating call facts (date/time, caller number, seeded data) in the agent's prompt |
 | [uninterruptible-greetings.md](uninterruptible-greetings.md) | Barge-in control for opening prompts |
-| [auxiliary-stt.md](auxiliary-stt.md) | `options.stt.aux`: a second STT engine's transcript of the caller logged as `user-aux`, metered as `stt-aux` |
+| [auxiliary-stt.md](auxiliary-stt.md) | Side STT engines: a second opinion on the caller (`options.stt.aux` → `user-aux`, `stt-aux`) and an audit of what the agent actually said (`options.tts.output` → `agent-speech`, `stt-output`) |
 | [ultravox-vendor-specific-options.md](ultravox-vendor-specific-options.md) | Ultravox model variants and tuning options |
 | [agent-concurrency-limits.md](agent-concurrency-limits.md) | Per-agent/user/organisation concurrency caps |
 | [agent-failover.md](agent-failover.md) | Automatic fallback agents and numbers |

--- a/docs/auxiliary-stt.md
+++ b/docs/auxiliary-stt.md
@@ -1,8 +1,11 @@
-# Auxiliary ("second opinion") STT — `options.stt.aux`
+# Auxiliary STT — a second opinion on the caller (`options.stt.aux`) and an audit of the agent (`options.tts.output`)
 
-An agent can run a **second, independent speech-recognition engine over the caller's audio** alongside its own recognition. Every final transcript the auxiliary engine produces is logged in the call's transaction log as a `user-aux` entry, next to the primary `user` entry for the same speech, and its consumption is metered as its own `stt-aux` usage component.
+An agent can run an **independent speech-recognition engine over the call's audio** alongside its own recognition, on either side of the conversation:
 
-The auxiliary engine is **observation only**: nothing it produces reaches the model. It exists so two recognitions of the same audio can be compared — for evaluating an STT vendor before switching to it, for measuring how well a realtime model's built-in transcription holds up against a dedicated engine, or for keeping an independent record of what the caller said.
+- **`options.stt.aux`** — over the **caller's** audio. Every final transcript the auxiliary engine produces is logged in the call's transaction log as a `user-aux` entry, next to the primary `user` entry for the same speech, and its consumption is metered as its own `stt-aux` usage component.
+- **`options.tts.output`** — over the **agent's own** audio: what the caller actually hears, whether synthesised by the pipeline TTS or produced by a realtime model. Each final transcript is logged as an `agent-speech` entry, next to the `agent` entry the model produced, and metered as `stt-output`. This is an audit of what the agent *said* against what it *thought it said* — a garbled synthesis, a mispronounced name, a realtime model whose own transcript of its output drifts from the audio.
+
+Both engines are **observation only**: nothing they produce reaches the model. **Nothing is installed on a call unless the option is set**: the workers build a tap only for a configured option, and never touch the audio path otherwise.
 
 It works on both voice workers and in both voice modes:
 
@@ -14,7 +17,7 @@ It works on both voice workers and in both voice modes:
 
 ## Configuration
 
-`options.stt.aux` has the **same shape as `options.stt`** (`vendor`, `language`), plus `enabled`:
+Both options have the **same shape as `options.stt`** (`vendor`, `language`), plus `enabled`. The caller side:
 
 ```json
 {
@@ -34,37 +37,49 @@ It works on both voice workers and in both voice modes:
 | `vendor` | the platform's default STT engine (Deepgram) | Same semantics as `stt.vendor`: a vendor name, optionally scoped as `vendor/model[:lang]` (e.g. `deepgram/nova-2:en`). LiveKit offers `deepgram`, `assemblyai`, `cartesia` (via LiveKit Inference; Deepgram only under `LIVEKIT_PIPELINE_USE_PROVIDER_KEYS`); Pipecat offers `deepgram` and `google`. |
 | `language` | `stt.language`, then `tts.language` | Language hint for the auxiliary engine (`Language` schema). The "no fixed language" sentinels (`any`, `multi`, …) are accepted and mean "let the engine decide", as for `stt.language`. |
 
-`{}` (or `true`) enables the engine with defaults. The block is validated when the agent is saved: unknown fields, a nested `aux`, a non-boolean `enabled`, a malformed vendor string or a non-BCP-47 language are rejected with a 400. A vendor the *worker* cannot build (say `google` on LiveKit) is not caught at save time: the worker logs a warning and the call runs without the second opinion.
+`{}` (or `true`) enables the engine with defaults. The block is validated when the agent is saved: unknown fields, a nested block, a non-boolean `enabled`, a malformed vendor string or a non-BCP-47 language are rejected with a 400. A vendor the *worker* cannot build (say `google` on LiveKit) is not caught at save time: the worker logs a warning and the call runs without the second opinion.
+
+The agent side is the same block under `tts`, and defaults its language to `tts.language` first, since that is the language the agent speaks:
+
+```json
+"tts": { "vendor": "ultravox", "voice": "Ciara", "output": { "vendor": "deepgram" } }
+```
+
+Models: `GET /models` advertises `hasAuxStt` and `hasOutputStt` per model (both true for `livekit:` and `pipecat:`), so a UI can offer each option only where it is accepted.
 
 ## What gets logged
 
-- Each **final** transcript segment from the auxiliary engine becomes one transaction-log entry of type **`user-aux`** with `isFinal: true` and `data` = the text, timestamped when the segment arrived. Interim results are not logged.
-- The primary `user` entries are unchanged. Consumers that compare the two should align them by `createdAt`: an auxiliary engine finalises per speech segment, whereas a realtime model or the pipeline STT may log one entry per turn, so one `user` entry can correspond to several `user-aux` entries.
-- The entries follow the same path as every other transcript entry — streamed live when the listener sets `streamLog`, otherwise batched onto the call record at the end — and the live progress socket carries them as `{ "user-aux": "<text>", isFinal, callId, timestamp }`. Front-ends that render transcripts by type should decide how (or whether) to show the new type; the platform does not merge it into `user`.
+- Each **final** transcript segment from a side engine becomes one transaction-log entry — type **`user-aux`** for the caller side, **`agent-speech`** for the agent side — with `isFinal: true` and `data` = the text, timestamped when the segment arrived. Interim results are not logged.
+- The primary `user` and `agent` entries are unchanged. Consumers that compare the two should align them by `createdAt`: a side engine finalises per speech segment, whereas a realtime model or the pipeline STT/TTS may log one entry per turn, so one primary entry can correspond to several side entries.
+- The entries follow the same path as every other transcript entry — streamed live when the listener sets `streamLog`, otherwise batched onto the call record at the end — and the live progress socket carries them as `{ "user-aux": "<text>", … }` / `{ "agent-speech": "<text>", … }`. Front-ends that render transcripts by type should decide how (or whether) to show the new types; the platform does not merge them into `user` / `agent`.
+- On the agent side only the agent's own speech is audited: the transfer confidence tone, a fixed fallback announcement and relayed audio from a bridged peer are not fed to the engine.
 
 ## Lifecycle
 
-- The engine is armed once the agent session is up, on the caller's audio only (never the agent's).
-- **Agent handover** (`transfer_agent`, or a hand-back after a bridged transfer): the auxiliary engine is re-armed with the *incoming* agent's own `options.stt.aux` — an agent without the option switches it off for the rest of the call.
-- **Consultative transfer** (LiveKit): while the caller is on hold during the consultation, auxiliary transcripts are suppressed, matching the primary transcript.
-- **Bridged transfer**: when the agent's media is detached and the caller talks to a human, the auxiliary engine is stopped — there is no agent transcript left to second-guess, and the human↔human segment has its own option, [`bridgedTransferTranscribe`](./call-transfers.md#transcribing-the-bridged-segment-bridgedtransfertranscribe). A WebRTC-origin transfer relay on Pipecat silences the auxiliary engine in the same way.
-- The engine stops when the caller leaves or the call ends. A failure inside it (vendor error, unsupported vendor, no audio track) is logged and never affects the call.
+- Each engine is armed once the agent session is up: the caller side on the caller's audio only, the agent side on the agent's own output only.
+- **Agent handover** (`transfer_agent`, or a hand-back after a bridged transfer): both engines are re-armed with the *incoming* agent's own options — an agent without an option switches that side off for the rest of the call.
+- **Consultative transfer** (LiveKit): while the caller is on hold during the consultation, caller-side transcripts are suppressed, matching the primary transcript; the consult conversation itself happens in the consult session and is not audited.
+- **Bridged transfer**: when the agent's media is detached and the caller talks to a human, both engines are stopped — there is no agent transcript left to second-guess, the agent is no longer speaking, and the human↔human segment has its own option, [`bridgedTransferTranscribe`](./call-transfers.md#transcribing-the-bridged-segment-bridgedtransfertranscribe). A WebRTC-origin transfer relay on Pipecat silences the caller-side engine in the same way.
+- An engine stops when the caller leaves or the call ends. A failure inside it (vendor error, rejected credentials, unsupported vendor, no audio track) is logged and never affects the call — and, see below, meters nothing.
 
 ## Billing
 
-The auxiliary engine is a real cost on every voice mode — including realtime models, whose *own* recognition is bundled into the model charge — so it is metered as its **own technology, `stt-aux`**, never folded into the primary `stt` meter:
+A side engine is a real cost on every voice mode — including realtime models, whose *own* recognition is bundled into the model charge — so each is metered as its **own technology, `stt-aux` (caller side) or `stt-output` (agent side)**, never folded into the primary `stt` meter:
 
 | Row | `technology` | `provider` | `detail` | `unit` | What is counted |
 |---|---|---|---|---|---|
-| audio | `stt-aux` | the aux vendor (e.g. `assemblyai`) | `vendor/model` where known | `milliseconds` | Audio the auxiliary engine accepted, silence included — the basis streaming STT vendors bill on. On LiveKit this is the engine's own usage report (the same `metrics_collected` event the primary STT meter reads), which counts only audio actually sent to the vendor, so an engine that never connects meters nothing. On Pipecat, whose STT services report no such figure, it is the audio streamed to the engine, metered only once the engine has returned its first transcript in the call; an engine that never does meters nothing. |
-| text | `stt-aux` | as above | as above | `characters` | Characters in the final transcripts the engine returned. |
+| audio | `stt-aux` / `stt-output` | the engine's vendor (e.g. `assemblyai`) | `vendor/model` where known | `milliseconds` | Audio the engine accepted, silence included — the basis streaming STT vendors bill on. On LiveKit this is the engine's own usage report (the same `metrics_collected` event the primary STT meter reads), which counts only audio actually sent to the vendor, so an engine that never connects meters nothing. On Pipecat, whose STT services report no such figure, it is the audio streamed to the engine, metered only once the engine has returned its first transcript in the call; an engine that never does meters nothing. |
+| text | `stt-aux` / `stt-output` | as above | as above | `characters` | Characters in the final transcripts the engine returned. |
 
 Rows are attributed to the agent call (the session's own call record, like the model's token and TTS meters) and finalised when it ends; a handover carries the running totals onto the continuation call.
 
-**Rate cards must price the component explicitly.** `GET /api/rate-components` advertises one `stt-aux:<engine>` component per STT engine (dimension `stt`, units `minute` | `character`) alongside the primary `stt:<engine>` components; a line keyed on `{ technology: "stt", provider }` does *not* match `stt-aux` rows, and a card with no `stt-aux` line leaves them uncosted (`no_line`), visible as `uncostedMeters` in `GET /api/usage`. This is deliberate: an operator decides whether the second opinion is priced like primary STT, at a premium, or given away, and the usage report shows it as its own line either way. Filter with `GET /api/usage?technology=stt-aux`.
+**Rate cards must price the components explicitly.** `GET /api/rate-components` advertises one `stt-aux:<engine>` and one `stt-output:<engine>` component per STT engine (dimension `stt`, units `minute` | `character`) alongside the primary `stt:<engine>` components; a line keyed on `{ technology: "stt", provider }` does *not* match them, and a card with no such line leaves those rows uncosted (`no_line`), visible as `uncostedMeters` in `GET /api/usage`. This is deliberate: an operator decides whether a side engine is priced like primary STT, at a premium, or given away, and the usage report shows it as its own line either way. Filter with `GET /api/usage?technology=stt-aux` or `technology=stt-output`.
 
 ## Implementation notes
 
-- **LiveKit worker** — [`agents/livekit/lib/aux-stt.ts`](../agents/livekit/lib/aux-stt.ts). The worker already holds its own connection to the room, so it opens one extra `AudioStream` on the caller participant's audio track (the technique the bridged-segment transcription uses) and pumps it into a fresh STT stream built by the pipeline's own resolution with `options.stt.aux` standing in for `options.stt`. The `AgentSession` is untouched.
-- **Pipecat worker** — [`agents/pipecat/pipecat_aplisay/aux_stt.py`](../agents/pipecat/pipecat_aplisay/aux_stt.py). An `AuxSttTap` sits right after `transport.input()` (behind the WebRTC relay tap). It passes every frame through untouched and copies each input audio frame into a side STT-only pipeline (`SttStream`, shared with the bridged-segment transcription), so nothing the auxiliary service emits — transcripts, metrics, settings — can enter the main chain or be mistaken for the primary STT's.
-- Transaction-log type: `user-aux` is a new value of `transaction_logs.type` (schema version 64; a `DB_FORCE_SYNC` boot adds it).
+Neither tap fetches audio the worker does not already hold: no extra room subscription, no second media stream.
+
+- **LiveKit worker, caller side** — [`agents/livekit/lib/aux-stt.ts`](../agents/livekit/lib/aux-stt.ts). The worker already holds its own connection to the room and the session already receives the caller's track, so it opens one extra rtc-node `AudioStream` on that same received track — which at the FFI layer is one more in-process sink on the one decoded WebRTC track, exactly what the session's own input is — and pumps it into a fresh STT stream built by the pipeline's own resolution with `options.stt.aux` standing in for `options.stt`. The `AgentSession` is untouched.
+- **LiveKit worker, agent side** — [`agents/livekit/lib/output-stt.ts`](../agents/livekit/lib/output-stt.ts). The agent's outbound audio is a stream of frames the process itself produces, so the audit is a tee on the session's audio output: an `AudioOutput` wrapper installed as `session.output.audio` that forwards every frame to the real participant output and copies it to the STT stream — the same construction the SDK's own recorder uses. Nothing touches the room.
+- **Pipecat worker** — [`agents/pipecat/pipecat_aplisay/aux_stt.py`](../agents/pipecat/pipecat_aplisay/aux_stt.py). One pass-through tap class serves both sides: on the caller's `InputAudioRawFrame`s right after `transport.input()` (behind the WebRTC relay tap), and on the agent's `TTSAudioRawFrame`s immediately before `transport.output()`. Each passes every frame through untouched and copies its own class of audio frame into a side STT-only pipeline (`SttStream`, shared with the bridged-segment transcription), so nothing a side service emits — transcripts, metrics, settings — can enter the main chain or be mistaken for the primary STT's.
+- Transaction-log types: `user-aux` (schema version 64) and `agent-speech` (schema version 65) are values of `transaction_logs.type`; a `DB_FORCE_SYNC` boot adds them.

--- a/docs/livekit-agent-architecture.md
+++ b/docs/livekit-agent-architecture.md
@@ -732,6 +732,7 @@ The catalog below covers every option that affects runtime behavior. The "Level"
 | `voiceMode` | Agent | Override mode selection (pipeline / realtime) | 4.1 |
 | `stt` | Agent | STT configuration (vendor, language) | 4.3, 4.4 |
 | `stt.aux` | Agent | Auxiliary ("second opinion") STT over the caller's audio, logged as `user-aux` and metered as `stt-aux` (vendor, language, enabled) | [auxiliary-stt.md](auxiliary-stt.md) |
+| `tts.output` | Agent | Output audit STT over the agent's own audio, logged as `agent-speech` and metered as `stt-output` (vendor, language, enabled) | [auxiliary-stt.md](auxiliary-stt.md) |
 | `tts` | Agent | TTS configuration (vendor, voice, language) | 4.3, 4.4 |
 | `vendorSpecific` | Agent | Free-form provider passthrough | 4.6 |
 | `greeting` | Agent | Uninterruptible opening greeting (text or instructions) | 4.5 |

--- a/docs/livekit-pipeline-api-implications.md
+++ b/docs/livekit-pipeline-api-implications.md
@@ -71,7 +71,7 @@ Supported shape:
 Notes:
 
 - If you omit `options.stt.vendor`, the default is at this time `deepgram` → `deepgram/nova-3:<derivedLang>`.
-- `options.stt.aux` (same shape: `vendor`, `language`, plus `enabled`) runs a *second* STT engine over the caller's audio purely for comparison — on realtime models too — logging `user-aux` transcript entries and `stt-aux` usage. See [`docs/auxiliary-stt.md`](./auxiliary-stt.md).
+- `options.stt.aux` (same shape: `vendor`, `language`, plus `enabled`) runs a *second* STT engine over the caller's audio purely for comparison — on realtime models too — logging `user-aux` transcript entries and `stt-aux` usage. `options.tts.output` does the same over the agent's own audio (`agent-speech`, `stt-output`). See [`docs/auxiliary-stt.md`](./auxiliary-stt.md).
 
 #### `options.tts`
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -19,7 +19,10 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 64;  // 64: transaction_logs.type gains 'user-aux' — the auxiliary ("second opinion")
+const schemaVersion = 65;  // 65: transaction_logs.type gains 'agent-speech' — the output audit STT's reading of
+                           //     what the agent's audio actually said (options.tts.output), logged next to
+                           //     the 'agent' turn the model produced. See docs/auxiliary-stt.md.
+                           // 64: transaction_logs.type gains 'user-aux' — the auxiliary ("second opinion")
                            //     STT transcript of the caller's speech (options.stt.aux), logged next to
                            //     the primary 'user' entry. See docs/auxiliary-stt.md.
                            // 63: `number_reservations` — a claim onto a CHARGEABLE trunk must present a
@@ -665,6 +668,17 @@ Agent.init({
           //  docs/auxiliary-stt.md.
           validateAuxSttShape(this.options.stt.aux, {
             hasAuxStt: Handler.hasAuxStt,
+            modelName: this.modelName,
+          });
+        }
+        if (this.options?.tts?.output !== undefined && this.options?.tts?.output !== null) {
+          // Output audit STT: an independent recognition of what the agent's
+          //  audio actually said, logged as `agent-speech` next to the `agent`
+          //  turn the model produced and metered as `stt-output` usage. Same
+          //  shape as options.stt. Same workers as the auxiliary STT — see
+          //  docs/auxiliary-stt.md.
+          validateOutputSttShape(this.options.tts.output, {
+            hasOutputStt: Handler.hasOutputStt,
             modelName: this.modelName,
           });
         }
@@ -1409,7 +1423,7 @@ TransactionLog.init({
   },
   type: {
     type: DataTypes.ENUM,
-    values: ['start', 'hangup', 'goodbye', 'answer', 'inject', 'call', 'call_failed', 'agent', 'user', 'user-aux', 'function_calls', 'rest_callout', 'function_results', 'error'],
+    values: ['start', 'hangup', 'goodbye', 'answer', 'inject', 'call', 'call_failed', 'agent', 'user', 'user-aux', 'agent-speech', 'function_calls', 'rest_callout', 'function_results', 'error'],
     required: true
   },
   data: {
@@ -3127,27 +3141,29 @@ function validateBridgedTransferTranscribeShape(transcribe, { hasTransfer, model
 const NON_SPECIFIC_LANGUAGE_VALUES = ['any', 'multi', '*', 'auto', 'all', 'global'];
 
 /**
- * Structural validation of an `options.stt.aux` value — the auxiliary ("second
- * opinion") STT configuration. An object of the same shape as `options.stt`
- * ({ vendor?, language? }) plus `enabled?`; nothing else, and never nested.
- * Shared between Agent.validate and any future listener-level override path.
+ * Structural validation shared by the two "side STT" options — the auxiliary
+ * ("second opinion") STT on the caller (`options.stt.aux`) and the output audit
+ * STT on the agent (`options.tts.output`). Each is an object of the same shape
+ * as `options.stt` ({ vendor?, language? }) plus `enabled?`; nothing else, and
+ * never nested.
  *
- * @param {object} aux the candidate value
- * @param {object} flags { hasAuxStt, modelName, context }
+ * @param {object} block the candidate value
+ * @param {object} flags { supported, feature, modelName, context }
  * @throws {Error} (status 400) on any shape violation
  */
-function validateAuxSttShape(aux, { hasAuxStt, modelName, context = 'options.stt.aux' } = {}) {
+function validateSideSttShape(block, { supported, feature, modelName, context }) {
   const fail = (message) => {
     const err = new Error(message);
     err.status = 400;
     throw err;
   };
-  if (aux === null || typeof aux !== 'object' || Array.isArray(aux)) {
+  if (block === null || typeof block !== 'object' || Array.isArray(block)) {
     fail(`${context} must be an object of the same shape as options.stt ({ vendor, language })`);
   }
-  if (!hasAuxStt) {
-    fail(`Model ${modelName} does not support auxiliary STT, but ${context} is set`);
+  if (!supported) {
+    fail(`Model ${modelName} does not support ${feature}, but ${context} is set`);
   }
+  const aux = block;
   const allowedFields = ['enabled', 'vendor', 'language'];
   const unknown = Object.keys(aux).filter((field) => !allowedFields.includes(field));
   if (unknown.length) {
@@ -3167,6 +3183,25 @@ function validateAuxSttShape(aux, { hasAuxStt, modelName, context = 'options.stt
   }
 }
 
+/**
+ * `options.stt.aux` — the auxiliary ("second opinion") STT on the caller. Shared
+ * between Agent.validate and any future listener-level override path.
+ * @param {object} aux the candidate value
+ * @param {object} flags { hasAuxStt, modelName, context }
+ */
+function validateAuxSttShape(aux, { hasAuxStt, modelName, context = 'options.stt.aux' } = {}) {
+  validateSideSttShape(aux, { supported: hasAuxStt, feature: 'auxiliary STT', modelName, context });
+}
+
+/**
+ * `options.tts.output` — the output audit STT on the agent's own audio.
+ * @param {object} output the candidate value
+ * @param {object} flags { hasOutputStt, modelName, context }
+ */
+function validateOutputSttShape(output, { hasOutputStt, modelName, context = 'options.tts.output' } = {}) {
+  validateSideSttShape(output, { supported: hasOutputStt, feature: 'output audit STT', modelName, context });
+}
+
 
 export {
   Metadata,
@@ -3176,6 +3211,7 @@ export {
   validateBridgedTransferToAgentShape,
   validateBridgedTransferTranscribeShape,
   validateAuxSttShape,
+  validateOutputSttShape,
   PhoneNumber,
   PhoneRegistration,
   B2buaNode,

--- a/lib/handlers/handler.js
+++ b/lib/handlers/handler.js
@@ -41,6 +41,10 @@ export default class Handler {
   // audio alongside the primary stack, logged as `user-aux` and metered as `stt-aux`.
   // Needs a worker that owns the caller's media independently of the model stack.
   static hasAuxStt = false;
+  // Supports options.tts.output: an output audit STT run over the agent's OWN audio,
+  // logged as `agent-speech` and metered as `stt-output`. Needs a worker that holds the
+  // agent's outbound audio in-process (it tees the frames it already produces).
+  static hasOutputStt = false;
   // The Agent.type implemented by this handler: 'interactive-audio' (default) or 'text'
   static agentType = 'interactive-audio';
 
@@ -103,6 +107,7 @@ export default class Handler {
               hasTelephony: this.hasTelephony,
               hasWebRTC: this.hasWebRTC,
               hasAuxStt: this.hasAuxStt,
+              hasOutputStt: this.hasOutputStt,
               description,
               implementation,
               audioModel: flags.audioModel ?? implementation.audioModel,

--- a/lib/handlers/livekit.js
+++ b/lib/handlers/livekit.js
@@ -23,6 +23,9 @@ class Livekit extends Handler {
   // Auxiliary STT (options.stt.aux): a second STT stream on the caller's room track,
   // alongside the AgentSession — see agents/livekit/lib/aux-stt.ts.
   static hasAuxStt = true;
+  // Output audit STT (options.tts.output): an in-process tee on the AgentSession's
+  // audio output — see agents/livekit/lib/output-stt.ts.
+  static hasOutputStt = true;
 
   static get models() {
     return [LiveKitModel];

--- a/lib/handlers/pipecat.js
+++ b/lib/handlers/pipecat.js
@@ -43,6 +43,9 @@ class Pipecat extends Handler {
   // Auxiliary STT (options.stt.aux): an audio tap after transport.input() feeds a
   // side STT-only pipeline — see pipecat_aplisay/aux_stt.py.
   static hasAuxStt = true;
+  // Output audit STT (options.tts.output): a pass-through tap on the agent's TTS audio
+  // frames just before transport.output() — see pipecat_aplisay/aux_stt.py.
+  static hasOutputStt = true;
 
   static get models() {
     return [PipecatModel];

--- a/lib/rate-components.js
+++ b/lib/rate-components.js
@@ -131,6 +131,14 @@ export function buildRateComponents({ implementations = [], models = [] } = {}) 
       match: { technology: 'stt-aux', provider }, units: ['minute', 'character'], available: true,
     });
   }
+  // stt-output: the output audit STT (options.tts.output) runs an engine over the
+  // agent's OWN audio — the same "own technology, own lines" reasoning as stt-aux.
+  for (const provider of STT_ENGINES) {
+    components.push({
+      dim: 'stt', key: `stt-output:${provider}`, label: `Output audit STT · ${provider}`,
+      match: { technology: 'stt-output', provider }, units: ['minute', 'character'], available: true,
+    });
+  }
 
   return components;
 }

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -35,7 +35,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * @param {string} [params.organisationId]
  * @param {string} [params.userId]
  * @param {string} [params.agentId]
- * @param {string} params.technology broad category ('llm'|'tts'|'stt'|'stt-aux'|'voice'|'function'|…)
+ * @param {string} params.technology broad category ('llm'|'tts'|'stt'|'stt-aux'|'stt-output'|'voice'|'function'|…)
  * @param {string} [params.provider] vendor ('anthropic'|'elevenlabs'|…)
  * @param {string} [params.detail] detailed model/tech name
  * @param {string} params.unit unit of measure ('input_tokens'|'characters'|'milliseconds'|…)

--- a/tests/agent-aux-stt-options.test.mjs
+++ b/tests/agent-aux-stt-options.test.mjs
@@ -3,7 +3,7 @@ import {
   Agent, TransactionLog, User, Organisation,
 } from './setup/database-test-wrapper.js';
 import { randomUUID } from 'crypto';
-import { validateAuxSttShape } from '../lib/database.js';
+import { validateAuxSttShape, validateOutputSttShape } from '../lib/database.js';
 
 /**
  * options.stt.aux — the auxiliary ("second opinion") STT: shape validation at
@@ -134,6 +134,55 @@ describe('options.stt.aux (auxiliary STT)', () => {
         WHERE t.typname = 'enum_transaction_logs_type' ORDER BY e.enumsortorder`,
     );
     expect(labels.map((l) => l.enumlabel)).toEqual(expect.arrayContaining(['user', 'user-aux', 'agent']));
+  });
+
+  test('options.tts.output (output audit STT): same contract, its own gate and log type', async () => {
+    for (const [modelName, output] of [
+      [LIVEKIT_MODEL, {}],
+      [LIVEKIT_MODEL, { vendor: 'deepgram', language: 'en-GB' }],
+      [LIVEKIT_MODEL, { enabled: false }],
+      [PIPECAT_MODEL, { vendor: 'google' }],
+    ]) {
+      const res = await create({ modelName, prompt: 'front desk', options: { tts: { output } } });
+      expect([res.statusCode, JSON.stringify(res.body)]).toEqual([200, expect.any(String)]);
+    }
+    // Round-trips beside the agent's own tts settings, and beside stt.aux.
+    const options = {
+      tts: { vendor: 'ultravox', voice: 'Ciara', output: { vendor: 'deepgram' } },
+      stt: { aux: { vendor: 'assemblyai' } },
+    };
+    const created = await create({ modelName: LIVEKIT_MODEL, prompt: 'front desk', options });
+    expect(created.statusCode).toBe(200);
+    const got = makeRes(user);
+    await getAgent(makeReq({}, { agentId: created.body.id }), got);
+    expect(got.body.options.tts.output).toEqual({ vendor: 'deepgram' });
+    expect(got.body.options.stt.aux).toEqual({ vendor: 'assemblyai' });
+
+    for (const [output, pattern] of [
+      [true, /same shape as options\.stt/],
+      [{ provider: 'deepgram' }, /unknown field/],
+      [{ output: {} }, /unknown field/],
+      [{ enabled: 'on' }, /enabled must be a boolean/],
+      [{ language: 'English!' }, /BCP-47/],
+    ]) {
+      const res = await create({ modelName: LIVEKIT_MODEL, prompt: 'front desk', options: { tts: { output } } });
+      expect([res.statusCode, JSON.stringify(res.body)]).toEqual([400, expect.stringMatching(pattern)]);
+    }
+    const text = await create({ modelName: TEXT_MODEL, type: 'text', prompt: 'writer', options: { tts: { output: {} } } });
+    expect([text.statusCode, JSON.stringify(text.body)]).toEqual([400, expect.stringMatching(/does not support output audit STT/)]);
+
+    expect(TransactionLog.rawAttributes.type.values).toContain('agent-speech');
+    const [labels] = await TransactionLog.sequelize.query(
+      `SELECT e.enumlabel FROM pg_enum e JOIN pg_type t ON e.enumtypid = t.oid
+        WHERE t.typname = 'enum_transaction_logs_type'`,
+    );
+    expect(labels.map((l) => l.enumlabel)).toEqual(expect.arrayContaining(['agent', 'agent-speech']));
+
+    let err;
+    try { validateOutputSttShape({}, { hasOutputStt: false, modelName: 'm' }); } catch (e) { err = e; }
+    expect(err?.status).toBe(400);
+    expect(err?.message).toMatch(/Model m does not support output audit STT, but options\.tts\.output is set/);
+    expect(() => validateOutputSttShape({ vendor: 'deepgram/nova-3:en', enabled: true }, { hasOutputStt: true, modelName: 'm' })).not.toThrow();
   });
 
   test('validateAuxSttShape: pure validator contract', () => {

--- a/tests/models-endpoint.test.mjs
+++ b/tests/models-endpoint.test.mjs
@@ -132,7 +132,7 @@ describe('Models Endpoint Test', () => {
     
     // All models should have the same structure
     for (const [modelName, modelInfo] of modelEntries) {
-      const requiredKeys = ['description', 'supportsFunctions', 'audioModel', 'hasTelephony', 'hasWebRTC', 'hasAuxStt'];
+      const requiredKeys = ['description', 'supportsFunctions', 'audioModel', 'hasTelephony', 'hasWebRTC', 'hasAuxStt', 'hasOutputStt'];
       
       for (const key of requiredKeys) {
         expect(modelInfo).toHaveProperty(key);

--- a/tests/rate-components.test.mjs
+++ b/tests/rate-components.test.mjs
@@ -60,6 +60,22 @@ describe('rate-components catalogue', () => {
     });
   });
 
+  it('advertises the output audit STT (options.tts.output) as its own stt-output component per engine', () => {
+    const out = comps.filter((c) => c.key.startsWith('stt-output:'));
+    expect(out.map((c) => c.match.provider).sort()).toEqual([...STT_ENGINES].sort());
+    expect(byKey('stt-output:deepgram')).toEqual({
+      dim: 'stt', key: 'stt-output:deepgram', label: 'Output audit STT · deepgram',
+      match: { technology: 'stt-output', provider: 'deepgram' }, units: ['minute', 'character'], available: true,
+    });
+    // …and it is priced only by its own line, never by the stt or stt-aux lines.
+    const line = (comp, unit, priceMicros) => ({ dim: comp.dim, match: comp.match, unit, priceMicros });
+    const row = { technology: 'stt-output', provider: 'deepgram', detail: 'deepgram/nova-3', unit: 'milliseconds', quantity: 60000 };
+    const others = { detail: { lines: [line(byKey('stt:deepgram'), 'minute', 100000), line(byKey('stt-aux:deepgram'), 'minute', 70000)] } };
+    expect(resolveRowCost(row, others).status).toBe('no_line');
+    const own = { detail: { lines: [...others.detail.lines, line(byKey('stt-output:deepgram'), 'minute', 50000)] } };
+    expect(resolveRowCost(row, own).costMicros).toBe(50000);
+  });
+
   it('an stt-aux row is priced only by an stt-aux line, never by the primary stt line', () => {
     const line = (comp, unit, priceMicros) => ({ dim: comp.dim, match: comp.match, unit, priceMicros });
     const auxRow = { technology: 'stt-aux', provider: 'deepgram', detail: 'deepgram/nova-3', unit: 'milliseconds', quantity: 60000 };


### PR DESCRIPTION
## Summary

The twin of `options.stt.aux` (#279) on the other side of the conversation: an independent STT engine over the **agent's own audio** — what the caller actually hears — with each final logged as a new transaction-log type **`agent-speech`** beside the `agent` turn the model produced. An audit of what the agent *said* against what it *thought it said*. Observation only.

```json
"tts": { "vendor": "ultravox", "voice": "Ciara", "output": { "vendor": "deepgram" } }
```

Same shape as `options.stt` plus `enabled`; language defaults to `tts.language` first. Validated at save time, gated on a new `hasOutputStt` capability (`livekit:`/`pipecat:`) advertised on `GET /models`. **Nothing is installed on a call unless the option is set** — both workers return before touching the session/chain when it is absent.

## Mechanism (no extra media path)

- **LiveKit:** the agent's outbound audio is a stream of frames the worker itself produces, so the audit is an in-process tee on `session.output.audio` — a `Proxy` over the live participant output intercepting only `captureFrame` (everything else bound to the original), the same construction as the SDK's own `RecorderIO`. No room subscription, no second media stream, no FFI sink. The SDK doesn't export `AudioOutput` at runtime, hence a Proxy over the instance rather than a subclass; `AgentSession.onAudioOutputChanged` is a no-op and the activity reads `output.audio` at use time, so a post-start swap is safe. The caller-side code is refactored onto a shared `startSideSttEngine`.
- **Pipecat:** the same tap class as the caller side, on `TTSAudioRawFrame`s immediately before `transport.output()` in both chains — TTS frames only, so the confidence tone, fixed fallback message and relayed peer audio are never audited.

## Billing

Own technology `stt-output` with `stt-output:<engine>` rate components (same reasoning as `stt-aux`); metered from the engine's own accepted-audio report on LiveKit, held back until the first transcript on Pipecat.

## Deploy notes

Schema **v65** (`DB_FORCE_SYNC` adds the enum value). Docs: `docs/auxiliary-stt.md` now covers both sides.

## Tests

| Suite | Result |
|---|---|
| Server jest (options/catalogue/roster/gating/agent-sets) | 51 passed |
| LiveKit `aux-stt` (12) + new `output-stt` (7), `tsc`, `tsup` | green |
| Pipecat full suite | 464 passed |
