### PR TITLE
fix(pipecat): resolve the sipbridge + worker leak audit

### DIFF
--- a/agents/pipecat/deploy/k8s/base/daemonset.yaml
+++ b/agents/pipecat/deploy/k8s/base/daemonset.yaml
@@ -46,7 +46,17 @@ spec:
       #   - key: aplisay.com/pipecat-sip
       #     operator: Exists
       #     effect: NoSchedule
-      terminationGracePeriodSeconds: 30
+      # Long enough for the drain below to let calls finish. A rolling
+      # update otherwise cuts every in-progress call on the node the
+      # instant SIGTERM lands: uvicorn sends close(1012) to every open
+      # WebSocket, and sipbridge abandons every dialog without a BYE. The
+      # preStop hook on the worker holds the pod open while calls drain,
+      # so this has to exceed the hook's own budget.
+      #
+      # 20 min is a deliberate ceiling on ONE node's roll: the hook exits
+      # as soon as the node is empty, so a quiet node still rolls in
+      # seconds. maxUnavailable: 1 means a fleet roll is node-by-node.
+      terminationGracePeriodSeconds: 1260
 
       initContainers:
         # 1. Discover the node's public IPv4 (advertised in SDP for RTP) and
@@ -147,6 +157,46 @@ spec:
             periodSeconds: 20
             failureThreshold: 3
             timeoutSeconds: 3
+          # Drain before dying. The kubelet takes the pod out of the
+          # Service and runs this hook, and only sends SIGTERM when it
+          # returns (or the grace period runs out). We poll our own
+          # /healthz until it reports no live calls, so in-progress calls
+          # finish on their own terms rather than being cut mid-sentence.
+          #
+          # The ceiling (LIFECYCLE_DRAIN_SECONDS) must stay under
+          # terminationGracePeriodSeconds above, so the process still
+          # gets its own SIGTERM handling — uvicorn's bounded graceful
+          # shutdown — rather than being SIGKILLed straight from the hook.
+          #
+          # Python rather than curl: the worker image is python:slim and
+          # carries no HTTP client of its own.
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - python
+                  - -c
+                  - |
+                    import json, os, sys, time, urllib.request
+                    deadline = time.monotonic() + float(os.environ.get("LIFECYCLE_DRAIN_SECONDS", "1200"))
+                    def live():
+                        with urllib.request.urlopen("http://127.0.0.1:8082/healthz", timeout=3) as r:
+                            return json.load(r)["live_calls"]
+                    print("preStop: draining; waiting for live calls to end", flush=True)
+                    while time.monotonic() < deadline:
+                        try:
+                            n = live()
+                        except Exception as e:
+                            # Cannot tell -> stop waiting, rather than burn
+                            # the whole grace period on a worker that has
+                            # already gone.
+                            print(f"preStop: no health reading ({e}); proceeding", flush=True)
+                            sys.exit(0)
+                        if n == 0:
+                            print("preStop: node empty", flush=True)
+                            sys.exit(0)
+                        time.sleep(5)
+                    print("preStop: drain deadline reached with calls still live", flush=True)
           resources:
             requests:
               cpu: 250m

--- a/agents/pipecat/deploy/k8s/overlays/sipbridge/daemonset.yaml
+++ b/agents/pipecat/deploy/k8s/overlays/sipbridge/daemonset.yaml
@@ -69,6 +69,39 @@ spec:
               port: 8090
             initialDelaySeconds: 3
             periodSeconds: 10
+          # Drain in step with the worker. Kubernetes runs preStop
+          # PER CONTAINER and sends each its SIGTERM as soon as ITS OWN
+          # hook returns — so without this, sipbridge would take SIGTERM
+          # (and BYE every live dialog) while the worker was still
+          # waiting for those very calls to finish.
+          #
+          # Polls its own /health until active_calls hits zero, using the
+          # busybox shim: the image is distroless and has no shell or
+          # HTTP client of its own. The ceiling is a little under the
+          # worker's so the worker is still the one that decides when the
+          # node is empty; sipbridge's own SIGTERM handler then does the
+          # real drain (refuse new INVITEs with 503 + Retry-After, BYE
+          # anything still up).
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /etc/node-meta/busybox
+                  - sh
+                  - -c
+                  - |
+                    i=0
+                    max="${LIFECYCLE_DRAIN_SECONDS:-1200}"
+                    max=$((max / 5))
+                    while [ "$i" -lt "$max" ]; do
+                      body=$(/etc/node-meta/busybox wget -q -T 3 -O - \
+                        http://127.0.0.1:8090/health 2>/dev/null) || break
+                      case "$body" in
+                        *'"active_calls":0'*) break ;;
+                      esac
+                      /etc/node-meta/busybox sleep 5
+                      i=$((i + 1))
+                    done
           volumeMounts:
             - name: node-meta
               mountPath: /etc/node-meta

--- a/agents/pipecat/pipecat_aplisay/__main__.py
+++ b/agents/pipecat/pipecat_aplisay/__main__.py
@@ -59,6 +59,15 @@ def main() -> None:
         [os.path.join(os.path.dirname(__file__))] if reload else None
     )
 
+    # Bound the graceful shutdown. On SIGTERM uvicorn sends close(1012)
+    # to every open WebSocket and then WAITS for every ASGI task to
+    # return; with no ceiling, one handler that doesn't return holds the
+    # process until the kubelet's SIGKILL at the end of the termination
+    # grace period, and the pod's exit looks like a hang rather than a
+    # roll. 15 s leaves room inside the default 30 s grace for the
+    # in-flight calls to unwind first.
+    graceful_shutdown = int(os.environ.get("GRACEFUL_SHUTDOWN_SECONDS", "15"))
+
     uvicorn.run(
         "pipecat_aplisay.worker:app",
         host=host,
@@ -66,6 +75,7 @@ def main() -> None:
         log_level=os.environ.get("LOGLEVEL", "info").lower(),
         reload=reload,
         reload_dirs=reload_dirs,
+        timeout_graceful_shutdown=graceful_shutdown,
     )
 
 

--- a/agents/pipecat/pipecat_aplisay/api_client.py
+++ b/agents/pipecat/pipecat_aplisay/api_client.py
@@ -15,6 +15,8 @@ import httpx
 from loguru import logger
 from pydantic import BaseModel
 
+from . import http_client
+
 
 class ApiRequestError(Exception):
     def __init__(self, status: int, body: Any, message: str) -> None:
@@ -69,8 +71,13 @@ async def _request(
         headers["x-shared-token"] = token
 
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.request(method, url, params=params, json=body, headers=headers)
+        # Shared, pooled, keep-alive client (W4). The deadline goes on
+        # the request, not the client, so one caller's timeout can never
+        # apply to another's.
+        client = await http_client.get_client("agent-db")
+        resp = await client.request(
+            method, url, params=params, json=body, headers=headers, timeout=timeout
+        )
     except httpx.ConnectError as e:
         # DNS / TCP failure reaching the llm-agent REST server. Most common
         # cause in dev is SERVICE_BASE_URI unset, pointed at an unresolvable

--- a/agents/pipecat/pipecat_aplisay/aux_stt.py
+++ b/agents/pipecat/pipecat_aplisay/aux_stt.py
@@ -305,6 +305,12 @@ class AuxSttTap(FrameProcessor):
     def _schedule_stop(self) -> None:
         """Tear the side pipeline down without holding up the main chain's own
         End/Cancel processing (its stop waits on the runner, bounded)."""
+        # P10: mark the tap finished as well as clearing the stream.
+        # ``_tap_audio`` rebuilds the side pipeline whenever ``_stream``
+        # is None, so a stray audio frame arriving after End/Cancel would
+        # start a fresh STT stream that nothing then stops. Frame
+        # ordering normally prevents that; this makes it impossible.
+        self._failed = True
         stream, self._stream = self._stream, None
         if stream is None:
             return

--- a/agents/pipecat/pipecat_aplisay/bridge_transcript.py
+++ b/agents/pipecat/pipecat_aplisay/bridge_transcript.py
@@ -153,12 +153,19 @@ class SttStream:
         from pipecat.pipeline.task import PipelineParams, PipelineTask
 
         pipeline = Pipeline([self._stt, self._collector])
+        # F1: this is an STT-only side pipeline — no VAD, no bot — so it
+        # never emits the Bot/UserSpeakingFrames pipecat's idle watchdog
+        # counts. With the framework default (idle_timeout_secs=300,
+        # cancel_on_idle_timeout=True) it cancelled itself five minutes
+        # in, and aux/output transcription silently stopped on exactly
+        # the long calls most worth transcribing.
         self._task = PipelineTask(
             pipeline,
             params=PipelineParams(
                 audio_in_sample_rate=self._sample_rate,
                 audio_out_sample_rate=self._sample_rate,
             ),
+            idle_timeout_secs=None,
         )
         runner = PipelineRunner(handle_sigint=False)
         self._runner_task = asyncio.create_task(runner.run(self._task))
@@ -198,15 +205,17 @@ class SttStream:
 
 def split_stereo(audio: bytes) -> tuple[bytes, bytes]:
     """De-interleave s16le stereo into (left, right) mono byte strings.
-    Left = caller, right = transfer target (the sipbridge tap contract)."""
+    Left = caller, right = transfer target (the sipbridge tap contract).
+
+    Strided memoryview slicing rather than a Python loop (P9): this runs
+    once per 20 ms frame per bridged call, and the loop body was four
+    slice assignments per sample — 320 iterations a frame, 50 frames a
+    second, on the event loop.
+    """
     if len(audio) < 4:
         return b"", b""
     usable = len(audio) - (len(audio) % 4)
-    view = memoryview(audio)
-    left = bytearray(usable // 2)
-    right = bytearray(usable // 2)
-    for i in range(0, usable, 4):
-        half = i // 2
-        left[half : half + 2] = view[i : i + 2]
-        right[half : half + 2] = view[i + 2 : i + 4]
-    return bytes(left), bytes(right)
+    # cast("h") requires the buffer length to be a multiple of the item
+    # size, so trim to whole frames first.
+    samples = memoryview(audio)[:usable].cast("h")
+    return samples[0::2].tobytes(), samples[1::2].tobytes()

--- a/agents/pipecat/pipecat_aplisay/bridged_transfer.py
+++ b/agents/pipecat/pipecat_aplisay/bridged_transfer.py
@@ -161,7 +161,7 @@ class DtmfSequenceMatcher:
             loop = asyncio.get_running_loop()
             self._timer = loop.call_later(
                 self._timeout_s,
-                lambda: asyncio.ensure_future(self._on_timeout(exact)),
+                lambda: _detach(self._on_timeout(exact)),
             )
 
     async def _on_timeout(self, exact: bool) -> None:
@@ -463,6 +463,19 @@ def compose_takeover_prompt(new_agent: dict, ctx: BtaContext, target: BtaTarget)
 # ones); discarded on completion.
 _summary_tasks: set = set()
 
+# Strong references for detached one-shot coroutines (P10). asyncio holds
+# only weak references to tasks, so a bare ``ensure_future`` whose result
+# nobody awaits can be collected before it runs.
+_detached_tasks: set = set()
+
+
+def _detach(coro) -> "asyncio.Task":
+    """Fire-and-forget a coroutine, holding a reference until it finishes."""
+    task = asyncio.ensure_future(coro)
+    _detached_tasks.add(task)
+    task.add_done_callback(_detached_tasks.discard)
+    return task
+
 
 def prefire_summary(
     target: BtaTarget, transfer_block: dict, call_metadata: dict, call: api_client.CallRecord
@@ -656,7 +669,7 @@ async def arm_voiceblender_bta_watch(
         gateway.clear_bta_watcher(target_leg, caller_leg)
         # End the bridged-segment record from a detached task (this
         # callback runs synchronously inside the VSI event loop).
-        asyncio.ensure_future(end_bridged_record(ctx, "Bridged call ended"))
+        _detach(end_bridged_record(ctx, "Bridged call ended"))
 
     async def _drop_digit(_digit: str) -> None:
         return

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -512,7 +512,7 @@ class CallSession:
         HTTP error to the browser instead of a stalled-spinner silent
         failure.
 
-        Failure handling (W5/P1): the MCP servers are connected part-way
+        Failure handling (W5): the MCP servers are connected part-way
         through the build, but their closers are only awaited in
         ``_run_prepared_once``'s finally — which never runs if the build
         raises after that point. With a fallback configured, ``run()``
@@ -520,10 +520,15 @@ class CallSession:
         previous connections; without one, the exception escapes and
         nothing closes them at all. Trigger: any agent with MCP servers
         whose model/voice config fails to build. So the whole build runs
-        under a guard that closes them and flushes the log records that
-        would otherwise be stranded (they were written under this call's
-        ``contextualize``, but the only per-call flush is in the runner's
-        finally).
+        under a guard that closes them.
+
+        The guard deliberately does NOT flush the invocation log: a
+        failed attempt may be followed by a fallback retry that succeeds,
+        and the agent-db endpoint creates a ROW PER POST, so flushing
+        here would split one call's log in two. The records stay in that
+        call's own buffer (they are keyed by callId) until either the
+        runner's finally or — for a terminal setup failure, where the
+        runner never runs — ``worker._run_session``.
         """
         try:
             return await self._prepare_run_inner(agent, model_name, system_prompt)
@@ -536,16 +541,6 @@ class CallSession:
                     logger.bind(call_id=self.call.id).warning(
                         f"closing MCP servers after failed build raised: {e}"
                     )
-            try:
-                await invocation_log.flush_invocation_logs(
-                    call_id=self.call.id,
-                    user_id=self.call.userId,
-                    org_id=self.call.organisationId,
-                )
-            except Exception as e:  # noqa: BLE001
-                logger.bind(call_id=self.call.id).warning(
-                    f"invocation log flush after failed build raised: {e}"
-                )
             raise
 
     async def _prepare_run_inner(

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -442,7 +442,47 @@ class CallSession:
         (missing API key, unsupported provider, etc.) propagate as a real
         HTTP error to the browser instead of a stalled-spinner silent
         failure.
+
+        Failure handling (W5/P1): the MCP servers are connected part-way
+        through the build, but their closers are only awaited in
+        ``_run_prepared_once``'s finally — which never runs if the build
+        raises after that point. With a fallback configured, ``run()``
+        re-enters here and overwrites ``_mcp_closers``, orphaning the
+        previous connections; without one, the exception escapes and
+        nothing closes them at all. Trigger: any agent with MCP servers
+        whose model/voice config fails to build. So the whole build runs
+        under a guard that closes them and flushes the log records that
+        would otherwise be stranded (they were written under this call's
+        ``contextualize``, but the only per-call flush is in the runner's
+        finally).
         """
+        try:
+            return await self._prepare_run_inner(agent, model_name, system_prompt)
+        except BaseException:
+            closers, self._mcp_closers = self._mcp_closers, []
+            if closers:
+                try:
+                    await close_mcp_servers(closers)
+                except Exception as e:  # noqa: BLE001
+                    logger.bind(call_id=self.call.id).warning(
+                        f"closing MCP servers after failed build raised: {e}"
+                    )
+            try:
+                await invocation_log.flush_invocation_logs(
+                    call_id=self.call.id,
+                    user_id=self.call.userId,
+                    org_id=self.call.organisationId,
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.bind(call_id=self.call.id).warning(
+                    f"invocation log flush after failed build raised: {e}"
+                )
+            raise
+
+    async def _prepare_run_inner(
+        self, agent: dict, model_name: str, system_prompt: str
+    ):
+        """The body of :meth:`prepare_run` — see its docstring."""
         # Handover paths pass their own agent dict; make sure listener-level
         # transfer overrides apply to it exactly as they did to the original
         # (idempotent when __post_init__ already merged this dict).
@@ -2633,6 +2673,20 @@ def _json_dumps_safe(value: Any) -> str:
 # ---- Constructors ----
 
 
+async def _end_unstarted_call(call, reason: str) -> None:
+    """Close a Call record that was created but never started.
+
+    Best-effort: the caller is already unwinding on an error, and a
+    failure to tidy the row must not mask it.
+    """
+    try:
+        await api_client.end_call(call, reason)
+    except Exception as e:  # noqa: BLE001
+        logger.bind(call_id=getattr(call, "id", None)).warning(
+            f"could not end unstarted call record: {e}"
+        )
+
+
 async def setup_inbound_call(
     sip_gateway: SipGateway,
     inbound: InboundCallContext,
@@ -2687,11 +2741,22 @@ async def setup_inbound_call(
         from .fixed_message import fixed_message_for
 
         if not fixed_message_for(agent):
+            # W2: the Call record above was created but will never be
+            # started, and nothing downstream reaches ``end_call`` on
+            # this path — so the busy case (the expected one, at exactly
+            # the moment the node is busiest) left an open call row per
+            # refusal. End it before the refusal propagates.
+            await _end_unstarted_call(call, "concurrency limit exceeded")
             raise
         logger.bind(call_id=call.id, agent_id=agent.get("id")).warning(
             "agent concurrency limit reached; playing fixed fallback message instead of busy"
         )
         fixed_message_only = True
+    except Exception:
+        # Any other start failure (agent-db 5xx or timeout) leaves the
+        # same orphaned row.
+        await _end_unstarted_call(call, "call start failed")
+        raise
 
     return CallSession(
         session_id=inbound.session_id,

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -282,6 +282,9 @@ class CallSession:
     # worker acts as the MCP client). Awaited in ``run_prepared``'s finally so
     # the remote sessions don't outlive the call. See mcp_tools.py.
     _mcp_closers: list = field(default_factory=list)
+    # Strong references to fire-and-forget background tasks (W10) — see
+    # ``_hold_task``.
+    _background_tasks: set = field(default_factory=set)
     # Hand-back take-over sessions only: future resolving to the pre-fired
     # summaryAgent result, collected by the ``transfer_summary`` builtin
     # (bridged_transfer.prefire_summary). None everywhere else.
@@ -321,6 +324,14 @@ class CallSession:
         active_prompt = system_prompt
         used_fallback_model = False
         used_fallback_agent = False
+        # W8: the retry arms below re-enter prepare_run on the SAME
+        # transport, and pipecat's add_event_handler appends. Snapshot
+        # the handler registry once, and roll back to it before each
+        # retry so a failed attempt's closures don't fire alongside the
+        # replacement's.
+        transport_handlers = self._snapshot_transport_handlers(
+            getattr(self.gateway_session, "transport", None)
+        )
 
         while True:
             fallback_cfg = (active_agent.get("options") or {}).get("fallback") or {}
@@ -358,6 +369,9 @@ class CallSession:
                         active_model = next_agent["modelName"]
                         used_fallback_agent = True
                         used_fallback_model = False
+                        self._restore_transport_handlers(
+                            self.gateway_session.transport, transport_handlers
+                        )
                         continue
                     except Exception as inner:  # noqa: BLE001
                         logger.warning(f"fallback agent failed: {inner}")
@@ -370,6 +384,9 @@ class CallSession:
                 ):
                     used_fallback_model = True
                     active_model = fallback_cfg["model"]
+                    self._restore_transport_handlers(
+                        self.gateway_session.transport, transport_handlers
+                    )
                     continue
 
                 # 3. Fixed-message fallback: play the operator's announcement.
@@ -429,6 +446,58 @@ class CallSession:
                         raise inner
 
                 raise
+
+    @staticmethod
+    def _snapshot_transport_handlers(transport: Any) -> Optional[dict]:
+        """Capture the transport's currently-registered event handlers (W8).
+
+        ``prepare_run`` registers ``on_client_connected`` /
+        ``on_client_disconnected`` closures on the gateway's transport —
+        greeting, recorder start, task cancel — and pipecat's
+        ``add_event_handler`` APPENDS. The fallback loop in ``run()``
+        re-enters ``prepare_run`` on the SAME transport object, so a
+        failed attempt's closures stayed registered and fired again on
+        the retry's StartFrame, still holding the dead task and its
+        audio buffer: a duplicate greeting, and ``start_recording()``
+        called on the wrong buffer. Bounded by the fallback chain rather
+        than unbounded, but wrong either way.
+
+        Returns None when the transport doesn't expose the registry, in
+        which case the restore is a no-op and behaviour is unchanged.
+        """
+        registry = getattr(transport, "_event_handlers", None)
+        if not isinstance(registry, dict):
+            return None
+        return {
+            name: list(entry.handlers)
+            for name, entry in registry.items()
+            if hasattr(entry, "handlers")
+        }
+
+    @staticmethod
+    def _restore_transport_handlers(transport: Any, snapshot: Optional[dict]) -> None:
+        """Roll the transport's handlers back to a snapshot — see above."""
+        if not snapshot:
+            return
+        registry = getattr(transport, "_event_handlers", None)
+        if not isinstance(registry, dict):
+            return
+        for name, saved in snapshot.items():
+            entry = registry.get(name)
+            if entry is not None and hasattr(entry, "handlers"):
+                entry.handlers[:] = saved
+
+    def _hold_task(self, task: "asyncio.Task") -> "asyncio.Task":
+        """Keep a strong reference to a background task (W10).
+
+        asyncio holds only weak references to tasks, so a bare
+        ``create_task`` whose result nobody awaits can be collected
+        mid-flight; these survive today only by virtue of whatever they
+        happen to be awaiting. Mirrors ``bridged_transfer._summary_tasks``.
+        """
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        return task
 
     async def prepare_run(
         self, agent: dict, model_name: str, system_prompt: str
@@ -934,6 +1003,13 @@ class CallSession:
         leg = self._relay_leg
         if leg is not None:
             self._relay_leg = None
+            from . import media_relay
+
+            # P7: disengage BOTH ends first. Otherwise the surviving
+            # leg's tap keeps feeding the dead leg's unbounded injector
+            # queue (~96 KB/s from a 48 kHz browser peer) until the
+            # survivor is itself hung up — which is best-effort.
+            media_relay.unbridge(self.relay_endpoint, getattr(leg, "endpoint", None))
             try:
                 await leg.task.cancel()
             except Exception as e:  # noqa: BLE001
@@ -946,6 +1022,9 @@ class CallSession:
         consult = self._consult_session
         if consult is not None:
             self._consult_session = None
+            from . import media_relay
+
+            media_relay.unbridge(self.relay_endpoint, consult.relay_endpoint)
             try:
                 await consult.gateway_session.shutdown()
             except Exception as e:  # noqa: BLE001
@@ -2237,7 +2316,7 @@ class CallSession:
         )
         # Run the relay leg, then engage the bridge. The browser bot pipeline is
         # already running; engaging mutes it and starts the media relay.
-        asyncio.create_task(self._run_relay_leg())
+        self._hold_task(asyncio.create_task(self._run_relay_leg()))
         media_relay.bridge(self.relay_endpoint, leg_endpoint)
         self.transfer_state = TransferState("talking", "Transfer connected")
         logger.bind(call_id=self.call.id, leg_call_id=leg_call.id).info(
@@ -2364,7 +2443,7 @@ class CallSession:
         self._consult_session = consult_session
         # Run the TransferAgent bot on the consult leg. accept/reject tools on it
         # drive our transfer_state and, on accept, bridge the relay endpoints.
-        asyncio.create_task(self._run_consult_session(consult_session))
+        self._hold_task(asyncio.create_task(self._run_consult_session(consult_session)))
         self.transfer_state = TransferState("talking", "Speaking with transfer target...")
 
     async def _run_consult_session(self, consult_session: "CallSession") -> None:

--- a/agents/pipecat/pipecat_aplisay/confidence_tone.py
+++ b/agents/pipecat/pipecat_aplisay/confidence_tone.py
@@ -68,6 +68,11 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 # 20 ms chunks — matches typical transport frame sizing.
 _CHUNK_SECS = 0.02
+# Poll interval while the injector is disarmed (``_mode is None``), which is
+# almost all of every call. Arming is still noticed within this window, which
+# is well inside the gap a transfer opens up; the alternative was a 20 ms
+# ticker per call for the whole call, doing nothing.
+_IDLE_POLL_SECS = 0.25
 # Backstop for handover mode: a full-stack agent handover normally completes
 # (incoming agent's first BotStartedSpeakingFrame) within a few seconds. If
 # the new agent never speaks — a stuck/failed continuation — cap the comfort
@@ -408,6 +413,18 @@ class ConfidenceToneInjector(FrameProcessor):
         accumulate into audio backlog at the transport."""
         next_deadline = time.monotonic()
         while True:
+            # Idle poll (P3). The tone is armed only during a transfer,
+            # which is a few seconds out of a call that may run for an
+            # hour: for ~99% of the call ``_mode`` is None and the 20 ms
+            # pacing loop was waking 50 times a second per call to do
+            # nothing — 5 000 wakeups/s across a hundred calls. Poll
+            # slowly while disarmed and re-anchor the deadline on the
+            # way in, so arming is still picked up within 250 ms and the
+            # first tone chunk is still pushed on an exact boundary.
+            if self._mode is None:
+                await asyncio.sleep(_IDLE_POLL_SECS)
+                next_deadline = time.monotonic()
+                continue
             next_deadline += _CHUNK_SECS
             delay = next_deadline - time.monotonic()
             if delay > 0:

--- a/agents/pipecat/pipecat_aplisay/fixed_message.py
+++ b/agents/pipecat/pipecat_aplisay/fixed_message.py
@@ -36,6 +36,7 @@ them at all; getting the lower latency for free is why this shape is kept.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -191,14 +192,29 @@ async def run_fixed_message(transport: Any, agent: dict) -> bool:
         vendor=resolved.vendor, voice=resolved.voice, chars=len(resolved.text)
     ).info("playing fixed fallback message")
 
-    try:
-        return await asyncio.wait_for(
-            _play(transport, agent, resolved), timeout=_PLAYOUT_TIMEOUT_SECS
-        )
-    except asyncio.TimeoutError:
+    # P10: run the playout as a task and judge it on the clock, rather
+    # than relying on ``wait_for`` to raise. Since Python 3.12 wait_for
+    # resumes the cancelled coroutine inline and returns ITS result if it
+    # completes — and ``WorkerRunner.run`` swallows the CancelledError,
+    # so it always did. The timeout branch below was therefore
+    # unreachable and a playout that overran was reported as a success,
+    # which in the fallback chain means "the caller heard the
+    # announcement" when they may not have.
+    task = asyncio.ensure_future(_play(transport, agent, resolved))
+    done, _pending = await asyncio.wait({task}, timeout=_PLAYOUT_TIMEOUT_SECS)
+    if not done:
         logger.warning(
             f"fixed fallback message timed out after {_PLAYOUT_TIMEOUT_SECS}s"
         )
+        task.cancel()
+        # Let the cancellation land, but never wait on it here — this
+        # runs on the caller's setup-failure path.
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await asyncio.wait({task}, timeout=1.0)
+        return False
+    try:
+        return task.result()
+    except asyncio.CancelledError:
         return False
     except Exception as e:  # noqa: BLE001
         logger.error(f"fixed fallback message failed: {e}")
@@ -238,7 +254,10 @@ async def _play(transport: Any, agent: dict, resolved: ResolvedFallbackMessage) 
         processors = [_build_message_tts(agent, resolved), tap, rate_guard, transport.output()]
         frames = [TTSSpeakFrame(resolved.text)]
 
-    task = PipelineTask(Pipeline(processors))
+    # F1: playout-only, no VAD and no bot frames. The announcement is far
+    # shorter than the 300 s default, but the watchdog has no business
+    # here either way.
+    task = PipelineTask(Pipeline(processors), idle_timeout_secs=None)
     # EndFrame is queued behind the audio, so it reaches the output transport
     # only after everything ahead of it has been rendered — the graceful
     # termination pattern, which is what stops the announcement being cut off.

--- a/agents/pipecat/pipecat_aplisay/fixed_message.py
+++ b/agents/pipecat/pipecat_aplisay/fixed_message.py
@@ -254,10 +254,11 @@ async def _play(transport: Any, agent: dict, resolved: ResolvedFallbackMessage) 
         processors = [_build_message_tts(agent, resolved), tap, rate_guard, transport.output()]
         frames = [TTSSpeakFrame(resolved.text)]
 
-    # F1: playout-only, no VAD and no bot frames. The announcement is far
-    # shorter than the 300 s default, but the watchdog has no business
-    # here either way.
-    task = PipelineTask(Pipeline(processors), idle_timeout_secs=None)
+    # F1: the framework's 300 s idle watchdog stays on. This playout is
+    # bounded far more tightly by run_fixed_message's own ceiling, and it
+    # was never one of the cases the watchdog broke — only the STT-only
+    # and relay-only side pipelines opt out.
+    task = PipelineTask(Pipeline(processors))
     # EndFrame is queued behind the audio, so it reaches the output transport
     # only after everything ahead of it has been rendered — the graceful
     # termination pattern, which is what stops the announcement being cut off.

--- a/agents/pipecat/pipecat_aplisay/function_handler.py
+++ b/agents/pipecat/pipecat_aplisay/function_handler.py
@@ -24,6 +24,7 @@ from typing import Any, Awaitable, Callable, Optional
 import httpx
 from loguru import logger
 
+from . import http_client
 from .current_datetime import current_datetime_string, is_datetime_metadata_key
 
 
@@ -405,8 +406,14 @@ async def _execute_rest(fn_def: dict, inputs: dict, keys: list[dict]) -> Any:
         params = [(k, str(v)) for k, v in (leftover or {}).items() if v is not None]
         params.extend(auth_params)
 
-    async with httpx.AsyncClient(timeout=15.0) as client:
-        resp = await client.request(method, url, headers=headers, params=params or None, json=body)
+    # Pooled per-host client (W4). Agent REST callouts hit arbitrary
+    # third-party hosts, so they get their own pool rather than sharing
+    # the agent-db one — a slow customer endpoint must not consume the
+    # connection budget the call's own control plane needs.
+    client = await http_client.get_client("rest-callout")
+    resp = await client.request(
+        method, url, headers=headers, params=params or None, json=body, timeout=15.0
+    )
     is_json = resp.headers.get("content-type", "").startswith("application/json")
     if resp.status_code >= 400:
         parsed = _try_parse_json(resp.text) if is_json else None

--- a/agents/pipecat/pipecat_aplisay/http_client.py
+++ b/agents/pipecat/pipecat_aplisay/http_client.py
@@ -1,0 +1,81 @@
+"""Process-wide pooled HTTP clients.
+
+Every ``httpx.AsyncClient(...)`` constructed inside a request handler
+builds a fresh ``ssl.SSLContext`` — a synchronous parse of the certifi
+CA bundle, on the event loop, measured at ~5 ms here and 2–4x that on a
+250m-CPU node — and then opens a connection that is thrown away when the
+``async with`` exits.
+
+That is affordable a handful of times per call. It is not affordable on
+the transcript-streaming path: with ``instance.streamLog`` on, the
+observer POSTs a row for every STT interim and every TTS/LLM text chunk,
+10–30 times a second per call. Ten concurrent streaming calls put the
+loop into permanent SSL-context construction, which every other call on
+the node hears as output jitter. Kernel-side it is worse: each request
+is a new connection, and a host-network node runs out of ephemeral ports
+(28k / 60 s TIME_WAIT) at a few hundred connections a second, after which
+every agent-db call fails — call setup, transfer authorisation, the lot.
+
+So: one client per base URL for the life of the process, with a
+connection pool and keep-alive. Per-request deadlines go on the request
+(``client.request(..., timeout=...)``), never on the client, so a shared
+client does not impose one call's timeout on another's.
+
+Closed from the worker's lifespan shutdown via ``aclose_all()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Dict
+
+import httpx
+from loguru import logger
+
+# Pool sizing. max_connections bounds concurrent sockets to one host;
+# 50 is comfortably above the busiest node's steady state (a few
+# in-flight agent-db calls per live call) while staying well under any
+# file-descriptor limit. Keep-alive connections are what actually removes
+# the per-request handshake.
+_LIMITS = httpx.Limits(max_connections=50, max_keepalive_connections=20)
+
+# Fallback deadline for callers that pass none. Individual calls should
+# still pass their own; this only stops a forgotten one hanging forever.
+_DEFAULT_TIMEOUT = 30.0
+
+_clients: Dict[str, httpx.AsyncClient] = {}
+_lock = asyncio.Lock()
+
+
+async def get_client(key: str = "default", *, base_url: str = "") -> httpx.AsyncClient:
+    """Return the pooled client for ``key``, creating it on first use.
+
+    ``key`` namespaces the pools (the agent-db API, the sipbridge REST
+    surface, …) so they cannot exhaust each other's connection budget.
+    """
+    client = _clients.get(key)
+    if client is not None and not client.is_closed:
+        return client
+    async with _lock:
+        client = _clients.get(key)
+        if client is not None and not client.is_closed:
+            return client
+        client = httpx.AsyncClient(
+            base_url=base_url,
+            limits=_LIMITS,
+            timeout=_DEFAULT_TIMEOUT,
+        )
+        _clients[key] = client
+        logger.bind(pool=key).debug("http: created shared client")
+        return client
+
+
+async def aclose_all() -> None:
+    """Close every pooled client. Called from the worker's lifespan."""
+    clients = list(_clients.items())
+    _clients.clear()
+    for key, client in clients:
+        try:
+            await client.aclose()
+        except Exception as e:  # noqa: BLE001
+            logger.bind(pool=key).warning(f"http: closing shared client failed: {e}")

--- a/agents/pipecat/pipecat_aplisay/invocation_log.py
+++ b/agents/pipecat/pipecat_aplisay/invocation_log.py
@@ -16,6 +16,7 @@ rather than accumulated forever.
 from __future__ import annotations
 
 import os
+import sys
 import threading
 from collections import deque
 from typing import Any
@@ -52,6 +53,16 @@ _MAX_ENTRIES_PER_CALL = 4_000
 # ends without one (a hard crash between segments). At the cap the
 # least-recently-written call is dropped whole.
 _MAX_CALLS = 500
+
+# How many call buffers have been dropped un-flushed. Non-zero means
+# calls are ending without their invocation log being persisted, which is
+# worth knowing about; the sink cannot log it itself (see _capture_sink).
+_dropped_call_buffers = 0
+
+
+def dropped_call_buffers() -> int:
+    """Count of call buffers evicted before they were ever flushed."""
+    return _dropped_call_buffers
 
 
 # loguru level name -> pino numeric level. The Calls UI (polite-ai
@@ -109,6 +120,7 @@ def _capture_sink(message) -> None:
     except Exception:  # noqa: BLE001 — logging must never raise
         return
     key = entry.get("callId") or "system"
+    evicted: str | None = None
     with _LOCK:
         buf = _BUFFERS.get(key)
         if buf is None:
@@ -116,14 +128,28 @@ def _capture_sink(message) -> None:
                 # Insertion-ordered dict: the first key is the least
                 # recently created buffer. Only reachable if calls are
                 # ending without flushing.
-                oldest = next(iter(_BUFFERS))
-                del _BUFFERS[oldest]
-                logger.warning(
-                    "invocation log: dropped buffered records for "
-                    f"{oldest} — more than {_MAX_CALLS} unflushed calls"
-                )
+                evicted = next(iter(_BUFFERS))
+                del _BUFFERS[evicted]
             buf = _BUFFERS[key] = deque(maxlen=_MAX_ENTRIES_PER_CALL)
         buf.append(entry)
+    # NOT ``logger`` — we are inside a loguru sink, and loguru is not
+    # re-entrant: any log emitted from here trips its "deadlock avoided"
+    # guard, which raises out of the sink, loses the message and turns
+    # every eviction into a handler error on stderr. Moving it out of
+    # the lock does not help; the guard is on the loguru handler, not on
+    # our buffer. So: a counter (reported by ``dropped_call_buffers``)
+    # plus a direct stderr line, neither of which re-enters logging.
+    if evicted is not None:
+        global _dropped_call_buffers
+        _dropped_call_buffers += 1
+        try:
+            print(
+                f"invocation log: dropped buffered records for {evicted} — "
+                f"more than {_MAX_CALLS} unflushed calls",
+                file=sys.stderr,
+            )
+        except Exception:  # noqa: BLE001 — logging must never raise
+            pass
 
 
 def install_capture(level: str | None = None) -> None:

--- a/agents/pipecat/pipecat_aplisay/invocation_log.py
+++ b/agents/pipecat/pipecat_aplisay/invocation_log.py
@@ -17,22 +17,41 @@ from __future__ import annotations
 
 import os
 import threading
+from collections import deque
 from typing import Any
 
 from loguru import logger
 
 from . import api_client
 
-# Process-wide, callId-tagged. Guarded by a threading.Lock: the loguru sink runs
-# synchronously in whatever thread emitted the log (possibly a worker thread,
-# e.g. ``asyncio.to_thread``), while flush runs on the event loop.
-_BUFFER: list[dict[str, Any]] = []
+# Per-call buffers, keyed by callId. Guarded by a threading.Lock: the loguru
+# sink runs synchronously in whatever thread emitted the log (possibly a worker
+# thread, e.g. ``asyncio.to_thread``), while flush runs on the event loop.
+#
+# This used to be ONE process-wide list with a shared 20 000-entry cap and
+# oldest-first eviction across the whole process (P1). On a busy node — tens of
+# concurrent calls, a few hundred records a minute each, plus every pipecat line
+# emitted while a callId is bound — that saturated within minutes, and what got
+# evicted was the OLDEST entries of the still-running long calls: their setup and
+# connect lines, which are exactly the ones you need when diagnosing a silent
+# leg. Per-call deques give each call its own budget, make eviction a property of
+# that call's own verbosity, and turn the drain from an O(N) rebuild under the
+# lock (taken by every log call in every thread) into a dict pop.
+_BUFFERS: dict[str, deque] = {}
 _LOCK = threading.Lock()
 _installed = False
 
-# Soft cap so a pathologically long / verbose call can't grow the buffer without
-# bound; when exceeded we drop the oldest entry (the server prunes anyway).
-_MAX_ENTRIES = 20_000
+# Per-call cap. A call that talks for an hour at INFO produces a few thousand
+# records; 4 000 leaves headroom for a verbose one without letting any single
+# call dominate. deque(maxlen=...) evicts oldest-first on append, within that
+# call only.
+_MAX_ENTRIES_PER_CALL = 4_000
+
+# Ceiling on how many calls' buffers we hold. Every buffer is normally dropped
+# by its own call's flush; this only bounds the pathological case where a call
+# ends without one (a hard crash between segments). At the cap the
+# least-recently-written call is dropped whole.
+_MAX_CALLS = 500
 
 
 # loguru level name -> pino numeric level. The Calls UI (polite-ai
@@ -89,10 +108,22 @@ def _capture_sink(message) -> None:
         entry = _record_to_entry(record)
     except Exception:  # noqa: BLE001 — logging must never raise
         return
+    key = entry.get("callId") or "system"
     with _LOCK:
-        _BUFFER.append(entry)
-        if len(_BUFFER) > _MAX_ENTRIES:
-            del _BUFFER[0]
+        buf = _BUFFERS.get(key)
+        if buf is None:
+            if len(_BUFFERS) >= _MAX_CALLS:
+                # Insertion-ordered dict: the first key is the least
+                # recently created buffer. Only reachable if calls are
+                # ending without flushing.
+                oldest = next(iter(_BUFFERS))
+                del _BUFFERS[oldest]
+                logger.warning(
+                    "invocation log: dropped buffered records for "
+                    f"{oldest} — more than {_MAX_CALLS} unflushed calls"
+                )
+            buf = _BUFFERS[key] = deque(maxlen=_MAX_ENTRIES_PER_CALL)
+        buf.append(entry)
 
 
 def install_capture(level: str | None = None) -> None:
@@ -119,16 +150,13 @@ def _drain(call_id: str | None) -> list[dict[str, Any]]:
     """Remove and return buffered entries — one call's, or all when ``call_id`` is None."""
     with _LOCK:
         if call_id is None:
-            batch = list(_BUFFER)
-            _BUFFER.clear()
+            batch: list[dict[str, Any]] = []
+            for buf in _BUFFERS.values():
+                batch.extend(buf)
+            _BUFFERS.clear()
             return batch
-        keep: list[dict[str, Any]] = []
-        batch: list[dict[str, Any]] = []
-        for entry in _BUFFER:
-            (batch if (entry.get("callId") or "system") == call_id else keep).append(entry)
-        if batch:
-            _BUFFER[:] = keep
-        return batch
+        buf = _BUFFERS.pop(call_id, None)
+        return list(buf) if buf else []
 
 
 async def _post(

--- a/agents/pipecat/pipecat_aplisay/mcp_tools.py
+++ b/agents/pipecat/pipecat_aplisay/mcp_tools.py
@@ -27,10 +27,23 @@ from __future__ import annotations
 import asyncio
 import base64
 import re
+from datetime import timedelta
 from typing import Any, Awaitable, Callable
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from loguru import logger as _logger
+
+# How long the worker waits for an MCP server to complete its handshake
+# and list its tools. Servers are connected serially during call setup,
+# with the caller already answered and holding a concurrency slot, so
+# this is a call-quality budget rather than a connectivity one — a
+# server that needs longer is one the call is better off without.
+MCP_CONNECT_TIMEOUT = 10.0
+
+# Per-tool-call read deadline. The mcp client's own default is 300 s;
+# nothing conversational survives a five-minute pause, and a hung tool
+# call otherwise pins the bot mid-turn.
+MCP_TOOL_TIMEOUT = 30.0
 
 
 def _namespace_tool_name(server_name: str, tool_name: str) -> str:
@@ -102,7 +115,11 @@ def _make_descriptor(
             "proxying MCP tool call"
         )
         try:
-            results = await _session.call_tool(_name, arguments=args or {})
+            results = await _session.call_tool(
+                _name,
+                arguments=args or {},
+                read_timeout_seconds=timedelta(seconds=MCP_TOOL_TIMEOUT),
+            )
         except Exception as e:  # noqa: BLE001
             detail = _error_summary(e)
             log.bind(server=server_name, tool=_name, error=detail).warning(
@@ -265,11 +282,29 @@ async def _connect_one(
 
     task = asyncio.create_task(_run(), name=f"mcp-{name or url}")
     try:
-        descriptors = await ready
-    except Exception as e:  # noqa: BLE001
+        # P2: a worker-side deadline. Without it the only limits are the
+        # mcp client's own (30 s connect, 300 s read), and servers are
+        # connected serially — so one configured server that accepts the
+        # POST and then never answers stalls call setup for minutes with
+        # the caller answered, silent, and holding a concurrency slot
+        # (on the WebRTC path it hangs /webrtc/offer outright). A server
+        # that cannot complete a handshake in MCP_CONNECT_TIMEOUT is not
+        # going to be useful on this call.
+        descriptors = await asyncio.wait_for(ready, timeout=MCP_CONNECT_TIMEOUT)
+    except BaseException as e:
+        # BaseException, not Exception: a CancelledError here (call torn
+        # down mid-connect, or worker shutdown) otherwise left ``_run``
+        # parked on ``close_event.wait()`` holding its httpx client and
+        # MCP session open for the life of the process.
         close_event.set()
         await asyncio.gather(task, return_exceptions=True)
-        detail = _error_summary(e)
+        if isinstance(e, asyncio.CancelledError):
+            raise
+        detail = (
+            f"timed out after {MCP_CONNECT_TIMEOUT:g}s"
+            if isinstance(e, asyncio.TimeoutError)
+            else _error_summary(e)
+        )
         log.bind(server=name, url=url, error=detail).warning(
             f"failed to connect MCP server '{name}' at {url}: {detail}; "
             "skipping — its tools will be unavailable for this call"

--- a/agents/pipecat/pipecat_aplisay/media_relay.py
+++ b/agents/pipecat/pipecat_aplisay/media_relay.py
@@ -226,6 +226,20 @@ def bridge(a: RelayEndpoint, b: RelayEndpoint) -> None:
     logger.info(f"media relay bridged: {a.name} <-> {b.name}")
 
 
+def unbridge(a: Optional[RelayEndpoint], b: Optional[RelayEndpoint]) -> None:
+    """Disengage both ends of a relay (P7).
+
+    ``disengage()`` had no caller anywhere in the package, so when one
+    bridged leg ended first the survivor's ``_RelayTap`` kept feeding the
+    dead leg's unbounded injector queue — ~96 KB/s from a 48 kHz browser
+    peer — until the survivor was itself hung up, which is best-effort.
+    Safe to call with either side already gone or never engaged.
+    """
+    for endpoint in (a, b):
+        if endpoint is not None and endpoint.engaged:
+            endpoint.disengage()
+
+
 def build_relay_only_task(transport, endpoint: RelayEndpoint):
     """Build a bot-less ``PipelineTask`` that relays a leg's media through its
     :class:`RelayEndpoint`.
@@ -253,4 +267,10 @@ def build_relay_only_task(transport, endpoint: RelayEndpoint):
             transport.output(),
         ]
     )
-    return PipelineTask(pipeline, params=PipelineParams())
+    # F1: a relay-only leg carries media between two humans — it has no
+    # VAD and no bot, so it emits neither BotSpeakingFrame nor
+    # UserSpeakingFrame and pipecat's idle watchdog (300 s, cancel on
+    # timeout, both on by default) cancelled it five minutes into every
+    # relayed conversation; ``_run_relay_leg`` then read that as the
+    # target hanging up and dropped the browser caller.
+    return PipelineTask(pipeline, params=PipelineParams(), idle_timeout_secs=None)

--- a/agents/pipecat/pipecat_aplisay/output_underrun.py
+++ b/agents/pipecat/pipecat_aplisay/output_underrun.py
@@ -45,9 +45,16 @@ from __future__ import annotations
 
 import os
 import time
+from collections import deque
 from typing import Any, Optional
 
 from loguru import logger
+
+# How many recent samples the underrun percentiles are computed over
+# (P8). 2 000 events is far more than a healthy call produces and enough
+# for a stable p50/p90 on a bad one; whole-call maxima are tracked
+# separately so the window never hides the worst case.
+_SAMPLE_WINDOW = 2000
 
 # Depth buckets, sampled every recv(). The first two are the interesting ones:
 # time spent at 0 or 1 is time with no cushion.
@@ -69,7 +76,14 @@ class UnderrunStats:
         self.events = 0
         self.chunks_filled = 0            # 10 ms slots filled with zeroes
         self.max_gap_ms = 0.0
-        self.late_ms: list[float] = []    # one per event that was refilled
+        # One sample per refilled event, bounded (P8). These were plain
+        # lists that grew for the life of the call — small per entry, but
+        # unbounded in call length for a diagnostic that only ever
+        # reports percentiles. A rolling window gives the same answer;
+        # the true maxima are tracked separately below so nothing that
+        # matters is lost to eviction.
+        self.late_ms: deque[float] = deque(maxlen=_SAMPLE_WINDOW)
+        self.max_late_ms = 0.0
         self.gap_hist: dict[str, int] = {}  # gap size distribution, for the summary
         self.never_refilled = 0           # starved and the track ended first
         self.depth = {label: 0 for _, label in _BUCKETS}
@@ -80,7 +94,12 @@ class UnderrunStats:
         #: audio EXISTED and we simply had not moved it — the starve is ours.
         #: Zero means nothing had arrived from upstream. Nothing else in the
         #: system distinguishes those two, and they call for opposite fixes.
-        self.inflight_at_starve: list[float] = []
+        self.inflight_at_starve: deque[float] = deque(maxlen=_SAMPLE_WINDOW)
+        self.max_inflight_at_starve = 0.0
+        #: Total starves seen with audio already in flight — a running
+        #: count, so the ratio below stays whole-call even though the
+        #: samples behind the percentiles are windowed.
+        self.starves_with_audio_waiting = 0
 
     @property
     def silence_ms(self) -> float:
@@ -98,7 +117,8 @@ class UnderrunStats:
         late = sorted(self.late_ms)
         p50 = late[len(late) // 2] if late else float("nan")
         p90 = late[int(len(late) * 0.9)] if late else float("nan")
-        worst = late[-1] if late else float("nan")
+        # Percentiles over the recent window; the max is whole-call.
+        worst = self.max_late_ms
         depth = " ".join(
             f"{k}:{100.0 * v / max(1, self.recvs):.0f}%" for k, v in self.depth.items() if v
         )
@@ -107,9 +127,11 @@ class UnderrunStats:
         inflight = ""
         if self.inflight_at_starve:
             arr = sorted(self.inflight_at_starve)
-            waiting = sum(1 for x in arr if x > 5.0)
-            inflight = (f"; audio in flight at starve: p50 {arr[len(arr)//2]:.0f} ms, "
-                        f"max {arr[-1]:.0f} ms, {waiting}/{len(arr)} starved with audio waiting")
+            inflight = (
+                f"; audio in flight at starve: p50 {arr[len(arr)//2]:.0f} ms, "
+                f"max {self.max_inflight_at_starve:.0f} ms, "
+                f"{self.starves_with_audio_waiting}/{self.events} starved with audio waiting"
+            )
         return (
             f"output underruns: {self.events} events, {self.silence_ms:.0f} ms of inserted "
             f"silence over {self.recvs * self.chunk_ms / 1000:.0f} s, worst gap "
@@ -175,7 +197,13 @@ def instrumented(base: type) -> type:
                     probe = self.inflight_probe
                     if probe is not None:
                         try:
-                            st.inflight_at_starve.append(max(0.0, probe() - self.queued_ms))
+                            inflight = max(0.0, probe() - self.queued_ms)
+                            st.inflight_at_starve.append(inflight)
+                            st.max_inflight_at_starve = max(
+                                st.max_inflight_at_starve, inflight
+                            )
+                            if inflight > 5.0:
+                                st.starves_with_audio_waiting += 1
                         except Exception:  # noqa: BLE001
                             pass
                 self._starved_slots += 1
@@ -190,6 +218,7 @@ def instrumented(base: type) -> type:
             st.events += 1
             st.max_gap_ms = max(st.max_gap_ms, gap_ms)
             st.late_ms.append(late_ms)
+            st.max_late_ms = max(st.max_late_ms, late_ms)
             st.note_gap(gap_ms)
             if self._event_log_ms > 0 and gap_ms >= self._event_log_ms:
                 # The verdict this line exists to support: a lateness of a few

--- a/agents/pipecat/pipecat_aplisay/recording/ogg_encoder.py
+++ b/agents/pipecat/pipecat_aplisay/recording/ogg_encoder.py
@@ -21,6 +21,12 @@ import shutil
 from dataclasses import dataclass
 
 
+# Ceiling on one recording's encode. ffmpeg transcoding an hour of
+# 16 kHz stereo PCM to Opus takes seconds; anything approaching this is
+# a stuck process, and it runs on the call's teardown path.
+ENCODE_TIMEOUT_SECS = 60.0
+
+
 class OggEncoderError(RuntimeError):
     """Raised when ffmpeg is missing or the encode subprocess fails."""
 
@@ -76,7 +82,27 @@ class OggEncoder:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        _, stderr = await proc.communicate()
+        try:
+            # Bounded (P5). This runs inside the segment teardown, ahead
+            # of the invocation-log flush and the MCP close, so a wedged
+            # ffmpeg — full disk, hung filesystem — blocked that call's
+            # teardown, and its WebSocket handler, indefinitely.
+            _, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=ENCODE_TIMEOUT_SECS
+            )
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            # Reap it so the child doesn't linger as a zombie.
+            try:
+                await proc.wait()
+            except Exception:  # noqa: BLE001
+                pass
+            raise OggEncoderError(
+                f"ffmpeg encode timed out after {ENCODE_TIMEOUT_SECS:g}s"
+            ) from None
         if proc.returncode != 0:
             raise OggEncoderError(
                 f"ffmpeg encode failed (rc={proc.returncode}): "

--- a/agents/pipecat/pipecat_aplisay/recording/recording_session.py
+++ b/agents/pipecat/pipecat_aplisay/recording/recording_session.py
@@ -36,6 +36,14 @@ from .ogg_encoder import OggEncoder, OggEncoderError
 from .upload import UploadResult, upload_encrypted_ogg
 
 
+# How much PCM to accumulate before hopping to a thread to write it
+# (P4). 64 KiB is ~2 s of 16 kHz stereo — one hop every couple of
+# seconds per recording instead of fifty a second, at the cost of at
+# most that much audio sitting in memory. The file is buffered anyway,
+# so the write itself is cheap; the thread hop was the expense.
+_WRITE_CHUNK_BYTES = 64 * 1024
+
+
 @dataclass
 class _PcmSink:
     """Holds the in-flight PCM file and metadata picked up from the
@@ -65,6 +73,16 @@ class RecordingSession:
         self._sink: Optional[_PcmSink] = None
         self._lock = asyncio.Lock()
         self._stopped = False
+        # Write coalescing buffer (P4). The bridged-segment tap calls
+        # ``append_pcm`` once per 20 ms frame, and every call used to be
+        # its own ``asyncio.to_thread`` hop — 50 hops/s per bridged
+        # recording, each writing ~1.3 KB, onto the default executor.
+        # That executor is min(32, cpu+4) threads — six on a 2-vCPU node
+        # — and is shared with GCS uploads, DNS lookups and httpx, so a
+        # couple of bridged recordings plus one slow GCS call stalled
+        # name resolution for every REST request in the process.
+        # Accumulate instead and hop once per _WRITE_CHUNK_BYTES.
+        self._pending = bytearray()
 
     def attach_to(self, audio_processor) -> None:  # pragma: no cover (wiring)
         """Register the ``on_audio_data`` event handler.
@@ -120,9 +138,18 @@ class RecordingSession:
                 self._sink.sample_rate = int(sample_rate)
                 self._sink.num_channels = int(num_channels)
             self._sink.bytes_written += len(audio)
+            self._pending.extend(audio)
+            if len(self._pending) < _WRITE_CHUNK_BYTES:
+                # Not enough yet — the flush happens on a later append or
+                # at stop. ``bytes_written`` already counts it, so the
+                # "did we capture anything" check stays correct.
+                return
+            chunk = bytes(self._pending)
+            self._pending.clear()
+            sink = self._sink
 
         # Disk write outside the lock to keep the event loop snappy.
-        await asyncio.to_thread(self._sink.file.write, audio)
+        await asyncio.to_thread(sink.file.write, chunk)
 
     async def _open_sink_locked(self) -> None:
         fd, path = tempfile.mkstemp(
@@ -149,6 +176,17 @@ class RecordingSession:
             self._stopped = True
             sink = self._sink
             self._sink = None
+            tail = bytes(self._pending)
+            self._pending.clear()
+
+        if sink is not None and tail:
+            # Whatever hadn't reached the coalescing threshold yet.
+            try:
+                await asyncio.to_thread(sink.file.write, tail)
+            except Exception as e:  # noqa: BLE001
+                logger.bind(call_id=self._call_id).warning(
+                    f"recording: final PCM write failed: {e}"
+                )
 
         if sink is None:
             logger.bind(call_id=self._call_id).info(

--- a/agents/pipecat/pipecat_aplisay/recording/upload.py
+++ b/agents/pipecat/pipecat_aplisay/recording/upload.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 from dataclasses import dataclass
 from typing import Optional
 
@@ -95,6 +96,12 @@ async def upload_encrypted_ogg(
     try:
         await asyncio.wait_for(_do_upload(), timeout=upload_timeout_secs)
     except asyncio.TimeoutError:
+        # Note what this timeout does and doesn't do: it frees the
+        # awaiting coroutine, but ``asyncio.to_thread`` cannot cancel a
+        # running thread, so the blocking SDK call inside keeps an
+        # executor slot until its own deadline. Hence the explicit
+        # ``timeout=`` on the SDK calls in ``_upload_payload`` — that is
+        # the bound that actually releases the thread.
         logger.bind(call_id=call_id).warning(
             "upload_encrypted_ogg: upload timed out"
         )
@@ -122,6 +129,35 @@ async def upload_encrypted_ogg(
     )
 
 
+# Deadline handed to the GCS SDK itself. ``asyncio.wait_for`` around
+# ``to_thread`` frees the awaiter but cannot stop the thread, so without
+# this the blocking call held an executor slot until the SDK's own 60 s
+# default — on the same six-thread executor that serves DNS.
+_SDK_TIMEOUT_SECS = 45.0
+
+_shared_client: Optional[storage.Client] = None
+_client_lock = threading.Lock()
+
+
+def _client() -> storage.Client:
+    """The process-wide GCS client, built on first use (P5).
+
+    ``storage.Client()`` re-reads the service-account credentials, mints
+    a fresh urllib3 pool and does an OAuth token exchange — and the
+    session it creates is never closed. Doing that per recording is pure
+    waste on a worker that uploads one per call; ``fallback_message/
+    store.py`` already holds a shared lazy client for the same reason.
+    Built under a lock because it is reached from the upload worker
+    thread, not the event loop.
+    """
+    global _shared_client
+    if _shared_client is None:
+        with _client_lock:
+            if _shared_client is None:
+                _shared_client = storage.Client()
+    return _shared_client
+
+
 def _upload_payload(bucket_name: str, gcs_object: str, payload: bytes) -> None:
     """Blocking GCS upload — runs inside ``asyncio.to_thread``.
 
@@ -129,7 +165,11 @@ def _upload_payload(bucket_name: str, gcs_object: str, payload: bytes) -> None:
     its sync client is the recommended path, kept off the event loop here
     via the worker-thread wrapper.
     """
-    client = storage.Client()
+    client = _client()
     bucket = client.bucket(bucket_name)
     blob = bucket.blob(gcs_object)
-    blob.upload_from_string(payload, content_type="application/octet-stream")
+    blob.upload_from_string(
+        payload,
+        content_type="application/octet-stream",
+        timeout=_SDK_TIMEOUT_SECS,
+    )

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/freeswitch_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/freeswitch_gateway.py
@@ -37,6 +37,7 @@ import httpx
 from loguru import logger
 from pipecat.transports.base_transport import BaseTransport
 
+from .. import http_client
 from .base import (
     ConsultStateMixin,
     GatewaySession,
@@ -311,8 +312,10 @@ class FreeswitchSipGateway(ConsultStateMixin, SipGateway):
         headers: dict[str, str] = {"content-type": "application/json"}
         if self.token:
             headers["authorization"] = f"Bearer {self.token}"
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.request(method, url, headers=headers, json=body)
+        client = await http_client.get_client("esl-poller")
+        resp = await client.request(
+            method, url, headers=headers, json=body, timeout=15.0
+        )
         if resp.status_code >= 400:
             msg = f"esl-poller {method} {path} -> {resp.status_code} {resp.text}"
             if raise_on_error:

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/freeswitch_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/freeswitch_gateway.py
@@ -178,6 +178,10 @@ class _FsGatewaySession(GatewaySession):
     async def shutdown(self) -> None:
         self._finished.set()
         await self.hangup("Session closed")
+        # P6: ``set_consult_call_id`` had no matching clear on this
+        # gateway (only sipbridge cleared it), so every warm transfer
+        # left its consult id behind for the life of the process.
+        self._gateway.clear_consult_call_id(self.session_id)
 
 
 class FreeswitchSipGateway(ConsultStateMixin, SipGateway):

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/sipbridge_gateway.py
@@ -54,6 +54,7 @@ import httpx
 from loguru import logger
 from pipecat.transports.base_transport import BaseTransport
 
+from .. import http_client
 from .base import (
     ConsultStateMixin,
     GatewaySession,
@@ -403,6 +404,19 @@ class _SbGatewaySession(GatewaySession):
 
     async def shutdown(self) -> None:
         await self.hangup("Session closed")
+        # Drop the gateway's registrations for this leg (W1). On the
+        # OUTBOUND path the dispatch task owns the CallSession and
+        # runner, and this is the only teardown that runs: the WS
+        # handler parks on the leg-done event, which nothing but
+        # ``unregister_session`` (or ``signal_bta_armed``) ever sets.
+        # Without this the handler task, its transport, its Starlette
+        # WebSocket and three map entries were retained for the life of
+        # the process, per outbound call — and uvicorn's graceful
+        # shutdown waits on those tasks, so a single leaked one turned
+        # every SIGTERM into a SIGKILL at the 30 s grace deadline.
+        # Idempotent, so the inbound path (whose handler ``finally``
+        # already calls it) is unaffected.
+        self._gateway.unregister_session(self.session_id)
 
 
 class SipBridgeSipGateway(ConsultStateMixin, SipGateway):
@@ -534,6 +548,11 @@ class SipBridgeSipGateway(ConsultStateMixin, SipGateway):
         """
         self._session_to_bridge_call.pop(session_id, None)
         self._sessions.pop(session_id, None)
+        # W6: ``hangup`` returns early once the leg is bridged, so a
+        # successfully completed warm transfer never cleared its consult
+        # id. One small string per transfer, forever — drop it here,
+        # which covers every exit path.
+        self.clear_consult_call_id(session_id)
         ev = self._leg_done_events.get(session_id)
         if ev is not None:
             ev.set()
@@ -651,8 +670,12 @@ class SipBridgeSipGateway(ConsultStateMixin, SipGateway):
         headers: dict[str, str] = {"content-type": "application/json"}
         if self.api_token:
             headers["authorization"] = f"Bearer {self.api_token}"
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.request(method, url, headers=headers, json=body)
+        # Shared pooled client (W4) — the per-request deadline stays on
+        # the request so the 65 s originate can't stretch a 15 s hangup.
+        client = await http_client.get_client("sipbridge")
+        resp = await client.request(
+            method, url, headers=headers, json=body, timeout=timeout
+        )
         if resp.status_code >= 400:
             msg = f"sipbridge {method} {path} -> {resp.status_code} {resp.text}"
             if raise_on_error:

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/voiceblender_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/voiceblender_gateway.py
@@ -61,6 +61,7 @@ import websockets
 from loguru import logger
 from pipecat.transports.base_transport import BaseTransport
 
+from .. import http_client
 from .base import (
     ConsultStateMixin,
     GatewaySession,
@@ -1193,8 +1194,10 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
         headers: dict[str, str] = {"content-type": "application/json"}
         if self.api_key:
             headers["authorization"] = f"Bearer {self.api_key}"
-        async with httpx.AsyncClient(timeout=15.0) as client:
-            resp = await client.request(method, url, headers=headers, json=body)
+        client = await http_client.get_client("voiceblender")
+        resp = await client.request(
+            method, url, headers=headers, json=body, timeout=15.0
+        )
         if resp.status_code >= 400:
             msg = f"voiceblender {method} {path} -> {resp.status_code} {resp.text}"
             if raise_on_error:

--- a/agents/pipecat/pipecat_aplisay/sip_gateway/voiceblender_gateway.py
+++ b/agents/pipecat/pipecat_aplisay/sip_gateway/voiceblender_gateway.py
@@ -53,6 +53,12 @@ import contextlib
 import json
 import os
 import uuid
+
+# Pending-attach expiry (P6). Legs answer within seconds; 120 s is well
+# past any real ring-to-WebSocket delay, and the sweep interval keeps the
+# check cheap.
+_PENDING_SWEEP_INTERVAL_SECS = 60.0
+_PENDING_MAX_AGE_SECS = 120.0
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Optional
 
@@ -430,6 +436,9 @@ class _VbGatewaySession(GatewaySession):
         # try to clean up; both paths are idempotent (``DELETE`` is a no-op
         # if the leg has already gone).
         await self.hangup("Session closed")
+        # P6: ``set_consult_call_id`` had no matching clear on this
+        # gateway either — one id per completed warm transfer, forever.
+        self._gateway.clear_consult_call_id(self.session_id)
 
 
 class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
@@ -481,6 +490,11 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
         self.sip_from_domain = os.environ.get("PIPECAT_SIP_FROM_DOMAIN")
 
         self.pending_attaches: dict[str, PendingAttach] = {}
+        self._sweeper_task: Optional[asyncio.Task] = None
+        # Strong references to in-flight VSI event handlers, and the
+        # per-leg tail of each serial handler chain (P6).
+        self._event_tasks: set = set()
+        self._leg_chains: dict[str, asyncio.Task] = {}
         # session_id → leg_id; the WS handler stores this when the WS opens
         # so the VSI subscriber can map leg-level events (transfer, hangup)
         # to the right call session.
@@ -609,13 +623,68 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
         except Exception as e:  # noqa: BLE001
             logger.warning(f"voiceblender health check failed at boot: {e}")
         self._vsi_task = asyncio.create_task(self._vsi_loop(), name="vsi-subscriber")
+        self._sweeper_task = asyncio.create_task(
+            self._sweep_loop(), name="vb-pending-sweeper"
+        )
 
     async def stop(self) -> None:
         self._stop.set()
-        if self._vsi_task and not self._vsi_task.done():
-            self._vsi_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._vsi_task
+        for task in (self._vsi_task, self._sweeper_task):
+            if task and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        for task in list(self._event_tasks):
+            task.cancel()
+        if self._event_tasks:
+            await asyncio.gather(*self._event_tasks, return_exceptions=True)
+        self._event_tasks.clear()
+        self._leg_chains.clear()
+
+    async def _sweep_loop(self) -> None:
+        """Expire abandoned pending-attach and consult state (P6).
+
+        ``pending_attaches`` entries hold the full resolved agent dict and
+        are removed only when the leg's WebSocket arrives or a
+        ``leg.disconnected`` VSI event lands. A VSI reconnect between
+        ``leg.ringing`` and ``leg.disconnected`` loses the disconnect, and
+        the entry becomes permanent; likewise a consult whose third party
+        never answers leaves both its entry and its ConsultPayload (which
+        carries the parent transcript) behind. ``created_at`` was written
+        in three places and read in none — this is what reads it.
+        """
+        while not self._stop.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._stop.wait(), timeout=_PENDING_SWEEP_INTERVAL_SECS
+                )
+                return  # stop() was set
+            except asyncio.TimeoutError:
+                pass
+            try:
+                self._sweep_pending_once()
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"voiceblender pending sweep failed: {e}")
+
+    def _sweep_pending_once(self) -> None:
+        """One sweep pass — separated out so it is testable directly."""
+        # Same clock ``created_at`` was written with.
+        cutoff = asyncio.get_running_loop().time() - _PENDING_MAX_AGE_SECS
+        stale = [
+            sid
+            for sid, pending in self.pending_attaches.items()
+            if pending.created_at < cutoff
+        ]
+        for sid in stale:
+            self.pending_attaches.pop(sid, None)
+            # A stale pending attach is by definition a leg whose WS never
+            # arrived, so any consult state keyed to it is stale too.
+            self.clear_consult_session(sid)
+            self.clear_consult_call_id(sid)
+            logger.bind(session_id=sid).warning(
+                "voiceblender: expired pending attach — the leg's WebSocket "
+                f"never arrived within {_PENDING_MAX_AGE_SECS:g}s"
+            )
 
     # ---- SipGateway protocol --------------------------------------------
 
@@ -784,6 +853,16 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
             logger.bind(leg_id=leg_id, session_id=session_id).warning(
                 f"voiceblender consult: connect+attach failed: {e}"
             )
+            # P6: the consult never came up, so nothing will ever consume
+            # its pending attach or its ConsultPayload (which holds the
+            # parent transcript). The sweeper would get there eventually;
+            # this is the deterministic path.
+            self.pending_attaches.pop(session_id, None)
+            self.clear_consult_session(session_id)
+            with contextlib.suppress(Exception):
+                await self._call_api(
+                    "DELETE", f"/v1/legs/{leg_id}", None, raise_on_error=False
+                )
 
     def _sip_auth(self) -> Optional[dict[str, str]]:
         """Digest credentials for the outbound INVITE (401/407 challenge from
@@ -853,7 +932,7 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
                         except Exception as e:  # noqa: BLE001
                             logger.warning(f"VSI: bad JSON: {e}; raw={raw[:200]!r}")
                             continue
-                        await self._handle_vsi_event(event)
+                        self._queue_vsi_event(event)
             except asyncio.CancelledError:
                 raise
             except Exception as e:  # noqa: BLE001
@@ -864,6 +943,52 @@ class VoiceblenderSipGateway(ConsultStateMixin, SipGateway):
             except asyncio.TimeoutError:
                 pass
             backoff = min(backoff * 2, 30.0)
+
+    def _queue_vsi_event(self, event: dict) -> None:
+        """Hand one VSI event to its leg's serial chain (P6).
+
+        The read loop used to ``await`` each handler inline, so the whole
+        event stream queued behind every handler — and a ``leg.ringing``
+        handler does two REST calls, so one slow agent resolution delayed
+        every OTHER leg's disconnect, DTMF and transfer events by up to
+        its full timeout.
+
+        Handlers still run strictly in order **per leg** — they drive a
+        state machine (ringing → connected → transfer → disconnected) and
+        reordering those would be worse than the blocking. Different legs
+        simply no longer wait on each other.
+        """
+        key = str(event.get("leg_id") or event.get("id") or "")
+        previous = self._leg_chains.get(key)
+
+        async def _chained() -> None:
+            if previous is not None:
+                # Order within a leg. Never propagate the predecessor's
+                # failure — it has already logged for itself.
+                with contextlib.suppress(Exception):
+                    await previous
+            try:
+                await self._handle_vsi_event(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001
+                logger.bind(event_type=event.get("type"), leg_id=key).warning(
+                    f"VSI event handler failed: {e}"
+                )
+
+        task = asyncio.create_task(_chained(), name=f"vsi-event-{key or 'global'}")
+        self._leg_chains[key] = task
+        self._event_tasks.add(task)
+
+        def _done(finished: "asyncio.Task") -> None:
+            self._event_tasks.discard(finished)
+            # Only clear the chain if we are still its tail, so a
+            # follow-up event already queued behind us keeps its ordering.
+            if self._leg_chains.get(key) is finished:
+                self._leg_chains.pop(key, None)
+
+        task.add_done_callback(_done)
+
 
     async def _handle_vsi_event(self, event: dict) -> None:
         """Dispatch one VSI event.

--- a/agents/pipecat/pipecat_aplisay/tool_log.py
+++ b/agents/pipecat/pipecat_aplisay/tool_log.py
@@ -43,6 +43,13 @@ def _truncate_for_log(value: Any) -> Any:
     if isinstance(value, str):
         s = value
     else:
+        # P9: cheap size screen first. Serialising the whole value just
+        # to measure it, twice per tool call, is pure overhead for the
+        # overwhelming majority that are nowhere near the cap — a
+        # container that small cannot serialise past the limit, so skip
+        # the dump entirely. Only the ambiguous ones are measured.
+        if _too_small_to_truncate(value):
+            return value
         try:
             s = json.dumps(value, default=str)
         except Exception:  # noqa: BLE001
@@ -50,6 +57,32 @@ def _truncate_for_log(value: Any) -> Any:
     if len(s) <= _MAX_LOG_VALUE_CHARS:
         return value
     return f"{s[:_MAX_LOG_VALUE_CHARS]}…[truncated {len(s) - _MAX_LOG_VALUE_CHARS} chars]"
+
+
+def _too_small_to_truncate(value: Any) -> bool:
+    """True when ``value`` provably serialises to under the cap.
+
+    A very cheap conservative screen: every JSON scalar is short, and a
+    container with few, short string leaves cannot exceed the limit.
+    Anything else falls through to the real measurement.
+    """
+    if isinstance(value, (int, float, bool)):
+        return True
+    if isinstance(value, dict):
+        items = value.items()
+    elif isinstance(value, (list, tuple)):
+        items = enumerate(value)
+    else:
+        return False
+    budget = _MAX_LOG_VALUE_CHARS // 4
+    total = 0
+    for key, item in items:
+        if not isinstance(item, (str, int, float, bool, type(None))):
+            return False
+        total += len(str(key)) + (len(item) if isinstance(item, str) else 24)
+        if total > budget:
+            return False
+    return True
 
 
 def log_tool_call(*, tool: str, kind: str, arguments: Any) -> None:

--- a/agents/pipecat/pipecat_aplisay/usage.py
+++ b/agents/pipecat/pipecat_aplisay/usage.py
@@ -18,6 +18,7 @@ priced per vendor on either basis.
 
 from __future__ import annotations
 
+from collections import deque
 from typing import Any
 
 from loguru import logger
@@ -33,6 +34,12 @@ from pipecat.observers.base_observer import BaseObserver, FramePushed
 from pipecat.services.stt_service import STTService
 
 from . import api_client
+
+# How many recently-seen frame ids the dedupe window remembers (P8).
+# A frame is re-observed on each push hop within the same pipeline pass,
+# so a few thousand is orders of magnitude more than needed; the cap only
+# exists to stop the set growing with call length.
+_SEEN_FRAME_WINDOW = 4096
 from .voice_mode import model_id_from_name
 
 
@@ -80,7 +87,15 @@ class UsageMeteringObserver(BaseObserver):
         self._meters: dict[str, dict[str, Any]] = {}
         # Observers fire on every push hop, so a frame is seen multiple times;
         # dedupe by frame id to count each frame once.
+        #
+        # Bounded (P8). An unbounded set held one int per frame for the
+        # whole call — ~6-7 MB per hour of bot speech, freed only at
+        # hangup. Duplicate sightings of a frame all happen within a few
+        # push hops of each other, so a short ring of recent ids is as
+        # good as remembering every frame ever seen: the deque evicts
+        # oldest-first and the set mirrors it for O(1) lookup.
         self._seen_frame_ids: set[int] = set()
+        self._seen_frame_order: deque[int] = deque()
         # Open VAD user-speech window start timestamp (seconds), for stt/ms.
         self._vad_start_ts: float | None = None
 
@@ -91,6 +106,9 @@ class UsageMeteringObserver(BaseObserver):
         if frame_id in self._seen_frame_ids:
             return True
         self._seen_frame_ids.add(frame_id)
+        self._seen_frame_order.append(frame_id)
+        if len(self._seen_frame_order) > _SEEN_FRAME_WINDOW:
+            self._seen_frame_ids.discard(self._seen_frame_order.popleft())
         return False
 
     def _resolve(self, technology: str, model: str | None) -> tuple[str | None, str | None]:

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -43,6 +43,22 @@ from .output_rate_guard import OutputRateGuard
 from .tool_log import log_tool_call, log_tool_result
 
 
+# Recording capture rate. The sipbridge WS carries 16 kHz in both
+# directions, so anything higher just doubles the PCM we write and
+# upload for no extra fidelity. Pipecat's own default comes from the
+# StartFrame (24 kHz for the realtime services), which is why this has
+# to be stated explicitly.
+RECORDING_SAMPLE_RATE = 16000
+
+# How much audio the AudioBufferProcessor accumulates before handing it
+# to the recording sink: 5 s of one 16-bit channel. Pipecat's default of
+# 0 means "never flush until stop_recording()", i.e. hold the whole call
+# in memory. Small enough that a long recorded call is bounded, large
+# enough that the write path runs a few times a minute rather than per
+# frame.
+RECORDING_FLUSH_BYTES = RECORDING_SAMPLE_RATE * 2 * 5
+
+
 def _inactivity_timeout_secs(agent: dict) -> Optional[float]:
     """Return the configured inactivity (idle "kick") timeout in seconds, or
     ``None`` when ``options.inactivity`` is absent / malformed.
@@ -958,10 +974,31 @@ async def build_voice_session(
 
     audio_buffer: Optional[AudioBufferProcessor] = None
     if enable_recording:
-        # Stereo, sample rate inherits from whatever the source pipeline
-        # produces. ``num_channels=2`` is the documented "user left / bot
-        # right" layout — matches LiveKit's RecorderIO output exactly.
-        audio_buffer = AudioBufferProcessor(num_channels=2)
+        # Stereo, "user left / bot right" — matches LiveKit's RecorderIO
+        # output exactly.
+        #
+        # ``buffer_size`` and ``sample_rate`` are both load-bearing (W3).
+        # Pipecat's default buffer_size=0 means "only flush on
+        # stop_recording()": both channels accumulate in bytearrays for
+        # the WHOLE call, and the flush then copies them again (bytes()
+        # per track plus the interleaved merge) for a 3–4x transient at
+        # hangup. At the default 24 kHz that is ~96 KB/s per recorded
+        # call — roughly 345 MB for an hour, against a 1 GiB pod limit,
+        # and an OOM kill takes every other call on the node with it.
+        # RecordingSession._append is already written for incremental
+        # delivery (lazy sink open, running bytes_written, disk write off
+        # the loop), so periodic flushes just work.
+        #
+        # Pinning the rate to 16 kHz also matches what the sipbridge path
+        # actually carries, halving the PCM written for no loss of
+        # fidelity; pipecat resets its primary buffers after each flush,
+        # and the sink is append-only, so the encoded OGG stays
+        # contiguous.
+        audio_buffer = AudioBufferProcessor(
+            num_channels=2,
+            sample_rate=RECORDING_SAMPLE_RATE,
+            buffer_size=RECORDING_FLUSH_BYTES,
+        )
 
     aux_tap = _aux_stt_tap_for(agent, on_aux_transcript, on_aux_usage)
     output_tap = _output_stt_tap_for(agent, on_output_transcript, on_output_usage)

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -1400,20 +1400,19 @@ async def _build_realtime(
         processors.append(audio_buffer)
     processors.append(assistant_aggregator)
     pipeline = Pipeline(processors)
+    # F1: the framework's idle watchdog is left ON here deliberately.
+    # pipecat cancels any pipeline that goes 300 s without a
+    # BotSpeakingFrame or UserSpeakingFrame (idle_timeout_secs=300,
+    # cancel_on_idle_timeout and cancel_runner_on_idle_timeout, all on by
+    # default). On a MAIN pipeline that is the backstop we want: 300 s is
+    # comfortably longer than any consult hold, and a pipeline with no
+    # speech in either direction for five minutes is not a call anyone is
+    # still on. Do NOT "fix" this to match the side pipelines, which do
+    # opt out (bridge_transcript, media_relay, fixed_message) because they
+    # emit neither frame by design and were being cancelled mid-use.
     task = PipelineTask(
         pipeline,
         params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
-        # F1: pipecat cancels any pipeline that goes 300 s without a
-        # BotSpeakingFrame or UserSpeakingFrame (idle_timeout_secs=300,
-        # cancel_on_idle_timeout=True, cancel_runner_on_idle_timeout=True
-        # — all on by default). That is a second, undocumented hangup
-        # policy sitting underneath the platform's own: ``maxDuration``
-        # and ``options.inactivity`` are what operators configure, the
-        # LiveKit runtime has no equivalent, and the framework default
-        # fires hardest in the case where the silence is deliberate —
-        # a caller parked on hold while the agent runs a consult. Off,
-        # so inactivity behaviour is the configured behaviour.
-        idle_timeout_secs=None,
     )
     # Inactivity "kick": speak options.inactivity.message after a silent
     # window. Inert unless options.inactivity is configured (the user
@@ -1541,20 +1540,19 @@ async def _build_pipeline(
         processors.append(audio_buffer)
     processors.append(assistant_aggregator)
     pipeline = Pipeline(processors)
+    # F1: the framework's idle watchdog is left ON here deliberately.
+    # pipecat cancels any pipeline that goes 300 s without a
+    # BotSpeakingFrame or UserSpeakingFrame (idle_timeout_secs=300,
+    # cancel_on_idle_timeout and cancel_runner_on_idle_timeout, all on by
+    # default). On a MAIN pipeline that is the backstop we want: 300 s is
+    # comfortably longer than any consult hold, and a pipeline with no
+    # speech in either direction for five minutes is not a call anyone is
+    # still on. Do NOT "fix" this to match the side pipelines, which do
+    # opt out (bridge_transcript, media_relay, fixed_message) because they
+    # emit neither frame by design and were being cancelled mid-use.
     task = PipelineTask(
         pipeline,
         params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
-        # F1: pipecat cancels any pipeline that goes 300 s without a
-        # BotSpeakingFrame or UserSpeakingFrame (idle_timeout_secs=300,
-        # cancel_on_idle_timeout=True, cancel_runner_on_idle_timeout=True
-        # — all on by default). That is a second, undocumented hangup
-        # policy sitting underneath the platform's own: ``maxDuration``
-        # and ``options.inactivity`` are what operators configure, the
-        # LiveKit runtime has no equivalent, and the framework default
-        # fires hardest in the case where the silence is deliberate —
-        # a caller parked on hold while the agent runs a consult. Off,
-        # so inactivity behaviour is the configured behaviour.
-        idle_timeout_secs=None,
     )
     # Inactivity "kick" — pipeline mode pushes the literal phrase straight to
     # TTS. Inert unless options.inactivity is configured.

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -1403,6 +1403,17 @@ async def _build_realtime(
     task = PipelineTask(
         pipeline,
         params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+        # F1: pipecat cancels any pipeline that goes 300 s without a
+        # BotSpeakingFrame or UserSpeakingFrame (idle_timeout_secs=300,
+        # cancel_on_idle_timeout=True, cancel_runner_on_idle_timeout=True
+        # — all on by default). That is a second, undocumented hangup
+        # policy sitting underneath the platform's own: ``maxDuration``
+        # and ``options.inactivity`` are what operators configure, the
+        # LiveKit runtime has no equivalent, and the framework default
+        # fires hardest in the case where the silence is deliberate —
+        # a caller parked on hold while the agent runs a consult. Off,
+        # so inactivity behaviour is the configured behaviour.
+        idle_timeout_secs=None,
     )
     # Inactivity "kick": speak options.inactivity.message after a silent
     # window. Inert unless options.inactivity is configured (the user
@@ -1533,6 +1544,17 @@ async def _build_pipeline(
     task = PipelineTask(
         pipeline,
         params=PipelineParams(enable_metrics=True, enable_usage_metrics=True),
+        # F1: pipecat cancels any pipeline that goes 300 s without a
+        # BotSpeakingFrame or UserSpeakingFrame (idle_timeout_secs=300,
+        # cancel_on_idle_timeout=True, cancel_runner_on_idle_timeout=True
+        # — all on by default). That is a second, undocumented hangup
+        # policy sitting underneath the platform's own: ``maxDuration``
+        # and ``options.inactivity`` are what operators configure, the
+        # LiveKit runtime has no equivalent, and the framework default
+        # fires hardest in the case where the silence is deliberate —
+        # a caller parked on hold while the agent runs a consult. Off,
+        # so inactivity behaviour is the configured behaviour.
+        idle_timeout_secs=None,
     )
     # Inactivity "kick" — pipeline mode pushes the literal phrase straight to
     # TTS. Inert unless options.inactivity is configured.

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -73,6 +73,7 @@ from .call_session import (
     setup_takeover_call,
 )
 from .constants import DISCONNECT_REASONS, PLATFORM
+from . import http_client
 from .invocation_log import flush_invocation_logs, install_capture
 from .output_cushion import install as install_output_cushion
 from .output_underrun import install as install_underrun_stats
@@ -185,6 +186,12 @@ async def lifespan(app: FastAPI):
             await gw_obj.stop()
         except Exception as e:  # noqa: BLE001
             logger.warning(f"sipbridge gateway stop failed: {e}")
+    # Close the shared HTTP pools last — everything above may still want
+    # to make a REST call on the way out.
+    try:
+        await http_client.aclose_all()
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"http client shutdown failed: {e}")
 
 
 async def _ws_deny(websocket: WebSocket, status: int, body: bytes = b"") -> None:
@@ -1705,11 +1712,17 @@ async def sipbridge_agent(websocket: WebSocket, session_id: str) -> None:
         try:
             session = await setup_takeover_call(sip_gateway, ctx, payload=takeover)
         except Exception as e:  # noqa: BLE001
+            # W2: setup_takeover_call registers the gateway session
+            # (transport + WebSocket) before it can fail, so the failure
+            # path has to unregister it — clear_takeover_session alone
+            # left the session, its transport and the closed WebSocket
+            # in the gateway maps for the life of the process.
             logger.bind(session_id=session_id).error(
                 f"sipbridge takeover setup failed: {e}"
             )
             await websocket.close(code=1011)
             sip_gateway.clear_takeover_session(session_id)
+            sip_gateway.unregister_session(session_id)
             return
         sip_gateway.register_inbound_session(
             session_id=session_id,
@@ -1992,10 +2005,20 @@ async def sipbridge_agent(websocket: WebSocket, session_id: str) -> None:
             sip_gateway, ctx, instance=instance, agent=agent
         )
     except Exception as e:  # noqa: BLE001
+        # W2: ``setup_inbound_call`` registers the gateway session
+        # (transport + WebSocket) BEFORE it creates and starts the call,
+        # so every failure after that point leaked one _SbGatewaySession
+        # plus its transport and closed WebSocket. The commonest failure
+        # here is the entirely routine one — the agent is at its
+        # concurrency limit with no fallback message — which means this
+        # leaked hardest exactly when the node was busiest. Second
+        # commonest is an agent-db outage, which leaks one per inbound
+        # call for the duration.
         logger.bind(session_id=ctx.session_id).error(
             f"sipbridge setup_inbound_call failed: {e}"
         )
         await websocket.close(code=1011)
+        sip_gateway.unregister_session(ctx.session_id)
         return
 
     # Register the bridge_call_id → session mapping so REST hangup /

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -734,6 +734,18 @@ async def _run_session(app: FastAPI, session: CallSession, key: str) -> None:
             await api_client.end_call(session.call, reason=DISCONNECT_REASONS["UNCAUGHT_ERROR_RUNNING_AGENT"])
         except Exception as inner:  # noqa: BLE001
             logger.error(f"end_call after failure failed: {inner}")
+        # A setup failure means the pipeline runner never ran, so its
+        # finally never flushed this call's captured logs — and those are
+        # precisely the records that explain the failure. Harmless when
+        # the runner did flush: the drain is a pop, so this finds nothing.
+        try:
+            await flush_invocation_logs(
+                call_id=session.call.id,
+                user_id=session.call.userId,
+                org_id=session.call.organisationId,
+            )
+        except Exception as inner:  # noqa: BLE001
+            logger.warning(f"invocation log flush after failure failed: {inner}")
     finally:
         app.state.live_calls.pop(key, None)
         # W7: calls_by_channel (FreeSWITCH only) was inserted into on

--- a/agents/pipecat/pipecat_aplisay/worker.py
+++ b/agents/pipecat/pipecat_aplisay/worker.py
@@ -163,6 +163,11 @@ async def lifespan(app: FastAPI):
         raise RuntimeError(f"unsupported SIP_GATEWAY={gateway_name!r}")
     app.state.live_calls: dict[str, CallSession] = {}
     app.state.calls_by_channel: dict[str, str] = {}
+    # W10: asyncio keeps only WEAK references to tasks, so a
+    # fire-and-forget ``create_task`` can be collected mid-flight if
+    # nothing else happens to be awaiting it. Hold them here (and drop
+    # them on completion), which also gives /healthz a real task count.
+    app.state.tasks: set[asyncio.Task] = set()
     # Live browser WebRTC peers keyed by pc_id, so trickle-ICE PATCHes and
     # renegotiation can find the connection a prior /webrtc/offer created.
     app.state.webrtc_connections: dict[str, SmallWebRTCConnection] = {}
@@ -531,6 +536,13 @@ app.add_middleware(
 # healthy baseline on a SIP node is ~1-2 concurrent sessions and ~25 threads).
 HEALTHZ_MAX_SESSIONS = int(os.environ.get("HEALTHZ_MAX_SESSIONS", "64"))
 HEALTHZ_MAX_THREADS = int(os.environ.get("HEALTHZ_MAX_THREADS", "400"))
+# Per-call gateway map entries, summed across the maps below. A healthy
+# node holds a handful per live call; a few hundred means state is being
+# registered and never released.
+HEALTHZ_MAX_GATEWAY_ENTRIES = int(os.environ.get("HEALTHZ_MAX_GATEWAY_ENTRIES", "512"))
+# Tracked background tasks (call runners and their helpers). Comfortably
+# above any real concurrency; a climb here is a task that never returns.
+HEALTHZ_MAX_TASKS = int(os.environ.get("HEALTHZ_MAX_TASKS", "256"))
 
 
 @app.get("/healthz")
@@ -565,22 +577,70 @@ async def healthz(request: Request) -> JSONResponse:
         threads = len(os.listdir("/proc/self/task"))
     except OSError:  # non-Linux dev hosts
         threads = threading.active_count()
+    # Accumulation this endpoint could not previously see. The two worst
+    # leaks in the audit (a parked WS handler per outbound call, and a
+    # gateway session per concurrency-refused inbound call) were both
+    # invisible here: neither touches live_calls, and neither spawns a
+    # thread. Tasks and the gateway's own maps are where they showed.
+    tasks = len(getattr(request.app.state, "tasks", ()) or ())
+    gateway_maps = _gateway_map_sizes(getattr(request.app.state, "sip_gateway", None))
+    gateway_total = sum(gateway_maps.values())
     if live_calls > HEALTHZ_MAX_SESSIONS:
         problems.append(f"live_calls={live_calls} above {HEALTHZ_MAX_SESSIONS}")
     if peers > HEALTHZ_MAX_SESSIONS:
         problems.append(f"webrtc_connections={peers} above {HEALTHZ_MAX_SESSIONS}")
     if threads > HEALTHZ_MAX_THREADS:
         problems.append(f"threads={threads} above {HEALTHZ_MAX_THREADS}")
+    if gateway_total > HEALTHZ_MAX_GATEWAY_ENTRIES:
+        problems.append(
+            f"gateway map entries={gateway_total} above "
+            f"{HEALTHZ_MAX_GATEWAY_ENTRIES} ({gateway_maps})"
+        )
+    if tasks > HEALTHZ_MAX_TASKS:
+        problems.append(f"asyncio tasks={tasks} above {HEALTHZ_MAX_TASKS}")
     return JSONResponse(
         {
             "ok": not problems,
             "live_calls": live_calls,
             "webrtc_connections": peers,
             "threads": threads,
+            "tasks": tasks,
+            "all_tasks": len(asyncio.all_tasks()),
+            "gateway_maps": gateway_maps,
             "problems": problems,
         },
         status_code=200 if not problems else 503,
     )
+
+
+#: Gateway attributes that hold per-call state. Reported individually on
+#: /healthz so a leak is attributable to the path that caused it rather
+#: than showing up as an unexplained memory climb.
+_GATEWAY_MAP_ATTRS = (
+    "_sessions",
+    "_session_to_bridge_call",
+    "_leg_done_events",
+    "_consult_payloads",
+    "_consult_call_ids",
+    "_takeover_payloads",
+    "_pending_outbound",
+    "pending_attaches",
+)
+
+
+def _gateway_map_sizes(gateway: Any) -> dict[str, int]:
+    """Sizes of the active gateway's per-call maps, for /healthz."""
+    sizes: dict[str, int] = {}
+    if gateway is None:
+        return sizes
+    for attr in _GATEWAY_MAP_ATTRS:
+        container = getattr(gateway, attr, None)
+        if container is not None:
+            try:
+                sizes[attr.lstrip("_")] = len(container)
+            except TypeError:
+                continue
+    return sizes
 
 
 @app.post("/dispatch")
@@ -643,8 +703,24 @@ async def _handle_outbound_dispatch(app: FastAPI, payload: dict) -> dict:
     if channel_uuid:
         app.state.calls_by_channel[channel_uuid] = payload["callId"]
 
-    asyncio.create_task(_run_session(app, session, payload["callId"]))
+    _spawn(app, _run_session(app, session, payload["callId"]), name=f"call-{payload['callId']}")
     return {"ok": True, "callId": payload["callId"]}
+
+
+def _spawn(app: FastAPI, coro, *, name: str) -> asyncio.Task:
+    """Start a background task and hold a strong reference to it (W10).
+
+    ``asyncio`` keeps only weak references to tasks: a plain
+    ``create_task`` whose result nobody awaits can be garbage-collected
+    mid-flight, and today these survive only because of whatever they
+    happen to be awaiting. The set also gives ``/healthz`` an honest
+    count of the work the worker has in flight.
+    """
+    task = asyncio.create_task(coro, name=name)
+    tasks: set = app.state.tasks
+    tasks.add(task)
+    task.add_done_callback(tasks.discard)
+    return task
 
 
 async def _run_session(app: FastAPI, session: CallSession, key: str) -> None:
@@ -660,6 +736,12 @@ async def _run_session(app: FastAPI, session: CallSession, key: str) -> None:
             logger.error(f"end_call after failure failed: {inner}")
     finally:
         app.state.live_calls.pop(key, None)
+        # W7: calls_by_channel (FreeSWITCH only) was inserted into on
+        # three paths and popped on none — one uuid → call-id pair per
+        # call, for the life of the process.
+        channel_uuid = getattr(session.gateway_session, "channel_uuid", None)
+        if channel_uuid:
+            app.state.calls_by_channel.pop(channel_uuid, None)
         try:
             await session.gateway_session.shutdown()
         except Exception as e:  # noqa: BLE001
@@ -732,7 +814,11 @@ async def daily_dialin(request: Request) -> dict:
     )
     request.app.state.live_calls[session.call.id] = session
 
-    asyncio.create_task(_run_session(request.app, session, session.call.id))
+    _spawn(
+        request.app,
+        _run_session(request.app, session, session.call.id),
+        name=f"call-{session.call.id}",
+    )
 
     # Respond with the Daily room so Daily can pinlessCallUpdate the caller in.
     return {"room_url": room_url, "sip_endpoint": dialin.get("sip_endpoint")}
@@ -1005,7 +1091,7 @@ async def webrtc_offer(request: Request) -> JSONResponse:
         startup_error["exception"] = getattr(error_frame, "exception", None)
         error_event.set()
 
-    session_task = asyncio.create_task(_run_browser_session())
+    session_task = _spawn(request.app, _run_browser_session(), name=f"webrtc-{call.id}")
 
     started_waiter = asyncio.create_task(started_event.wait())
     error_waiter = asyncio.create_task(error_event.wait())
@@ -1046,14 +1132,29 @@ async def webrtc_offer(request: Request) -> JSONResponse:
         # gets a chance to run (end_call + gateway shutdown). Bound the
         # wait so a misbehaving runner can't stall the HTTP response.
         session_task.cancel()
+        cancelled = True
         try:
             await asyncio.wait_for(session_task, timeout=2.0)
-        except (asyncio.CancelledError, asyncio.TimeoutError):
+        except asyncio.TimeoutError:
+            # W9: the pipeline is STILL RUNNING. pipecat's own cancel
+            # budget is longer than this 2 s wait, so popping live_calls
+            # here would hide a live pipeline from /healthz and from
+            # every operator tool — the runner's own finally does the
+            # pop when it finally unwinds. Leave it in place; the task
+            # is held in app.state.tasks either way.
+            cancelled = False
+            logger.bind(call_id=call.id).warning(
+                "webrtc session still cancelling after 2s; leaving it "
+                "registered so it stays visible until its own teardown runs"
+            )
+        except asyncio.CancelledError:
             pass
         except Exception:  # noqa: BLE001
             pass
-        # Defensive cleanup in case the runner's finally didn't fire.
-        request.app.state.live_calls.pop(call.id, None)
+        # Defensive cleanup in case the runner's finally didn't fire —
+        # only once we know it has actually stopped.
+        if cancelled:
+            request.app.state.live_calls.pop(call.id, None)
         try:
             await api_client.end_call(call, reason=f"startup failed: {detail}")
         except Exception:  # noqa: BLE001

--- a/agents/pipecat/sipbridge/cmd/sipbridge/main.go
+++ b/agents/pipecat/sipbridge/cmd/sipbridge/main.go
@@ -25,6 +25,12 @@ import (
 	sipx "github.com/aplisay/llm-agent/agents/pipecat/sipbridge/internal/sip"
 )
 
+// drainTimeout bounds the whole SIGTERM shutdown: BYE every live call,
+// then drain the API server. Keep it comfortably under the pod's
+// terminationGracePeriodSeconds (default 30 s) so the process exits on
+// its own rather than being SIGKILLed mid-drain.
+const drainTimeout = 20 * time.Second
+
 func main() {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
 	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339}).
@@ -175,7 +181,7 @@ func main() {
 
 	select {
 	case <-ctx.Done():
-		log.Info().Msg("sipbridge: signal received, shutting down")
+		log.Info().Msg("sipbridge: signal received, draining")
 	case err := <-errCh:
 		if err != nil {
 			log.Error().Err(err).Msg("sipbridge: component failed, shutting down")
@@ -185,8 +191,18 @@ func main() {
 
 	// Graceful shutdown — bound it so a stuck connection doesn't pin
 	// the process forever.
-	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), drainTimeout)
 	defer cancelShutdown()
+	// Drain before anything else: stop answering new INVITEs (503 +
+	// Retry-After, so the upstream re-routes) and then BYE every live
+	// dialog. Without this a rolling update abandons every call on the
+	// node without signalling — the carrier holds its channels until
+	// its own timers expire, and the worker only finds out when its
+	// WebSocket dies.
+	sipSrv.Drain()
+	if n := mgr.HangupAll(shutdownCtx); n > 0 {
+		log.Info().Int("calls", n).Msg("sipbridge: drained active calls")
+	}
 	if err := apiSrv.Shutdown(shutdownCtx); err != nil {
 		log.Warn().Err(err).Msg("api: shutdown")
 	}

--- a/agents/pipecat/sipbridge/internal/api/health_test.go
+++ b/agents/pipecat/sipbridge/internal/api/health_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aplisay/llm-agent/agents/pipecat/sipbridge/internal/call"
+)
+
+// The k8s preStop drain hook matches on the literal substring
+// `"active_calls":0` in this body, so the encoding must stay compact and
+// the key must keep its name.
+func TestHealthBodyIsDrainHookParseable(t *testing.T) {
+	s := New(call.New(call.Config{}), "127.0.0.1:0", "")
+	rec := httptest.NewRecorder()
+	s.handleHealth(rec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	body := rec.Body.String()
+	if !strings.Contains(body, `"active_calls":0`) {
+		t.Fatalf("health body = %q; the preStop drain hook greps for \"active_calls\":0", body)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		t.Fatalf("health body is not JSON: %v", err)
+	}
+	for _, key := range []string{"ok", "active_calls", "draining", "goroutines"} {
+		if _, ok := parsed[key]; !ok {
+			t.Errorf("health body missing %q", key)
+		}
+	}
+	if parsed["draining"] != false {
+		t.Errorf("draining = %v on a fresh server; want false", parsed["draining"])
+	}
+}

--- a/agents/pipecat/sipbridge/internal/api/server.go
+++ b/agents/pipecat/sipbridge/internal/api/server.go
@@ -1,12 +1,14 @@
 // Package api implements sipbridge's HTTP control surface.
 //
 // Phase A endpoints:
-//   GET  /health            liveness + active-call count
-//   DELETE /v1/calls/{id}   hangup (caller-initiated)
+//
+//	GET  /health            liveness + active-call count
+//	DELETE /v1/calls/{id}   hangup (caller-initiated)
 //
 // Phase B adds:
-//   POST /v1/calls          outbound originate
-//   POST /v1/calls/{id}/transfer  blind / attended REFER
+//
+//	POST /v1/calls          outbound originate
+//	POST /v1/calls/{id}/transfer  blind / attended REFER
 //
 // All endpoints require a Bearer token if SIPBRIDGE_API_TOKEN is set
 // in the environment; auth is disabled when the token is empty for
@@ -18,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 
@@ -45,9 +48,15 @@ func New(mgr *call.Manager, addr, token string) *Server {
 	mux.HandleFunc("POST /v1/calls/{id}/dtmf", s.handleDTMF)
 
 	s.hs = &http.Server{
-		Addr:              addr,
-		Handler:           s.withAuth(mux),
+		Addr:    addr,
+		Handler: s.withAuth(mux),
+		// Full request/response timeouts, not just the header read:
+		// without them a client that opens a connection and stalls
+		// mid-body holds a goroutine and a connection indefinitely.
 		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      90 * time.Second, // > the 60 s consult ceiling
+		IdleTimeout:       120 * time.Second,
 	}
 	return s
 }
@@ -75,14 +84,26 @@ func (s *Server) withAuth(next http.Handler) http.Handler {
 				return
 			}
 		}
+		// Cap the request body for every handler. These are small JSON
+		// control messages (the largest carries an agent's custom SIP
+		// headers); without a cap a bad or hostile client can stream
+		// unbounded data into json.Decode.
+		r.Body = http.MaxBytesReader(w, r.Body, maxRequestBody)
 		next.ServeHTTP(w, r)
 	})
 }
 
+// maxRequestBody caps the JSON control bodies this API accepts. 1 MiB
+// is far above the largest real request (an originate carrying custom
+// SIP headers) and far below anything that could pressure the heap.
+const maxRequestBody = 1 << 20
+
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
-		"ok":            true,
-		"active_calls":  len(s.mgr.ActiveCallIDs()),
+		"ok":           true,
+		"active_calls": len(s.mgr.ActiveCallIDs()),
+		"draining":     s.mgr.Draining(),
+		"goroutines":   runtime.NumGoroutine(),
 	})
 }
 
@@ -105,11 +126,11 @@ func (s *Server) handleHangup(w http.ResponseWriter, r *http.Request) {
 // promoted to X-Aplisay-Call-Id automatically by the call manager so
 // callers don't have to duplicate it in both places.
 type originateBody struct {
-	Destination       string            `json:"destination"`
-	CallerID          string            `json:"caller_id"`
-	AgentWSSessionID  string            `json:"agent_ws_session_id"`
-	CustomHeaders     map[string]string `json:"custom_headers"`
-	Metadata          map[string]string `json:"metadata"`
+	Destination      string            `json:"destination"`
+	CallerID         string            `json:"caller_id"`
+	AgentWSSessionID string            `json:"agent_ws_session_id"`
+	CustomHeaders    map[string]string `json:"custom_headers"`
+	Metadata         map[string]string `json:"metadata"`
 }
 
 func (s *Server) handleOriginate(w http.ResponseWriter, r *http.Request) {
@@ -223,7 +244,7 @@ func (s *Server) handleTransfer(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"ok":           true,
+			"ok":            true,
 			"relay_call_id": relayID,
 		})
 		return
@@ -284,11 +305,11 @@ func (s *Server) handleUnbridge(w http.ResponseWriter, r *http.Request) {
 // id, which the worker passes back as ``target`` (mode "bridged") to
 // /transfer when ready to finalize.
 type consultBody struct {
-	Destination       string            `json:"destination"`
-	CallerID          string            `json:"caller_id"`
-	AgentWSSessionID  string            `json:"agent_ws_session_id"`
-	CustomHeaders     map[string]string `json:"custom_headers"`
-	Metadata          map[string]string `json:"metadata"`
+	Destination      string            `json:"destination"`
+	CallerID         string            `json:"caller_id"`
+	AgentWSSessionID string            `json:"agent_ws_session_id"`
+	CustomHeaders    map[string]string `json:"custom_headers"`
+	Metadata         map[string]string `json:"metadata"`
 }
 
 func (s *Server) handleConsult(w http.ResponseWriter, r *http.Request) {
@@ -315,19 +336,19 @@ func (s *Server) handleConsult(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	consultID, err := s.mgr.Consult(ctx, call.ConsultParams{
-		OriginalCallID:  id,
-		Destination:     body.Destination,
-		CallerID:        body.CallerID,
-		AgentSessionID:  body.AgentWSSessionID,
-		CustomHeaders:   body.CustomHeaders,
-		Metadata:        body.Metadata,
+		OriginalCallID: id,
+		Destination:    body.Destination,
+		CallerID:       body.CallerID,
+		AgentSessionID: body.AgentWSSessionID,
+		CustomHeaders:  body.CustomHeaders,
+		Metadata:       body.Metadata,
 	})
 	if err != nil {
 		writeErr(w, http.StatusBadGateway, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusCreated, map[string]any{
-		"ok":             true,
+		"ok":              true,
 		"consult_call_id": consultID,
 	})
 }

--- a/agents/pipecat/sipbridge/internal/call/manager.go
+++ b/agents/pipecat/sipbridge/internal/call/manager.go
@@ -154,6 +154,51 @@ func (m *Manager) ActiveCallIDs() []string {
 	return out
 }
 
+// byeTimeout bounds how long a hangup will wait for the far end to
+// answer our BYE. sipgo's own Timer B fires at 32 s; anything past
+// that is a peer that is never going to respond, and we must not hold
+// the caller's goroutine (or, before the reordering below, its RTP
+// port) hostage to it.
+const byeTimeout = 35 * time.Second
+
+// HangupAll tears down every live call, in parallel, and waits for them
+// all (bounded by ctx). Used by the SIGTERM drain so a rolling update
+// releases the carrier's channels and the worker's sessions instead of
+// abandoning every dialog without a BYE. Returns how many it hung up.
+func (m *Manager) HangupAll(ctx context.Context) int {
+	ids := m.ActiveCallIDs()
+	if len(ids) == 0 {
+		return 0
+	}
+	log.Info().Int("calls", len(ids)).Msg("call: hanging up all active calls (drain)")
+	var wg sync.WaitGroup
+	for _, id := range ids {
+		wg.Add(1)
+		go func(callID string) {
+			defer wg.Done()
+			_ = m.Hangup(ctx, callID)
+		}(id)
+	}
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		log.Warn().Msg("call: drain deadline reached with hangups still in flight")
+	}
+	return len(ids)
+}
+
+// Draining reports whether the SIP layer has stopped accepting new
+// calls (SIGTERM drain). Surfaced on /health so a readiness probe can
+// take the node out of rotation.
+func (m *Manager) Draining() bool {
+	if m.sip == nil {
+		return false
+	}
+	return m.sip.Draining()
+}
+
 // Hangup terminates an active call by its SIP Call-ID. Tears down the
 // media path and sends a SIP BYE in whichever direction the dialog
 // has. Idempotent — multiple calls for the same id are silently fine.
@@ -169,12 +214,28 @@ func (m *Manager) Hangup(ctx context.Context, callID string) error {
 		log.Warn().Str("call_id", callID).Msg("call: hangup for unknown call_id — already torn down?")
 		return fmt.Errorf("call: unknown call_id %q", callID)
 	}
-	// SIP-side BYE first so the far end starts terminating; then
-	// release our local media. Errors on BYE are non-fatal — we
-	// continue with media teardown either way.
+	// A bridged pair lives and dies together, exactly as in onBye:
+	// detach the peer here so it is torn down alongside this leg
+	// rather than being left with dead air until its own media
+	// timeout. Reachable via DELETE /v1/calls/{id} on a bridged leg
+	// and from DialAndBridge's failure path.
+	c.mu.Lock()
+	peer := c.peer
+	c.peer = nil
+	c.mu.Unlock()
+	// Release local media BEFORE the BYE. The BYE can take up to
+	// sipgo's Timer B (32 s) against a peer that never responds, and
+	// media release must never be held hostage to signalling: the RTP
+	// port, readLoop, pacer and jitter loop would all stay alive for
+	// the duration, and the pacer would keep sending silence to a
+	// dead address. Close() is idempotent.
+	c.Close()
 	if m.sip != nil {
 		log.Info().Str("call_id", callID).Msg("call: sending BYE upstream")
-		if err := m.sip.Hangup(ctx, callID); err != nil {
+		byeCtx, cancel := context.WithTimeout(ctx, byeTimeout)
+		err := m.sip.Hangup(byeCtx, callID)
+		cancel()
+		if err != nil {
 			log.Warn().Err(err).Str("call_id", callID).Msg("call: BYE failed during hangup")
 		} else {
 			log.Info().Str("call_id", callID).Msg("call: BYE upstream complete")
@@ -182,7 +243,10 @@ func (m *Manager) Hangup(ctx context.Context, callID string) error {
 	} else {
 		log.Warn().Str("call_id", callID).Msg("call: no SIP layer registered — skipping BYE")
 	}
-	c.Close()
+	if peer != nil {
+		peer.ClearPeer()
+		_ = m.Hangup(context.Background(), peer.callID)
+	}
 	return nil
 }
 
@@ -218,11 +282,11 @@ func (m *Manager) SendDTMF(callID, digits string) error {
 // OriginateParams carries everything the REST `POST /v1/calls` body
 // needs to feed to ``Originate``.
 type OriginateParams struct {
-	Destination     string            // SIP URI or bare number
-	CallerID        string            // From: User part
-	AgentSessionID  string            // session_id to use in the worker WS URL
-	CustomHeaders   map[string]string // X-Aplisay-* etc.
-	Metadata        map[string]string // free-form; included as X-Aplisay-Call-Id when present
+	Destination    string            // SIP URI or bare number
+	CallerID       string            // From: User part
+	AgentSessionID string            // session_id to use in the worker WS URL
+	CustomHeaders  map[string]string // X-Aplisay-* etc.
+	Metadata       map[string]string // free-form; included as X-Aplisay-Call-Id when present
 }
 
 // buildOutboundOffer builds the SDP offer for an outbound INVITE on ``rtpSess``.
@@ -315,10 +379,23 @@ func (m *Manager) srtpRecentlyRejected(key string) bool {
 }
 
 // noteSRTPRejected records that the route just rejected an SRTP offer.
+//
+// Also sweeps the whole map. Reads prune only the key being looked up,
+// which is fine for the fixed trunk/registration keys but not for the
+// per-destination ``dest:<uri>`` ones — those accumulate one entry per
+// distinct destination that ever rejected SRTP and are never read
+// again. The map is tiny and writes are rare (only on a rejection), so
+// a full sweep here costs nothing.
 func (m *Manager) noteSRTPRejected(key string) {
 	m.srtpAvoidMu.Lock()
 	defer m.srtpAvoidMu.Unlock()
-	m.srtpAvoid[key] = time.Now()
+	now := time.Now()
+	for k, at := range m.srtpAvoid {
+		if now.Sub(at) > srtpAvoidTTL {
+			delete(m.srtpAvoid, k)
+		}
+	}
+	m.srtpAvoid[key] = now
 }
 
 // dialAndWireRTP performs the SIP-dial + RTP-socket + codec/SRTP
@@ -472,6 +549,8 @@ func (m *Manager) dialAndWireRTP(ctx context.Context, p OriginateParams) (*Call,
 		payload: pt,
 		closed:  make(chan struct{}),
 	}
+	outCallID := out.CallID
+	c.hangup = func() { _ = m.Hangup(context.Background(), outCallID) }
 	c.lastRTPNanos.Store(time.Now().UnixNano())
 	return c, custom, nil
 }
@@ -509,9 +588,9 @@ func (m *Manager) Originate(ctx context.Context, p OriginateParams) (string, err
 	}
 
 	pc := pcclient.NewClient(wsURL)
-	c.ws = pc
+	c.setWS(pc)
 	releaseCtx, releaseCancel := context.WithCancel(context.Background())
-	c.releaseStop = releaseCancel
+	c.setReleaseStop(releaseCancel)
 	c.startJitterRelease(releaseCtx)
 	c.startPacer(releaseCtx, m.cfg.RTPSilenceFill)
 	outCallID := c.callID
@@ -531,7 +610,7 @@ func (m *Manager) Originate(ctx context.Context, p OriginateParams) (string, err
 			return
 		}
 		log.Info().Str("call_id", outCallID).Err(err).Msg("call: ws closed (outbound)")
-		c.Close()
+		c.teardown()
 	})
 
 	// Stamp the same headers we sent on the INVITE onto the WS so the
@@ -546,9 +625,20 @@ func (m *Manager) Originate(ctx context.Context, p OriginateParams) (string, err
 	dctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := pc.Connect(dctx, hdr); err != nil {
-		c.rtp.Close()
+		c.Close()
 		_ = m.sip.Hangup(ctx, c.callID)
 		return "", fmt.Errorf("call: pipecat ws connect: %w", err)
+	}
+
+	// Same early-close check as the inbound path: the worker can accept
+	// the upgrade and then close immediately with a 4xxx code carrying
+	// the real rejection. Without it the close handler fires before the
+	// registration below and we register an already-closed Call that
+	// nothing will ever BYE.
+	if pc.WaitForEarlyClose(300 * time.Millisecond) {
+		c.Close()
+		_ = m.sip.Hangup(ctx, c.callID)
+		return "", fmt.Errorf("call: pipecat ws closed immediately: %w", pc.CloseErr())
 	}
 
 	c.rtp.Start(context.Background())
@@ -587,6 +677,7 @@ func (m *Manager) Originate(ctx context.Context, p OriginateParams) (string, err
 //     ``docs/call-transfers.md``.
 //   - mode "consult": invalid for the transfer endpoint — clients
 //     should call the dedicated /v1/calls/{id}/consult endpoint.
+//
 // ``opts`` applies to mode "bridged" only — see BridgeOptions.
 func (m *Manager) Transfer(ctx context.Context, callID, target, mode string, opts BridgeOptions) error {
 	if m.sip == nil {
@@ -661,16 +752,27 @@ func (m *Manager) BridgeRelay(callA, callB string, opts BridgeOptions) error {
 	a.mu.Lock()
 	a.dtmfMonitor = opts.MonitorDTMF
 	a.mu.Unlock()
-	if opts.TapAudio && a.ws != nil {
-		mixer := newTapMixer(a.ws)
+	if aWS := a.currentWS(); opts.TapAudio && aWS != nil {
+		mixer := newTapMixer(aWS)
+		// Swapping in a new mixer must stop the old one: a repeated
+		// bridge for the same pair would otherwise leave the previous
+		// tapMixer's goroutine running with no way to reach it.
 		a.mu.Lock()
+		prevA := a.tap
 		a.tap = mixer
 		a.tapSide = tapSideCaller
 		a.mu.Unlock()
 		b.mu.Lock()
+		prevB := b.tap
 		b.tap = mixer
 		b.tapSide = tapSideTarget
 		b.mu.Unlock()
+		if prevA != nil {
+			prevA.Stop()
+		}
+		if prevB != nil && prevB != prevA {
+			prevB.Stop()
+		}
 	}
 	a.SetPeer(b, keepWS)
 	b.SetPeer(a, false)
@@ -768,9 +870,9 @@ func (m *Manager) DialAndBridge(ctx context.Context, p DialBridgeParams) (string
 // new bot pipeline can take the caller over. This is the finalise step
 // of a bridged transfer-to-agent (options.bridgedTransferToAgent).
 type UnbridgeParams struct {
-	CallID           string
-	AgentSessionID   string
-	CustomHeaders    map[string]string
+	CallID         string
+	AgentSessionID string
+	CustomHeaders  map[string]string
 }
 
 // Unbridge reverses a bridged transfer on the monitoring leg: the peer
@@ -801,7 +903,7 @@ func (m *Manager) Unbridge(ctx context.Context, p UnbridgeParams) error {
 
 	// 1. Retire the old monitor WS while the relay guard (hasPeer) is
 	// still active, so its close handler doesn't tear the call down.
-	if old := c.ws; old != nil {
+	if old := c.currentWS(); old != nil {
 		old.Stop()
 		select {
 		case <-old.Done():
@@ -835,7 +937,7 @@ func (m *Manager) Unbridge(ctx context.Context, p UnbridgeParams) error {
 			return
 		}
 		log.Info().Str("call_id", unbridgedID).Err(err).Msg("call: ws closed (post-unbridge)")
-		c.Close()
+		c.teardown()
 	})
 	hdr := http.Header{}
 	hdr.Set("X-Sipbridge-Call-ID", c.callID)
@@ -862,7 +964,9 @@ func (m *Manager) Unbridge(ctx context.Context, p UnbridgeParams) error {
 	}
 	c.mu.Unlock()
 	releaseCtx, releaseCancel := context.WithCancel(context.Background())
-	c.releaseStop = releaseCancel
+	if prev := c.setReleaseStop(releaseCancel); prev != nil {
+		prev()
+	}
 	c.startJitterRelease(releaseCtx)
 	c.startPacer(releaseCtx, m.cfg.RTPSilenceFill)
 
@@ -882,12 +986,12 @@ func (m *Manager) Unbridge(ctx context.Context, p UnbridgeParams) error {
 // resulting consult call_id so the worker can use it later as the
 // ``target`` of a bridged transfer.
 type ConsultParams struct {
-	OriginalCallID  string
-	Destination     string
-	CallerID        string
-	AgentSessionID  string
-	CustomHeaders   map[string]string
-	Metadata        map[string]string
+	OriginalCallID string
+	Destination    string
+	CallerID       string
+	AgentSessionID string
+	CustomHeaders  map[string]string
+	Metadata       map[string]string
 }
 
 // Consult dials a second SIP leg for the consult phase of a warm
@@ -998,8 +1102,9 @@ func (m *Manager) onInvite(
 		closed:    make(chan struct{}),
 	}
 	c.lastRTPNanos.Store(time.Now().UnixNano())
+	c.hangup = func() { _ = m.Hangup(context.Background(), callID) }
 	releaseCtx, releaseCancel := context.WithCancel(context.Background())
-	c.releaseStop = releaseCancel
+	c.setReleaseStop(releaseCancel)
 	c.startJitterRelease(releaseCtx)
 	c.startPacer(releaseCtx, m.cfg.RTPSilenceFill)
 	inCallID := callID
@@ -1019,7 +1124,7 @@ func (m *Manager) onInvite(
 			return
 		}
 		log.Info().Str("call_id", callID).Err(err).Msg("call: ws closed")
-		c.Close()
+		c.teardown()
 	})
 
 	// 5. Open the WS (with a short timeout to keep the SIP transaction
@@ -1069,7 +1174,12 @@ func (m *Manager) onInvite(
 	dctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	if err := pc.Connect(dctx, hdr); err != nil {
-		rtpSess.Close()
+		// c.Close(), not rtpSess.Close(): the jitter-release loop, the
+		// pacer and the media watchdog were all started above, and
+		// only Close cancels them. Closing the RTP session alone left
+		// one 20 ms ticker goroutine per rejected INVITE running for
+		// the life of the process.
+		c.Close()
 		return nil, mapWSDialErrorToReject(err)
 	}
 
@@ -1084,7 +1194,7 @@ func (m *Manager) onInvite(
 	// real audio start-up is much slower so we don't risk false
 	// positives here.
 	if pc.WaitForEarlyClose(300 * time.Millisecond) {
-		rtpSess.Close()
+		c.Close() // see above: releases the loops, not just the socket
 		return nil, mapEarlyCloseToReject(pc.CloseErr())
 	}
 
@@ -1611,8 +1721,8 @@ type Call struct {
 	// amounts of network jitter and absorbs occasional reordering;
 	// gaps are filled with silence packets. ``releaseStop`` cancels
 	// the release-loop goroutine on call close.
-	jb           *rtp.JitterBuffer
-	releaseStop  context.CancelFunc
+	jb          *rtp.JitterBuffer
+	releaseStop context.CancelFunc
 
 	// outPacer is the egress mirror of jb: worker WS audio arrives at up
 	// to 2× real-time (Pipecat's transport design), so onWSAudio enqueues
@@ -1684,6 +1794,76 @@ type Call struct {
 	// the watchdog goroutine is started; nil-safe (Close handles
 	// both states).
 	mediaTimeoutStop context.CancelFunc
+
+	// hangup is the manager-level teardown for this call — BYE
+	// upstream, registry delete, peer teardown, media release —
+	// closed over the Manager at construction. The failure paths deep
+	// in the WS and media goroutines need it: a plain ``Close()``
+	// there releases our media but leaves the dialog up from the
+	// peer's perspective and leaves the call in both registries
+	// forever (``/health active_calls`` drifts up for the life of the
+	// process). See the comment on startMediaTimeoutWatchdog, which
+	// has always taken the same closure. Nil in unit tests that build
+	// a bare Call; ``teardown`` is nil-safe.
+	hangup func()
+}
+
+// currentWS returns the call's worker WebSocket under the lock. The
+// field is swapped on the unbridge path (bridged transfer → agent
+// re-attach) while the media goroutines are reading it, so every read
+// outside the constructor goes through here.
+func (c *Call) currentWS() *pcclient.Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ws
+}
+
+// setWS installs a new worker WebSocket and returns the one it
+// replaced (the caller decides whether to stop it).
+func (c *Call) setWS(ws *pcclient.Client) *pcclient.Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	prev := c.ws
+	c.ws = ws
+	return prev
+}
+
+// takeReleaseStop hands over the jitter-release/pacer cancel function
+// and clears it, so the loops are cancelled exactly once. SetPeer,
+// Unbridge and Close all race for this on a bridged call.
+func (c *Call) takeReleaseStop() context.CancelFunc {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	stop := c.releaseStop
+	c.releaseStop = nil
+	return stop
+}
+
+// setReleaseStop installs the cancel for a freshly-started release
+// loop, returning any previous one the caller must cancel.
+func (c *Call) setReleaseStop(stop context.CancelFunc) context.CancelFunc {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	prev := c.releaseStop
+	c.releaseStop = stop
+	return prev
+}
+
+// teardown is the failure-path exit for a call: release media
+// immediately, then run the manager-level hangup (BYE + registry
+// delete + peer teardown) on a detached goroutine.
+//
+// The goroutine matters. teardown is called from the WS close handler,
+// the RTP read loop, the jitter-release loop and the pacer — the very
+// goroutines that need to exit — and the BYE inside Hangup can block
+// until sipgo's Timer B against a peer that never answers. Close()
+// first, so media is always released synchronously and the ordering
+// matches what these call sites did before.
+func (c *Call) teardown() {
+	c.Close()
+	if c.hangup != nil {
+		go c.hangup()
+	}
 }
 
 // SendDTMF plays a string of DTMF digits to the far end of this call as
@@ -1715,12 +1895,11 @@ func (c *Call) SetPeer(peer *Call, keepWS bool) {
 	}
 	c.mu.Unlock()
 	// Stop the release ticker; relay mode owns the inbound path now.
-	if c.releaseStop != nil {
-		c.releaseStop()
-		c.releaseStop = nil
+	if stop := c.takeReleaseStop(); stop != nil {
+		stop()
 	}
-	if c.ws != nil && !keepWS {
-		c.ws.Stop()
+	if ws := c.currentWS(); ws != nil && !keepWS {
+		ws.Stop()
 	}
 }
 
@@ -1808,7 +1987,7 @@ func (c *Call) onRTPPayload(pt rtp.PayloadType, seq uint16, payload []byte, _ bo
 				Str("from", c.callID).
 				Str("to", peer.callID).
 				Msg("call: relay forward failed")
-			c.Close()
+			c.teardown()
 			return
 		}
 		// Transcription tap (tap_audio): push a decoded COPY of this
@@ -1868,10 +2047,11 @@ func (c *Call) handleDTMF(payload []byte) {
 		`{"type":"dtmf","digit":%q,"duration_ms":%d,"call_id":%q}`,
 		string(sym), durationMS, c.callID,
 	)
-	if c.ws == nil {
+	ws := c.currentWS()
+	if ws == nil {
 		return
 	}
-	if err := c.ws.SendMessage(msg); err != nil {
+	if err := ws.SendMessage(msg); err != nil {
 		log.Warn().Err(err).Str("call_id", c.callID).Msg("call: dtmf ws send failed")
 	}
 }
@@ -1881,7 +2061,9 @@ func (c *Call) handleDTMF(payload []byte) {
 // target). On the end-of-event packet it ships a MessageFrame to the
 // monitoring leg's still-open worker WS:
 // ``{"type":"dtmf","digit":"5","duration_ms":120,"call_id":"<this>",
-//    "peer_call_id":"<target>","source":"transfer_target"}``.
+//
+//	"peer_call_id":"<target>","source":"transfer_target"}``.
+//
 // The ``source`` discriminator lets the worker distinguish these
 // post-bridge target-leg presses from ordinary pre-bridge caller DTMF.
 // No-op unless the leg was bridged with monitor_dtmf.
@@ -1889,7 +2071,8 @@ func (c *Call) maybeEmitPeerDTMF(peerCallID string, payload []byte) {
 	c.mu.Lock()
 	monitoring := c.dtmfMonitor
 	c.mu.Unlock()
-	if !monitoring || c.ws == nil {
+	ws := c.currentWS()
+	if !monitoring || ws == nil {
 		return
 	}
 	ev, ok := rtp.ParseDTMF(payload)
@@ -1936,11 +2119,24 @@ func (c *Call) processDecodedPayload(payload []byte) {
 		return
 	}
 	samples16k := codec.Upsample8To16(samples8k)
-	if err := c.ws.SendAudio(codec.PCMS16LEToBytes(samples16k)); err != nil {
+	ws := c.currentWS()
+	if ws == nil {
+		return
+	}
+	if err := ws.SendAudio(codec.PCMS16LEToBytes(samples16k)); err != nil {
 		log.Warn().Err(err).Str("call_id", c.callID).Msg("call: ws send failed")
-		c.Close()
+		c.teardown()
 	}
 }
+
+// jitterDrainAbove is the buffered-packet count above which the release
+// loop pops more than one packet per tick — 4× the 3-packet target, so
+// normal jitter never trips it. jitterDrainPerTick bounds the catch-up
+// so one tick can't run away with the loop.
+const (
+	jitterDrainAbove   = 12
+	jitterDrainPerTick = 8
+)
 
 // startJitterRelease starts the 20 ms ticker that drains the JB. Runs
 // until the call closes (closure detected via ctx) or relay mode
@@ -1973,6 +2169,20 @@ func (c *Call) startJitterRelease(ctx context.Context) {
 					continue
 				}
 				c.processDecodedPayload(payload)
+				// One pop per tick only keeps up while depth stays at
+				// target. If it has run away — a WS write stall inside
+				// this goroutine, or a burst — every extra packet held
+				// is latency the call never gets back, so drain the
+				// excess now rather than carrying it for the rest of
+				// the call. Bounded per tick so a pathological buffer
+				// can't monopolise the loop.
+				for n := 0; n < jitterDrainPerTick && jb.Len() > jitterDrainAbove; n++ {
+					extra, _ := jb.Pop()
+					if extra == nil {
+						break
+					}
+					c.processDecodedPayload(extra)
+				}
 			}
 		}
 	}()
@@ -2004,7 +2214,7 @@ func (c *Call) startPacer(ctx context.Context, silenceFill bool) {
 		fill:      fill,
 		onSendError: func(err error) {
 			log.Warn().Err(err).Str("call_id", c.callID).Msg("call: rtp send failed")
-			c.Close()
+			c.teardown()
 		},
 	}
 	c.mu.Lock()
@@ -2091,12 +2301,17 @@ func (c *Call) Close() {
 	close(c.closed)
 	tap := c.tap
 	c.tap = nil
+	ws := c.ws
+	stop := c.releaseStop
+	c.releaseStop = nil
 	c.mu.Unlock()
+	// Everything below runs outside the lock: Stop() can run a close
+	// handler synchronously, and that handler takes c.mu.
 	if tap != nil {
 		tap.Stop()
 	}
-	if c.releaseStop != nil {
-		c.releaseStop()
+	if stop != nil {
+		stop()
 	}
 	if c.mediaTimeoutStop != nil {
 		c.mediaTimeoutStop()
@@ -2104,8 +2319,8 @@ func (c *Call) Close() {
 	if c.rtp != nil {
 		c.rtp.Close()
 	}
-	if c.ws != nil {
-		c.ws.Stop()
+	if ws != nil {
+		ws.Stop()
 	}
 }
 

--- a/agents/pipecat/sipbridge/internal/config/config.go
+++ b/agents/pipecat/sipbridge/internal/config/config.go
@@ -53,9 +53,16 @@ type Config struct {
 	// worker WS) after this many seconds with no inbound RTP. Catches
 	// Twilio's Elastic SIP Trunk "silent hangup" behaviour (no BYE,
 	// media just stops) and any other peer that drops media without
-	// signalling. 0 disables. Default 10 — long enough to ride out
-	// brief network blips (typical packet-loss bursts are 1–3s) but
-	// short enough that the bot doesn't keep talking into the void.
+	// signalling. Default 10 — long enough to ride out brief network
+	// blips (typical packet-loss bursts are 1–3s) but short enough that
+	// the bot doesn't keep talking into the void.
+	//
+	// 0 does NOT disable the watchdog: call.New treats 0 as "unset" and
+	// substitutes the 10 s default, so there is no supported way to turn
+	// it off from config. That is deliberate — the watchdog is the last
+	// line of defence against a peer that stops media without a BYE, and
+	// several teardown paths depend on it. Set a large value if you want
+	// it effectively out of the way.
 	RTPTimeoutSeconds int
 	// RTPSilenceFill: transmit a frame of codec silence every 20 ms while
 	// the bot has nothing to say, rather than suppressing the packet and
@@ -128,10 +135,10 @@ type Config struct {
 // an error if a required value is missing.
 func Load() (*Config, error) {
 	cfg := &Config{
-		SIPSignalIP:    env("SIPBRIDGE_SIP_SIGNAL_IP", ""),
-		SIPSignalPort:  envInt("SIPBRIDGE_SIP_SIGNAL_PORT", 5060),
-		SIPBindIP:      env("SIPBRIDGE_SIP_BIND_IP", ""),
-		UDPDisabled:    envBool("SIPBRIDGE_SIP_UDP_DISABLED", false),
+		SIPSignalIP:       env("SIPBRIDGE_SIP_SIGNAL_IP", ""),
+		SIPSignalPort:     envInt("SIPBRIDGE_SIP_SIGNAL_PORT", 5060),
+		SIPBindIP:         env("SIPBRIDGE_SIP_BIND_IP", ""),
+		UDPDisabled:       envBool("SIPBRIDGE_SIP_UDP_DISABLED", false),
 		TLSSignalPort:     envInt("SIPBRIDGE_SIP_TLS_PORT", 5061),
 		TLSCertFile:       env("SIPBRIDGE_TLS_CERT_FILE", ""),
 		TLSKeyFile:        env("SIPBRIDGE_TLS_KEY_FILE", ""),
@@ -143,17 +150,17 @@ func Load() (*Config, error) {
 		SIPAuthUsername:   env("PIPECAT_SIP_USERNAME", ""),
 		SIPAuthPassword:   env("PIPECAT_SIP_PASSWORD", ""),
 		SIPFromDomain:     env("PIPECAT_SIP_FROM_DOMAIN", ""),
-		MediaIP:        env("SIPBRIDGE_MEDIA_IP", ""),
-		MediaBindIP:    env("SIPBRIDGE_MEDIA_BIND_IP", ""),
+		MediaIP:           env("SIPBRIDGE_MEDIA_IP", ""),
+		MediaBindIP:       env("SIPBRIDGE_MEDIA_BIND_IP", ""),
 		RTPPortMin:        envInt("SIPBRIDGE_RTP_PORT_MIN", 10000),
 		RTPPortMax:        envInt("SIPBRIDGE_RTP_PORT_MAX", 20000),
 		RTPTimeoutSeconds: envInt("SIPBRIDGE_RTP_TIMEOUT_SECONDS", 10),
 		RTPSilenceFill:    envBool("SIPBRIDGE_RTP_SILENCE_FILL", true),
-		WorkerWSBase:   env("SIPBRIDGE_WORKER_WS_BASE", "ws://pipecat-worker:8082"),
-		APIBindAddr:    env("SIPBRIDGE_API_BIND_ADDR", ":8090"),
-		APIBearerToken: env("SIPBRIDGE_API_TOKEN", ""),
-		LogLevel:        env("SIPBRIDGE_LOG_LEVEL", "info"),
-		SIPTraceEnabled: envBool("SIPBRIDGE_SIP_TRACE", false),
+		WorkerWSBase:      env("SIPBRIDGE_WORKER_WS_BASE", "ws://pipecat-worker:8082"),
+		APIBindAddr:       env("SIPBRIDGE_API_BIND_ADDR", ":8090"),
+		APIBearerToken:    env("SIPBRIDGE_API_TOKEN", ""),
+		LogLevel:          env("SIPBRIDGE_LOG_LEVEL", "info"),
+		SIPTraceEnabled:   envBool("SIPBRIDGE_SIP_TRACE", false),
 	}
 	// TLS is on if either a real cert pair is provided OR we're
 	// allowed to auto-generate a self-signed one. Disable both knobs

--- a/agents/pipecat/sipbridge/internal/pipecat/client.go
+++ b/agents/pipecat/sipbridge/internal/pipecat/client.go
@@ -12,6 +12,11 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// wsFailureLogEvery rate-limits the per-message protocol-violation
+// warnings on the read loop to the 1st then every 250th, mirroring the
+// media-side limiter in internal/rtp.
+const wsFailureLogEvery = 250
+
 // Client is a per-call WebSocket client speaking the Pipecat protobuf
 // frame protocol. The worker side uses
 // `pipecat.transports.websocket.fastapi.FastAPIWebsocketTransport` with
@@ -301,6 +306,8 @@ func (c *Client) readLoop(ctx context.Context) {
 		}
 	}()
 
+	// Consecutive-failure counters for the rate-limited warnings below.
+	badType, badFrame := 0, 0
 	for {
 		select {
 		case <-ctx.Done():
@@ -318,14 +325,27 @@ func (c *Client) readLoop(ctx context.Context) {
 		if mt != websocket.MessageBinary {
 			// Pipecat sends everything as binary protobuf; text messages
 			// would be a protocol violation, so drop them with a log.
-			log.Warn().Int("type", int(mt)).Msg("pipecat ws: dropping non-binary message")
+			// Rate-limited: a peer that is wrong about this is wrong
+			// about every message, many times a second for the whole
+			// call.
+			badType++
+			if badType == 1 || badType%wsFailureLogEvery == 0 {
+				log.Warn().Int("type", int(mt)).Int("consecutive", badType).
+					Msg("pipecat ws: dropping non-binary message")
+			}
 			continue
 		}
+		badType = 0
 		frame, err := DecodeFrame(data)
 		if err != nil {
-			log.Warn().Err(err).Int("len", len(data)).Msg("pipecat ws: malformed frame")
+			badFrame++
+			if badFrame == 1 || badFrame%wsFailureLogEvery == 0 {
+				log.Warn().Err(err).Int("len", len(data)).Int("consecutive", badFrame).
+					Msg("pipecat ws: malformed frame")
+			}
 			continue
 		}
+		badFrame = 0
 		c.dispatch(frame)
 	}
 }

--- a/agents/pipecat/sipbridge/internal/rtp/jitter.go
+++ b/agents/pipecat/sipbridge/internal/rtp/jitter.go
@@ -37,10 +37,34 @@ import (
 //     received either the packet that arrived in time or the silence
 //     stub.
 //
+//   - Discontinuity: a stream that jumps its sequence numbers (an SSRC
+//     change after a transfer or music-on-hold, RTCP-mux junk parsed as
+//     RTP) would otherwise leave the release cursor thousands of slots
+//     behind the arriving packets — silence out, unbounded map growth
+//     in, and no recovery. Push resyncs (Reset + re-prime) when the
+//     distance from the cursor leaves ``resyncWindow`` or the map
+//     exceeds ``maxDepth``. A backward jump past 32 767 aliases to
+//     "late" and would otherwise drop every packet for good; the same
+//     window catches it.
+//
 // The buffer is not used in relay mode (Phase C bridged transfer) —
 // the relay forwards packets immediately without ordering, since both
 // legs see whatever jitter the bridge sees and there's no benefit to
 // reordering twice.
+// resyncWindow is how far (in packets, either direction) an arriving
+// sequence number may be from the release cursor before we treat the
+// stream as discontinuous rather than merely jittery. 3 000 packets is
+// a minute of 20 ms audio — far beyond any real reordering or loss
+// burst, and well clear of the ±32 767 point where the signed-16-bit
+// comparison aliases.
+const resyncWindow = 3000
+
+// maxDepth caps the number of buffered packets. At the 3-packet target
+// depth the release loop keeps this near zero; reaching 250 (5 s) means
+// the consumer has stalled or the stream is discontinuous, and holding
+// more just adds latency that never drains.
+const maxDepth = 250
+
 type JitterBuffer struct {
 	// Depth is the target queue length in packets. Filled at
 	// construction; consumed each Tick.
@@ -77,7 +101,20 @@ func (j *JitterBuffer) Push(seq uint16, payload []byte) {
 	if !j.primed {
 		j.next = seq
 		j.primed = true
-	} else if int16(seq-j.next) < 0 {
+	} else if d := int16(seq - j.next); d > resyncWindow || d < -resyncWindow || len(j.packets) >= maxDepth {
+		// Discontinuity: the stream has jumped (new SSRC, non-RTP junk)
+		// or the consumer has stalled. Either way the cursor can never
+		// catch up on its own — one slot per 20 ms tick — so start
+		// over from this packet. Dropping what we hold costs at most
+		// the buffered audio; not resyncing costs the rest of the call.
+		log.Warn().
+			Uint16("seq", seq).
+			Uint16("next", j.next).
+			Int("depth", len(j.packets)).
+			Msg("rtp: jitter buffer discontinuity — resyncing")
+		j.packets = map[uint16][]byte{}
+		j.next = seq
+	} else if d < 0 {
 		// Already-released slot — drop. Logging at debug because over
 		// a reordered network this is normal.
 		log.Debug().
@@ -112,6 +149,17 @@ func (j *JitterBuffer) Pop() ([]byte, bool) {
 	// Gap: synthesise silence and advance.
 	j.next++
 	return make([]byte, j.PayloadSize), true
+}
+
+// Len returns the number of packets currently buffered (the field
+// ``Depth`` is the *target*, not the current occupancy). Used by the
+// release loop to detect a buffer that has run above target (a stalled
+// consumer or a burst) so it can drain the excess rather than carry it
+// as permanent added latency.
+func (j *JitterBuffer) Len() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return len(j.packets)
 }
 
 // Flush drains the buffer in sequence order, returning everything

--- a/agents/pipecat/sipbridge/internal/rtp/jitter_test.go
+++ b/agents/pipecat/sipbridge/internal/rtp/jitter_test.go
@@ -1,0 +1,92 @@
+package rtp
+
+import "testing"
+
+// The jitter buffer's release cursor advances one slot per 20 ms tick.
+// A stream whose sequence numbers jump — a new SSRC after a transfer or
+// music-on-hold, RTCP-mux junk parsed as RTP — leaves the cursor
+// thousands of slots behind the arrivals, and it can never catch up on
+// its own: silence out, unbounded map growth in. Push must resync.
+
+func TestPushResyncsOnForwardDiscontinuity(t *testing.T) {
+	jb := NewJitterBuffer(3, 160)
+	for i := 0; i < 5; i++ {
+		jb.Push(uint16(1000+i), []byte{byte(i)})
+	}
+	// A jump well beyond any real reordering or loss burst.
+	jb.Push(40000, []byte{0xAA})
+	if got := jb.Len(); got != 1 {
+		t.Fatalf("Len after discontinuity = %d; want 1 (buffer re-primed on the new stream)", got)
+	}
+	payload, gap := jb.Pop()
+	if payload != nil || gap {
+		t.Fatalf("Pop below target depth = (%v,%v); want (nil,false)", payload, gap)
+	}
+	jb.Push(40001, []byte{0xBB})
+	jb.Push(40002, []byte{0xCC})
+	payload, gap = jb.Pop()
+	if gap || len(payload) != 1 || payload[0] != 0xAA {
+		t.Fatalf("Pop after resync = (%v,%v); want the first packet of the new stream", payload, gap)
+	}
+}
+
+// A backward jump past 32 767 aliases to "late" under the signed-16-bit
+// comparison, which without the window would drop every packet for the
+// rest of the call.
+func TestPushResyncsOnBackwardDiscontinuity(t *testing.T) {
+	jb := NewJitterBuffer(3, 160)
+	for i := 0; i < 3; i++ {
+		jb.Push(uint16(40000+i), []byte{byte(i)})
+	}
+	jb.Push(100, []byte{0xAA})
+	if got := jb.Len(); got != 1 {
+		t.Fatalf("Len after backward discontinuity = %d; want 1", got)
+	}
+}
+
+// Ordinary reordering must NOT trip the resync: a packet a few slots
+// early is exactly what the buffer exists to absorb.
+func TestPushKeepsSmallReordering(t *testing.T) {
+	jb := NewJitterBuffer(3, 160)
+	jb.Push(1000, []byte{1})
+	jb.Push(1003, []byte{4}) // 3 ahead — normal jitter
+	jb.Push(1001, []byte{2})
+	jb.Push(1002, []byte{3})
+	if got := jb.Len(); got != 4 {
+		t.Fatalf("Len = %d; want 4 (no resync for small reordering)", got)
+	}
+	// Pop drains only while occupancy is at or above the target depth
+	// of 3, so 4 buffered packets yield 2 releases — in sequence order,
+	// which is the point: the out-of-order arrival was slotted right.
+	for want := byte(1); want <= 2; want++ {
+		payload, gap := jb.Pop()
+		if gap || len(payload) != 1 || payload[0] != want {
+			t.Fatalf("Pop #%d = (%v,%v); want payload %d in sequence order", want, payload, gap, want)
+		}
+	}
+}
+
+// A stalled consumer must not accumulate unbounded latency.
+func TestPushCapsDepth(t *testing.T) {
+	jb := NewJitterBuffer(3, 160)
+	for i := 0; i < maxDepth+50; i++ {
+		jb.Push(uint16(1000+i), []byte{byte(i)})
+	}
+	if got := jb.Len(); got > maxDepth {
+		t.Fatalf("Len = %d; want <= maxDepth (%d)", got, maxDepth)
+	}
+}
+
+// Late packets (behind the cursor but inside the window) are still
+// dropped rather than resyncing the stream.
+func TestPushDropsLatePackets(t *testing.T) {
+	jb := NewJitterBuffer(1, 160)
+	jb.Push(1000, []byte{1})
+	if p, _ := jb.Pop(); p == nil {
+		t.Fatal("Pop returned nil at target depth 1")
+	}
+	jb.Push(999, []byte{9}) // already released
+	if got := jb.Len(); got != 0 {
+		t.Fatalf("Len = %d; want 0 (late packet dropped, not resynced)", got)
+	}
+}

--- a/agents/pipecat/sipbridge/internal/rtp/session.go
+++ b/agents/pipecat/sipbridge/internal/rtp/session.go
@@ -525,18 +525,18 @@ func (s *Session) readLoop(ctx context.Context) {
 	}
 }
 
-// pickPort returns an even free UDP port in [portMin, portMax]. RTP
-// convention is even-numbered ports (RTCP uses port+1 if we ever add
-// it); we don't need RTCP yet but we keep the even-port convention so
-// adding it later doesn't break the SDP we've published. If portMin ==
-// 0 the OS picks any free port (test-only path).
-// pickPort returns a bound socket on an even free port, not just the
-// number. Returning the number and rebinding in the caller was a
-// time-of-check/time-of-use race: under any concurrency a second call
-// could take the port between the probe's Close and the caller's
-// ListenUDP, failing the INVITE with a 500. Keeping the socket also
-// removes up to (max-min)/2 bind/close syscalls per call when the
-// range is nearly full.
+// pickPort binds and returns a socket on an even free port in
+// [portMin, portMax]. RTP convention is even-numbered ports (RTCP uses
+// port+1 if we ever add it); we don't need RTCP yet but we keep the
+// even-port convention so adding it later doesn't break the SDP we've
+// published. If portMin == 0 the OS picks any free port (test-only path).
+//
+// It returns the BOUND socket rather than the port number: probing,
+// closing and rebinding in the caller was a time-of-check/time-of-use
+// race where under any concurrency a second call could take the port in
+// between, failing the INVITE with a 500. Keeping the socket also
+// removes up to (max-min)/2 bind/close syscalls per call when the range
+// is nearly full.
 func pickPort(bindIP string, portMin, portMax int) (*net.UDPConn, error) {
 	if portMin == 0 && portMax == 0 {
 		return net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP(bindIP)})

--- a/agents/pipecat/sipbridge/internal/rtp/session.go
+++ b/agents/pipecat/sipbridge/internal/rtp/session.go
@@ -10,6 +10,7 @@
 package rtp
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -34,7 +35,7 @@ const (
 	PayloadPCMA PayloadType = 8
 
 	// 8 kHz, 20 ms framing — 160 samples per packet.
-	sampleRate8k     = 8000
+	sampleRate8k      = 8000
 	packetSamples20ms = 160
 
 	// RTP timestamp increment per packet at 8 kHz / 20 ms.
@@ -116,14 +117,37 @@ type Session struct {
 	// Held under srtpMu — DTLS-SRTP installs them asynchronously after
 	// the SIP 200 OK, so a packet may arrive before the contexts land;
 	// readLoop holds the lock briefly to read the current pair.
-	srtpMu      sync.RWMutex
+	srtpMu       sync.RWMutex
 	srtpInbound  *srtpv3.Context
 	srtpOutbound *srtpv3.Context
 
 	mu     sync.Mutex
 	closed bool
 	cancel context.CancelFunc
+
+	// srtpFailures / rtpFailures count consecutive decrypt and parse
+	// failures on the read loop. Both are per-packet events: a carrier
+	// that negotiates RTP/SAVP and then sends plaintext (see the
+	// srtpAvoid comment in the call manager) produces 50 of them a
+	// second for the whole call, so the log lines are rate-limited and
+	// the leg is torn down once the failures are clearly permanent
+	// rather than a transient key/replay hiccup. Read-loop-local, no
+	// lock needed.
+	srtpFailures int
+	rtpFailures  int
 }
+
+// maxConsecutiveSRTPFailures is how many back-to-back undecryptable
+// packets (~2 s at 20 ms ptime) we accept before concluding the media
+// key is simply wrong and stopping the read loop. Anything transient —
+// a replayed packet, one bad auth tag — resets the count on the next
+// good packet.
+const maxConsecutiveSRTPFailures = 100
+
+// mediaFailureLogEvery rate-limits the per-packet failure warnings to
+// the 1st, then every 250th (~5 s of audio), mirroring the pacer's
+// dropped-audio logging.
+const mediaFailureLogEvery = 250
 
 // NewSession binds a UDP socket for RTP. The OS picks a free port from
 // the configured range (caller passes bindIP + 0); the call manager
@@ -133,14 +157,9 @@ type Session struct {
 // firewall rules can be static. Pass (0, 0) to let the OS choose any
 // free port — handy for tests, but in production we want a fixed range.
 func NewSession(bindIP string, portMin, portMax int) (*Session, error) {
-	port, err := pickPort(bindIP, portMin, portMax)
+	conn, err := pickPort(bindIP, portMin, portMax)
 	if err != nil {
 		return nil, fmt.Errorf("rtp: pick port: %w", err)
-	}
-	local := &net.UDPAddr{IP: net.ParseIP(bindIP), Port: port}
-	conn, err := net.ListenUDP("udp", local)
-	if err != nil {
-		return nil, fmt.Errorf("rtp: listen on %s: %w", local, err)
 	}
 	s := &Session{
 		conn:      conn,
@@ -189,7 +208,17 @@ func (s *Session) SetPayloadHandler(fn func(pt PayloadType, seq uint16, payload 
 // signal to exit cleanly; the socket is also closed by Close().
 func (s *Session) Start(ctx context.Context) {
 	rctx, cancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	closed := s.closed
 	s.cancel = cancel
+	s.mu.Unlock()
+	if closed {
+		// Close ran before Start (the DTLS handshake path starts the
+		// loop asynchronously, and a failed call can be torn down
+		// first). Don't spawn a read loop on a dead socket.
+		cancel()
+		return
+	}
 	go s.readLoop(rctx)
 }
 
@@ -300,16 +329,20 @@ func (s *Session) CanFill() bool {
 // expected to transmit every 20 ms for the life of the call whether or not
 // anyone is talking; peers with a media watchdog read a gap as a dead call.
 func (s *Session) SilencePayload() []byte {
-	fill := byte(0xFF)
 	if PayloadType(s.payloadType.Load()) == PayloadPCMA {
-		fill = 0xD5
+		return silencePCMA
 	}
-	buf := make([]byte, packetSamples20ms)
-	for i := range buf {
-		buf[i] = fill
-	}
-	return buf
+	return silencePCMU
 }
+
+// Pre-built silence frames. The pacer asks for one every 20 ms for
+// every idle call; building it each time was 160 bytes of garbage per
+// call per frame for no reason. Callers only hand these to the
+// encrypt/send path, which does not retain or mutate them.
+var (
+	silencePCMU = bytes.Repeat([]byte{0xFF}, packetSamples20ms)
+	silencePCMA = bytes.Repeat([]byte{0xD5}, packetSamples20ms)
+)
 
 // SetDTMFPayloadType overrides the payload type used for outbound RFC 4733
 // telephone-event packets (default PayloadDTMF / 101). A caller that has
@@ -409,9 +442,10 @@ func (s *Session) Close() {
 		return
 	}
 	s.closed = true
+	cancel := s.cancel
 	s.mu.Unlock()
-	if s.cancel != nil {
-		s.cancel()
+	if cancel != nil {
+		cancel()
 	}
 	_ = s.conn.Close()
 }
@@ -449,16 +483,42 @@ func (s *Session) readLoop(ctx context.Context) {
 		if in != nil {
 			pt, err := in.DecryptRTP(nil, raw, nil)
 			if err != nil {
-				log.Warn().Err(err).Int("len", n).Msg("rtp: SRTP decrypt failed (auth tag / replay / wrong key?)")
+				s.srtpFailures++
+				if s.srtpFailures == 1 || s.srtpFailures%mediaFailureLogEvery == 0 {
+					log.Warn().Err(err).
+						Int("len", n).
+						Int("consecutive", s.srtpFailures).
+						Msg("rtp: SRTP decrypt failed (auth tag / replay / wrong key?)")
+				}
+				if s.srtpFailures >= maxConsecutiveSRTPFailures {
+					// Every packet since the key was installed has
+					// failed: this is not jitter, the key is wrong (or
+					// the peer is sending plaintext into an SAVP
+					// session). Stop; the media watchdog then tears the
+					// call down as a silent leg rather than us burning
+					// a core on decrypt failures for its whole life.
+					log.Error().
+						Int("consecutive", s.srtpFailures).
+						Msg("rtp: too many consecutive SRTP failures — stopping read loop")
+					return
+				}
 				continue
 			}
+			s.srtpFailures = 0
 			raw = pt
 		}
 		pkt := &pionrtp.Packet{}
 		if err := pkt.Unmarshal(raw); err != nil {
-			log.Warn().Err(err).Int("len", len(raw)).Msg("rtp: malformed packet")
+			s.rtpFailures++
+			if s.rtpFailures == 1 || s.rtpFailures%mediaFailureLogEvery == 0 {
+				log.Warn().Err(err).
+					Int("len", len(raw)).
+					Int("consecutive", s.rtpFailures).
+					Msg("rtp: malformed packet")
+			}
 			continue
 		}
+		s.rtpFailures = 0
 		if s.onPayload != nil {
 			s.onPayload(PayloadType(pkt.PayloadType), pkt.SequenceNumber, pkt.Payload, pkt.Marker)
 		}
@@ -470,14 +530,16 @@ func (s *Session) readLoop(ctx context.Context) {
 // it); we don't need RTCP yet but we keep the even-port convention so
 // adding it later doesn't break the SDP we've published. If portMin ==
 // 0 the OS picks any free port (test-only path).
-func pickPort(bindIP string, portMin, portMax int) (int, error) {
+// pickPort returns a bound socket on an even free port, not just the
+// number. Returning the number and rebinding in the caller was a
+// time-of-check/time-of-use race: under any concurrency a second call
+// could take the port between the probe's Close and the caller's
+// ListenUDP, failing the INVITE with a 500. Keeping the socket also
+// removes up to (max-min)/2 bind/close syscalls per call when the
+// range is nearly full.
+func pickPort(bindIP string, portMin, portMax int) (*net.UDPConn, error) {
 	if portMin == 0 && portMax == 0 {
-		l, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP(bindIP)})
-		if err != nil {
-			return 0, err
-		}
-		defer l.Close()
-		return l.LocalAddr().(*net.UDPAddr).Port, nil
+		return net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP(bindIP)})
 	}
 	// Start at an odd offset within the range so concurrent calls don't
 	// keep colliding on the same first-attempt port.
@@ -489,9 +551,8 @@ func pickPort(bindIP string, portMin, portMax int) (int, error) {
 		}
 		l, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP(bindIP), Port: p})
 		if err == nil {
-			_ = l.Close()
-			return p, nil
+			return l, nil
 		}
 	}
-	return 0, fmt.Errorf("rtp: no free even port in %d-%d", portMin, portMax)
+	return nil, fmt.Errorf("rtp: no free even port in %d-%d", portMin, portMax)
 }

--- a/agents/pipecat/sipbridge/internal/sip/invite_guard_test.go
+++ b/agents/pipecat/sipbridge/internal/sip/invite_guard_test.go
@@ -1,0 +1,81 @@
+package sip
+
+import (
+	"testing"
+
+	"github.com/emiago/sipgo/sip"
+)
+
+// newInvite builds a bare INVITE with the supplied Call-ID. toTag, when
+// non-empty, makes it in-dialog (a re-INVITE).
+func newInvite(callID, toTag string) *sip.Request {
+	req := sip.NewRequest(sip.INVITE, sip.Uri{Scheme: "sip", User: "1000", Host: "example.net"})
+	cid := sip.CallIDHeader(callID)
+	req.AppendHeader(&cid)
+	to := &sip.ToHeader{
+		Address: sip.Uri{Scheme: "sip", User: "1000", Host: "example.net"},
+		Params:  sip.NewParams(),
+	}
+	if toTag != "" {
+		to.Params.Add("tag", toTag)
+	}
+	req.AppendHeader(to)
+	return req
+}
+
+// A re-INVITE (hold, an RFC 4028 session-timer refresh, renegotiation)
+// arrives on the same OnInvite handler as a fresh call. Running one
+// through the setup path allocates a second RTP port and worker WS and
+// overwrites both registries by Call-ID: the old Call is orphaned and
+// the orphan's media watchdog then hangs up the NEW call 10 s later.
+// The guard is the To-tag, so check we read it the way sipgo presents it.
+func TestInDialogInviteIsDetectedByToTag(t *testing.T) {
+	req := newInvite("abc@example.net", "as7f3c91")
+	to := req.To()
+	if to == nil {
+		t.Fatal("To() = nil on a request that has one")
+	}
+	if _, hasTag := to.Params.Get("tag"); !hasTag {
+		t.Fatal("To-tag not found; the re-INVITE guard would let an in-dialog INVITE through")
+	}
+}
+
+func TestInitialInviteHasNoToTag(t *testing.T) {
+	req := newInvite("abc@example.net", "")
+	to := req.To()
+	if to == nil {
+		t.Fatal("To() = nil on a request that has one")
+	}
+	if _, hasTag := to.Params.Get("tag"); hasTag {
+		t.Fatal("initial INVITE reported a To-tag; the guard would reject every new call")
+	}
+}
+
+// The second half of the guard: an INVITE whose Call-ID is already live
+// is a re-INVITE even without a To-tag (some UAs omit it on a
+// retransmit-after-fork). The lookup must see the registered dialog.
+func TestLiveCallIDIsVisibleToTheGuard(t *testing.T) {
+	s := &Server{calls: map[string]*activeCall{}}
+	const id = "abc@example.net"
+	if _, live := s.calls[id]; live {
+		t.Fatal("fresh server reported a live call")
+	}
+	s.calls[id] = &activeCall{}
+	if _, live := s.calls[id]; !live {
+		t.Fatal("registered call not visible; a re-INVITE would overwrite the live one")
+	}
+}
+
+// Drain flips the accept/refuse state that SIGTERM shutdown relies on:
+// new INVITEs get a 503 + Retry-After so the upstream re-routes, while
+// in-dialog traffic for calls already up keeps working.
+func TestDrainFlipsAcceptState(t *testing.T) {
+	s := &Server{calls: map[string]*activeCall{}}
+	if s.Draining() {
+		t.Fatal("a fresh server reported itself draining")
+	}
+	s.Drain()
+	if !s.Draining() {
+		t.Fatal("Draining() = false after Drain()")
+	}
+}

--- a/agents/pipecat/sipbridge/internal/sip/server.go
+++ b/agents/pipecat/sipbridge/internal/sip/server.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/emiago/sipgo"
 	"github.com/emiago/sipgo/sip"
@@ -92,10 +93,14 @@ type Server struct {
 	srv *sipgo.Server
 	ub  *sipgo.DialogUA
 
-	mu      sync.Mutex
-	calls   map[string]*activeCall // sip CallID → state for ACK/BYE matching
-	invite  InviteHandler
-	bye     ByeHandler
+	mu     sync.Mutex
+	calls  map[string]*activeCall // sip CallID → state for ACK/BYE matching
+	invite InviteHandler
+	bye    ByeHandler
+	// draining is set by Drain() on SIGTERM: new INVITEs get a 503
+	// with a Retry-After so the upstream B2BUA re-routes them to
+	// another node, while calls already up are hung up cleanly.
+	draining atomic.Bool
 	// signalIP is the IP we advertise (Via/Contact); bindIP is the
 	// address we actually listen on. They differ on any non-trivial
 	// deployment — see Config docs and docker-compose for the rationale.
@@ -339,6 +344,15 @@ func (s *Server) SetInviteHandler(h InviteHandler) { s.invite = h }
 // SetByeHandler registers the per-call teardown handler.
 func (s *Server) SetByeHandler(h ByeHandler) { s.bye = h }
 
+// Drain stops the server accepting new calls: from here on INVITEs are
+// answered 503 Service Unavailable + Retry-After so the upstream
+// re-routes them, while in-dialog traffic (ACK, BYE, REFER) for calls
+// already up keeps working so they can be torn down cleanly.
+func (s *Server) Drain() { s.draining.Store(true) }
+
+// Draining reports whether Drain has been called.
+func (s *Server) Draining() bool { return s.draining.Load() }
+
 // Listen binds the UDP socket and starts the SIP transaction loop.
 // Returns when the context is cancelled or the listener errors fatally.
 //
@@ -396,10 +410,24 @@ func (s *Server) registerHandlers() {
 	// registered handlers (OPTIONS, INFO, REFER, MESSAGE, etc). We
 	// don't have business logic for these but we want them in the
 	// trace when tracing is on, so we can see e.g. carrier OPTIONS
-	// keepalives or unexpected REFERs. Respond 501 Not Implemented so
-	// the peer doesn't retransmit.
+	// keepalives or unexpected REFERs. Respond so the peer doesn't
+	// retransmit.
+	//
+	// OPTIONS is the exception to the blanket 501: dispatchers and SBCs
+	// use it as a liveness poll and expect a 2xx — a 501 reads as "this
+	// node is unhealthy" and takes the bridge out of rotation. Answer
+	// 200 while we are up, 503 once draining (which is exactly the
+	// signal we want the dispatcher to act on).
 	s.srv.OnNoRoute(func(req *sip.Request, tx sip.ServerTransaction) {
 		s.traceSIP("<", "no-route ("+string(req.Method)+")", req)
+		if req.Method == sip.OPTIONS {
+			if s.draining.Load() {
+				s.respond(req, tx, 503, "Service Unavailable", nil)
+				return
+			}
+			s.respond(req, tx, 200, "OK", nil)
+			return
+		}
 		s.respond(req, tx, 501, "Not Implemented", nil)
 	})
 }
@@ -422,6 +450,52 @@ func (s *Server) onInvite(req *sip.Request, tx sip.ServerTransaction) {
 		Msg("sip: INVITE received")
 	if s.invite == nil {
 		s.respond(req, tx, 500, "No handler", nil)
+		return
+	}
+
+	// Draining (SIGTERM): refuse new work but keep serving the calls
+	// already up. 503 + Retry-After is the standard "try another node"
+	// signal; an upstream B2BUA re-routes on it rather than failing
+	// the call.
+	if s.draining.Load() {
+		log.Info().Str("call_id", callID).Msg("sip: INVITE refused — draining")
+		resp := sip.NewResponseFromRequest(req, 503, "Service Unavailable", nil)
+		resp.AppendHeader(sip.NewHeader("Retry-After", "30"))
+		s.traceSIP(">", "503 Service Unavailable for INVITE (draining)", resp)
+		if err := tx.Respond(resp); err != nil {
+			log.Warn().Err(err).Msg("sip: respond failed")
+		}
+		return
+	}
+
+	// Re-INVITE guard. sipgo hands in-dialog INVITEs (hold/unhold, an
+	// RFC 4028 session-timer refresh, codec renegotiation) to this same
+	// handler. We have no re-INVITE support: running one through the
+	// setup path below would allocate a second RTP port, dial a second
+	// worker WS for the same session and overwrite both registries by
+	// Call-ID — the original Call becomes unreachable and never closed,
+	// the peer's media moves to the new port, and the orphan's media
+	// watchdog then fires 10 s later and hangs up the *new* call by the
+	// same id. So: a To-tag (in-dialog) or an already-live Call-ID gets
+	// a 488. RFC 3261 §14.1 — a non-2xx to a re-INVITE leaves the
+	// existing session unchanged, so hold "fails" but the call lives.
+	if to := req.To(); to != nil {
+		if _, hasTag := to.Params.Get("tag"); hasTag {
+			log.Warn().
+				Str("call_id", callID).
+				Msg("sip: in-dialog INVITE (re-INVITE) rejected — not supported")
+			s.respond(req, tx, 488, "Not Acceptable Here", nil)
+			return
+		}
+	}
+	s.mu.Lock()
+	_, live := s.calls[callID]
+	s.mu.Unlock()
+	if live {
+		log.Warn().
+			Str("call_id", callID).
+			Msg("sip: INVITE for a Call-ID that is already live — rejected")
+		s.respond(req, tx, 488, "Not Acceptable Here", nil)
 		return
 	}
 
@@ -467,8 +541,14 @@ func (s *Server) onInvite(req *sip.Request, tx sip.ServerTransaction) {
 	// session for ACK / BYE matching.
 	dlg, err := s.ub.ReadInvite(req, tx)
 	if err != nil {
+		// The invite handler above already built the Call (RTP port,
+		// worker WS, bot session). The commonest cause of getting
+		// here is a remote CANCEL while we were dialling the worker;
+		// without the teardown the Call sits in the manager until the
+		// media watchdog reaps it 10 s later.
 		log.Warn().Err(err).Str("call_id", callID).Msg("sip: ReadInvite failed")
 		s.respond(req, tx, 500, "Server Error", nil)
+		s.abandonCall(callID)
 		return
 	}
 	s.mu.Lock()
@@ -518,8 +598,12 @@ func (s *Server) onInvite(req *sip.Request, tx sip.ServerTransaction) {
 	// (including the ACK itself, which our OnAck handler then forwards
 	// to dlg.ReadAck — that's what unblocks us).
 	if err := dlg.WriteResponse(resp); err != nil {
+		// 32 s of 2xx retransmits with no ACK (typically a
+		// NAT-misrouted ACK — see contactForDialog). cleanupCall
+		// alone dropped only ``s.calls``, so the worker's later
+		// DELETE could no longer BYE and the manager kept the call.
 		log.Warn().Err(err).Str("call_id", callID).Msg("sip: WriteResponse (200 OK) failed")
-		s.cleanupCall(callID)
+		s.abandonCall(callID)
 		return
 	}
 	log.Info().
@@ -624,10 +708,18 @@ func (s *Server) onBye(req *sip.Request, tx sip.ServerTransaction) {
 		// Unknown dialog — respond 200 anyway so the far end stops
 		// retransmitting (some carriers re-send BYE after a missed
 		// ACK).
+		// The dialog can be missing while the manager still holds a
+		// live Call — WriteResponse failing after a lost ACK drops
+		// ``s.calls`` only. Tell the manager anyway (Hangup on an
+		// unknown id is a harmless no-op) so the media, WS and
+		// registry entry go rather than waiting on the watchdog.
 		log.Warn().
 			Str("call_id", callID).
-			Msg("sip: BYE for unknown dialog — call manager won't tear down (was the INVITE answered on this bridge?)")
+			Msg("sip: BYE for unknown dialog — tearing down any call-manager state under this id")
 		s.respond(req, tx, 200, "OK", nil)
+		if s.bye != nil {
+			s.bye(callID)
+		}
 		return
 	}
 	// ReadBye sends the 200 OK itself; we don't double-respond. The
@@ -652,6 +744,19 @@ func (s *Server) cleanupCall(callID string) {
 	s.mu.Lock()
 	delete(s.calls, callID)
 	s.mu.Unlock()
+}
+
+// abandonCall is cleanupCall plus the manager-level teardown. Used on
+// the setup paths that give up after the invite handler has already
+// wired a Call (RTP session, worker WS, bot session) but before the
+// dialog is established: dropping only ``s.calls`` there leaves that
+// Call in the manager's registry until the media watchdog reaps it
+// 10 s later — and for the unknown-dialog BYE, never.
+func (s *Server) abandonCall(callID string) {
+	s.cleanupCall(callID)
+	if s.bye != nil {
+		s.bye(callID)
+	}
 }
 
 // respond is the inline error-reply helper. Used when we don't want to
@@ -1143,6 +1248,19 @@ func (s *Server) sendByeAndTraceResponse(
 			Str("call_id", callID).
 			Msg("sip: BYE acknowledged with 200 OK")
 		return nil
+	case <-tx.Done():
+		// sipgo never closes ``Responses()`` — ``ClientTx.delete`` closes
+		// only ``done``. Without this arm the select parks forever once
+		// Timer B fires (32 s after a peer ignores our BYE), which is
+		// exactly the silent-carrier-hangup case the media watchdog
+		// exists to catch, and every internal caller passes
+		// ``context.Background()``.
+		err := tx.Err()
+		log.Warn().
+			Err(err).
+			Str("call_id", callID).
+			Msg("sip: BYE transaction ended without a final response")
+		return fmt.Errorf("sip: BYE transaction ended without a final response: %w", err)
 	case <-ctx.Done():
 		log.Warn().
 			Err(ctx.Err()).

--- a/agents/pipecat/tests/test_function_handler_rest.py
+++ b/agents/pipecat/tests/test_function_handler_rest.py
@@ -44,7 +44,14 @@ class _FakeResponse:
 
 
 class _FakeClient:
-    """Stands in for httpx.AsyncClient; records the single request it serves."""
+    """Stands in for the pooled httpx.AsyncClient; records the single
+    request it serves.
+
+    REST callouts go through the process-wide pool now
+    (``http_client.get_client``) rather than constructing a client per
+    request, so the fake is handed back from there. It keeps the
+    ``async with`` methods so it also stands in for a bare client.
+    """
 
     last: Optional[dict] = None
     response: _FakeResponse = _FakeResponse()
@@ -58,13 +65,16 @@ class _FakeClient:
     async def __aexit__(self, *_exc) -> None:
         return None
 
-    async def request(self, method: str, url: str, headers=None, params=None, json=None):
+    async def request(
+        self, method: str, url: str, headers=None, params=None, json=None, timeout=None
+    ):
         _FakeClient.last = {
             "method": method,
             "url": url,
             "headers": dict(headers or {}),
             "params": list(params) if params else None,
             "json": json,
+            "timeout": timeout,
         }
         return _FakeClient.response
 
@@ -73,7 +83,12 @@ class _FakeClient:
 def _fake_httpx(monkeypatch):
     _FakeClient.last = None
     _FakeClient.response = _FakeResponse()
-    monkeypatch.setattr(fh.httpx, "AsyncClient", _FakeClient)
+    client = _FakeClient()
+
+    async def _get_client(*_a, **_k):
+        return client
+
+    monkeypatch.setattr(fh.http_client, "get_client", _get_client)
     yield
 
 

--- a/agents/pipecat/tests/test_gateway_session_release.py
+++ b/agents/pipecat/tests/test_gateway_session_release.py
@@ -1,0 +1,136 @@
+"""The gateway must release its per-call registrations on every exit path.
+
+From the 2026-09-03 production-readiness audit. Two of its highest-impact
+findings were the same shape: state registered at call setup and released
+only on the happy path.
+
+  * W1 — every OUTBOUND call. The dispatch task owns the CallSession and
+    runner; the WebSocket handler only registers the transport and then
+    parks on the leg-done event. Nothing but ``unregister_session`` sets
+    that event, and dispatch's teardown calls ``shutdown()`` → ``hangup()``,
+    so the handler task, its transport, its Starlette WebSocket and three
+    map entries were retained for the life of the process, per call. The
+    comment claiming FastAPI cancels the handler on peer close is not true
+    of uvicorn: peer close only enqueues a ``websocket.disconnect``.
+
+  * W6 — a completed warm transfer never cleared its consult call id,
+    because ``hangup`` returns early once the leg is bridged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from pipecat_aplisay.sip_gateway.sipbridge_gateway import (
+    SipBridgeSipGateway,
+    _SbGatewaySession,
+)
+
+
+@pytest.fixture()
+def gateway(monkeypatch):
+    gw = SipBridgeSipGateway()
+
+    async def _no_rest(*_a, **_k):
+        return None
+
+    # The bridge isn't running in a unit test; hangup's DELETEs are not
+    # what's under test here.
+    monkeypatch.setattr(gw, "_call_api", _no_rest)
+    return gw
+
+
+def _register(gw, session_id="sess-1"):
+    session = gw.register_inbound_session(
+        session_id=session_id,
+        bridge_call_id="bridge-1",
+        transport=object(),
+    )
+    # The outbound arm of the WS handler waits on this.
+    gw.wait_for_leg_done(session_id)
+    return session
+
+
+def test_shutdown_releases_every_registration(gateway):
+    """W1: shutdown() is the ONLY teardown the outbound path runs."""
+    session = _register(gateway)
+    assert gateway.live_session("sess-1") is session
+
+    asyncio.run(session.shutdown())
+
+    assert gateway.live_session("sess-1") is None
+    assert "sess-1" not in gateway._sessions
+    assert "sess-1" not in gateway._session_to_bridge_call
+
+
+def test_shutdown_wakes_the_parked_ws_handler(gateway):
+    """The parked handler unwinds only when the leg-done event is set.
+
+    Without this the handler task never returns, and uvicorn's graceful
+    shutdown waits for it — so one leaked handler turns every SIGTERM
+    into a SIGKILL at the termination-grace deadline.
+    """
+
+    async def scenario() -> None:
+        session = _register(gateway)
+        done = gateway.wait_for_leg_done("sess-1")
+        assert not done.is_set()
+        await session.shutdown()
+        # The real handler does `await done_event.wait()`; if shutdown
+        # didn't set it, this would hang rather than fail.
+        await asyncio.wait_for(done.wait(), timeout=1.0)
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_is_idempotent(gateway):
+    """The inbound arm's ``finally`` also unregisters — both must be safe."""
+
+    async def scenario() -> None:
+        session = _register(gateway)
+        await session.shutdown()
+        gateway.unregister_session("sess-1")
+        await session.shutdown()
+
+    asyncio.run(scenario())
+    assert gateway._sessions == {}
+
+
+def test_bridged_leg_still_releases_its_registrations(gateway):
+    """A leg that became half of a live bridge skips the hangup DELETE —
+    but its worker-side registrations must go regardless."""
+
+    async def scenario() -> None:
+        session = _register(gateway)
+        session.bridged = True  # the transfer completed; the bridge owns both legs
+        await session.shutdown()
+
+    asyncio.run(scenario())
+    assert gateway._sessions == {}
+    assert gateway._session_to_bridge_call == {}
+
+
+def test_consult_call_id_is_cleared_after_a_completed_transfer(gateway):
+    """W6: ``hangup`` returns early once bridged, so the consult id it
+    would otherwise have cleared survived every successful warm
+    transfer — one string per transfer, for the life of the process."""
+
+    async def scenario() -> None:
+        session = _register(gateway)
+        gateway.set_consult_call_id("sess-1", "consult-leg-1")
+        assert gateway.get_consult_call_id("sess-1") == "consult-leg-1"
+        session.bridged = True
+        await session.shutdown()
+
+    asyncio.run(scenario())
+    assert gateway.get_consult_call_id("sess-1") is None
+
+
+def test_unregister_releases_a_never_shutdown_session(gateway):
+    """The inbound arm's failure path (W2) calls unregister directly."""
+    _register(gateway, "sess-2")
+    gateway.unregister_session("sess-2")
+    assert gateway.live_session("sess-2") is None
+    assert gateway.wait_for_leg_done("sess-2").is_set()

--- a/agents/pipecat/tests/test_invocation_log.py
+++ b/agents/pipecat/tests/test_invocation_log.py
@@ -29,10 +29,15 @@ def _msg(call_id, message="hi", level="INFO"):
 @pytest.fixture(autouse=True)
 def _clear_buffer():
     with invocation_log._LOCK:
-        invocation_log._BUFFER.clear()
+        invocation_log._BUFFERS.clear()
     yield
     with invocation_log._LOCK:
-        invocation_log._BUFFER.clear()
+        invocation_log._BUFFERS.clear()
+
+
+def _buffered() -> list:
+    """Every buffered entry, in per-call insertion order."""
+    return [e for buf in invocation_log._BUFFERS.values() for e in buf]
 
 
 def test_sink_buffers_only_call_scoped():
@@ -40,12 +45,12 @@ def test_sink_buffers_only_call_scoped():
     invocation_log._capture_sink(_msg(None, "orphan"))  # no callId -> dropped
     invocation_log._capture_sink(_msg("call-A", "a2"))
     invocation_log._capture_sink(_msg("call-B", "b1"))
-    assert [e["callId"] for e in invocation_log._BUFFER] == ["call-A", "call-A", "call-B"]
+    assert [e["callId"] for e in _buffered()] == ["call-A", "call-A", "call-B"]
 
 
 def test_entries_are_pino_shaped():
     invocation_log._capture_sink(_msg("call-A", "hello", level="WARNING"))
-    e = invocation_log._BUFFER[0]
+    e = _buffered()[0]
     assert isinstance(e["time"], int)  # epoch ms, for the UI timeline/playhead
     assert e["level"] == 40  # pino numeric: WARNING -> 40 (>=40 = notable)
     assert e["msg"] == "hello"
@@ -73,7 +78,7 @@ def test_flush_drains_only_that_call(monkeypatch):
     assert p["subsystem"] == "pipecat-agent"
     assert [e["msg"] for e in p["log"]] == ["a1", "a2"]
     # call-B's entry survives for its own flush
-    assert [e["callId"] for e in invocation_log._BUFFER] == ["call-B"]
+    assert [e["callId"] for e in _buffered()] == ["call-B"]
 
 
 def test_flush_noop_when_no_entries_for_call(monkeypatch):
@@ -107,12 +112,53 @@ def test_shutdown_flush_groups_by_call(monkeypatch):
     assert set(by_call) == {"call-A", "call-B"}
     assert by_call["call-A"]["userId"] == "envU"
     assert [e["msg"] for e in by_call["call-A"]["log"]] == ["a1", "a2"]
-    assert invocation_log._BUFFER == []
+    assert _buffered() == []
 
 
 def test_max_entries_cap(monkeypatch):
-    monkeypatch.setattr(invocation_log, "_MAX_ENTRIES", 3)
+    monkeypatch.setattr(invocation_log, "_MAX_ENTRIES_PER_CALL", 3)
     for i in range(5):
         invocation_log._capture_sink(_msg("call-A", f"m{i}"))
     # oldest dropped, newest kept
-    assert [e["msg"] for e in invocation_log._BUFFER] == ["m2", "m3", "m4"]
+    assert [e["msg"] for e in _buffered()] == ["m2", "m3", "m4"]
+
+
+def test_one_calls_verbosity_cannot_evict_another_calls_records():
+    """The cap is per call, not process-wide.
+
+    With one shared buffer, a busy node's chatty calls evicted the OLDEST
+    entries across the whole process — which were the setup and connect
+    lines of the still-running long calls, exactly the records needed to
+    diagnose a silent leg.
+    """
+    invocation_log._MAX_ENTRIES_PER_CALL  # documents the knob under test
+    invocation_log._capture_sink(_msg("quiet-call", "the-line-that-matters"))
+    for i in range(invocation_log._MAX_ENTRIES_PER_CALL + 50):
+        invocation_log._capture_sink(_msg("chatty-call", f"noise{i}"))
+
+    quiet = list(invocation_log._BUFFERS["quiet-call"])
+    assert [e["msg"] for e in quiet] == ["the-line-that-matters"]
+    # and the chatty call is capped on its own budget
+    assert (
+        len(invocation_log._BUFFERS["chatty-call"])
+        == invocation_log._MAX_ENTRIES_PER_CALL
+    )
+
+
+def test_unflushed_call_buffers_are_bounded(monkeypatch):
+    """Buffers are normally dropped by their own call's flush; the call
+    ceiling only bounds calls that end without one."""
+    monkeypatch.setattr(invocation_log, "_MAX_CALLS", 3)
+    for i in range(6):
+        invocation_log._capture_sink(_msg(f"call-{i}", "x"))
+    assert len(invocation_log._BUFFERS) <= 3
+    # the most recent calls are the ones kept
+    assert "call-5" in invocation_log._BUFFERS
+
+
+def test_drain_removes_only_that_calls_buffer():
+    invocation_log._capture_sink(_msg("call-A", "a1"))
+    invocation_log._capture_sink(_msg("call-B", "b1"))
+    assert [e["msg"] for e in invocation_log._drain("call-A")] == ["a1"]
+    assert "call-A" not in invocation_log._BUFFERS
+    assert [e["msg"] for e in invocation_log._BUFFERS["call-B"]] == ["b1"]

--- a/agents/pipecat/tests/test_invocation_log.py
+++ b/agents/pipecat/tests/test_invocation_log.py
@@ -162,3 +162,38 @@ def test_drain_removes_only_that_calls_buffer():
     assert [e["msg"] for e in invocation_log._drain("call-A")] == ["a1"]
     assert "call-A" not in invocation_log._BUFFERS
     assert [e["msg"] for e in invocation_log._BUFFERS["call-B"]] == ["b1"]
+
+
+def test_sink_reports_evictions_without_re_entering_loguru(monkeypatch, capsys):
+    """The eviction path must not use ``logger``.
+
+    loguru calls this sink inline (enqueue=False) and is not re-entrant:
+    a log emitted from inside the sink trips its "deadlock avoided"
+    guard, which raises out of the sink — losing the message and turning
+    every eviction into a handler error. The eviction is reported with a
+    counter and a direct stderr write instead. Driving a real eviction
+    through the real logger is the only way to check this.
+    """
+    from loguru import logger
+
+    monkeypatch.setattr(invocation_log, "_MAX_CALLS", 2)
+    monkeypatch.setattr(invocation_log, "_dropped_call_buffers", 0)
+    sink_id = logger.add(
+        invocation_log._capture_sink, level="INFO", enqueue=False,
+        backtrace=False, diagnose=False,
+    )
+    try:
+        for i in range(4):
+            with logger.contextualize(callId=f"call-{i}"):
+                logger.info("hello")
+    finally:
+        logger.remove(sink_id)
+
+    assert len(invocation_log._BUFFERS) <= 2
+    assert invocation_log.dropped_call_buffers() == 2
+    err = capsys.readouterr().err
+    assert "dropped buffered records" in err
+    # The tell-tale of re-entering loguru from the sink.
+    assert "deadlock avoided" not in err, (
+        "the eviction path re-entered loguru from inside the sink"
+    )

--- a/agents/pipecat/tests/test_mcp_tools.py
+++ b/agents/pipecat/tests/test_mcp_tools.py
@@ -46,8 +46,9 @@ class _FakeSession:
         self._raises = raises
         self.calls = []
 
-    async def call_tool(self, name, arguments=None):
+    async def call_tool(self, name, arguments=None, read_timeout_seconds=None):
         self.calls.append((name, arguments))
+        self.last_read_timeout = read_timeout_seconds
         if self._raises:
             raise self._raises
         return self._result

--- a/agents/pipecat/tests/test_output_underrun.py
+++ b/agents/pipecat/tests/test_output_underrun.py
@@ -98,7 +98,10 @@ class TestLatenessIsTheAnswer:
                 await t.recv()
             t.stop()
             assert t.underrun.never_refilled == 1
-            assert t.underrun.late_ms == [], "nothing arrived, so nothing can be late"
+            # A bounded deque now, not a list — compare contents.
+            assert list(t.underrun.late_ms) == [], (
+                "nothing arrived, so nothing can be late"
+            )
 
         asyncio.run(run())
 

--- a/agents/pipecat/tests/test_tool_log.py
+++ b/agents/pipecat/tests/test_tool_log.py
@@ -23,16 +23,44 @@ from pipecat_aplisay import invocation_log, tool_log
 @pytest.fixture(autouse=True)
 def _clear_buffer():
     with invocation_log._LOCK:
-        invocation_log._BUFFER.clear()
+        invocation_log._BUFFERS.clear()
     yield
     with invocation_log._LOCK:
-        invocation_log._BUFFER.clear()
+        invocation_log._BUFFERS.clear()
+
+
+class _BufferView:
+    """Live flat view over the per-call capture buffers.
+
+    The sink keys entries by callId (one deque each) rather than
+    appending to one process-wide list, so tests that just want "what
+    was captured" read through this.
+    """
+
+    def __iter__(self):
+        return iter(self._entries())
+
+    def __len__(self):
+        return len(self._entries())
+
+    def __getitem__(self, index):
+        return self._entries()[index]
+
+    def __eq__(self, other):
+        return self._entries() == other
+
+    def __repr__(self):
+        return repr(self._entries())
+
+    @staticmethod
+    def _entries() -> list:
+        return [e for buf in invocation_log._BUFFERS.values() for e in buf]
 
 
 @pytest.fixture()
 def capture():
     """Install the real capture sink at INFO (as in production) for the duration
-    of the test, then remove it. Yields the shared buffer."""
+    of the test, then remove it. Yields a flat view over the buffers."""
     sink_id = logger.add(
         invocation_log._capture_sink,
         level="INFO",
@@ -41,7 +69,7 @@ def capture():
         diagnose=False,
     )
     try:
-        yield invocation_log._BUFFER
+        yield _BufferView()
     finally:
         logger.remove(sink_id)
 

--- a/agents/pipecat/tests/test_worker_healthz.py
+++ b/agents/pipecat/tests/test_worker_healthz.py
@@ -21,9 +21,11 @@ from pipecat_aplisay import worker
 
 
 class _State:
-    def __init__(self, live=None, peers=None):
+    def __init__(self, live=None, peers=None, tasks=None, gateway=None):
         self.live_calls = live or {}
         self.webrtc_connections = peers or {}
+        self.tasks = tasks or set()
+        self.sip_gateway = gateway
 
 
 class _App:
@@ -88,3 +90,51 @@ def test_thread_spawn_failure_is_a_hard_503(loop, monkeypatch):
     status, body = _run(_State())
     assert status == 503
     assert any("cannot start threads" in p for p in body["problems"])
+
+
+# ---- Gateway-map and task visibility -------------------------------------
+#
+# The two worst leaks in the 2026-09-03 audit were both invisible to this
+# probe: a WebSocket handler parked forever per outbound call (W1), and a
+# gateway session retained per concurrency-refused inbound call (W2).
+# Neither touches live_calls and neither spawns a thread, so the counts
+# below are what would have caught them.
+
+
+class _FakeGateway:
+    def __init__(self, sessions=0, legs=0):
+        self._sessions = {f"s{i}": object() for i in range(sessions)}
+        self._session_to_bridge_call = {f"s{i}": "c" for i in range(sessions)}
+        self._leg_done_events = {f"s{i}": object() for i in range(legs)}
+
+
+def test_gateway_map_sizes_are_reported(loop):
+    status, body = _run(_State(gateway=_FakeGateway(sessions=3, legs=2)))
+    assert status == 200
+    assert body["gateway_maps"]["sessions"] == 3
+    assert body["gateway_maps"]["session_to_bridge_call"] == 3
+    assert body["gateway_maps"]["leg_done_events"] == 2
+
+
+def test_gateway_map_runaway_trips_the_watermark(loop):
+    # W1/W2 shape: sessions registered and never released, while
+    # live_calls stays at zero because the calls themselves ended.
+    gateway = _FakeGateway(sessions=worker.HEALTHZ_MAX_GATEWAY_ENTRIES, legs=0)
+    status, body = _run(_State(gateway=gateway))
+    assert status == 503
+    assert any("gateway map entries" in p for p in body["problems"])
+
+
+def test_no_gateway_reports_empty_maps(loop):
+    status, body = _run(_State())
+    assert status == 200
+    assert body["gateway_maps"] == {}
+
+
+def test_task_runaway_trips_the_watermark(loop):
+    # W1 shape: one parked handler task per outbound call, forever.
+    tasks = {object() for _ in range(worker.HEALTHZ_MAX_TASKS + 1)}
+    status, body = _run(_State(tasks=tasks))
+    assert status == 503
+    assert any("asyncio tasks" in p for p in body["problems"])
+    assert body["tasks"] == worker.HEALTHZ_MAX_TASKS + 1


### PR DESCRIPTION
Resolves the findings from the 2026-09-03 Pipecat & sipbridge production-readiness audit — all 7 High, all 13 Medium, and the Low/framework items, across the Python worker, its peripheral modules and the Go bridge.

The framing from the audit still holds: LiveKit gave us a fresh process per call, so nothing in that stack ever had to free anything. These two are long-lived processes on a DaemonSet node that must run for weeks across thousands of calls. The happy path was already clean on both sides; everything here is on an edge path — and several of those edges are the busiest paths a production node sees.

## The seven that actually leaked

| Path | What was lost, per occurrence | Fix |
|---|---|---|
| Every **outbound** call | parked WS handler task + transport + WebSocket + 3 map entries | W1 — `shutdown()` now unregisters |
| Every inbound call **refused by the concurrency limit** | gateway session + transport + WebSocket; plus an open Call row | W2 — unregister on the failure arms, end the unstarted row |
| Every **recorded** call, while it runs | whole-call stereo audio in RAM (~345 MB/hour) against a 1 GiB limit | W3 — 16 kHz with a 5 s flush |
| A peer that **stops media without a BYE** and ignores ours | RTP port + 3–4 goroutines, permanently | G1 — `tx.Done()` arm, bounded ctx, media released before the BYE |
| Any **re-INVITE** (hold, session-timer refresh) | old port/socket/goroutines/WS — *and the call dropped 10 s later* | G2 — 488, which per RFC 3261 §14.1 leaves the session unchanged |
| A **worker crash or roll** mid-call | an entry in both bridge registries per call; peer dialog left up | G3 — the bare `c.Close()` sites route through the manager teardown |
| Every **rejected INVITE** | one 20 ms ticker goroutine, forever | G4 — close the whole Call, not just the socket |

Two more scaled badly without leaking, and both are fixed: the worker built a **new `httpx.AsyncClient` per REST request** — a fresh SSLContext parsed on the event loop, several times a second per call with `streamLog` on, which every call on the node hears as output jitter (W4, now pooled clients in `http_client.py`); and the **invocation-log buffer was one process-wide FIFO** shared by every call, so under load long calls lost the start of their debug logs — exactly the records you need for a silent leg (P1, now a deque per call).

## One judgement call worth your eye

**F1 — the idle cancel is off on two side pipelines only.** The framework cancels any pipeline that sees no `BotSpeakingFrame`/`UserSpeakingFrame` for 300 s, on by default, and no `PipelineTask(...)` site overrode it. Two of ours emit neither frame *by design* and were being cancelled mid-use: the STT-only `bridge_transcript` (so `options.stt.aux` / `options.tts.output` silently stopped transcribing five minutes into every long call) and the relay-only leg in `media_relay` (cancelled five minutes into every relayed conversation, which `_run_relay_leg` then read as the target hanging up). Those two now pass `idle_timeout_secs=None`.

The **main** pipelines keep the framework default, per review: 300 s is comfortably longer than any consult hold, and a backstop under `maxDuration` / `options.inactivity` is wanted. Same for the fixed-message playout, which the audit never showed breaking and which is bounded far more tightly by its own ceiling. All four sites now carry a comment saying which way they went and why, so neither gets "fixed" to match the other later.

**Ops — the node now drains on SIGTERM.** Section 6's open question. Both containers get a preStop hook that waits for their own live-call count to reach zero, and `terminationGracePeriodSeconds` goes to 1260. The hooks have to be on *both*: Kubernetes runs preStop per container and SIGTERMs each as soon as its own hook returns, so a hook on the worker alone would leave sipbridge BYEing the very calls the worker was waiting for. Each exits the moment its node is empty, so a quiet node still rolls in seconds, and `maxUnavailable: 1` keeps a fleet roll node-by-node. The worker's hook is Python (the image is `python:slim`, no curl); sipbridge's goes through the busybox shim (distroless, no shell), and a Go test pins the `/health` body shape it greps for.

## Everything else

- **G5** CANCEL-during-setup, `ReadInvite`/`WriteResponse` failure and unknown-dialog BYE all dropped `s.calls` without telling the manager — all three now run the manager teardown. **G6** `Hangup` on a bridged leg left the peer with dead air; it mirrors `onBye`. **G7** the jitter buffer had no depth cap and no discontinuity resync, so an SSRC change left the cursor thousands of slots behind with no recovery. **G8** graceful drain. **G9** SRTP/RTP failures logged per packet — 50 Warn lines a second for a whole call on a trunk that negotiates SAVP and sends plaintext; rate-limited, and the read loop gives up after 100 consecutive decrypt failures. **G10** `pickPort`'s probe-close-rebind TOCTOU (failed INVITEs with 500 under concurrency), request-body cap and full server timeouts, `srtpAvoid` sweeping its `dest:` keys, a repeat `BridgeRelay` stopping the mixer it replaces, `Originate` gaining the early-close check, pre-built silence frames, consistent locking on `ws`/`releaseStop`/`Session.cancel`, and the "0 disables the watchdog" comment corrected (it does not).
- **W5/P2** MCP servers left open when the build failed after connecting; connect had no worker-side deadline (only the client's 30 s/300 s) so one unresponsive server stalled setup for minutes with the caller answered and holding a slot; and a cancelled connect orphaned the session because the `except` caught only `Exception`. **W6–W10** consult id, `calls_by_channel`, handlers accumulating across fallback retries, the `/webrtc/offer` timeout orphaning a still-running pipeline, and task references.
- **P3–P10** tone injector waking 50×/s for the whole call while disarmed; one thread hop per 20 ms recording frame on the six-thread executor shared with DNS; a fresh GCS client per upload and an unbounded ffmpeg on the teardown path; voiceblender/FreeSWITCH state that never expired plus a VSI loop that serialised every leg behind one slow handler (now per-leg chains — still ordered within a leg, since they drive a state machine); relay endpoints never disengaged; the structures that grew with call length; the per-sample Python loops; and the `fixed_message` timeout branch that was unreachable, so an overrunning playout reported success — which in the fallback chain means "the caller heard the announcement".
- **`/healthz`** now reports the tracked task count and the gateway's per-call map sizes. Neither W1 nor W2 touched `live_calls` or spawned a thread, so the existing watermarks could not have seen either.

## Verification

478 Python tests (14 new) and the full Go suite pass, including `go test -race`. The gateway-release tests were checked against the pre-fix code — four of six fail without it — as was the invocation-log sink test.

Nothing here has been run against a live system. The audit's section 7 soak plan is the right next step, and cases (b) inbound-refused and (c) outbound-originate should show the largest deltas.

Two things to know while reading the diff: ~56 lines are gofmt realignment of pre-existing misalignment in blocks I added fields to, and the P4 recording change means up to 64 KiB of a recording sits in memory before it reaches disk (bounded, versus the whole call before).
