### PR TITLE
Registrar accounts: mode, kind and bindings on phone registrations (schema 66)

### DIFF
--- a/api/api-doc.yaml
+++ b/api/api-doc.yaml
@@ -1844,7 +1844,10 @@ components:
       description: |-
         Schema for creating a new phone endpoint. Supports two types of endpoints:
         DDI endpoints are created using an E.164 phone number with trunk configuration.
-        Phone registration endpoints are created using a SIP contact URI, username, and password.
+        Phone registration endpoints are created using a SIP contact URI, username, and password
+        (client mode, the default: we register out to the customer's registrar), or with
+        `mode: registrar` and no credentials at all (a registrar account: the customer's PBX
+        registers to us with a username and password the platform mints and returns once).
         Both kinds of endpoints can be created with a user-defined descriptive name and optionally set to support outbound calling
         (if supported by the handler and trunk/registration account).
       allOf:
@@ -1901,7 +1904,7 @@ components:
                     number, trunk and organisation; it is consumed by the claim. Missing gives
                     403 code reservation_required; expired, used or mismatched gives 403 code
                     reservation_invalid.
-            - description: Phone registration endpoint
+            - description: Phone registration endpoint, client mode — we register out to the customer's registrar with the credentials given here
               type: object
               required:
                 - registrar
@@ -1912,6 +1915,11 @@ components:
                   type: string
                   description: User-defined descriptive name
                   nullable: true
+                mode:
+                  type: string
+                  enum: [client]
+                  default: client
+                  description: Direction of service. Omit, or `client`, for a line we register out with. See the registrar-account branch for `registrar`.
                 registrar:
                   $ref: '#/components/schemas/Registrar'
                 username:
@@ -1942,6 +1950,41 @@ components:
                 didCountry:
                   type: string
                   description: ISO 3166-1 alpha-2 country used to normalise a national-format dialled number to E.164. Null = platform default.
+            - description: |-
+                Registrar account (`mode: registrar`): the customer's PBX registers to us. The platform
+                mints the account's identity — `registrar` (the deployment's balancer name, also the
+                digest realm), `username` and `password` — and returns it once in the 201 response;
+                supplying any of the three, or `b2buaId`, is refused with 400. Everything else
+                (`trunk`, `trunkId`, `didSource`, `didCountry`, `options`, `handler`, `outbound`,
+                `name`) behaves as for a client-mode registration. Served by regserver; 503 with code
+                `registrar_unavailable` on a deployment with no registrar configured.
+              type: object
+              required:
+                - mode
+              properties:
+                mode:
+                  type: string
+                  enum: [registrar]
+                kind:
+                  type: string
+                  enum: [pbx]
+                  default: pbx
+                  description: What registers to us. Only `pbx` exists; `device` is reserved and refused.
+                options:
+                  $ref: '#/components/schemas/PhoneRegistrationOptions'
+                trunk:
+                  type: boolean
+                  default: false
+                  description: Create the account as a registration trunk that numbers attach to, exactly as for a client-mode registration.
+                trunkId:
+                  type: string
+                  description: "Name the trunk instead of the default `reg-<registration id>`; requires trunk:create, and only with trunk set to true."
+                didSource:
+                  type: string
+                  description: Where the dialled number is found on an INVITE from the PBX (`request-uri` default, `to`, `header:<Name>`, `none`).
+                didCountry:
+                  type: string
+                  description: ISO 3166-1 alpha-2 country used to normalise a national-format dialled number to E.164.
     PhoneEndpointUpdateInput:
       description: |-
         Schema for updating a phone endpoint. All fields are optional.
@@ -1950,6 +1993,9 @@ components:
         or the unallocated pool and is refused with 409 code number_in_use while it is attached to an agent.
         For phone-registration endpoints, `name`, `outbound`, `handler`, `registrar`, `username`, `password`, and `options` can be updated.
         When credentials (registrar, username, password) are updated, the registration state is reset to initial.
+        `mode` cannot change after creation (400 code mode_immutable). On a registrar account `registrar`,
+        `username`, `password` and `b2buaId` are the platform's and are refused (400 code
+        registrar_identity_immutable); POST /phone-endpoints/{id}/credentials/rotate issues a new password.
       type: object
       properties:
         name:
@@ -2025,9 +2071,11 @@ components:
           example: 10.154.0.62
         type:
           type: string
-          enum: [regclient, freeswitch]
+          enum: [regclient, regserver, freeswitch]
           default: regclient
-          description: Which stack this node is running. Only regclient serves the trace and probe API.
+          description: |-
+            Which stack this node is running. regclient and regserver both serve the trace API;
+            only regclient runs probes; the FreeSWITCH stack serves neither.
         version:
           type: string
           description: Build version, for telling a fleet mid-rollout apart
@@ -2038,6 +2086,9 @@ components:
         failedRegistrations:
           type: integer
           description: How many of those are currently failing
+        bindings:
+          type: integer
+          description: regserver only — PBXes currently registered to this node. Zero from regclient.
         systemLoad:
           type: number
           description: One-minute load average as the node sees it
@@ -2053,7 +2104,7 @@ components:
           description: Where the node answers from inside its own network, or null if it reported none.
         type:
           type: string
-          enum: [regclient, freeswitch]
+          enum: [regclient, regserver, freeswitch]
         version:
           type: string
           nullable: true
@@ -2061,6 +2112,9 @@ components:
           type: integer
         failedRegistrations:
           type: integer
+        bindings:
+          type: integer
+          description: PBXes currently registered to a regserver node; zero for the others.
         systemLoad:
           type: number
           nullable: true
@@ -2169,6 +2223,84 @@ components:
           description: |-
             For a call, how many more messages its platform leg holds — the same call between the
             b2bua node and the platform. The detail route adds them under `debug=1`.
+    RegistrarAccountCredentials:
+      type: object
+      description: |-
+        What a customer enters into their PBX for a registrar account. Revealed only for
+        registrar-mode registrations, only to callers holding phoneEndpoint:update, and every
+        reveal is written to the audit log.
+      required: [id, registrar, port, transport, username, password]
+      properties:
+        id:
+          type: string
+          description: The registration endpoint ID
+        registrar:
+          type: string
+          description: The name the PBX registers to (the deployment's balancer name), which is also the digest realm.
+          example: sip.polite.ai
+        port:
+          type: integer
+          example: 5061
+        transport:
+          type: string
+          enum: [tls]
+        username:
+          type: string
+          example: pbx-k7m2x9q4wz
+        password:
+          type: string
+    RegistrationBinding:
+      type: object
+      description: One PBX socket currently registered to the owning regserver node for this account.
+      properties:
+        contact:
+          type: string
+          description: The Contact URI as the PBX sent it, often a private address.
+        received:
+          type: string
+          description: The socket's remote address, host:port — where the node actually sends.
+        transport:
+          type: string
+        userAgent:
+          type: string
+          nullable: true
+        registeredAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        node:
+          type: string
+          description: The node holding the socket; the same value as the registration's b2buaId.
+    RegistrationBindings:
+      type: object
+      description: |-
+        The bindings held for a registrar account. By default the mirror the owning node last wrote
+        onto the row; with `live=1` the node's own view, fetched through the node API.
+      properties:
+        registrationId:
+          type: string
+        node:
+          type: string
+          nullable: true
+          description: The owning node, or null when nothing has registered yet.
+        live:
+          type: boolean
+        bindings:
+          type: array
+          items:
+            $ref: '#/components/schemas/RegistrationBinding'
+        bindingsUpdatedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When the owning node last mirrored the bindings onto the row.
+        fetchedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: With `live=1`, when the node answered; null for the mirror.
     SipTraceIndex:
       type: object
       description: |-

--- a/api/paths/agent-db/b2bua-nodes.js
+++ b/api/paths/agent-db/b2bua-nodes.js
@@ -1,5 +1,5 @@
 import { B2buaNode, B2BUA_NODE_TYPES } from '../../../lib/database.js';
-import { rememberNodeCapability, CAPABILITY_TRACE, CAPABILITY_NONE } from '../../../lib/regclient.js';
+import { rememberNodeCapability, nodeServesTraceApi, CAPABILITY_TRACE, CAPABILITY_NONE } from '../../../lib/regclient.js';
 
 let log;
 
@@ -37,7 +37,7 @@ const heartbeat = async (req, res) => {
     return res.status(403).send({ message: 'b2bua node heartbeats are accepted only from internal callers' });
   }
 
-  const { nodeId, privateAddress, type = 'regclient', version, registrations, failedRegistrations, systemLoad } = req.body || {};
+  const { nodeId, privateAddress, type = 'regclient', version, registrations, failedRegistrations, bindings, systemLoad } = req.body || {};
 
   if (!nodeId || typeof nodeId !== 'string' || !nodeId.trim()) {
     return res.status(400).send({ message: 'nodeId is required' });
@@ -61,13 +61,16 @@ const heartbeat = async (req, res) => {
       // zero the fleet view by accident.
       registrations: Number.isFinite(registrations) ? registrations : 0,
       failedRegistrations: Number.isFinite(failedRegistrations) ? failedRegistrations : 0,
+      // PBXes currently registered to a regserver node; a regclient node
+      // reports none.
+      bindings: Number.isFinite(bindings) ? bindings : 0,
       systemLoad: Number.isFinite(systemLoad) ? systemLoad : null,
       lastSeenAt: now
     }, { returning: true });
 
     // Prime the in-process capability cache from the same fact, so the very
     // next trace request on this replica skips even the database read.
-    rememberNodeCapability(nodeId.trim(), type === 'regclient' ? CAPABILITY_TRACE : CAPABILITY_NONE);
+    rememberNodeCapability(nodeId.trim(), nodeServesTraceApi(type) ? CAPABILITY_TRACE : CAPABILITY_NONE);
 
     return res.status(200).send({
       nodeId: record?.nodeId ?? nodeId.trim(),
@@ -117,6 +120,7 @@ const listNodes = async (req, res) => {
           version: node.version,
           registrations: node.registrations,
           failedRegistrations: node.failedRegistrations,
+          bindings: node.bindings ?? 0,
           systemLoad: node.systemLoad,
           lastSeenAt: lastSeenAt ? lastSeenAt.toISOString() : null,
           // A node that has stopped heartbeating is reported as stale rather

--- a/api/paths/phone-endpoints.js
+++ b/api/paths/phone-endpoints.js
@@ -3,6 +3,8 @@ import { getTelephonyHandler, HANDLER_NAMES, TELEPHONY_HANDLER_NAMES } from '../
 import { validateE164, normalizeE164, validateSipUri, validatePhoneRegistration, validateE164Ddi, validateRegistrationTrunkFields } from '../../lib/validation.js';
 import { scopeWhereForOrganisation } from '../../lib/scope.js';
 import { requirePermission, can } from '../../lib/auth/permissions.js';
+import { mintRegistrarUsername, mintRegistrarPassword } from '../../lib/utils/credentials.js';
+import { registrarRealm, REGISTRAR_PORT, REGISTRAR_TRANSPORT } from '../../lib/registrar-accounts.js';
 
 let appParameters, log;
 
@@ -149,7 +151,9 @@ const phoneEndpointList = (async (req, res) => {
         handler: r.handler,
         outbound: !!r.outbound,
         trunkId: r.trunkId || null,
-        trunk: !!r.trunkId
+        trunk: !!r.trunkId,
+        mode: r.mode || 'client',
+        kind: r.kind || null
       }));
       const nextOffset = rows.length === size ? startOffset + size : null;
       return res.send({ items, nextOffset });
@@ -185,7 +189,7 @@ const phoneEndpointList = (async (req, res) => {
       regWhere
         ? PhoneRegistration.findAll({
             where: regWhere,
-            attributes: ['id', 'name', 'registrar', 'username', 'b2buaId', 'status', 'state', 'handler', 'outbound', 'callReceived', 'createdAt', 'trunkId'],
+            attributes: ['id', 'name', 'registrar', 'username', 'b2buaId', 'status', 'state', 'handler', 'outbound', 'callReceived', 'createdAt', 'trunkId', 'mode', 'kind'],
             limit: size,
             offset: startOffset
           })
@@ -216,6 +220,8 @@ const phoneEndpointList = (async (req, res) => {
       b2buaId: r.b2buaId || null,
       trunkId: r.trunkId || null,
       trunk: !!r.trunkId,
+      mode: r.mode || 'client',
+      kind: r.kind || null,
       status: r.status,
       state: r.state,
       handler: r.handler,
@@ -447,6 +453,10 @@ const createPhoneEndpoint = async (req, res) => {
         });
       }
 
+      // Direction of service. A client row registers out to the customer's
+      // registrar; a registrar row is an account the customer's PBX registers
+      // to us with, served by regserver. Fixed at creation.
+      const mode = data.mode === 'registrar' ? 'registrar' : 'client';
       const validation = validatePhoneRegistration(data);
       const trunkErrors = validateRegistrationTrunkFields(data);
       if (!validation.isValid || trunkErrors.length) {
@@ -473,33 +483,60 @@ const createPhoneEndpoint = async (req, res) => {
         return res.status(409).send({ error: `Trunk ${requestedTrunkId} already exists` });
       }
 
-      // Strip sip:/sips: prefix from registrar if present before saving
-      const normalizedRegistrar = data.registrar?.replace(/^sips?:/i, '') || data.registrar;
-
-      // Check for duplicate registration (same registrar and username)
-      const existingRegistration = await PhoneRegistration.findOne({
-        where: {
-          registrar: normalizedRegistrar,
-          username: data.username,
-          organisationId: organisationId
+      // The account's identity. A client row carries the credentials the
+      // customer gave us for their registrar. A registrar row is an identity we
+      // issue: the deployment's balancer name as realm, and a minted username
+      // and password the customer copies into their PBX. The password is
+      // returned once, here; after that only the audited credentials routes
+      // reveal or rotate it.
+      let normalizedRegistrar;
+      let username;
+      let password;
+      if (mode === 'registrar') {
+        normalizedRegistrar = registrarRealm();
+        if (!normalizedRegistrar) {
+          return res.status(503).send({
+            error: 'Registrar accounts are not available on this deployment (REGSERVER_REGISTRAR is not configured)',
+            code: 'registrar_unavailable'
+          });
         }
-      });
+        username = mintRegistrarUsername();
+        password = mintRegistrarPassword();
+      } else {
+        // Strip sip:/sips: prefix from registrar if present before saving
+        normalizedRegistrar = data.registrar?.replace(/^sips?:/i, '') || data.registrar;
+        username = data.username;
+        password = data.password;
 
-      if (existingRegistration) {
-        return res.status(409).send({
-          error: 'Phone registration with the same registrar and username already exists'
+        // Check for duplicate registration (same registrar and username)
+        const existingRegistration = await PhoneRegistration.findOne({
+          where: {
+            registrar: normalizedRegistrar,
+            username,
+            organisationId: organisationId
+          }
         });
+
+        if (existingRegistration) {
+          return res.status(409).send({
+            error: 'Phone registration with the same registrar and username already exists'
+          });
+        }
       }
 
-      const record = await PhoneRegistration.sequelize.transaction(async (transaction) => {
+      const createRow = (usernameToUse) => PhoneRegistration.sequelize.transaction(async (transaction) => {
         const reg = await PhoneRegistration.create({
           name: data.name,
           handler: data.handler ?? 'livekit',
           outbound: data.outbound ?? false,
           registrar: normalizedRegistrar,
-          username: data.username,
-          password: data.password,
-          b2buaId: data.b2buaId != null && String(data.b2buaId).trim() ? String(data.b2buaId).trim() : null,
+          username: usernameToUse,
+          password,
+          mode,
+          kind: mode === 'registrar' ? 'pbx' : null,
+          // A registrar row's owner is whichever node accepts its REGISTER;
+          // validation has already refused a supplied b2buaId for one.
+          b2buaId: mode === 'client' && data.b2buaId != null && String(data.b2buaId).trim() ? String(data.b2buaId).trim() : null,
           options: data.options || null,
           organisationId,
           status: 'disabled',
@@ -513,6 +550,41 @@ const createPhoneEndpoint = async (req, res) => {
         }
         return reg;
       });
+
+      let record;
+      if (mode === 'registrar') {
+        // A minted username carries 50 bits of randomness, so a collision on
+        // the partial unique index is a retry with a fresh one — never a 409
+        // to a caller who chose nothing.
+        for (let attempt = 0; ; attempt++) {
+          try {
+            record = await createRow(username);
+            break;
+          } catch (err) {
+            if (err.name !== 'SequelizeUniqueConstraintError' || attempt >= 2) throw err;
+            username = mintRegistrarUsername();
+          }
+        }
+        req.log?.info({
+          audit: 'registrar-account-created',
+          registrationId: record.id,
+          organisationId,
+          userId: res.locals.user?.id,
+          username
+        }, 'registrar account created; credentials issued once');
+        return res.status(201).send({
+          success: true,
+          id: record.id,
+          trunkId: record.trunkId || null,
+          mode,
+          registrar: normalizedRegistrar,
+          port: REGISTRAR_PORT,
+          transport: REGISTRAR_TRANSPORT,
+          username,
+          password
+        });
+      }
+      record = await createRow(username);
 
       return res.status(201).send({ success: true, id: record.id, trunkId: record.trunkId || null });
     }
@@ -734,7 +806,14 @@ createPhoneEndpoint.apiDoc = {
                     description: 'Response when type is phone-registration',
                     required: ['id'],
                     properties: {
-                      id: { type: 'string', description: 'Registration id for the created phone registration' }
+                      id: { type: 'string', description: 'Registration id for the created phone registration' },
+                      trunkId: { type: 'string', nullable: true, description: 'The trunk created for a registration trunk, else null' },
+                      mode: { type: 'string', enum: ['registrar'], description: 'Present for a registrar account only' },
+                      registrar: { type: 'string', description: 'Registrar accounts only: the name the PBX registers to, also the digest realm' },
+                      port: { type: 'integer', description: 'Registrar accounts only: always 5061' },
+                      transport: { type: 'string', enum: ['tls'], description: 'Registrar accounts only' },
+                      username: { type: 'string', description: 'Registrar accounts only: the minted account username' },
+                      password: { type: 'string', description: 'Registrar accounts only: the minted password, shown here once; GET /phone-endpoints/{id}/credentials reveals it again, audited' }
                     }
                   }
                 ]

--- a/api/paths/phone-endpoints/{identifier}.js
+++ b/api/paths/phone-endpoints/{identifier}.js
@@ -146,7 +146,16 @@ const getPhoneEndpoint = async (req, res) => {
         trunkId: registration.trunkId || null,
         trunk: !!registration.trunkId,
         didSource: registration.didSource || null,
-        didCountry: registration.didCountry || null
+        didCountry: registration.didCountry || null,
+        mode: registration.mode || 'client',
+        kind: registration.kind || null,
+        // The bindings the owning regserver node last mirrored onto the row:
+        // who is registered to this account, from where, until when. Client
+        // rows have none, and the password is never here for either.
+        ...(registration.mode === 'registrar' ? {
+          bindings: Array.isArray(registration.bindings) ? registration.bindings : [],
+          bindingsUpdatedAt: registration.bindingsUpdatedAt ? new Date(registration.bindingsUpdatedAt).toISOString() : null
+        } : {})
       });
     }
 
@@ -317,6 +326,24 @@ const updatePhoneEndpoint = async (req, res) => {
       }
       if (registration.organisationId !== organisationId) {
         return res.status(403).send({ error: 'Access denied' });
+      }
+
+      // Mode is fixed at creation, and a registrar account's identity is the
+      // platform's: the realm is the deployment's, the username and password
+      // are minted (a new password comes from /credentials/rotate), and
+      // b2buaId is written by the node that accepts the REGISTER — ownership
+      // follows the socket, never this route.
+      if (updateData.mode !== undefined && updateData.mode !== (registration.mode || 'client')) {
+        return res.status(400).send({ error: 'mode cannot be changed after creation', code: 'mode_immutable' });
+      }
+      if (registration.mode === 'registrar') {
+        const refused = ['registrar', 'username', 'password', 'b2buaId'].filter((field) => updateData[field] !== undefined);
+        if (refused.length) {
+          return res.status(400).send({
+            error: `${refused.join(', ')} cannot be set on a registrar account; POST /phone-endpoints/{id}/credentials/rotate issues a new password`,
+            code: 'registrar_identity_immutable'
+          });
+        }
       }
 
       // Update allowed fields for registrations

--- a/api/paths/phone-endpoints/{identifier}/bindings.js
+++ b/api/paths/phone-endpoints/{identifier}/bindings.js
@@ -1,0 +1,151 @@
+import { PhoneRegistration } from '../../../../lib/database.js';
+import { userOwnsRow } from '../../../../lib/scope.js';
+import { requirePermission } from '../../../../lib/auth/permissions.js';
+import { isRegistrarAccount } from '../../../../lib/registrar-accounts.js';
+import { resolveRegistrationNode, nodeDialAddress } from '../../../../lib/regclient-facade.js';
+import {
+  buildBindingsUrl,
+  nodeRequest,
+  describeNodeFailure,
+  capabilityFromFailure,
+  unsupportedNodeBody,
+  boolEnv,
+  CAPABILITY_NONE
+} from '../../../../lib/regclient.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    GET: getBindings
+  };
+};
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Who is registered to a registrar account, from where, and until when.
+ *
+ * Two sources for one answer. The default is the mirror: the array the owning
+ * regserver node last wrote onto the row, which costs nothing to read and is
+ * what a listing or a drawer should show. `live=1` asks the owning node itself
+ * through the node API, the same way a trace is fetched, for the moment
+ * somebody is asking "is it really registered right now" — at the cost of a
+ * round trip to that node and a 504 if it is not answering.
+ */
+const getBindings = async (req, res) => {
+  if (!requirePermission(res, 'phoneEndpoint', 'read')) return;
+  const { identifier } = req.params;
+  const live = boolEnv(req.query?.live, false);
+
+  try {
+    if (!identifier || identifier.match(/^\+?[0-9]+$/)) {
+      return res.status(400).send({ error: 'Identifier must be a registration ID, not a phone number' });
+    }
+    if (!UUID.test(identifier)) {
+      return res.status(404).send({ error: 'Phone endpoint not found' });
+    }
+    const registration = await PhoneRegistration.findByPk(identifier);
+    if (!registration) {
+      return res.status(404).send({ error: 'Phone endpoint not found' });
+    }
+    if (!userOwnsRow(res.locals.user, registration)) {
+      return res.status(403).send({ error: 'Access denied' });
+    }
+    if (!isRegistrarAccount(registration)) {
+      return res.status(404).send({
+        error: 'This registration is a client-mode line; bindings exist only for registrar accounts',
+        code: 'not_registrar_account'
+      });
+    }
+
+    if (!live) {
+      return res.send({
+        registrationId: registration.id,
+        node: registration.b2buaId || null,
+        live: false,
+        bindings: Array.isArray(registration.bindings) ? registration.bindings : [],
+        bindingsUpdatedAt: registration.bindingsUpdatedAt ? new Date(registration.bindingsUpdatedAt).toISOString() : null,
+        fetchedAt: null
+      });
+    }
+
+    const resolved = await resolveRegistrationNode({ identifier, user: res.locals.user, log: req.log });
+    if (!resolved.ok) return res.status(resolved.status).send(resolved.body);
+    const { node, config } = resolved;
+
+    const address = await nodeDialAddress(node, config, { log: req.log });
+    const url = buildBindingsUrl({ node: address, registrationId: identifier }, config);
+
+    let response;
+    try {
+      response = await nodeRequest({ url, responseType: 'json', config, node });
+    }
+    catch (err) {
+      if (capabilityFromFailure(err) === CAPABILITY_NONE) {
+        return res.status(501).send(unsupportedNodeBody(node));
+      }
+      req.log?.warn({ err: err.message, node }, 'b2bua node bindings fetch failed');
+      return res.status(504).send(describeNodeFailure(err, node));
+    }
+
+    if (response.status === 404) {
+      // The node named on the row does not hold this account: it has moved,
+      // or that node restarted and the PBX has not come back yet. The mirror
+      // says what was last known; the caller asked for now.
+      return res.status(404).send({ message: 'The owning node holds no bindings for this account', node });
+    }
+    if (response.status >= 400) {
+      req.log?.warn({ node, status: response.status }, 'b2bua node rejected bindings request');
+      return res.status(502).send({ error: 'bindings unavailable', node, reason: `node returned ${response.status}` });
+    }
+
+    const fetchedAt = new Date().toISOString();
+    res.setHeader('X-Regclient-Node', node);
+    res.setHeader('X-Regclient-Fetched-At', fetchedAt);
+    const data = response.data && typeof response.data === 'object' ? response.data : {};
+    return res.send({
+      registrationId: registration.id,
+      node,
+      live: true,
+      bindings: Array.isArray(data.bindings) ? data.bindings : [],
+      bindingsUpdatedAt: registration.bindingsUpdatedAt ? new Date(registration.bindingsUpdatedAt).toISOString() : null,
+      fetchedAt
+    });
+  }
+  catch (err) {
+    req.log?.error(err, 'fetching registrar account bindings');
+    return res.status(500).send({ error: 'Internal server error' });
+  }
+};
+
+getBindings.apiDoc = {
+  summary: 'The bindings held for a registrar account',
+  description: `Who is registered to this account, from where, and until when. By default the mirror
+                the owning node last wrote onto the row, which is what the Connections table shows.
+                With \`live=1\` the owning node is asked directly through the node API, exactly as a
+                trace is fetched: 409 when nothing has registered yet, 404 when the named node no
+                longer holds the account, 504 when it does not answer in time.`,
+  operationId: 'getRegistrarAccountBindings',
+  tags: ['Phone Endpoints'],
+  parameters: [
+    { name: 'identifier', in: 'path', required: true, schema: { type: 'string' }, description: 'Registration endpoint ID (registrar accounts only)' },
+    { name: 'live', in: 'query', required: false, schema: { type: 'boolean', default: false }, description: 'Ask the owning node rather than reading the mirror on the row' }
+  ],
+  responses: {
+    200: {
+      description: 'The bindings',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/RegistrationBindings' } } }
+    },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    404: { description: 'Not found, not a registrar account, or (live) the owning node holds no bindings', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    409: { description: 'Live view requested but no node has accepted a REGISTER for this account yet', content: { 'application/json': { schema: { $ref: '#/components/schemas/Conflict' } } } },
+    501: { description: 'The owning node does not provide the node API', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeCapabilityUnavailable' } } } },
+    502: { description: 'The owning node answered with an error, or is not an address we will contact', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    503: { description: 'Node proxying is not configured in this deployment', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    504: { description: 'The owning node did not answer in time', content: { 'application/json': { schema: { $ref: '#/components/schemas/NodeUnavailable' } } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};

--- a/api/paths/phone-endpoints/{identifier}/credentials.js
+++ b/api/paths/phone-endpoints/{identifier}/credentials.js
@@ -1,0 +1,108 @@
+import { PhoneRegistration } from '../../../../lib/database.js';
+import { userOwnsRow } from '../../../../lib/scope.js';
+import { requirePermission } from '../../../../lib/auth/permissions.js';
+import { credentialsFor, isRegistrarAccount } from '../../../../lib/registrar-accounts.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    GET: revealCredentials
+  };
+};
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * What a customer types into their PBX for a registrar account: the name to
+ * register to, the port and transport, and the minted username and password.
+ *
+ * The create response showed the password once. This is the only other place
+ * it is readable, and it is deliberately not the endpoint's ordinary GET: a
+ * listing or an edit drawer should not carry a live credential on every render.
+ * Gated on phoneEndpoint:update — whoever may set a line's password may read an
+ * account's — and every reveal is written to the log as an audit line naming
+ * the user and the row.
+ */
+const revealCredentials = async (req, res) => {
+  if (!requirePermission(res, 'phoneEndpoint', 'update')) return;
+  const { identifier } = req.params;
+
+  try {
+    const registration = await loadRegistrarAccount(identifier, res);
+    if (!registration) return;
+
+    req.log?.info({
+      audit: 'registrar-credentials-revealed',
+      registrationId: registration.id,
+      organisationId: registration.organisationId,
+      userId: res.locals.user?.id
+    }, 'registrar account credentials revealed');
+
+    return res.send(credentialsFor(registration));
+  }
+  catch (err) {
+    req.log?.error(err, 'revealing registrar account credentials');
+    return res.status(500).send({ error: 'Internal server error' });
+  }
+};
+
+/**
+ * The registrar account named by the path, or null after answering the
+ * request: a phone number, an unknown id, another organisation's row, or a
+ * client-mode line (which has no platform-issued credentials to show) are each
+ * refused with the status that says which.
+ */
+export async function loadRegistrarAccount(identifier, res) {
+  if (!identifier || identifier.match(/^\+?[0-9]+$/)) {
+    res.status(400).send({ error: 'Identifier must be a registration ID, not a phone number' });
+    return null;
+  }
+  if (!UUID.test(identifier)) {
+    res.status(404).send({ error: 'Phone endpoint not found' });
+    return null;
+  }
+  const registration = await PhoneRegistration.findByPk(identifier);
+  if (!registration) {
+    res.status(404).send({ error: 'Phone endpoint not found' });
+    return null;
+  }
+  if (!userOwnsRow(res.locals.user, registration)) {
+    res.status(403).send({ error: 'Access denied' });
+    return null;
+  }
+  if (!isRegistrarAccount(registration)) {
+    res.status(404).send({
+      error: 'This registration is a client-mode line, not a registrar account; its credentials are the ones you supplied',
+      code: 'not_registrar_account'
+    });
+    return null;
+  }
+  return registration;
+}
+
+revealCredentials.apiDoc = {
+  summary: 'Reveal the credentials of a registrar account',
+  description: `The name, port, transport, username and password a customer enters into their PBX
+                for a registrar account (a phone registration created with \`mode: registrar\`).
+                The password was returned once when the account was created; this route is the only
+                other place it can be read. Requires phoneEndpoint:update, and every call is recorded
+                in the audit log. 404 for a client-mode registration, whose credentials are the
+                customer's own.`,
+  operationId: 'revealRegistrarAccountCredentials',
+  tags: ['Phone Endpoints'],
+  parameters: [
+    { name: 'identifier', in: 'path', required: true, schema: { type: 'string' }, description: 'Registration endpoint ID (registrar accounts only)' }
+  ],
+  responses: {
+    200: {
+      description: 'The account credentials',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/RegistrarAccountCredentials' } } }
+    },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    404: { description: 'Not found, or not a registrar account', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};

--- a/docs/phone-endpoints-api.md
+++ b/docs/phone-endpoints-api.md
@@ -190,6 +190,35 @@ The `options` object carries provider-specific and behavioural settings for the 
 
 > **Trunk counterpart:** SIP trunks default to **bridging** for transfers. To make a trunk default to **SIP REFER** instead, set `forceReferTransfer: true` in the trunk's `flags` (trunk configuration, not this endpoint API). The same per-transfer `forceRefer` / `forceBridged` parameters override either default. See [call-transfers.md](./call-transfers.md#transfer-mode-selection).
 
+#### Registrar accounts (`mode: registrar`)
+
+A phone registration normally has the platform register *out* to the customer's registrar (`mode: client`, the default). A **registrar account** inverts it: the customer's PBX registers *to* the platform, at the deployment's registrar name, with a username and password the platform mints. This is what a PBX whose trunk model is "register to your provider" (3CX, Yeastar and Grandstream register trunks, Avaya IP Office SIP Line, and most NATted PBXes) needs. Accounts are served by the `regserver` binary of aplisay-b2bua, never by regclient.
+
+- **Request body**: `type: "phone-registration"`, `mode: "registrar"`, optionally `kind: "pbx"` (the only kind; `device` is reserved), and any of `name`, `outbound`, `handler`, `options`, `trunk`, `trunkId`, `didSource`, `didCountry` exactly as for a client-mode registration. `registrar`, `username`, `password` and `b2buaId` must **not** be supplied (400).
+- **Response (201)**: the credentials, shown here once:
+
+```json
+{
+  "success": true,
+  "id": "<registration-uuid>",
+  "trunkId": null,
+  "mode": "registrar",
+  "registrar": "sip.polite.ai",
+  "port": 5061,
+  "transport": "tls",
+  "username": "pbx-k7m2x9q4wz",
+  "password": "…24 characters…"
+}
+```
+
+- `registrar` is `REGSERVER_REGISTRAR` on the deployment (503 code `registrar_unavailable` when it is unset), and is also the digest realm. `username` is unique across every organisation, since one realm serves them all.
+- `GET /api/phone-endpoints/{id}` returns `mode`, `kind`, and for a registrar account `bindings` (the PBX sockets the owning node last mirrored onto the row: `contact`, `received`, `transport`, `userAgent`, `registeredAt`, `expiresAt`, `node`) and `bindingsUpdatedAt`. Never the password.
+- `PUT` refuses `registrar`, `username`, `password` and `b2buaId` on a registrar account (400 code `registrar_identity_immutable`) and refuses a change of `mode` on any registration (400 code `mode_immutable`).
+- `GET /api/phone-endpoints/{id}/credentials` reveals the credentials again (`phoneEndpoint:update`; every call is audit-logged). `POST /api/phone-endpoints/{id}/credentials/rotate` mints a new password, returns the credentials once and resets the state to `initial`; the PBX's next REGISTER with the old password is refused. Both answer 404 for a client-mode registration.
+- `GET /api/phone-endpoints/{id}/bindings` returns the mirror; `?live=1` asks the owning node through the node API (same proxying and status codes as the trace routes).
+
+Design record: `aplisay-strategy/implementation/regserver-tactical-spec.md`.
+
 ---
 
 ### PUT /api/phone-endpoints/{identifier}

--- a/environment-example
+++ b/environment-example
@@ -203,6 +203,15 @@ LIVEKIT_API_SECRET=<LIVEKIT API SECRET>
 # Dev only: skip TLS verification (and, with REGCLIENT_API_SCHEME=http, TLS).
 # REGCLIENT_API_INSECURE=0
 
+# ── Registrar accounts (regserver) ──────────────────────────────────────────
+# The name customers' PBXes register to, which is also the digest realm on every
+# registrar-mode phone registration this deployment issues (a bare hostname; the
+# port is always 5061, TLS). Unset, registrar accounts cannot be created (503,
+# code registrar_unavailable). Permanent once the first account exists: the
+# realm is what every PBX hashes its password against. Design:
+# aplisay-strategy implementation/regserver-tactical-spec.md.
+# REGSERVER_REGISTRAR=sip.polite.ai
+
 # ── Number administration (tools/number.js — manual admin script only) ──────
 # Magrathea carrier credentials + SIP ingress hosts for bulk/manual number
 # maintenance. NOT read by the API service itself; the self-service Buy-number

--- a/lib/database-models/b2bua-node.js
+++ b/lib/database-models/b2bua-node.js
@@ -24,8 +24,14 @@ import { Model, DataTypes } from 'sequelize';
  */
 class B2buaNode extends Model {}
 
-/** How the node identifies its own stack. */
-export const B2BUA_NODE_TYPES = ['regclient', 'freeswitch'];
+/**
+ * How the node identifies its own stack. regclient registers outward to
+ * customers' PBXes and providers; regserver is the tactical registrar customers'
+ * PBXes register to (aplisay-strategy regserver-tactical-spec.md). Both are Go
+ * binaries from the same repository and both serve the trace API; only regclient
+ * runs probes, which is why the two are told apart rather than folded together.
+ */
+export const B2BUA_NODE_TYPES = ['regclient', 'regserver', 'freeswitch'];
 
 export function initB2buaNode(sequelize, types = DataTypes) {
   B2buaNode.init({
@@ -66,6 +72,13 @@ export function initB2buaNode(sequelize, types = DataTypes) {
       defaultValue: 0
     },
     failedRegistrations: {
+      type: types.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    },
+    // Live bindings a regserver node holds — PBXes currently registered to
+    // it. Zero for regclient, which holds none by construction.
+    bindings: {
       type: types.INTEGER,
       allowNull: false,
       defaultValue: 0

--- a/lib/database-models/phone-registration.js
+++ b/lib/database-models/phone-registration.js
@@ -1,5 +1,5 @@
 import { Model, DataTypes } from 'sequelize';
-import { encryptSecret, decryptSecret, PHONE_REGISTRATION_STATE_VALUES, PHONE_REGISTRATION_STATUS_VALUES, PHONE_REGISTRATION_SCHEMA_VERSION } from '../utils/credentials.js';
+import { encryptSecret, decryptSecret, PHONE_REGISTRATION_STATE_VALUES, PHONE_REGISTRATION_STATUS_VALUES, PHONE_REGISTRATION_MODE_VALUES, PHONE_REGISTRATION_KIND_VALUES, PHONE_REGISTRATION_SCHEMA_VERSION } from '../utils/credentials.js';
 
 class PhoneRegistration extends Model {}
 
@@ -98,6 +98,35 @@ export function initPhoneRegistration(sequelize, types = DataTypes) {
     didCountry: {
       type: types.STRING(2),
       allowNull: true
+    },
+    // Direction of service. 'client', the default and every row before schema
+    // 66: the b2bua registers out to `registrar` with these credentials.
+    // 'registrar': the customer's PBX registers to us at `registrar` (the
+    // deployment's balancer name) with credentials the platform minted; such a
+    // row is served by regserver and never claimed by regclient. Design:
+    // aplisay-strategy implementation/regserver-tactical-spec.md §2.
+    mode: {
+      type: types.STRING,
+      allowNull: false,
+      defaultValue: 'client'
+    },
+    // Registrar rows only: what registers to us. Only 'pbx' exists today;
+    // 'device' is reserved for the cell and refused by validation.
+    kind: {
+      type: types.STRING,
+      allowNull: true
+    },
+    // Registrar rows only: the bindings the owning node currently holds for
+    // this account, mirrored for the dashboard and the API. The node's memory
+    // is the routing truth; this array is written only by the node named in
+    // b2bua_id, and cleared when that node shuts down or restarts.
+    bindings: {
+      type: types.JSONB,
+      allowNull: true
+    },
+    bindingsUpdatedAt: {
+      type: types.DATE,
+      allowNull: true
     }
   }, {
     sequelize,
@@ -106,7 +135,19 @@ export function initPhoneRegistration(sequelize, types = DataTypes) {
     charset: 'utf8',
     collate: 'utf8_general_ci',
     modelName: 'PhoneRegistration',
-    tableName: 'phone_registrations'
+    tableName: 'phone_registrations',
+    indexes: [
+      // One realm per deployment means an issued username has to be unique
+      // across every organisation, not per (registrar, organisation) as the
+      // create route checks for lines. Partial, so client-mode rows — whose
+      // usernames are whatever their providers issued — are untouched.
+      {
+        name: 'phone_registrations_registrar_username',
+        unique: true,
+        fields: ['username'],
+        where: { mode: 'registrar' }
+      }
+    ]
   });
 
   return PhoneRegistration;
@@ -118,6 +159,6 @@ export const PHONE_REGISTRATION_ENUMS = {
   status: PHONE_REGISTRATION_STATUS_VALUES
 };
 export { PHONE_REGISTRATION_SCHEMA_VERSION };
-export { PHONE_REGISTRATION_STATE_VALUES, PHONE_REGISTRATION_STATUS_VALUES };
+export { PHONE_REGISTRATION_STATE_VALUES, PHONE_REGISTRATION_STATUS_VALUES, PHONE_REGISTRATION_MODE_VALUES, PHONE_REGISTRATION_KIND_VALUES };
 
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -19,7 +19,15 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 65;  // 65: transaction_logs.type gains 'agent-speech' — the output audit STT's reading of
+const schemaVersion = 66;  // 66: registrar accounts (regserver) — `phone_registrations.mode` ('client' |
+                           //     'registrar'), `kind` ('pbx'), `bindings` JSONB and `bindings_updated_at`, plus
+                           //     the partial unique index `phone_registrations_registrar_username` (username
+                           //     WHERE mode = 'registrar': one realm per deployment, so an issued username is
+                           //     unique across every organisation). Rows are created with minted credentials
+                           //     and served by regserver; regclient's claim excludes them. `b2bua_nodes` gains
+                           //     `bindings` and the type 'regserver'. Design: aplisay-strategy
+                           //     implementation/regserver-tactical-spec.md §2.
+                           // 65: transaction_logs.type gains 'agent-speech' — the output audit STT's reading of
                            //     what the agent's audio actually said (options.tts.output), logged next to
                            //     the 'agent' turn the model produced. See docs/auxiliary-stt.md.
                            // 64: transaction_logs.type gains 'user-aux' — the auxiliary ("second opinion")

--- a/lib/regclient-facade.js
+++ b/lib/regclient-facade.js
@@ -27,7 +27,8 @@ import {
   CAPABILITY_TRACE,
   CAPABILITY_NONE,
   CAPABILITY_UNKNOWN,
-  boolEnv
+  boolEnv,
+  nodeServesTraceApi
 } from './regclient.js';
 
 /**
@@ -73,7 +74,7 @@ export async function capabilityFromHeartbeat(node, { now = Date.now, model = B2
     const record = await model.findByPk(node);
     if (!record?.lastSeenAt) return CAPABILITY_UNKNOWN;
     if (now() - new Date(record.lastSeenAt).getTime() > HEARTBEAT_FRESH_MS) return CAPABILITY_UNKNOWN;
-    return record.type === 'regclient' ? CAPABILITY_TRACE : CAPABILITY_NONE;
+    return nodeServesTraceApi(record.type) ? CAPABILITY_TRACE : CAPABILITY_NONE;
   }
   catch (err) {
     // The registry is an optimisation, not a dependency. If it cannot be read,

--- a/lib/regclient.js
+++ b/lib/regclient.js
@@ -536,3 +536,28 @@ export function unsupportedNodeBody(node) {
       'It is running the FreeSWITCH stack, which has no such interface; migrate the registration to a regclient node to use it.'
   };
 }
+
+// ── Registrar nodes ─────────────────────────────────────────────────────────
+
+/**
+ * Whether a node of this stack serves the node API's trace routes. regclient
+ * and regserver are the two Go binaries from aplisay-b2bua and both do; the
+ * FreeSWITCH stack has no HTTP surface at all. Probing stays regclient-only —
+ * a probe is an outbound registration trial, which a registrar never runs — so
+ * this deliberately says nothing about probes (see pickLeastLoadedNode).
+ */
+export function nodeServesTraceApi(type) {
+  return type === 'regclient' || type === 'regserver';
+}
+
+/**
+ * URL of the live bindings a regserver node holds for a registrar account:
+ * the PBX sockets currently registered to it, as the node sees them right now.
+ * The row's `bindings` column is the same information as last mirrored; this
+ * is the authoritative view for a "is it really registered" question.
+ */
+export function buildBindingsUrl({ node, registrationId }, config) {
+  const { scheme, port } = config;
+  const host = net.isIP(node) === 6 ? `[${node}]` : node;
+  return `${scheme}://${host}:${port}/debug/registrations/${encodeURIComponent(registrationId)}/bindings`;
+}

--- a/lib/registrar-accounts.js
+++ b/lib/registrar-accounts.js
@@ -1,0 +1,56 @@
+/**
+ * Registrar accounts: the platform-issued identities a customer's PBX registers
+ * to us with (regserver, hitlist H16).
+ *
+ * A registrar-mode `phone_registrations` row inverts a line. `registrar` is no
+ * longer the customer's registrar but ours — the deployment's balancer name,
+ * which is also the digest realm every PBX hashes its password against — and
+ * `username` and `password` are minted rather than given. This module holds
+ * the two facts the create route and the credentials routes share: what the
+ * realm is on this deployment, and what a customer needs to type into a PBX.
+ *
+ * Design: aplisay-strategy implementation/regserver-tactical-spec.md §2.
+ */
+
+/** The port every deployment's balancer listens on; TLS only. */
+export const REGISTRAR_PORT = 5061;
+export const REGISTRAR_TRANSPORT = 'tls';
+
+const HOSTNAME_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+/**
+ * The name this deployment's PBXes register to, from REGSERVER_REGISTRAR.
+ *
+ * A bare hostname. A scheme, port or parameter that found its way into the
+ * variable is stripped rather than stored, because the value becomes the
+ * `registrar` column of every account and the realm the node challenges with,
+ * and the regserver checks that the two agree row by row. Null when unset or
+ * not a hostname, which the create route reports as 503: an account issued
+ * against a realm nothing serves is worse than no account.
+ */
+export function registrarRealm(env = process.env) {
+  const raw = String(env.REGSERVER_REGISTRAR || '').trim().replace(/^sips?:/i, '');
+  if (!raw) return null;
+  const host = raw.split(/[:;/]/)[0].toLowerCase();
+  return HOSTNAME_RE.test(host) ? host : null;
+}
+
+export function isRegistrarAccount(registration) {
+  return registration?.mode === 'registrar';
+}
+
+/**
+ * What a customer enters into their PBX. The password comes back through the
+ * model getter, which decrypts it; callers that just minted one may pass it
+ * explicitly to avoid depending on the instance having been reloaded.
+ */
+export function credentialsFor(registration, password = registration.password) {
+  return {
+    id: registration.id,
+    registrar: registration.registrar,
+    port: REGISTRAR_PORT,
+    transport: REGISTRAR_TRANSPORT,
+    username: registration.username,
+    password
+  };
+}

--- a/lib/schemas/phone-registration.ts
+++ b/lib/schemas/phone-registration.ts
@@ -14,6 +14,24 @@
 
 export type PhoneRegistrationStatus = 'active' | 'failed' | 'disabled';
 export type PhoneRegistrationState = 'initial' | 'registering' | 'registered' | 'failed';
+/** Direction of service: we register out ('client', the default) or the customer's PBX registers to us ('registrar'). */
+export type PhoneRegistrationMode = 'client' | 'registrar';
+/** Registrar rows only. 'device' is reserved for the cell and not accepted yet. */
+export type PhoneRegistrationKind = 'pbx';
+
+/** One binding the owning regserver node holds for a registrar account, as mirrored onto the row. */
+export interface RegistrationBinding {
+  /** The Contact URI as the PBX sent it (often a private address). */
+  contact: string;
+  /** The socket's remote address, host:port — where the node actually sends. */
+  received: string;
+  transport: string;
+  userAgent?: string | null;
+  registeredAt: string; // ISO 8601
+  expiresAt: string; // ISO 8601
+  /** The node holding the socket; the same value as b2buaId. */
+  node: string;
+}
 
 export interface PhoneRegistrationSchema {
   id: string; // UUID
@@ -37,13 +55,22 @@ export interface PhoneRegistrationSchema {
   didSource?: string | null;
   /** ISO 3166-1 alpha-2 for national-format dialled numbers; null = platform default. */
   didCountry?: string | null;
+  /** Direction of service; 'client' for every row created before schema 66. */
+  mode: PhoneRegistrationMode;
+  /** Registrar rows only: 'pbx'. Null for client rows. */
+  kind?: PhoneRegistrationKind | null;
+  /** Registrar rows only: bindings mirrored by the owning node; null or empty when nothing is registered. */
+  bindings?: RegistrationBinding[] | null;
+  bindingsUpdatedAt?: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
 
 export const PhoneRegistrationStatusValues: PhoneRegistrationStatus[] = ['active', 'failed', 'disabled'];
 export const PhoneRegistrationStateValues: PhoneRegistrationState[] = ['initial', 'registering', 'registered', 'failed'];
+export const PhoneRegistrationModeValues: PhoneRegistrationMode[] = ['client', 'registrar'];
+export const PhoneRegistrationKindValues: PhoneRegistrationKind[] = ['pbx'];
 
 // Schema version for migration/validation tracking
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 

--- a/lib/utils/credentials.js
+++ b/lib/utils/credentials.js
@@ -120,4 +120,50 @@ export const PHONE_REGISTRATION_STATUS_VALUES = ['active', 'failed', 'disabled']
 export const PHONE_REGISTRATION_STATE_VALUES = ['initial', 'registering', 'registered', 'failed'];
 export const PHONE_REGISTRATION_SCHEMA_VERSION = 1;
 
+// ── Registrar accounts (regserver) ──────────────────────────────────────────
+//
+// A registrar-mode phone_registrations row is an identity the platform issues:
+// the customer's PBX registers to us with it. Both halves are minted here and
+// never chosen by the customer. The username carries 50 bits of randomness so it
+// can be neither guessed nor enumerated, which is what lets one realm serve every
+// organisation; the password is 24 characters from a 62-symbol alphabet. Design:
+// aplisay-strategy implementation/regserver-tactical-spec.md §2.2 and §8.
+
+export const PHONE_REGISTRATION_MODE_VALUES = ['client', 'registrar'];
+export const PHONE_REGISTRATION_KIND_VALUES = ['pbx'];
+
+const REGISTRAR_USERNAME_PREFIX = 'pbx-';
+const REGISTRAR_USERNAME_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567'; // base32, lower case
+const REGISTRAR_USERNAME_LENGTH = 10;
+const REGISTRAR_PASSWORD_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const REGISTRAR_PASSWORD_LENGTH = 24;
+
+/** The shape of a username this module mints. */
+export const REGISTRAR_USERNAME_RE = /^pbx-[a-z2-7]{10}$/;
+
+/**
+ * Uniformly random characters from an alphabet. A byte that would bias the
+ * modulo is rejected rather than folded, so every symbol is equally likely.
+ */
+function randomString(alphabet, length) {
+  const limit = 256 - (256 % alphabet.length);
+  let out = '';
+  while (out.length < length) {
+    for (const byte of randomBytes(length)) {
+      if (byte < limit && out.length < length) out += alphabet[byte % alphabet.length];
+    }
+  }
+  return out;
+}
+
+/** A fresh account username: `pbx-` and ten lower-case base32 characters. */
+export function mintRegistrarUsername() {
+  return REGISTRAR_USERNAME_PREFIX + randomString(REGISTRAR_USERNAME_ALPHABET, REGISTRAR_USERNAME_LENGTH);
+}
+
+/** A fresh account password: 24 characters, letters and digits. */
+export function mintRegistrarPassword() {
+  return randomString(REGISTRAR_PASSWORD_ALPHABET, REGISTRAR_PASSWORD_LENGTH);
+}
+
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -160,6 +160,17 @@ export function hasRoutableRegisterProxy(options) {
 export function validatePhoneRegistration(data) {
   const errors = [];
 
+  // Direction of service. A registrar-mode row is an account the customer's
+  // PBX registers to us with, and nothing about its identity is the caller's
+  // to supply; everything below this branch is about the client mode, where
+  // we register out with credentials the customer gives us.
+  if (data.mode !== undefined && data.mode !== null && !['client', 'registrar'].includes(data.mode)) {
+    return { isValid: false, errors: ["mode must be 'client' or 'registrar'"] };
+  }
+  if (data.mode === 'registrar') {
+    return validateRegistrarAccount(data);
+  }
+
   // A registration always needs a registrar (the SIP account identity / realm).
   // Historically the registrar also had to be a routable FQDN/public IP because
   // it doubled as the next hop. Some providers, however, use a non-FQDN host in
@@ -199,6 +210,37 @@ export function validatePhoneRegistration(data) {
     }
   }
   
+  return {
+    isValid: errors.length === 0,
+    errors
+  };
+}
+
+/**
+ * A registrar-mode account (regserver): the customer's PBX registers to us with
+ * credentials the platform mints. The realm is the deployment's, the username
+ * and password are minted, and a node — not the API — writes b2buaId when an
+ * authenticated REGISTER lands. Only `kind: 'pbx'` exists; `device` is reserved
+ * for the cell and refused. Design: regserver-tactical-spec.md §2.
+ * @param {object} data - The registration data to validate
+ * @returns {object} - Validation result with isValid and errors
+ */
+export function validateRegistrarAccount(data = {}) {
+  const errors = [];
+  for (const field of ['registrar', 'username', 'password']) {
+    if (data[field] !== undefined && data[field] !== null) {
+      errors.push(`${field} is issued by the platform for a registrar account and must not be supplied`);
+    }
+  }
+  if (data.kind !== undefined && data.kind !== null && data.kind !== 'pbx') {
+    errors.push("kind must be 'pbx' for a registrar account ('device' is reserved and not yet supported)");
+  }
+  if (data.b2buaId !== undefined && data.b2buaId !== null) {
+    errors.push('b2buaId is written by the node that accepts the REGISTER and must not be supplied for a registrar account');
+  }
+  if (data.options !== undefined && data.options !== null && typeof data.options !== 'object') {
+    errors.push('options must be an object if provided');
+  }
   return {
     isValid: errors.length === 0,
     errors

--- a/tests/b2bua-node-regserver.test.mjs
+++ b/tests/b2bua-node-regserver.test.mjs
@@ -1,0 +1,128 @@
+import { jest } from '@jest/globals';
+
+/**
+ * A regserver node announcing itself. It is the registrar customers' PBXes
+ * register to (aplisay-strategy regserver-tactical-spec.md): it serves the
+ * trace API like regclient, reports how many PBXes are bound to it, and is
+ * never chosen to run a probe.
+ */
+
+const rows = new Map();
+
+const B2buaNode = {
+  async upsert(values) {
+    rows.set(values.nodeId, { ...values });
+    return [rows.get(values.nodeId), true];
+  },
+  async findByPk(id) {
+    return rows.get(id) || null;
+  },
+  async findAll() {
+    return [...rows.values()].sort((a, b) => a.nodeId.localeCompare(b.nodeId));
+  }
+};
+
+jest.unstable_mockModule('../lib/database.js', () => ({
+  B2buaNode,
+  B2BUA_NODE_TYPES: ['regclient', 'regserver', 'freeswitch'],
+  PhoneRegistration: { findByPk: async () => null }
+}));
+
+const { default: route } = await import('../api/paths/agent-db/b2bua-nodes.js');
+const {
+  nodeCapability, resetNodeCapabilities, nodeServesTraceApi, pickLeastLoadedNode, buildBindingsUrl,
+  CAPABILITY_TRACE, CAPABILITY_NONE
+} = await import('../lib/regclient.js');
+const { capabilityFromHeartbeat } = await import('../lib/regclient-facade.js');
+
+const quietLog = { info() {}, error() {}, warn() {}, debug() {} };
+const post = route(quietLog).POST;
+const get = route(quietLog).GET;
+
+const makeRes = () => ({
+  locals: { user: { id: 'system', isSystem: true } },
+  _status: null,
+  _body: null,
+  status(code) { this._status = code; return this; },
+  send(body) { this._body = body; this._status = this._status || 200; return this; },
+  json(body) { return this.send(body); }
+});
+
+const beat = async (body) => {
+  const res = makeRes();
+  await post({ body, log: quietLog }, res);
+  return res;
+};
+
+beforeEach(() => {
+  rows.clear();
+  resetNodeCapabilities();
+});
+
+describe('a regserver heartbeat', () => {
+  it('is accepted, with its bindings count, and identified by its DNS name', async () => {
+    const res = await beat({
+      nodeId: 'lon1-1.sip.polite.ai',
+      privateAddress: '10.106.0.4',
+      type: 'regserver',
+      version: 'beta-0.3.0',
+      registrations: 11,
+      failedRegistrations: 1,
+      bindings: 12,
+      systemLoad: 0.2
+    });
+    expect(res._status).toBe(200);
+    const row = rows.get('lon1-1.sip.polite.ai');
+    expect(row.type).toBe('regserver');
+    expect(row.bindings).toBe(12);
+    expect(row.privateAddress).toBe('10.106.0.4');
+  });
+
+  it('primes the capability cache: a regserver node serves traces', async () => {
+    await beat({ nodeId: 'lon1-1.sip.polite.ai', type: 'regserver' });
+    expect(nodeCapability('lon1-1.sip.polite.ai')).toBe(CAPABILITY_TRACE);
+    resetNodeCapabilities();
+    expect(await capabilityFromHeartbeat('lon1-1.sip.polite.ai')).toBe(CAPABILITY_TRACE);
+  });
+
+  it('leaves the other stacks as they were', async () => {
+    await beat({ nodeId: '203.0.113.10', type: 'regclient', registrations: 3 });
+    await beat({ nodeId: '203.0.113.11', type: 'freeswitch' });
+    expect(rows.get('203.0.113.10').bindings).toBe(0);
+    expect(nodeCapability('203.0.113.10')).toBe(CAPABILITY_TRACE);
+    expect(nodeCapability('203.0.113.11')).toBe(CAPABILITY_NONE);
+    expect(nodeServesTraceApi('regclient')).toBe(true);
+    expect(nodeServesTraceApi('regserver')).toBe(true);
+    expect(nodeServesTraceApi('freeswitch')).toBe(false);
+  });
+
+  it('shows bindings in the fleet listing', async () => {
+    await beat({ nodeId: 'lon1-1.sip.polite.ai', type: 'regserver', bindings: 5 });
+    await beat({ nodeId: '203.0.113.10', type: 'regclient' });
+    const res = makeRes();
+    await get({ query: {}, log: quietLog }, res);
+    expect(res._status).toBe(200);
+    const byId = Object.fromEntries(res._body.nodes.map((n) => [n.nodeId, n]));
+    expect(byId['lon1-1.sip.polite.ai'].bindings).toBe(5);
+    expect(byId['203.0.113.10'].bindings).toBe(0);
+  });
+
+  it('is never chosen to probe an unclaimed line', () => {
+    const now = Date.now();
+    const chosen = pickLeastLoadedNode([
+      { nodeId: 'lon1-1.sip.polite.ai', type: 'regserver', systemLoad: 0.01, registrations: 0, lastSeenAt: new Date(now) },
+      { nodeId: '203.0.113.10', type: 'regclient', systemLoad: 2.5, registrations: 40, lastSeenAt: new Date(now) }
+    ], { now });
+    expect(chosen).toBe('203.0.113.10');
+  });
+});
+
+describe('buildBindingsUrl', () => {
+  it('addresses the node API bindings route, bracketing IPv6', () => {
+    const config = { scheme: 'https', port: 8443 };
+    expect(buildBindingsUrl({ node: 'lon1-1.sip.polite.ai', registrationId: 'abc' }, config))
+      .toBe('https://lon1-1.sip.polite.ai:8443/debug/registrations/abc/bindings');
+    expect(buildBindingsUrl({ node: '2001:db8::1', registrationId: 'abc' }, config))
+      .toBe('https://[2001:db8::1]:8443/debug/registrations/abc/bindings');
+  });
+});

--- a/tests/registrar-accounts-validation.test.mjs
+++ b/tests/registrar-accounts-validation.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * Registrar accounts (regserver): the rules that need no database.
+ *
+ * A registrar-mode registration is an identity the platform issues, so the
+ * validation is the mirror image of a line's: the fields a line requires are
+ * the ones an account refuses. The minted credentials are what makes one realm
+ * per deployment safe, so their shape and uniqueness are pinned here too.
+ */
+import { validatePhoneRegistration, validateRegistrarAccount } from '../lib/validation.js';
+import { mintRegistrarUsername, mintRegistrarPassword, REGISTRAR_USERNAME_RE } from '../lib/utils/credentials.js';
+import { registrarRealm, credentialsFor, REGISTRAR_PORT, REGISTRAR_TRANSPORT } from '../lib/registrar-accounts.js';
+
+describe('validatePhoneRegistration in registrar mode', () => {
+  test('needs no credentials at all', () => {
+    const result = validatePhoneRegistration({ mode: 'registrar' });
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('refuses a supplied registrar, username or password', () => {
+    const result = validatePhoneRegistration({
+      mode: 'registrar', registrar: 'sip.example.com', username: 'me', password: 'x'
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toHaveLength(3);
+    for (const field of ['registrar', 'username', 'password']) {
+      expect(result.errors.some((e) => e.startsWith(`${field} is issued by the platform`))).toBe(true);
+    }
+  });
+
+  test('accepts kind pbx and nothing else', () => {
+    expect(validatePhoneRegistration({ mode: 'registrar', kind: 'pbx' }).isValid).toBe(true);
+    const device = validatePhoneRegistration({ mode: 'registrar', kind: 'device' });
+    expect(device.isValid).toBe(false);
+    expect(device.errors[0]).toMatch(/kind must be 'pbx'/);
+  });
+
+  test('refuses b2buaId: ownership follows the socket, not the API', () => {
+    const result = validatePhoneRegistration({ mode: 'registrar', b2buaId: '203.0.113.10' });
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0]).toMatch(/b2buaId is written by the node/);
+  });
+
+  test('still checks that options is an object', () => {
+    expect(validateRegistrarAccount({ options: 'nope' }).isValid).toBe(false);
+    expect(validateRegistrarAccount({ options: { max_bindings: 1 } }).isValid).toBe(true);
+  });
+
+  test('an unknown mode is refused before anything else is looked at', () => {
+    const result = validatePhoneRegistration({ mode: 'proxy', registrar: 'sip.example.com', username: 'u', password: 'p' });
+    expect(result.isValid).toBe(false);
+    expect(result.errors).toEqual(["mode must be 'client' or 'registrar'"]);
+  });
+
+  test('client mode is unchanged: registrar, username and password are required', () => {
+    const missing = validatePhoneRegistration({ mode: 'client' });
+    expect(missing.isValid).toBe(false);
+    expect(missing.errors.some((e) => e.startsWith('registrar is required'))).toBe(true);
+    expect(missing.errors.some((e) => e.startsWith('username is required'))).toBe(true);
+    expect(missing.errors.some((e) => e.startsWith('password is required'))).toBe(true);
+
+    const fine = validatePhoneRegistration({ registrar: 'sip.example.com', username: 'u', password: 'p' });
+    expect(fine.isValid).toBe(true);
+  });
+});
+
+describe('minted credentials', () => {
+  test('usernames are pbx- plus ten lower-case base32 characters, and do not repeat', () => {
+    const seen = new Set();
+    for (let i = 0; i < 2000; i++) {
+      const username = mintRegistrarUsername();
+      expect(username).toMatch(REGISTRAR_USERNAME_RE);
+      seen.add(username);
+    }
+    expect(seen.size).toBe(2000);
+  });
+
+  test('passwords are 24 letters and digits, and do not repeat', () => {
+    const seen = new Set();
+    for (let i = 0; i < 500; i++) {
+      const password = mintRegistrarPassword();
+      expect(password).toMatch(/^[A-Za-z0-9]{24}$/);
+      seen.add(password);
+    }
+    expect(seen.size).toBe(500);
+  });
+});
+
+describe('registrarRealm', () => {
+  test('is the configured hostname, lower-cased', () => {
+    expect(registrarRealm({ REGSERVER_REGISTRAR: 'SIP.polite.ai' })).toBe('sip.polite.ai');
+  });
+
+  test('strips a scheme, port or parameter that found its way into the variable', () => {
+    expect(registrarRealm({ REGSERVER_REGISTRAR: 'sips:sip.polite.ai:5061;transport=tls' })).toBe('sip.polite.ai');
+    expect(registrarRealm({ REGSERVER_REGISTRAR: ' sip.polite.ai/ ' })).toBe('sip.polite.ai');
+  });
+
+  test('is null when unset or not a hostname', () => {
+    expect(registrarRealm({})).toBeNull();
+    expect(registrarRealm({ REGSERVER_REGISTRAR: '' })).toBeNull();
+    expect(registrarRealm({ REGSERVER_REGISTRAR: 'not a host' })).toBeNull();
+    expect(registrarRealm({ REGSERVER_REGISTRAR: 'localhost' })).toBeNull();
+  });
+});
+
+describe('credentialsFor', () => {
+  test('is what a PBX form needs, with the port and transport fixed', () => {
+    const view = credentialsFor({ id: 'r1', registrar: 'sip.polite.ai', username: 'pbx-abcdefghij', password: 'secret' });
+    expect(view).toEqual({
+      id: 'r1', registrar: 'sip.polite.ai', port: REGISTRAR_PORT, transport: REGISTRAR_TRANSPORT,
+      username: 'pbx-abcdefghij', password: 'secret'
+    });
+    expect(REGISTRAR_PORT).toBe(5061);
+    expect(REGISTRAR_TRANSPORT).toBe('tls');
+  });
+
+  test('takes an explicit password over the instance getter', () => {
+    const view = credentialsFor({ id: 'r1', registrar: 'x', username: 'u', password: 'old' }, 'new');
+    expect(view.password).toBe('new');
+  });
+});

--- a/tests/registrar-accounts.test.mjs
+++ b/tests/registrar-accounts.test.mjs
@@ -1,0 +1,292 @@
+/**
+ * Registrar accounts through the real route handlers against the test
+ * database: create with minted credentials, the read shape, the immutable
+ * identity on update, reveal and rotate, the bindings mirror, the trunk case,
+ * and the partial unique index one realm per deployment relies on.
+ *
+ * Design: aplisay-strategy implementation/regserver-tactical-spec.md §2.
+ */
+import { setupRealDatabase, teardownRealDatabase, PhoneRegistration, User, Organisation, Trunk, Op } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+const REALM = 'sip.test.polite.ai';
+
+describe('registrar accounts', () => {
+  let testOrgId;
+  let testUserId;
+  const created = [];
+
+  let createPhoneEndpoint;
+  let listPhoneEndpoints;
+  let getPhoneEndpoint;
+  let updatePhoneEndpoint;
+  let revealCredentials;
+  let rotateCredentials;
+  let getBindings;
+
+  const mockLogger = { info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, child: () => mockLogger };
+
+  beforeAll(async () => {
+    process.env.REGSERVER_REGISTRAR = REALM;
+    await setupRealDatabase();
+
+    const phoneEndpointsModule = await import('../api/paths/phone-endpoints.js');
+    const identifierModule = await import('../api/paths/phone-endpoints/{identifier}.js');
+    const credentialsModule = await import('../api/paths/phone-endpoints/{identifier}/credentials.js');
+    const rotateModule = await import('../api/paths/phone-endpoints/{identifier}/credentials/rotate.js');
+    const bindingsModule = await import('../api/paths/phone-endpoints/{identifier}/bindings.js');
+
+    const phoneEndpoints = phoneEndpointsModule.default(mockLogger, {}, {});
+    const identifier = identifierModule.default(mockLogger);
+    createPhoneEndpoint = phoneEndpoints.POST;
+    listPhoneEndpoints = phoneEndpoints.GET;
+    getPhoneEndpoint = identifier.GET;
+    updatePhoneEndpoint = identifier.PUT;
+    revealCredentials = credentialsModule.default(mockLogger).GET;
+    rotateCredentials = rotateModule.default(mockLogger).POST;
+    getBindings = bindingsModule.default(mockLogger).GET;
+  }, 30000);
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 60000);
+
+  beforeEach(async () => {
+    testOrgId = randomUUID();
+    testUserId = randomUUID();
+    await Organisation.create({ id: testOrgId, name: 'Registrar accounts test org' });
+    await User.create({ id: testUserId, organisationId: testOrgId, name: 'Test User', email: `${testUserId}@example.com` });
+  });
+
+  afterEach(async () => {
+    try {
+      const rows = await PhoneRegistration.findAll({ where: { organisationId: testOrgId } });
+      const trunkIds = rows.map((r) => r.trunkId).filter(Boolean);
+      await PhoneRegistration.destroy({ where: { organisationId: testOrgId } });
+      if (trunkIds.length) await Trunk.destroy({ where: { id: { [Op.in]: trunkIds } } });
+      await User.destroy({ where: { id: testUserId } });
+      await Organisation.destroy({ where: { id: testOrgId } });
+    } catch (err) {
+      // best effort
+    }
+    created.length = 0;
+  });
+
+  const req = (overrides = {}) => ({ body: {}, params: {}, query: {}, headers: {}, log: mockLogger, ...overrides });
+  const res = (user) => ({
+    _status: null,
+    _body: null,
+    _headers: {},
+    locals: { user: user || { id: testUserId, role: 'owner', organisationId: testOrgId } },
+    status(code) { this._status = code; return this; },
+    send(data) { this._body = data; this._status = this._status || 200; return this; },
+    json(data) { return this.send(data); },
+    setHeader(k, v) { this._headers[k] = v; }
+  });
+
+  const createAccount = async (extra = {}) => {
+    const r = res();
+    await createPhoneEndpoint(req({ body: { type: 'phone-registration', mode: 'registrar', name: 'Office 3CX', ...extra } }), r);
+    if (r._status === 201) created.push(r._body.id);
+    return r;
+  };
+
+  test('creates an account with minted credentials, shown once', async () => {
+    const r = await createAccount();
+    expect(r._status).toBe(201);
+    expect(r._body).toMatchObject({ success: true, mode: 'registrar', registrar: REALM, port: 5061, transport: 'tls', trunkId: null });
+    expect(r._body.username).toMatch(/^pbx-[a-z2-7]{10}$/);
+    expect(r._body.password).toMatch(/^[A-Za-z0-9]{24}$/);
+
+    const row = await PhoneRegistration.findByPk(r._body.id);
+    expect(row.mode).toBe('registrar');
+    expect(row.kind).toBe('pbx');
+    expect(row.registrar).toBe(REALM);
+    expect(row.username).toBe(r._body.username);
+    expect(row.password).toBe(r._body.password); // the getter decrypts
+    expect(row.getDataValue('password')).not.toBe(r._body.password); // and it is sealed at rest
+    expect(row.status).toBe('disabled');
+    expect(row.state).toBe('initial');
+    expect(row.b2buaId).toBeNull();
+    expect(row.bindings).toBeNull();
+  });
+
+  test('refuses an identity supplied by the caller', async () => {
+    const r = await createAccount({ registrar: 'sip.example.com', username: 'me', password: 'p' });
+    expect(r._status).toBe(400);
+    expect(r._body.details.join(' ')).toMatch(/registrar is issued by the platform/);
+
+    const withNode = await createAccount({ b2buaId: '203.0.113.10' });
+    expect(withNode._status).toBe(400);
+
+    const device = await createAccount({ kind: 'device' });
+    expect(device._status).toBe(400);
+  });
+
+  test('is unavailable on a deployment with no registrar configured', async () => {
+    const saved = process.env.REGSERVER_REGISTRAR;
+    delete process.env.REGSERVER_REGISTRAR;
+    try {
+      const r = await createAccount();
+      expect(r._status).toBe(503);
+      expect(r._body.code).toBe('registrar_unavailable');
+    } finally {
+      process.env.REGSERVER_REGISTRAR = saved;
+    }
+  });
+
+  test('reads back with mode, kind and an empty bindings mirror, never the password', async () => {
+    const createdRes = await createAccount();
+    const r = res();
+    await getPhoneEndpoint(req({ params: { identifier: createdRes._body.id } }), r);
+    expect(r._status).toBe(200);
+    expect(r._body).toMatchObject({ id: createdRes._body.id, mode: 'registrar', kind: 'pbx', registrar: REALM, bindings: [], bindingsUpdatedAt: null });
+    expect(r._body.password).toBeUndefined();
+
+    const list = res();
+    await listPhoneEndpoints(req({ query: { type: 'phone-registration' } }), list);
+    expect(list._status).toBe(200);
+    const item = list._body.items.find((i) => i.id === createdRes._body.id);
+    expect(item).toMatchObject({ mode: 'registrar', kind: 'pbx' });
+    expect(item.password).toBeUndefined();
+  });
+
+  test('a client-mode line reads back as mode client with no bindings field', async () => {
+    const r = res();
+    await createPhoneEndpoint(req({ body: { type: 'phone-registration', name: 'Line', registrar: 'sip.example.com', username: 'u1', password: 'p1' } }), r);
+    expect(r._status).toBe(201);
+    expect(r._body.password).toBeUndefined();
+    const g = res();
+    await getPhoneEndpoint(req({ params: { identifier: r._body.id } }), g);
+    expect(g._body.mode).toBe('client');
+    expect(g._body.kind).toBeNull();
+    expect(g._body.bindings).toBeUndefined();
+  });
+
+  test('the identity is immutable through PUT; other fields still update', async () => {
+    const createdRes = await createAccount();
+    const id = createdRes._body.id;
+
+    for (const body of [{ password: 'new' }, { username: 'other' }, { registrar: 'sip.example.com' }, { b2buaId: 'lon1-1.sip.polite.ai' }]) {
+      const r = res();
+      await updatePhoneEndpoint(req({ params: { identifier: id }, body }), r);
+      expect(r._status).toBe(400);
+      expect(r._body.code).toBe('registrar_identity_immutable');
+    }
+
+    const modeChange = res();
+    await updatePhoneEndpoint(req({ params: { identifier: id }, body: { mode: 'client' } }), modeChange);
+    expect(modeChange._status).toBe(400);
+    expect(modeChange._body.code).toBe('mode_immutable');
+
+    const rename = res();
+    await updatePhoneEndpoint(req({ params: { identifier: id }, body: { name: 'Renamed', options: { max_bindings: 2 } } }), rename);
+    expect(rename._status).toBe(200);
+    const row = await PhoneRegistration.findByPk(id);
+    expect(row.name).toBe('Renamed');
+    expect(row.options).toEqual({ max_bindings: 2 });
+    expect(row.username).toBe(createdRes._body.username);
+  });
+
+  test('reveals and rotates the credentials, and refuses both for a line', async () => {
+    const createdRes = await createAccount();
+    const id = createdRes._body.id;
+
+    const reveal = res();
+    await revealCredentials(req({ params: { identifier: id } }), reveal);
+    expect(reveal._status).toBe(200);
+    expect(reveal._body).toEqual({ id, registrar: REALM, port: 5061, transport: 'tls', username: createdRes._body.username, password: createdRes._body.password });
+
+    await PhoneRegistration.update({ state: 'registered' }, { where: { id } });
+    const rotate = res();
+    await rotateCredentials(req({ params: { identifier: id } }), rotate);
+    expect(rotate._status).toBe(200);
+    expect(rotate._body.username).toBe(createdRes._body.username);
+    expect(rotate._body.password).toMatch(/^[A-Za-z0-9]{24}$/);
+    expect(rotate._body.password).not.toBe(createdRes._body.password);
+
+    const row = await PhoneRegistration.findByPk(id);
+    expect(row.password).toBe(rotate._body.password);
+    expect(row.state).toBe('initial');
+    expect(row.error).toBeNull();
+
+    const line = res();
+    await createPhoneEndpoint(req({ body: { type: 'phone-registration', name: 'Line', registrar: 'sip.example.com', username: 'u2', password: 'p2' } }), line);
+    const lineReveal = res();
+    await revealCredentials(req({ params: { identifier: line._body.id } }), lineReveal);
+    expect(lineReveal._status).toBe(404);
+    expect(lineReveal._body.code).toBe('not_registrar_account');
+    const lineRotate = res();
+    await rotateCredentials(req({ params: { identifier: line._body.id } }), lineRotate);
+    expect(lineRotate._status).toBe(404);
+  });
+
+  test('refuses reveal to another organisation and to a caller without update', async () => {
+    const createdRes = await createAccount();
+    const other = res({ id: randomUUID(), role: 'owner', organisationId: randomUUID() });
+    await revealCredentials(req({ params: { identifier: createdRes._body.id } }), other);
+    expect(other._status).toBe(403);
+
+    const reader = res({ id: testUserId, role: 'user', organisationId: testOrgId });
+    await revealCredentials(req({ params: { identifier: createdRes._body.id } }), reader);
+    expect(reader._status).toBe(403);
+  });
+
+  test('serves the bindings mirror the owning node wrote onto the row', async () => {
+    const createdRes = await createAccount();
+    const id = createdRes._body.id;
+    const binding = {
+      contact: 'sip:10000@192.168.1.10:5061;transport=tls',
+      received: '203.0.113.7:51844',
+      transport: 'tls',
+      userAgent: '3CX Phone System 20.0.4.1',
+      registeredAt: '2026-09-04T10:00:00.000Z',
+      expiresAt: '2026-09-04T10:10:00.000Z',
+      node: 'lon1-1.sip.polite.ai'
+    };
+    await PhoneRegistration.update(
+      { b2buaId: 'lon1-1.sip.polite.ai', state: 'registered', bindings: [binding], bindingsUpdatedAt: new Date('2026-09-04T10:00:01Z') },
+      { where: { id } }
+    );
+
+    const r = res();
+    await getBindings(req({ params: { identifier: id }, query: {} }), r);
+    expect(r._status).toBe(200);
+    expect(r._body).toMatchObject({ registrationId: id, node: 'lon1-1.sip.polite.ai', live: false, bindings: [binding], bindingsUpdatedAt: '2026-09-04T10:00:01.000Z', fetchedAt: null });
+
+    const g = res();
+    await getPhoneEndpoint(req({ params: { identifier: id } }), g);
+    expect(g._body.bindings).toEqual([binding]);
+    expect(g._body.b2buaId).toBe('lon1-1.sip.polite.ai');
+  });
+
+  test('a registrar account can be a registration trunk', async () => {
+    const r = await createAccount({ trunk: true, didSource: 'to', didCountry: 'gb' });
+    expect(r._status).toBe(201);
+    expect(r._body.trunkId).toBe(`reg-${r._body.id}`);
+    const trunk = await Trunk.findByPk(r._body.trunkId);
+    expect(trunk.flags).toMatchObject({ provider: 'registration', registrationId: r._body.id });
+    const row = await PhoneRegistration.findByPk(r._body.id);
+    expect(row.didSource).toBe('to');
+    expect(row.didCountry).toBe('GB');
+  });
+
+  test('usernames are unique across the realm: the partial index refuses a duplicate', async () => {
+    const first = await createAccount();
+    const second = await createAccount();
+    expect(first._body.username).not.toBe(second._body.username);
+
+    const duplicate = PhoneRegistration.create({
+      mode: 'registrar', kind: 'pbx', registrar: REALM, username: first._body.username, password: 'x',
+      organisationId: testOrgId, status: 'disabled', state: 'initial'
+    });
+    await expect(duplicate).rejects.toMatchObject({ name: 'SequelizeUniqueConstraintError' });
+
+    // A client-mode line may reuse the string: the index is partial.
+    const line = await PhoneRegistration.create({
+      mode: 'client', registrar: 'sip.example.com', username: first._body.username, password: 'x',
+      organisationId: testOrgId, status: 'disabled', state: 'initial'
+    });
+    expect(line.id).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Item 1 of the tactical registrar (aplisay-strategy `implementation/regserver-tactical-spec.md`, hitlist H16): the platform side of an account a customer's PBX registers *to*, rather than a line polite.ai registers out on.

## What changes

- **Schema 66**: `mode` (`client` | `registrar`, default `client`), `kind`, `bindings` (JSONB) and `bindings_updated_at` on `phone_registrations`, with a partial unique index on `username` for registrar rows. Every existing row reads as a client row; nothing about lines changes.
- **Creating a registrar account** (`POST /phone-endpoints` with `mode: "registrar"`, `kind: "pbx"`) mints the username (`pbx-` + 10 base32 characters) and a 24-character password, sets `registrar` from `REGSERVER_REGISTRAR`, and returns the credentials once in the 201. Without `REGSERVER_REGISTRAR` the create answers 503 `registrar_unavailable`. Supplying a registrar, username, password or `b2buaId` on a registrar account is refused; `mode` is fixed at creation.
- **Reveal and rotate**: `GET /phone-endpoints/{id}/credentials` and `POST /phone-endpoints/{id}/credentials/rotate`, both under `phoneEndpoint:update` and audit-logged.
- **Bindings**: `GET /phone-endpoints/{id}/bindings` serves the row's mirror, or with `live=1` proxies the owning node's `/debug/registrations/{id}/bindings`.
- `B2BUA_NODE_TYPES` gains `regserver`; heartbeats carry `bindings`; a regserver node is trace-capable.

## Deployment order

The b2bua branch that follows this (aplisay/aplisay-b2bua#46) reads the new columns in every claim query, so **this schema has to be live everywhere before any node built from that branch is deployed**; a node started against the old schema fails every claim. Set `REGSERVER_REGISTRAR` (the balancer name, `sip.polite.ai` on LON1, `sip-staging.polite.ai` on staging) where accounts are to be created.

## Tests

`tests/registrar-accounts-validation.test.mjs`, `tests/b2bua-node-regserver.test.mjs`, `tests/registrar-accounts.test.mjs` (database), plus the existing suite, green under Node 24.
