### PR TITLE
Registrar accounts: commit the rotate route that .gitignore swallowed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .env*
 #Credentials
 credentials
+# `credentials` above is for secret files, but it also matches the route directory
+# api/paths/phone-endpoints/{identifier}/credentials/, whose files are code, not secrets.
+!api/paths/**/credentials/
 # Logs
 logs
 *.log

--- a/api/paths/phone-endpoints/{identifier}/credentials/rotate.js
+++ b/api/paths/phone-endpoints/{identifier}/credentials/rotate.js
@@ -1,0 +1,73 @@
+import { requirePermission } from '../../../../../lib/auth/permissions.js';
+import { mintRegistrarPassword } from '../../../../../lib/utils/credentials.js';
+import { credentialsFor } from '../../../../../lib/registrar-accounts.js';
+import { loadRegistrarAccount } from '../credentials.js';
+
+let log;
+
+export default function (logger) {
+  log = logger;
+  return {
+    POST: rotateCredentials
+  };
+};
+
+/**
+ * Issue a registrar account a new password.
+ *
+ * The username stays: it is the account's identity on the wire and in the
+ * regserver's bindings, and changing it would be a new account. The state goes
+ * back to `initial`, which is the one signal the node acts on — it reloads the
+ * credential on its next pass and keeps any existing binding until the PBX's
+ * next REGISTER, which then fails with 403 until the customer pastes the new
+ * password in. Audited like a reveal.
+ */
+const rotateCredentials = async (req, res) => {
+  if (!requirePermission(res, 'phoneEndpoint', 'update')) return;
+  const { identifier } = req.params;
+
+  try {
+    const registration = await loadRegistrarAccount(identifier, res);
+    if (!registration) return;
+
+    const password = mintRegistrarPassword();
+    await registration.update({ password, state: 'initial', error: null });
+
+    req.log?.info({
+      audit: 'registrar-credentials-rotated',
+      registrationId: registration.id,
+      organisationId: registration.organisationId,
+      userId: res.locals.user?.id
+    }, 'registrar account password rotated');
+
+    return res.send(credentialsFor(registration, password));
+  }
+  catch (err) {
+    req.log?.error(err, 'rotating registrar account credentials');
+    return res.status(500).send({ error: 'Internal server error' });
+  }
+};
+
+rotateCredentials.apiDoc = {
+  summary: 'Rotate the password of a registrar account',
+  description: `Mints a new password for a registrar account and returns the full credentials once.
+                The username is unchanged. The registration state is reset to \`initial\`; the node
+                serving the account picks the new password up on its next pass, and the PBX's next
+                REGISTER with the old one is refused. Requires phoneEndpoint:update; recorded in the
+                audit log.`,
+  operationId: 'rotateRegistrarAccountCredentials',
+  tags: ['Phone Endpoints'],
+  parameters: [
+    { name: 'identifier', in: 'path', required: true, schema: { type: 'string' }, description: 'Registration endpoint ID (registrar accounts only)' }
+  ],
+  responses: {
+    200: {
+      description: 'The new credentials',
+      content: { 'application/json': { schema: { $ref: '#/components/schemas/RegistrarAccountCredentials' } } }
+    },
+    400: { description: 'Bad request', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    403: { description: 'Forbidden', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    404: { description: 'Not found, or not a registrar account', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    500: { description: 'Internal server error', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } }
+  }
+};


### PR DESCRIPTION
Follow-up to #287. `.gitignore`'s bare `credentials` line ignores any directory of that name, so `api/paths/phone-endpoints/{identifier}/credentials/rotate.js` was never committed: the staging build's test step failed on the missing module and the rotate route answered 404. This re-includes that route directory in `.gitignore` and commits the file. The two registrar suites pass locally with the file in place.