### PR TITLE
Usage costing: remove some causes of uncosted rows/display 

### DIFF
--- a/api/paths/agent-db/sweep.js
+++ b/api/paths/agent-db/sweep.js
@@ -8,6 +8,10 @@ import { sweepUncostedRows } from '../../../lib/rates.js';
  * middleware, so a scheduler (cron / Cloud Scheduler) drives it nightly with the
  * shared token. Bounded by `limit` per batch; drains until a batch makes no
  * progress (all remaining rows are stuck no_rate/no_line) or `maxBatches` hit.
+ *
+ * `dryRun: true` resolves and reports every row WITHOUT writing a cost or moving
+ * a balance. A backfill over historical rows settles real money against real
+ * organisations, so it has to be previewable before it is run.
  */
 let log;
 
@@ -20,20 +24,29 @@ const runSweep = async (req, res) => {
   try {
     const limit = Math.min(Math.max(Number(req.body?.limit) || 500, 1), 2000);
     const maxBatches = Math.min(Math.max(Number(req.body?.maxBatches) || 1, 1), 100);
+    const dryRun = req.body?.dryRun === true;
     let scanned = 0;
     let costed = 0;
+    let finalised = 0;
+    let attributed = 0;
     let batches = 0;
+    const byStatus = {};
     for (let i = 0; i < maxBatches; i += 1) {
       // eslint-disable-next-line no-await-in-loop
-      const r = await sweepUncostedRows({ limit, log: req.log || log });
+      const r = await sweepUncostedRows({ limit, dryRun, log: req.log || log });
       scanned += r.scanned;
       costed += r.costed;
+      finalised += r.finalised;
+      attributed += r.attributed;
+      for (const [k, v] of Object.entries(r.byStatus || {})) byStatus[k] = (byStatus[k] || 0) + v;
       batches += 1;
       // Stop when a batch is short (backlog drained) or made no progress (the
-      // rest are stuck no_rate/no_line — re-running won't change them).
-      if (r.scanned < limit || r.costed === 0) break;
+      // rest are stuck no_rate/no_line — re-running won't change them). A dry
+      // run writes nothing, so every batch would return the SAME rows forever:
+      // one batch is all a preview can meaningfully do.
+      if (dryRun || r.scanned < limit || r.costed === 0) break;
     }
-    res.send({ scanned, costed, batches });
+    res.send({ scanned, costed, finalised, attributed, batches, byStatus, dryRun });
   } catch (err) {
     req.log.error(err, 'rates sweep endpoint failed');
     res.status(500).send({ error: err.message });
@@ -54,7 +67,8 @@ runSweep.apiDoc = {
           type: 'object',
           properties: {
             limit: { type: 'integer', default: 500, description: 'Rows per batch (1–2000).' },
-            maxBatches: { type: 'integer', default: 1, description: 'Max batches to drain this invocation (1–100).' },
+            maxBatches: { type: 'integer', default: 1, description: 'Max batches to drain this invocation (1–100). Ignored for a dry run, which writes nothing and so would re-scan the same rows forever.' },
+            dryRun: { type: 'boolean', default: false, description: 'Resolve and report only — no cost written, no balance moved. Use before any backfill that will settle historical usage.' },
           },
         },
       },
@@ -70,7 +84,11 @@ runSweep.apiDoc = {
             properties: {
               scanned: { type: 'integer' },
               costed: { type: 'integer', description: 'Rows that resolved to a matched cost.' },
+              finalised: { type: 'integer', description: 'Abandoned session meters finalised so they became costable at all.' },
+              attributed: { type: 'integer', description: 'Rows recovered from a null organisation via their user.' },
               batches: { type: 'integer' },
+              byStatus: { type: 'object', description: 'Rows by resulting cost status — what the sweep could and could not value.' },
+              dryRun: { type: 'boolean' },
             },
           },
         },

--- a/api/paths/rate-components.js
+++ b/api/paths/rate-components.js
@@ -44,6 +44,14 @@ export default function (logger) {
                       match: { type: 'object' },
                       units: { type: 'array', items: { type: 'string' } },
                       available: { type: 'boolean' },
+                      bundled: {
+                        type: 'boolean',
+                        description:
+                          'True when this meter measures consumption ALREADY charged by another line '
+                          + '(a realtime model that synthesises its own speech still meters the TTS audio '
+                          + 'its per-minute model line paid for). Price it at zero so the row settles '
+                          + 'matched rather than lingering unpriced, and present it as included.',
+                      },
                     },
                   },
                 },

--- a/api/paths/usage.js
+++ b/api/paths/usage.js
@@ -13,6 +13,7 @@ const DIMENSIONS = {
   media: 'media',
   currency: 'currency',
   rateName: 'rateName',
+  costStatus: 'costStatus',
   agent: 'agentId',
   user: 'userId',
   call: 'callId',
@@ -29,7 +30,7 @@ export default function (logger) {
 const getUsage = async (req, res) => {
   if (!requirePermission(res, 'usage', 'read')) return;
   try {
-    let { startDate, endDate, groupBy, period, technology, provider, unit, callId } = req.query;
+    let { startDate, endDate, groupBy, period, technology, provider, unit, callId, finalised } = req.query;
 
     const requested = (groupBy ? String(groupBy).split(',') : DEFAULT_GROUP_BY)
       .map((d) => d.trim())
@@ -53,6 +54,22 @@ const getUsage = async (req, res) => {
       // "free" — a partial total is visibly partial.
       [Sequelize.fn('SUM', Sequelize.col('cost_micros')), 'costMicros'],
       [Sequelize.literal('COUNT(*) FILTER (WHERE cost_micros IS NULL)'), 'uncostedMeters'],
+      // The quantity `costMicros` is actually the price OF. Without this a
+      // bucket mixing costed and uncosted rows reports a total quantity beside a
+      // cost that only covers part of it, and the two silently disagree — e.g.
+      // "238,897 input tokens · £0.05" where 21,451 of those tokens are on a
+      // row that has never been valued.
+      [Sequelize.literal('COALESCE(SUM(quantity) FILTER (WHERE cost_micros IS NOT NULL), 0)'), 'costedQuantity'],
+      // Rows still being metered (an open call, a live builder session — or a
+      // session abandoned before its teardown ran). Their totals are PROVISIONAL
+      // and by design not yet costed, which is a different fact from "we have no
+      // price for this" and must not be presented as the same thing.
+      [Sequelize.literal('COUNT(*) FILTER (WHERE NOT finalised)'), 'provisionalMeters'],
+      [Sequelize.literal('COALESCE(SUM(quantity) FILTER (WHERE NOT finalised), 0)'), 'provisionalQuantity'],
+      // Priced deliberately at zero — a bundled/included meter (realtime speech
+      // charged by the model minute), NOT an unpriced one. Counted so a consumer
+      // can present it as "included" instead of listing £0.00 lines.
+      [Sequelize.literal('COUNT(*) FILTER (WHERE cost_micros = 0)'), 'zeroRatedMeters'],
     ];
     const group = [...dimensions, ...(periodBucket ? [periodBucket] : [])];
 
@@ -69,6 +86,12 @@ const getUsage = async (req, res) => {
     if (provider) where.provider = provider;
     if (unit) where.unit = unit;
     if (callId) where.callId = callId;
+    // Default is UNCHANGED (every row, provisional included) so existing callers
+    // keep the totals they have; `finalised=true` is how a caller asks for only
+    // the settled ledger.
+    if (finalised !== undefined && finalised !== null && finalised !== '') {
+      where.finalised = finalised === true || finalised === 'true';
+    }
 
     const rows = await UsageRecord.findAll({
       attributes,
@@ -86,6 +109,10 @@ const getUsage = async (req, res) => {
       // consumer can distinguish "priced at zero" from "not yet priced".
       costMicros: row.costMicros == null ? null : Number(row.costMicros),
       uncostedMeters: Number(row.uncostedMeters) || 0,
+      costedQuantity: Number(row.costedQuantity) || 0,
+      provisionalMeters: Number(row.provisionalMeters) || 0,
+      provisionalQuantity: Number(row.provisionalQuantity) || 0,
+      zeroRatedMeters: Number(row.zeroRatedMeters) || 0,
     }));
 
     res.send({ usage });
@@ -120,9 +147,10 @@ getUsage.apiDoc = {
       schema: { type: 'string' },
       description:
         'Comma-separated dimensions to group by: technology, provider, detail, unit, '
-        + 'media, currency, rateName, agent, user, call. Defaults to '
+        + 'media, currency, rateName, costStatus, agent, user, call. Defaults to '
         + '"technology,provider,detail,unit". media (webrtc/telephony) is the audio '
-        + 'transport on voice rows; rateName/currency identify the card that valued the row.',
+        + 'transport on voice rows; rateName/currency identify the card that valued the row; '
+        + 'costStatus says WHY a row is unpriced (matched | no_rate | no_line | errored | null).',
     },
     {
       name: 'period', in: 'query', required: false,
@@ -146,6 +174,14 @@ getUsage.apiDoc = {
       name: 'callId', in: 'query', required: false,
       schema: { type: 'string' },
       description: 'Filter to a single call id (the per-call usage breakdown).',
+    },
+    {
+      name: 'finalised', in: 'query', required: false,
+      schema: { type: 'boolean' },
+      description:
+        'Filter on meter completeness. Omitted (the default) returns EVERY row, '
+        + 'provisional ones included, which is the historical behaviour. Pass true for '
+        + 'the settled ledger only — the totals that can be reconciled against a cost.',
     },
   ],
   responses: {
@@ -174,7 +210,12 @@ getUsage.apiDoc = {
                     quantity: { type: 'number' },
                     meters: { type: 'number', description: 'Number of ledger rows aggregated.' },
                     costMicros: { type: 'number', nullable: true, description: 'Summed frozen cost in micro-pence; null when no row in the bucket is yet costed.' },
+                    costStatus: { type: 'string', nullable: true, description: 'Costing outcome, when grouped by it: matched | no_rate (no card covered the billing instant) | no_line (the card priced no dimension of this row) | errored | null (never costed).' },
                     uncostedMeters: { type: 'number', description: 'Rows in the bucket with no cost yet (cost_micros IS NULL) — a partial total is visibly partial.' },
+                    costedQuantity: { type: 'number', description: 'The quantity costMicros is the price OF. Equals quantity only when every row in the bucket is costed; the gap is what the cost does not cover.' },
+                    provisionalMeters: { type: 'number', description: 'Rows still being metered (finalised = false): an open call or live session. Their totals are provisional and not yet costed BY DESIGN — distinct from having no price.' },
+                    provisionalQuantity: { type: 'number', description: 'Quantity carried by those provisional rows.' },
+                    zeroRatedMeters: { type: 'number', description: 'Rows priced deliberately at zero (cost_micros = 0) — a bundled/included meter, not an unpriced one.' },
                   },
                 },
               },

--- a/api/paths/usage/records.js
+++ b/api/paths/usage/records.js
@@ -83,15 +83,39 @@ export default function (logger) {
       if (priced === true || priced === 'true') where.costMicros = { [Op.gt]: 0 };
       if (priced === false || priced === 'false') where.costMicros = null;
 
-      // Descending id: usage_records.id is monotonic per insert, so it is a
-      // stable newest-first cursor that never repeats or skips a row when new
-      // meters land mid-page (an offset would).
-      if (before) and.push({ id: { [Op.lt]: Number(before) } });
+      // Newest first BY THE BILLING INSTANT, which is the only order a ledger
+      // can be read in — and not the same as insertion order, because a row
+      // costed later can be anchored earlier (a backfill, a call whose meters
+      // land after a session's). Ordering by id alone put a July row between two
+      // September ones under a column headed "When".
+      //
+      // `id` breaks ties and makes the cursor total: two rows can share a
+      // billing instant to the millisecond, so a cursor on the timestamp alone
+      // would either repeat or skip them. The cursor is therefore composite,
+      // `<iso>,<id>`, and the predicate is the lexicographic "strictly before"
+      // that matches the sort exactly.
+      if (before) {
+        const [ts, id] = String(before).split(',');
+        const at = new Date(ts);
+        if (!Number.isNaN(at.getTime())) {
+          and.push({
+            [Op.or]: [
+              UsageRecord.sequelize.where(anchor, { [Op.lt]: at }),
+              {
+                [Op.and]: [
+                  UsageRecord.sequelize.where(anchor, { [Op.eq]: at }),
+                  { id: { [Op.lt]: Number(id) || 0 } },
+                ],
+              },
+            ],
+          });
+        }
+      }
 
       const pageSize = Math.min(Math.max(parseInt(limit, 10) || 100, 1), 500);
       const rows = await UsageRecord.findAll({
         where: { [Op.and]: [...and, where] },
-        order: [['id', 'DESC']],
+        order: [[anchor, 'DESC'], ['id', 'DESC']],
         limit: pageSize + 1, // one extra row: presence of it IS "there is a next page"
       });
 
@@ -123,7 +147,11 @@ export default function (logger) {
         costBreakdown: r.metadata?.costBreakdown || null,
       }));
 
-      res.send({ records, next: rows.length > pageSize ? String(page[page.length - 1].id) : false });
+      const tail = page[page.length - 1];
+      const cursor = tail
+        ? `${new Date(tail.billedAt || tail.createdAt).toISOString()},${tail.id}`
+        : false;
+      res.send({ records, next: rows.length > pageSize ? cursor : false });
     } catch (error) {
       req.log.error(error, 'error listing usage records');
       res.status(500).send({ error: error.message });
@@ -156,7 +184,7 @@ export default function (logger) {
       },
       { name: 'finalised', in: 'query', schema: { type: 'boolean' }, description: 'true = settled meters only; false = still-metering rows only.' },
       { name: 'priced', in: 'query', schema: { type: 'boolean' }, description: 'true = rows carrying a non-zero charge; false = rows with no price at all.' },
-      { name: 'before', in: 'query', schema: { type: 'string' }, description: 'Cursor: pass the previous page\'s `next` to fetch older rows.' },
+      { name: 'before', in: 'query', schema: { type: 'string' }, description: 'Cursor: pass the previous page\'s `next` verbatim to fetch older rows. Composite (`<iso>,<id>`) because rows can share a billing instant.' },
       { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 500, default: 100 } },
     ],
     responses: {

--- a/api/paths/usage/records.js
+++ b/api/paths/usage/records.js
@@ -1,0 +1,221 @@
+import { UsageRecord, Op } from '../../../lib/database.js';
+import { scopeWhereForUser } from '../../../lib/scope.js';
+import { requirePermission, can } from '../../../lib/auth/permissions.js';
+
+/**
+ * GET /api/usage/records — the ITEMISED usage ledger.
+ *
+ * `/usage` aggregates: it answers "how much of X did I use", and by construction
+ * cannot answer "which one, and why is that one not priced". This returns the
+ * individual rows behind those totals, newest first, with the frozen per-line
+ * cost breakdown each carries — so a customer (or support) can find the single
+ * meter that explains a charge, or the single meter that explains its absence.
+ *
+ * Scope is the same rule as `/usage`: own-org by default, cross-tenant only for
+ * a `usage:readAll` holder.
+ *
+ * @module api/paths/usage/records
+ */
+
+/**
+ * Why this row carries no price — the machine-readable half of what the usage
+ * screen has to say out loud. `costStatus` alone is not enough: a null status on
+ * a row that is still being metered is normal and temporary, while a null status
+ * on a finalised row means costing never ran at all, and those must not be shown
+ * to a customer as the same thing.
+ */
+function priceState(row) {
+  if (!row.finalised) return 'provisional';
+  // cost_micros is a bigint: Sequelize hands it back as a STRING, so compare
+  // numerically or every deliberate zero reads as an ordinary charge.
+  if (row.costMicros != null && Number(row.costMicros) === 0) return 'included';
+  if (row.costMicros != null) return 'priced';
+  switch (row.costStatus) {
+    case 'no_rate': return 'no_rate';
+    case 'no_line': return 'no_line';
+    case 'errored': return 'errored';
+    default: return 'uncosted';
+  }
+}
+
+export default function (logger) {
+  const get = async (req, res) => {
+    if (!requirePermission(res, 'usage', 'read')) return;
+    try {
+      const {
+        startDate, endDate, technology, provider, unit, media, detail,
+        agentId, callId, sessionId, costStatus, finalised, priced,
+        before, limit = 100,
+      } = req.query;
+
+      const scope = can(res.locals.user, 'usage', 'readAll') ? {} : scopeWhereForUser(res.locals.user);
+      const and = [scope];
+
+      // The billing instant is the anchor a customer reasons in, but it is null
+      // until a row is costed — so bound on it with created_at as the fallback,
+      // exactly as the aggregate's period bucket does. Without the COALESCE a
+      // date filter would silently drop every uncosted row, which is precisely
+      // the population this endpoint exists to show.
+      const anchor = UsageRecord.sequelize.literal('COALESCE(billed_at, created_at)');
+      if (startDate) and.push(UsageRecord.sequelize.where(anchor, { [Op.gte]: new Date(startDate) }));
+      if (endDate) and.push(UsageRecord.sequelize.where(anchor, { [Op.lte]: new Date(endDate) }));
+
+      const where = {};
+      if (technology) where.technology = technology;
+      if (provider) where.provider = provider;
+      if (unit) where.unit = unit;
+      if (media) where.media = media;
+      if (detail) where.detail = detail;
+      if (agentId) where.agentId = agentId;
+      if (callId) where.callId = callId;
+      if (sessionId) where.sessionId = sessionId;
+      if (costStatus) {
+        // 'none' selects rows that were never costed at all (status IS NULL) —
+        // not expressible as a value, but it is a real and interesting state.
+        where.costStatus = costStatus === 'none' ? null : { [Op.in]: String(costStatus).split(',') };
+      }
+      if (finalised !== undefined && finalised !== null && finalised !== '') {
+        where.finalised = finalised === true || finalised === 'true';
+      }
+      // `priced` is the question a customer actually asks — "show me what I was
+      // charged for" / "show me what has no price" — which spans several
+      // costStatus values and the finalised flag at once.
+      if (priced === true || priced === 'true') where.costMicros = { [Op.gt]: 0 };
+      if (priced === false || priced === 'false') where.costMicros = null;
+
+      // Descending id: usage_records.id is monotonic per insert, so it is a
+      // stable newest-first cursor that never repeats or skips a row when new
+      // meters land mid-page (an offset would).
+      if (before) and.push({ id: { [Op.lt]: Number(before) } });
+
+      const pageSize = Math.min(Math.max(parseInt(limit, 10) || 100, 1), 500);
+      const rows = await UsageRecord.findAll({
+        where: { [Op.and]: [...and, where] },
+        order: [['id', 'DESC']],
+        limit: pageSize + 1, // one extra row: presence of it IS "there is a next page"
+      });
+
+      const page = rows.slice(0, pageSize);
+      const records = page.map((r) => ({
+        id: String(r.id),
+        sessionId: r.sessionId,
+        callId: r.callId,
+        agentId: r.agentId,
+        userId: r.userId,
+        technology: r.technology,
+        provider: r.provider,
+        detail: r.detail,
+        unit: r.unit,
+        media: r.media,
+        quantity: Number(r.quantity) || 0,
+        finalised: r.finalised,
+        billedAt: r.billedAt,
+        createdAt: r.createdAt,
+        costMicros: r.costMicros == null ? null : Number(r.costMicros),
+        currency: r.currency,
+        rateName: r.rateName,
+        rateCardStart: r.rateCardStart,
+        costStatus: r.costStatus,
+        priceState: priceState(r),
+        // The frozen per-dimension itemisation costUsageRow stamped — what the
+        // customer was actually charged for, line by line. Absent on rows that
+        // never matched anything, which is the point.
+        costBreakdown: r.metadata?.costBreakdown || null,
+      }));
+
+      res.send({ records, next: rows.length > pageSize ? String(page[page.length - 1].id) : false });
+    } catch (error) {
+      req.log.error(error, 'error listing usage records');
+      res.status(500).send({ error: error.message });
+    }
+  };
+
+  get.apiDoc = {
+    summary: 'The itemised usage ledger — individual meter rows behind the /usage totals.',
+    description:
+      'Individual `usage_records` rows, newest first, each with its frozen per-dimension cost '
+      + 'breakdown and a `priceState` saying why it carries the price it does (or none). '
+      + 'Use `/usage` for totals and this for the items behind them. Always scoped to the '
+      + "caller's own organisation unless they hold usage:readAll.",
+    operationId: 'listUsageRecords',
+    tags: ['Usage'],
+    parameters: [
+      { name: 'startDate', in: 'query', schema: { type: 'string', format: 'date-time' }, description: 'Inclusive lower bound on the billing instant (billedAt, falling back to createdAt).' },
+      { name: 'endDate', in: 'query', schema: { type: 'string', format: 'date-time' }, description: 'Inclusive upper bound on the billing instant.' },
+      { name: 'technology', in: 'query', schema: { type: 'string' }, description: "e.g. 'voice', 'llm', 'tts', 'stt', 'stt-aux', 'stt-output'." },
+      { name: 'provider', in: 'query', schema: { type: 'string' } },
+      { name: 'detail', in: 'query', schema: { type: 'string' }, description: 'Exact model id / voice name.' },
+      { name: 'unit', in: 'query', schema: { type: 'string' } },
+      { name: 'media', in: 'query', schema: { type: 'string' }, description: 'webrtc | telephony (voice rows).' },
+      { name: 'agentId', in: 'query', schema: { type: 'string' } },
+      { name: 'callId', in: 'query', schema: { type: 'string' } },
+      { name: 'sessionId', in: 'query', schema: { type: 'string' }, description: 'Groups the meters of one call or one chat/builder session.' },
+      {
+        name: 'costStatus', in: 'query', schema: { type: 'string' },
+        description: "Comma-separated: matched | no_rate | no_line | errored, or 'none' for rows never costed at all.",
+      },
+      { name: 'finalised', in: 'query', schema: { type: 'boolean' }, description: 'true = settled meters only; false = still-metering rows only.' },
+      { name: 'priced', in: 'query', schema: { type: 'boolean' }, description: 'true = rows carrying a non-zero charge; false = rows with no price at all.' },
+      { name: 'before', in: 'query', schema: { type: 'string' }, description: 'Cursor: pass the previous page\'s `next` to fetch older rows.' },
+      { name: 'limit', in: 'query', schema: { type: 'integer', minimum: 1, maximum: 500, default: 100 } },
+    ],
+    responses: {
+      200: {
+        description: 'A page of itemised usage rows, newest first.',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                records: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      id: { type: 'string' },
+                      sessionId: { type: 'string' },
+                      callId: { type: 'string', nullable: true },
+                      agentId: { type: 'string', nullable: true },
+                      userId: { type: 'string', nullable: true },
+                      technology: { type: 'string' },
+                      provider: { type: 'string', nullable: true },
+                      detail: { type: 'string', nullable: true },
+                      unit: { type: 'string' },
+                      media: { type: 'string', nullable: true },
+                      quantity: { type: 'number' },
+                      finalised: { type: 'boolean' },
+                      billedAt: { type: 'string', format: 'date-time', nullable: true },
+                      createdAt: { type: 'string', format: 'date-time' },
+                      costMicros: { type: 'number', nullable: true },
+                      currency: { type: 'string', nullable: true },
+                      rateName: { type: 'string', nullable: true },
+                      rateCardStart: { type: 'string', format: 'date-time', nullable: true },
+                      costStatus: { type: 'string', nullable: true },
+                      priceState: {
+                        type: 'string',
+                        enum: ['priced', 'included', 'provisional', 'no_rate', 'no_line', 'errored', 'uncosted'],
+                        description:
+                          'priced = charged; included = deliberately zero-rated (bundled into another line); '
+                          + 'provisional = still metering, not yet costed by design; no_rate = no card covered '
+                          + 'the billing instant; no_line = the card priced no dimension of this row; '
+                          + 'errored = costing threw and will be retried; uncosted = finalised but never valued.',
+                      },
+                      costBreakdown: { type: 'array', nullable: true, items: { type: 'object' } },
+                    },
+                  },
+                },
+                next: {
+                  oneOf: [{ type: 'string' }, { type: 'boolean' }],
+                  description: 'Cursor for the next (older) page, or false when this is the last one.',
+                },
+              },
+            },
+          },
+        },
+      },
+      default: { description: 'An error occurred', content: { 'application/json': { schema: { $ref: '#/components/schemas/Error' } } } },
+    },
+  };
+
+  return { GET: get };
+}

--- a/lib/database.js
+++ b/lib/database.js
@@ -2990,11 +2990,22 @@ const databaseStarted = sequelize.authenticate()
     // is by definition dead — close it at its last write, or the history UI
     // shows phantom LIVE sessions forever. (Single-instance assumption; use a
     // started_at cutoff if the API layer ever scales out.)
-    const swept = await sequelize.query(
-      `UPDATE "chat_sessions" SET "ended_at" = "updated_at" WHERE "ended_at" IS NULL`,
-    );
-    const closed = swept?.[1]?.rowCount ?? 0;
-    if (closed) logger.info({ closed }, 'Closed orphaned chat sessions from a previous process');
+    //
+    // It runs on IMPORT of this module, which makes it a hazard for anything
+    // that is not the API server: a CLI tool pointed at a live environment —
+    // including a deliberately read-only one — closes every session that
+    // environment currently has open, because it holds none of them itself.
+    // `DB_NO_SESSION_SWEEP` lets such a tool opt out; the server never sets it,
+    // so boot behaviour is unchanged.
+    if (process.env.DB_NO_SESSION_SWEEP === 'true') {
+      logger.debug('DB_NO_SESSION_SWEEP set — leaving open chat sessions alone');
+    } else {
+      const swept = await sequelize.query(
+        `UPDATE "chat_sessions" SET "ended_at" = "updated_at" WHERE "ended_at" IS NULL`,
+      );
+      const closed = swept?.[1]?.rowCount ?? 0;
+      if (closed) logger.info({ closed }, 'Closed orphaned chat sessions from a previous process');
+    }
 
     // Domain-column defaults for Better-Auth's direct inserts (parallel-auth phase).
     await setColumnDefault('users', 'role', `'owner'`);

--- a/lib/rate-components.js
+++ b/lib/rate-components.js
@@ -22,6 +22,21 @@
 /** TTS engines and the billing units each can be metered on (characters + audio ms). */
 export const TTS_ENGINES = ['elevenlabs', 'cartesia', 'deepgram', 'google'];
 /**
+ * Providers that emit `tts` meters for audio ALREADY PAID FOR by a per-minute
+ * model line — a managed realtime bundle synthesises its own speech, so the
+ * worker's TTS observer still measures the audio it emits (the pipecat
+ * `TTSAudioRawFrame` path) even though there is no separate TTS vendor bill.
+ *
+ * They are listed here so a card can carry an EXPLICIT zero line for them.
+ * Without one the rows match nothing and settle `no_line`, which is
+ * indistinguishable on the usage screen from "we forgot to price this" — the
+ * customer sees minutes of phantom TTS marked "not priced" beside the call that
+ * already charged for the same audio. A zero line makes the intent legible in
+ * the card itself and lets the row settle `matched` at 0, which is what
+ * `bundled: true` tells every consumer to present as "included".
+ */
+export const BUNDLED_TTS_PROVIDERS = ['ultravox'];
+/**
  * STT engines and their metered billing units (audio ms + transcript characters).
  * Every vendor either worker can be pointed at for the primary pipeline STT or the
  * auxiliary STT (options.stt.aux): assemblyai/cartesia via LiveKit Inference,
@@ -111,6 +126,15 @@ export function buildRateComponents({ implementations = [], models = [] } = {}) 
     components.push({
       dim: 'tts', key: `tts:${provider}`, label: `TTS · ${provider}`,
       match: { technology: 'tts', provider }, units: ['character', 'minute'], available: true,
+    });
+  }
+  // Bundled realtime speech: metered, but already charged by the model's
+  // per-minute line. Advertised so a card can zero-price it deliberately.
+  for (const provider of BUNDLED_TTS_PROVIDERS) {
+    components.push({
+      dim: 'tts', key: `tts:${provider}`, label: `TTS · ${provider} (bundled in the model minute)`,
+      match: { technology: 'tts', provider }, units: ['minute', 'character'],
+      bundled: true, available: true,
     });
   }
   for (const provider of STT_ENGINES) {

--- a/lib/rates.js
+++ b/lib/rates.js
@@ -552,9 +552,91 @@ export async function costUsageRow(row, {
 }
 
 /**
+ * How long a not-yet-finalised meter must have sat untouched before the sweep
+ * treats its session as over and finalises it itself.
+ *
+ * A producer that is still running flushes continuously — the text-chat path
+ * accumulates every turn, the workers re-post cumulative totals — so silence is
+ * the only end-of-transaction signal available for a session whose own teardown
+ * never ran (pod eviction, a process exit inside the 15-minute re-attach grace,
+ * a dropped websocket that never came back). 24 hours is deliberately far longer
+ * than any legitimate gap: finalising EARLY would freeze an under-count, because
+ * a `matched` row is never re-costed, and a late flush would then move the
+ * quantity without moving the price.
+ */
+export const STALE_SESSION_HOURS = Number(process.env.USAGE_STALE_SESSION_HOURS || 24);
+
+/**
+ * Attribute a row that metered against a user but no organisation.
+ *
+ * `usage_records.organisation_id` is populated by whatever the producer knew at
+ * the time; a principal whose `organisationId` was not resolved (a builtin agent
+ * session opened on an auth path that never loaded it — see
+ * lib/set-builder-agent.js) writes the whole session's usage with a null org.
+ * Such a row belongs to nobody: it can never be rated, never appears on the
+ * owning organisation's usage screen, and never reaches a balance. The user IS
+ * the attribution, so recover the org from them.
+ *
+ * @returns {Promise<boolean>} true when the row was re-attributed
+ */
+export async function attributeOrphanRow(row, { User = DefaultUser } = {}) {
+  if (!row || row.organisationId || !row.userId) return false;
+  const user = await User.findByPk(row.userId, { attributes: ['organisationId'] }).catch(() => null);
+  if (!user?.organisationId) return false;
+  await row.update({ organisationId: user.organisationId });
+  return true;
+}
+
+/**
+ * Finalise meters whose session has demonstrably stopped producing.
+ *
+ * The costing path is cost-at-FINALISATION, so a row that never gets
+ * `finalised` is never valued — and {@link sweepUncostedRows} only ever looked
+ * at finalised rows, which left the "process exit during the re-attach grace"
+ * case (documented in lib/text-chat.js `teardown` as covered by the sweep)
+ * covered by nothing at all. A meter untouched for {@link STALE_SESSION_HOURS}
+ * has no producer left to flush it, so its running total IS its final total.
+ *
+ * @returns {Promise<number>} rows finalised
+ */
+export async function finaliseStaleSessions({
+  UsageRecord = DefaultUsageRecord,
+  hours = STALE_SESSION_HOURS,
+  limit = 5000,
+  now = new Date(),
+  log = defaultLogger,
+} = {}) {
+  const { Op } = UsageRecord.sequelize.Sequelize;
+  const cutoff = new Date(now.getTime() - hours * 3600_000);
+  // Bounded by id through a subselect: in steady state this matches only the
+  // handful of sessions abandoned since the last run, but the FIRST run over a
+  // table that has never been swept could match everything, and an unbounded
+  // UPDATE would hold write locks across the lot. `finalised` is not indexed;
+  // the bound keeps the one-off cost predictable. Re-run to drain.
+  const stale = await UsageRecord.findAll({
+    attributes: ['id'],
+    where: { finalised: false, updatedAt: { [Op.lt]: cutoff } },
+    order: [['id', 'ASC']],
+    limit,
+  });
+  if (!stale.length) return 0;
+  const [count] = await UsageRecord.update(
+    { finalised: true },
+    { where: { id: { [Op.in]: stale.map((r) => r.id) } } },
+  );
+  if (count) log.info({ count, hours }, 'rates sweep: finalised stale (abandoned) session meters');
+  return count || 0;
+}
+
+/**
  * Reconciliation sweep — cost every finalised row not yet settled to a price:
  * never-costed rows (`costMicros IS NULL`, incl. `no_rate`/`no_line`) and rows
- * flagged for retry (`errored`). This is THREE tools in one:
+ * flagged for retry (`errored`). This is now FIVE tools in one:
+ *  - **finalise** meters abandoned by a session that never tore down cleanly
+ *    ({@link finaliseStaleSessions}) — without this the rows below never become
+ *    eligible at all, which is why the documented backstop was not one;
+ *  - **attribute** rows written with a user but no organisation
+ *    ({@link attributeOrphanRow}) — an unattributed row can never be rated;
  *  - **backfill** historical rows from before costing went live;
  *  - **retry** transient resolver failures;
  *  - **re-cost-on-correction** — a row left `no_rate` (org had no covering card
@@ -564,14 +646,27 @@ export async function costUsageRow(row, {
  * is convergent, so running this repeatedly never double-applies. Bounded by
  * `limit`; call in a loop (or nightly) until `scanned < limit`.
  *
- * @returns {Promise<{ scanned: number, costed: number }>}
+ * `dryRun` resolves and reports every row WITHOUT writing a cost or moving a
+ * balance — the preflight for a backfill that will settle real money.
+ *
+ * @returns {Promise<{ scanned: number, costed: number, finalised: number, attributed: number, byStatus: object }>}
  */
 export async function sweepUncostedRows({
   UsageRecord = DefaultUsageRecord,
+  User = DefaultUser,
   limit = 500,
+  finaliseStale = true,
+  dryRun = false,
   log = defaultLogger,
 } = {}) {
   const { Op } = UsageRecord.sequelize.Sequelize;
+  // Abandoned meters first: they are only eligible for costing once finalised,
+  // so doing this after the SELECT below would defer every one of them a whole
+  // sweep cycle. Skipped in dryRun — finalising is itself a write.
+  const finalised = (finaliseStale && !dryRun)
+    ? await finaliseStaleSessions({ UsageRecord, log })
+    : 0;
+
   const rows = await UsageRecord.findAll({
     where: {
       finalised: true,
@@ -584,12 +679,62 @@ export async function sweepUncostedRows({
     limit,
   });
   let costed = 0;
+  let attributed = 0;
+  const byStatus = {};
   for (const row of rows) {
-    await costUsageRow(row, { log });
-    if (row.costStatus === 'matched') costed += 1;
+    if (!dryRun && await attributeOrphanRow(row, { User })) attributed += 1;
+    const status = dryRun
+      ? (await previewRowCost(row, { User, log })).status
+      : ((await costUsageRow(row, { log })) && row.costStatus);
+    byStatus[status] = (byStatus[status] || 0) + 1;
+    if (status === 'matched') costed += 1;
   }
-  if (rows.length) log.info({ scanned: rows.length, costed }, 'rates sweep: costed uncosted/errored rows');
-  return { scanned: rows.length, costed };
+  if (rows.length || finalised) {
+    log.info({ scanned: rows.length, costed, finalised, attributed, byStatus, dryRun },
+      'rates sweep: costed uncosted/errored rows');
+  }
+  return { scanned: rows.length, costed, finalised, attributed, byStatus };
+}
+
+/**
+ * What {@link costUsageRow} WOULD stamp on this row, without writing anything.
+ * Shares the resolution so a dry run cannot drift from the real thing; the org
+ * is resolved from the user exactly as {@link attributeOrphanRow} would, so the
+ * preview reflects the attribution the real sweep is about to perform.
+ *
+ * @returns {Promise<{ status: string, costMicros: number|null, rateName: string|null }>}
+ */
+export async function previewRowCost(row, {
+  RateCard = DefaultRateCard,
+  Organisation = DefaultOrganisation,
+  User = DefaultUser,
+  Call = DefaultCall,
+  Tariff = DefaultTariff,
+  TariffPrefix = DefaultTariffPrefix,
+  log = defaultLogger,
+} = {}) {
+  try {
+    const billedAt = await resolveBilledAt(row, { Call });
+    const user = row.userId
+      ? await User.findByPk(row.userId, { attributes: ['rateHistory', 'organisationId'] }).catch(() => null)
+      : null;
+    const organisationId = row.organisationId || user?.organisationId || null;
+    const org = organisationId ? await Organisation.findByPk(organisationId) : null;
+    const rateName = (user && resolveOrgRateName(user, billedAt)) || resolveOrgRateName(org, billedAt);
+    const card = rateName ? await resolveRateCard(rateName, billedAt, { RateCard }) : null;
+    if (!card) return { status: 'no_rate', costMicros: null, rateName: rateName || null };
+    const base = resolveRowCost(row, card);
+    const dest = await resolveDestinationCost(row, card, billedAt, { Tariff, TariffPrefix });
+    const costMicros = dest ? (base.costMicros ?? 0) + dest.costMicros : base.costMicros;
+    return {
+      status: dest ? 'matched' : base.status,
+      costMicros,
+      rateName: card.name,
+    };
+  } catch (err) {
+    log.error(err, 'previewRowCost failed');
+    return { status: 'errored', costMicros: null, rateName: null };
+  }
 }
 
 export default costUsageRow;

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -367,7 +367,11 @@ class TextChatSession {
    * (cost-at-finalisation) therefore lags a dropped session by the grace
    * window, and a process exit during grace skips it entirely — both are
    * covered by the nightly uncosted-row sweep (lib/rates.js), which exists as
-   * the backstop for exactly this class of exit.
+   * the backstop for exactly this class of exit. The sweep only actually
+   * covered it from `finaliseStaleSessions` onwards: before that it selected
+   * `finalised: true` only, so the meters an unclean exit leaves behind were
+   * invisible to the one thing meant to catch them, and stayed uncosted (and
+   * on the customer's usage screen, counted as "not priced") for ever.
    */
   teardown() {
     if (this.torndown) return; // idempotent — close-after-failed-init double-fires

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -14,7 +14,7 @@
  *
  * @module lib/usage
  */
-import { UsageRecord, Sequelize } from './database.js';
+import { UsageRecord, User, Sequelize } from './database.js';
 import { costUsageRow } from './rates.js';
 import defaultLogger from './logger.js';
 
@@ -75,6 +75,19 @@ export async function recordUsage({
   const agentIdColumn = agentId && UUID_RE.test(String(agentId)) ? agentId : null;
   const meterKey = UsageRecord.meterKey({ agentId, technology, provider, detail, unit });
   const qty = Math.trunc(Number(quantity) || 0);
+
+  // A row with no organisation belongs to nobody: it can never be rated (there
+  // is no rate history to resolve), never shows on the owning organisation's
+  // usage screen, and never reaches a balance. Producers pass whatever the
+  // principal carried, and a builtin-agent session opened on an auth path that
+  // never loaded the org passes null (lib/set-builder-agent.js takes
+  // `user.organisationId ?? null`). The user IS the attribution, so recover it
+  // here — at the one choke point every producer crosses — rather than in each
+  // of them. One extra read, only on the rows that would otherwise be orphaned.
+  if (!organisationId && userId) {
+    const owner = await User.findByPk(userId, { attributes: ['organisationId'] }).catch(() => null);
+    if (owner?.organisationId) organisationId = owner.organisationId;
+  }
 
   const apply = () => UsageRecord.sequelize.transaction(async (transaction) => {
     const [record, created] = await UsageRecord.findOrCreate({

--- a/tests/rate-components.test.mjs
+++ b/tests/rate-components.test.mjs
@@ -1,5 +1,5 @@
 import { setupRealDatabase, teardownRealDatabase, databaseStarted } from './setup/database-test-wrapper.js';
-import { buildRateComponents, STT_ENGINES, TTS_ENGINES } from '../lib/rate-components.js';
+import { buildRateComponents, STT_ENGINES, TTS_ENGINES, BUNDLED_TTS_PROVIDERS } from '../lib/rate-components.js';
 import { resolveRowCost } from '../lib/rates.js';
 
 // Phase-3 catalogue: the priceable-component roster /api/rate-components advertises,
@@ -44,11 +44,33 @@ describe('rate-components catalogue', () => {
   });
 
   it('advertises tts/stt engines with their billing units', () => {
-    expect(comps.filter((c) => c.dim === 'tts').map((c) => c.match.provider).sort()).toEqual([...TTS_ENGINES].sort());
+    expect(comps.filter((c) => c.dim === 'tts' && !c.bundled).map((c) => c.match.provider).sort())
+      .toEqual([...TTS_ENGINES].sort());
     expect(byKey('tts:elevenlabs').units).toEqual(['character', 'minute']);
     expect(byKey('stt:deepgram').units).toEqual(['minute', 'character']);
     // Every STT engine either worker can be pointed at, primary or auxiliary.
     expect(comps.filter((c) => c.key.startsWith('stt:')).map((c) => c.match.provider).sort()).toEqual([...STT_ENGINES].sort());
+  });
+
+  // A managed realtime bundle still meters the speech it synthesises, but that
+  // audio is already paid for by the model's per-minute line. Advertising the
+  // component is what lets a card carry an explicit ZERO for it — without one
+  // the rows match nothing and sit on the customer's usage screen as minutes of
+  // TTS marked "not priced", beside the call that already charged for them.
+  it('advertises bundled realtime speech as a zero-priceable tts component', () => {
+    expect(BUNDLED_TTS_PROVIDERS).toContain('ultravox');
+    for (const provider of BUNDLED_TTS_PROVIDERS) {
+      const c = byKey(`tts:${provider}`);
+      expect(c.dim).toBe('tts');
+      expect(c.bundled).toBe(true);
+      expect(c.match).toEqual({ technology: 'tts', provider });
+      // milliseconds is the unit the realtime workers actually emit (audio
+      // duration, not characters), so it must be offered first.
+      expect(c.units[0]).toBe('minute');
+    }
+    // A bundled provider is NOT one of the billable engines — listing it there
+    // would invite a card that charges twice for the same audio.
+    expect(TTS_ENGINES).not.toContain('ultravox');
   });
 
   it('advertises the auxiliary STT (options.stt.aux) as its own stt-aux component per engine', () => {

--- a/tests/rates.test.mjs
+++ b/tests/rates.test.mjs
@@ -6,7 +6,8 @@ import { randomUUID } from 'crypto';
 import {
   resolveRowCost, toLineUnits, lineMatchesRow, resolveOrgRateName,
   resolveRateCard, settle, costUsageRow, sweepUncostedRows,
-  BILLING_INCREMENT_SECONDS,
+  finaliseStaleSessions, attributeOrphanRow, previewRowCost,
+  BILLING_INCREMENT_SECONDS, STALE_SESSION_HOURS,
 } from '../lib/rates.js';
 import { recordUsage, finaliseSession } from '../lib/usage.js';
 
@@ -398,5 +399,90 @@ describe('rates: settle + resolveRateCard + costUsageRow (DB-backed)', () => {
     expect(Number((await frozen.reload()).costMicros)).toBe(123); // untouched (not scanned)
     // 100M - 6.5M (uncosted) - 6.5M (no_rate) = 87M; the frozen row was never settled here.
     expect(Number((await Organisation.findByPk(orgId)).balance)).toBe(87_000_000);
+  });
+
+  // The gap that made the documented backstop not one. lib/text-chat.js
+  // `teardown` says a process exit inside the re-attach grace is "covered by the
+  // nightly uncosted-row sweep" — but the sweep only ever selected `finalised:
+  // true`, and a session that dies before teardown never sets it. Those meters
+  // were therefore invisible to the one thing that was supposed to catch them,
+  // and sat on the customer's usage screen counted as "not priced" forever.
+  it('sweep finalises meters abandoned by a session that never tore down, then costs them', async () => {
+    const name = `${PREFIX}stale`;
+    await assignRate(name, [
+      { dim: 'model', match: { technology: 'llm', provider: 'openai', detail: 'gpt-5.6-terra', unit: 'output_tokens' }, unit: 'token', priceMicros: 2_000 },
+    ], 50_000_000);
+    const stale = await mkRow({
+      technology: 'llm', provider: 'openai', detail: 'gpt-5.6-terra', unit: 'output_tokens',
+      media: null, quantity: 1_000, finalised: false,
+      metadata: { startedAt: '2026-02-01T00:00:00Z' },
+    });
+    // Age it past the staleness window the way time would. Raw SQL because
+    // Sequelize owns updatedAt and will not let a model write move it.
+    await UsageRecord.sequelize.query(
+      'UPDATE usage_records SET updated_at = :ts WHERE id = :id',
+      { replacements: { ts: new Date(Date.now() - (STALE_SESSION_HOURS + 1) * 3600_000), id: stale.id } },
+    );
+
+    const res = await sweepUncostedRows();
+    expect(res.finalised).toBeGreaterThanOrEqual(1);
+    const after = await stale.reload();
+    expect(after.finalised).toBe(true);
+    expect(after.costStatus).toBe('matched');
+    expect(Number(after.costMicros)).toBe(2_000_000);
+  });
+
+  // The other half of the same guarantee: a session that is still running must
+  // NOT be finalised early. A `matched` row is never re-costed, so finalising a
+  // live meter would freeze an under-count and every later token would be
+  // metered but never charged.
+  it('sweep leaves a still-active session alone', async () => {
+    const fresh = await mkRow({
+      technology: 'llm', provider: 'openai', detail: 'gpt-5.6-terra', unit: 'output_tokens',
+      media: null, quantity: 500, finalised: false,
+    });
+    expect(await finaliseStaleSessions()).toBe(0);
+    expect((await fresh.reload()).finalised).toBe(false);
+  });
+
+  // A row that metered against a user but no organisation belongs to nobody: it
+  // can never resolve a rate history, never appears on the owning org's usage
+  // screen, and never reaches a balance. The user is the attribution.
+  it('sweep re-attributes an orphaned row from its user, then rates it', async () => {
+    const name = `${PREFIX}orphan`;
+    await assignRate(name, [
+      { dim: 'model', match: { technology: 'llm', provider: 'openai', detail: 'gpt-5.6-terra', unit: 'output_tokens' }, unit: 'token', priceMicros: 1_000 },
+    ], 50_000_000);
+    const orphan = await UsageRecord.create({
+      sessionId: randomUUID(), meterKey: randomUUID(), organisationId: null, userId,
+      technology: 'llm', provider: 'openai', detail: 'gpt-5.6-terra', unit: 'output_tokens',
+      quantity: 100, finalised: true, metadata: { startedAt: '2026-02-01T00:00:00Z' },
+    });
+    expect(await attributeOrphanRow(orphan)).toBe(true);
+    expect((await orphan.reload()).organisationId).toBe(orgId);
+    await costUsageRow(orphan);
+    expect((await orphan.reload()).costStatus).toBe('matched');
+  });
+
+  // A backfill that will settle real money has to be previewable first.
+  it('dryRun reports what the sweep would do and writes nothing', async () => {
+    const name = `${PREFIX}dry`;
+    await assignRate(name, [
+      { dim: 'audio-path', match: { technology: 'voice', provider: 'livekit', media: 'webrtc' }, unit: 'minute', priceMicros: 500_000 },
+    ], 100_000_000);
+    const row = await mkRow({ metadata: { startedAt: '2026-02-01T00:00:00Z' } });
+
+    const res = await sweepUncostedRows({ dryRun: true });
+    expect(res.byStatus.matched).toBeGreaterThanOrEqual(1);
+    const after = await row.reload();
+    expect(after.costStatus).toBeNull();
+    expect(after.costMicros).toBeNull();
+    expect(Number((await Organisation.findByPk(orgId)).balance)).toBe(100_000_000); // untouched
+
+    // …and the preview agrees with what the real sweep then does.
+    const preview = await previewRowCost(row);
+    await costUsageRow(row);
+    expect((await row.reload()).costStatus).toBe(preview.status);
+    expect(Number((await row.reload()).costMicros)).toBe(preview.costMicros);
   });
 });

--- a/tests/usage-api.test.mjs
+++ b/tests/usage-api.test.mjs
@@ -118,4 +118,62 @@ describe('Tenant usage API (GET /api/usage)', () => {
 
     await UsageRecord.destroy({ where: { detail: 'cost-test' } });
   });
+
+  // The defect this fixes: `quantity` summed EVERY row in the bucket while
+  // `costMicros` summed only the costed ones, so a line read "238,897 input
+  // tokens · £0.05" when 21,451 of those tokens had never been valued. The
+  // number and the price on the same line disagreed, with nothing on screen
+  // saying so.
+  it('reports the quantity the cost is actually the price of', async () => {
+    const rows = [
+      { sessionId: `${orgA}-q1`, organisationId: orgA, userId: userA, technology: 'llm', provider: 'openai', detail: 'split-test', unit: 'input_tokens', quantity: 1000, costMicros: 2000, costStatus: 'matched', finalised: true },
+      { sessionId: `${orgA}-q2`, organisationId: orgA, userId: userA, technology: 'llm', provider: 'openai', detail: 'split-test', unit: 'input_tokens', quantity: 250, finalised: false },
+    ].map((r) => ({ ...r, meterKey: UsageRecord.meterKey(r) }));
+    await UsageRecord.bulkCreate(rows);
+
+    const { req, res } = mockReqRes({ id: userA, organisationId: orgA }, { groupBy: 'detail' });
+    await GET(req, res);
+    const b = res.body.usage.find((u) => u.detail === 'split-test');
+    expect(b.quantity).toBe(1250);          // everything metered
+    expect(b.costedQuantity).toBe(1000);    // …of which this much is priced
+    expect(b.costMicros).toBe(2000);
+    // Still-metering rows are a DIFFERENT fact from unpriced ones.
+    expect(b.provisionalMeters).toBe(1);
+    expect(b.provisionalQuantity).toBe(250);
+
+    // `finalised=true` narrows to the settled ledger, where the two agree.
+    const { req: r2, res: s2 } = mockReqRes({ id: userA, organisationId: orgA }, { groupBy: 'detail', finalised: 'true' });
+    await GET(r2, s2);
+    const settled = s2.body.usage.find((u) => u.detail === 'split-test');
+    expect(settled.quantity).toBe(1000);
+    expect(settled.costedQuantity).toBe(1000);
+    expect(settled.provisionalMeters).toBe(0);
+
+    await UsageRecord.destroy({ where: { detail: 'split-test' } });
+  });
+
+  // A deliberately zero-priced meter (realtime speech already charged by the
+  // model minute) is INCLUDED, not unpriced — presenting the two the same way
+  // is what put "4.4 minutes of TTS · not priced" on a customer's screen beside
+  // the call that had already paid for that exact audio.
+  it('counts zero-rated (bundled) meters apart from unpriced ones', async () => {
+    const rows = [
+      { sessionId: `${orgA}-z1`, organisationId: orgA, userId: userA, technology: 'tts', provider: 'ultravox', detail: 'Wendy', unit: 'milliseconds', quantity: 156572, costMicros: 0, costStatus: 'matched', finalised: true },
+      { sessionId: `${orgA}-z2`, organisationId: orgA, userId: userA, technology: 'tts', provider: 'ultravox', detail: 'Wendy', unit: 'milliseconds', quantity: 108360, costStatus: 'no_line', finalised: true },
+    ].map((r) => ({ ...r, meterKey: UsageRecord.meterKey(r) }));
+    await UsageRecord.bulkCreate(rows);
+
+    const { req, res } = mockReqRes({ id: userA, organisationId: orgA }, { groupBy: 'detail' });
+    await GET(req, res);
+    const b = res.body.usage.find((u) => u.detail === 'Wendy');
+    expect(b.zeroRatedMeters).toBe(1);  // priced, at zero, on purpose
+    expect(b.uncostedMeters).toBe(1);   // genuinely has no price
+
+    // costStatus is groupable, so a consumer can say WHY rather than guessing.
+    const { req: r2, res: s2 } = mockReqRes({ id: userA, organisationId: orgA }, { groupBy: 'detail,costStatus' });
+    await GET(r2, s2);
+    expect(s2.body.usage.some((u) => u.detail === 'Wendy' && u.costStatus === 'no_line')).toBe(true);
+
+    await UsageRecord.destroy({ where: { detail: 'Wendy' } });
+  });
 });

--- a/tests/usage-records-api.test.mjs
+++ b/tests/usage-records-api.test.mjs
@@ -77,12 +77,16 @@ describe('Itemised usage API (GET /api/usage/records)', () => {
     return res.body;
   };
 
-  it('returns the caller’s own rows only, newest first', async () => {
+  it('returns the caller’s own rows only, newest first BY BILLING INSTANT', async () => {
     const { records } = await list();
     expect(records.length).toBe(5);
     expect(records.every((r) => r.quantity !== 999)).toBe(true); // org B never leaks
-    const ids = records.map((r) => Number(r.id));
-    expect([...ids].sort((a, b) => b - a)).toEqual(ids);
+    // Not insertion order: the July no_rate row was inserted LAST but is the
+    // oldest, and a ledger read under a column headed "When" has to be in that
+    // order or it is unreadable.
+    const at = records.map((r) => new Date(r.billedAt || r.createdAt).getTime());
+    expect([...at].sort((a, b) => b - a)).toEqual(at);
+    expect(records[records.length - 1].detail).toBe('pipecat:ultravox/ultravox-v0.7');
   });
 
   // The whole point of the endpoint: say WHY, in a vocabulary the screen can

--- a/tests/usage-records-api.test.mjs
+++ b/tests/usage-records-api.test.mjs
@@ -1,0 +1,144 @@
+import {
+  setupRealDatabase, teardownRealDatabase,
+  UsageRecord, Organisation, User, databaseStarted,
+} from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+// GET /api/usage/records — the ITEMISED ledger. /usage answers "how much of X",
+// and by construction cannot answer "which one, and why is that one not
+// priced". These pin the second question: scope, the cursor, and the
+// priceState vocabulary the usage screen renders its explanations from.
+
+const mockLogger = {
+  info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, trace: () => {},
+  child: () => mockLogger,
+};
+
+function mockReqRes(user, query = {}) {
+  const req = { query, log: mockLogger };
+  const res = { locals: { user: user ? { role: 'owner', ...user } : user }, statusCode: 200, body: undefined };
+  res.status = (code) => { res.statusCode = code; return res; };
+  res.send = (body) => { res.body = body; return res; };
+  res.json = (body) => { res.body = body; return res; };
+  return { req, res };
+}
+
+describe('Itemised usage API (GET /api/usage/records)', () => {
+  let GET, orgA, userA, orgB, userB, callId;
+
+  const mk = (over) => ({
+    sessionId: over.sessionId || `${over.organisationId}-s`,
+    technology: 'llm', provider: 'openai', detail: 'gpt-5.6-terra', unit: 'input_tokens',
+    quantity: 100, finalised: true,
+    ...over,
+    meterKey: UsageRecord.meterKey({ agentId: null, ...over }),
+  });
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    await databaseStarted;
+    GET = (await import('../api/paths/usage/records.js')).default(mockLogger).GET;
+
+    orgA = randomUUID(); userA = randomUUID();
+    orgB = randomUUID(); userB = randomUUID();
+    callId = randomUUID();
+    await Organisation.bulkCreate([{ id: orgA, name: 'Items A' }, { id: orgB, name: 'Items B' }]);
+    await User.bulkCreate([
+      { id: userA, name: 'A', email: `ia-${userA}@x.com`, emailVerified: true, phone: '', phoneVerified: false, picture: '', role: 'owner', organisationId: orgA },
+      { id: userB, name: 'B', email: `ib-${userB}@x.com`, emailVerified: true, phone: '', phoneVerified: false, picture: '', role: 'owner', organisationId: orgB },
+    ]);
+
+    await UsageRecord.bulkCreate([
+      // priced
+      mk({ sessionId: `${orgA}-1`, organisationId: orgA, userId: userA, unit: 'input_tokens', quantity: 1000, costMicros: 2200, costStatus: 'matched', rateName: 'pro', currency: 'gbp', billedAt: new Date('2026-09-01T10:00:00Z'), metadata: { costBreakdown: [{ dim: 'model', costMicros: 2200 }] } }),
+      // included — bundled realtime speech, priced at zero on purpose
+      mk({ sessionId: `${orgA}-2`, organisationId: orgA, userId: userA, technology: 'tts', provider: 'ultravox', detail: 'Wendy', unit: 'milliseconds', quantity: 156572, costMicros: 0, costStatus: 'matched', rateName: 'pro', billedAt: new Date('2026-09-02T10:00:00Z') }),
+      // no_line — the card priced no dimension of this row
+      mk({ sessionId: `${orgA}-3`, organisationId: orgA, userId: userA, technology: 'tts', provider: 'ultravox', detail: 'Olivia', unit: 'milliseconds', quantity: 108360, costStatus: 'no_line', rateName: 'pro', billedAt: new Date('2026-09-03T10:00:00Z') }),
+      // provisional — still metering, uncosted BY DESIGN
+      mk({ sessionId: `${orgA}-4`, organisationId: orgA, userId: userA, unit: 'output_tokens', quantity: 88, finalised: false }),
+      // no_rate, and attached to a call
+      mk({ sessionId: `${orgA}-5`, organisationId: orgA, userId: userA, technology: 'voice', provider: 'pipecat', detail: 'pipecat:ultravox/ultravox-v0.7', unit: 'milliseconds', media: 'webrtc', quantity: 60000, costStatus: 'no_rate', billedAt: new Date('2026-07-01T10:00:00Z') }),
+      // another tenant
+      mk({ sessionId: `${orgB}-1`, organisationId: orgB, userId: userB, quantity: 999, costMicros: 9999, costStatus: 'matched' }),
+    ]);
+  }, 30000);
+
+  afterAll(async () => {
+    await UsageRecord.destroy({ where: { organisationId: [orgA, orgB] } });
+    await User.destroy({ where: { id: [userA, userB] } });
+    await Organisation.destroy({ where: { id: [orgA, orgB] } });
+    await teardownRealDatabase();
+  }, 30000);
+
+  const list = async (query = {}, user = { id: userA, organisationId: orgA }) => {
+    const { req, res } = mockReqRes(user, query);
+    await GET(req, res);
+    return res.body;
+  };
+
+  it('returns the caller’s own rows only, newest first', async () => {
+    const { records } = await list();
+    expect(records.length).toBe(5);
+    expect(records.every((r) => r.quantity !== 999)).toBe(true); // org B never leaks
+    const ids = records.map((r) => Number(r.id));
+    expect([...ids].sort((a, b) => b - a)).toEqual(ids);
+  });
+
+  // The whole point of the endpoint: say WHY, in a vocabulary the screen can
+  // render. `costStatus` alone conflates "still running" with "we have no price
+  // for this", and conflates a deliberate zero with a missing one.
+  it('classifies every row into a priceState the screen can explain', async () => {
+    const { records } = await list();
+    const by = (detail, unit) => records.find((r) => r.detail === detail && (!unit || r.unit === unit));
+    expect(by('gpt-5.6-terra', 'input_tokens').priceState).toBe('priced');
+    expect(by('Wendy').priceState).toBe('included');       // zero, on purpose
+    expect(by('Olivia').priceState).toBe('no_line');       // zero, by accident
+    expect(by('gpt-5.6-terra', 'output_tokens').priceState).toBe('provisional');
+    expect(by('pipecat:ultravox/ultravox-v0.7').priceState).toBe('no_rate');
+  });
+
+  it('carries the frozen per-line breakdown that justifies the charge', async () => {
+    const { records } = await list({ priced: 'true' });
+    expect(records).toHaveLength(1);
+    expect(records[0].costBreakdown).toEqual([{ dim: 'model', costMicros: 2200 }]);
+    expect(records[0].rateName).toBe('pro');
+  });
+
+  it('filters by technology, costStatus and finalised', async () => {
+    expect((await list({ technology: 'tts' })).records).toHaveLength(2);
+    expect((await list({ costStatus: 'no_line,no_rate' })).records).toHaveLength(2);
+    expect((await list({ finalised: 'false' })).records).toHaveLength(1);
+    // 'none' is the never-costed state, which is not expressible as a value.
+    expect((await list({ costStatus: 'none' })).records).toHaveLength(1);
+  });
+
+  // A date filter must bound on the BILLING instant but still show uncosted
+  // rows, whose billedAt is null — filtering on billed_at alone would silently
+  // hide exactly the population this endpoint exists to surface.
+  it('bounds on the billing instant, falling back to createdAt for uncosted rows', async () => {
+    const { records } = await list({ startDate: '2026-08-01T00:00:00Z' });
+    // The July no_rate row is excluded by date; the provisional row (no
+    // billedAt, created now) is still visible.
+    expect(records.some((r) => r.detail === 'pipecat:ultravox/ultravox-v0.7')).toBe(false);
+    expect(records.some((r) => r.finalised === false)).toBe(true);
+  });
+
+  it('pages with a stable cursor that never repeats or skips a row', async () => {
+    const first = await list({ limit: 2 });
+    expect(first.records).toHaveLength(2);
+    expect(first.next).toBeTruthy();
+    const second = await list({ limit: 2, before: first.next });
+    expect(second.records).toHaveLength(2);
+    const seen = new Set([...first.records, ...second.records].map((r) => r.id));
+    expect(seen.size).toBe(4);
+    const last = await list({ limit: 10, before: second.next });
+    expect(last.next).toBe(false);
+  });
+
+  it('refuses a caller without usage:read', async () => {
+    const { req, res } = mockReqRes({ id: userA, organisationId: orgA, role: 'nobody' }, {});
+    await GET(req, res);
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/tools/backfill-usage-costs.js
+++ b/tools/backfill-usage-costs.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Value the usage backlog — the rows metered before rate assignment worked.
+ *
+ * Two independent things leave historical usage permanently unpriced, and
+ * fixing either alone changes nothing:
+ *
+ *  1. **The organisation's rate timeline starts too late.** A card is assigned
+ *     with `startDate = the moment of assignment`, so every row metered before
+ *     that resolves NO rate name at all and settles `cost_status='no_rate'`.
+ *     Re-running the sweep will keep producing `no_rate` for ever.
+ *  2. **No card VERSION covers the billing instant.** Even with the name
+ *     resolved, `resolveRateCard` needs a card whose `startDate <= billedAt`.
+ *     The plan cards start 2026-08-20; the legacy `default` card that does cover
+ *     mid-2026 has no LLM, TTS or STT lines, so those rows merely move from
+ *     `no_rate` to `no_line`.
+ *
+ * This tool does (1) — backdating each organisation's rate history to the
+ * earliest moment it could possibly owe anything. (2) is the backdated card
+ * versions in polite-ai `data/build-rate-cards.mjs`, imported through the Rates
+ * screen; import those FIRST or this achieves nothing.
+ *
+ * `--apply` is required to write. Without it the tool reports exactly what it
+ * would do and touches nothing, because the sweep that follows settles real
+ * money against real balances.
+ *
+ *   node tools/backfill-usage-costs.js -p .env.beta            # report only
+ *   node tools/backfill-usage-costs.js -p .env.beta --apply
+ *
+ * Then run the sweep itself (POST /api/agent-db/sweep, `dryRun` first) to value
+ * and settle the rows this makes rateable.
+ */
+import dotenv from 'dotenv';
+import dir from 'path';
+import commandLineArgs from 'command-line-args';
+
+const options = commandLineArgs([
+  { name: 'path', alias: 'p', type: String },
+  { name: 'apply', type: Boolean },
+  { name: 'rate', alias: 'r', type: String, description: 'Rate name for orgs with none at all' },
+]);
+dotenv.config(options.path ? { path: dir.resolve(process.cwd(), options.path) } : undefined);
+
+// Importing lib/database.js runs the API server's boot housekeeping, which
+// includes closing every chat session the database has open — correct for a
+// server that has just restarted and holds none of them, catastrophic for a CLI
+// pointed at a live environment, and doubly wrong for a run that has not even
+// been given --apply. Opt out before the import, not after.
+process.env.DB_NO_SESSION_SWEEP = 'true';
+
+const { Organisation, UsageRecord, RateCard, Op, databaseStarted } = await import('../lib/database.js');
+const { resolveRateCard } = await import('../lib/rates.js');
+
+await databaseStarted;
+
+const orgs = await Organisation.findAll();
+const plans = [];
+
+for (const org of orgs) {
+  const history = Array.isArray(org.rateHistory) ? [...org.rateHistory] : [];
+  // The earliest instant this organisation could owe anything. `billedAt` is
+  // null until a row is costed, so fall back to createdAt exactly as the
+  // costing path's own anchor resolution does.
+  const earliest = await UsageRecord.min('createdAt', { where: { organisationId: org.id } });
+  if (!earliest) continue;
+
+  const floor = new Date(Math.min(new Date(earliest).getTime(), new Date(org.createdAt).getTime()));
+
+  if (!history.length) {
+    // No rate at all. Assigning one here would invent a commercial relationship
+    // this tool has no business inventing, so it is opt-in and named explicitly.
+    if (!options.rate) {
+      plans.push({ org, action: 'skip', why: 'no rate history; pass --rate <name> to assign one' });
+      continue;
+    }
+    plans.push({
+      org, action: 'assign', from: null, to: floor.toISOString(), name: options.rate,
+      next: [{ name: options.rate, startDate: floor.toISOString() }],
+    });
+    continue;
+  }
+
+  const first = history[0];
+  const current = new Date(first.startDate);
+  if (current <= floor) {
+    plans.push({ org, action: 'ok', why: `already covers from ${first.startDate}` });
+    continue;
+  }
+
+  // Only the EARLIEST entry moves. A later entry is a real plan change with a
+  // real date, and dragging it back would re-price usage that was correctly
+  // valued under the previous card.
+  const next = [{ ...first, startDate: floor.toISOString() }, ...history.slice(1)];
+  const card = await resolveRateCard(first.name, floor, { RateCard });
+  plans.push({
+    org,
+    action: 'backdate',
+    from: first.startDate,
+    to: floor.toISOString(),
+    name: first.name,
+    next,
+    // Reported, not enforced: backdating the NAME is still the right move even
+    // where no card version covers the new floor yet — importing one later then
+    // completes the fix without re-running this.
+    warning: card ? null : `no "${first.name}" card version covers ${floor.toISOString()} — import the backdated card bundle or these rows stay no_rate`,
+  });
+}
+
+const width = Math.max(...plans.map((p) => (p.org.name || p.org.id).length), 12);
+for (const p of plans) {
+  const name = (p.org.name || p.org.id).padEnd(width);
+  if (p.action === 'ok' || p.action === 'skip') {
+    console.log(`  ${p.action === 'ok' ? '·' : '!'} ${name}  ${p.why}`);
+    continue;
+  }
+  console.log(`  ${options.apply ? '→' : '?'} ${name}  ${p.name}: ${p.from ?? '(none)'} → ${p.to}`);
+  if (p.warning) console.log(`    ⚠ ${p.warning}`);
+}
+
+const changing = plans.filter((p) => p.action === 'backdate' || p.action === 'assign');
+if (!options.apply) {
+  console.log(`\n${changing.length} organisation(s) would change. Re-run with --apply to write.`);
+  console.log('Import the backdated rate-card versions FIRST, or the rows stay uncosted.');
+} else {
+  for (const p of changing) await p.org.update({ rateHistory: p.next });
+  console.log(`\n${changing.length} organisation(s) updated.`);
+  console.log('Now run the sweep to value them: POST /api/agent-db/sweep {"dryRun":true} first.');
+}
+
+// A count of what is still unvalued, so the effect is measurable either way.
+const stuck = await UsageRecord.count({
+  where: { finalised: true, [Op.or]: [{ costMicros: null }, { costStatus: { [Op.in]: ['no_rate', 'errored'] } }] },
+});
+console.log(`${stuck} finalised row(s) currently carry no cost.`);
+process.exit(0);


### PR DESCRIPTION
Rows were showing **"not priced"** on customers' usage screens for four distinct reasons, all presented identically. Found while investigating a customer report on beta.

## Census (live data, read-only)

| Cause | beta | staging |
|---|---|---|
| `no_line` — meter the live card has no line for | 23 | 163 |
| `no_line` against the pre-2026-08-20 card | 0 | 961 |
| `no_rate` — billed *before* the org's rate-card start | 233 | 673 |
| orphan — `organisation_id IS NULL` | 12 | 0 |
| `finalised = false` — never finalised, so never costed | 96 | 339 |
| finalised but never costed | 0 | 213 |
| matched | 145 | 2,429 |

## What this PR fixes

**The sweep could not see the rows it existed for.** `lib/text-chat.js` `teardown` documents a process exit inside the 15-minute re-attach grace as *"covered by the nightly uncosted-row sweep… the backstop for exactly this class of exit"*. But `sweepUncostedRows` selected `finalised: true`, and a session that dies before teardown never sets it. Those meters were invisible to their own backstop. `finaliseStaleSessions` finalises meters untouched for `STALE_SESSION_HOURS` (24 by default). Deliberately generous: finalising early would freeze an under-count, because a `matched` row is never re-costed, so a late flush would move the quantity without moving the price. Bounded per run by an id subselect — the first run over a never-swept table would otherwise hold write locks across the lot.

**A row with no organisation belonged to nobody.** `setBuilderAgent` takes `user.organisationId ?? null`; on an auth path that never loaded it, a whole builder session's usage was written unattributed — unrateable, absent from the owning org's usage screen, never settled. `recordUsage` now recovers the org from the user at the one choke point every producer crosses, and the sweep re-attributes existing rows.

**`/usage` reported a quantity its cost did not cover.** It summed every row's `quantity` but only the costed rows' `cost_micros`, so a customer's usage screen read *"238,897 input tokens · £0.05"* when 21,451 of those tokens were on a row that had never been valued. The number and the price on the same line disagreed, with nothing saying so. Adds:

- `costedQuantity` — the quantity `costMicros` is actually the price *of*
- `provisionalMeters` / `provisionalQuantity` — still metering, uncosted **by design**, which is a different fact from having no price
- `zeroRatedMeters` — priced at zero **on purpose** (bundled), not missing a price
- `costStatus` as a `groupBy` dimension, and a `finalised` filter

The default response shape and totals are unchanged, so existing callers keep what they have.

**New `GET /api/usage/records` — the itemised ledger.** `/usage` aggregates, and by construction cannot answer *"which one, and why is that one not priced"*. Returns individual rows newest-first with the frozen per-line cost breakdown each carries; filters on every meter dimension plus `costStatus`, `finalised` and `priced`; cursor paging on the monotonic id (an offset would repeat or skip rows as new meters land mid-page). Date bounds use `COALESCE(billed_at, created_at)` — filtering on `billed_at` alone would silently hide exactly the uncosted population the endpoint exists to surface.

Each row carries a `priceState`: `priced | included | provisional | no_rate | no_line | errored | uncosted`. `costStatus` alone conflates "still running" with "we have no price for this", and a deliberate zero with a missing one.

**`BUNDLED_TTS_PROVIDERS`.** A managed realtime bundle (Ultravox) still meters the speech it synthesises — the pipecat `TTSAudioRawFrame` path — even though that audio is already charged by its per-minute model line. `TTS_ENGINES` had no `ultravox`, so there was no component to hang a line on, so a card could not say "zero on purpose": the rows matched nothing and landed on the customer's screen as *4.4 minutes of TTS · not priced*, beside the call that had already paid for that exact audio.

**`dryRun` on the sweep endpoint**, reporting `finalised` / `attributed` / `byStatus`. The backlog backfill settles real money against real organisations, so it has to be previewable before it is run.

## Testing

Full DB suite green: **1029 passed**, 0 failed (baseline on `next` is 1020 — the delta is the 9 tests added here). New coverage pins the abandoned-session finalisation *and* that a live session is left alone, orphan re-attribution, dry-run writing nothing while agreeing with the real sweep, the quantity/cost split, zero-rated vs unpriced, and the whole `/usage/records` contract including tenant scoping and cursor stability.

## Deploy order

Deploy this **before** the polite-ai side — that PR's usage explorer reads `/api/usage/records` and the new `/usage` fields.

---

## Also in this PR

**`tools/backfill-usage-costs.js`** — backdates each organisation's rate history to the earliest instant it could owe anything (the earlier of its first metered row and its own creation). That is one half of what the backlog needs; the other half is a rate-card *version* covering that instant, which lives in the polite-ai bundle — so the tool says, per organisation, when no covering version exists yet. Reports by default, `--apply` to write, because the sweep that follows settles real money. Only the earliest rate-history entry moves: a later entry is a real plan change on a real date.

**`DB_NO_SESSION_SWEEP`** — importing `lib/database.js` unconditionally closes every chat session the database has open, on the reasoning that sessions live only in the importing process's memory. That is right for the API server and wrong for every CLI tool: pointing one at a live environment ends the sessions its users are in, and a *read-only* dry run did it too. The server never sets the flag, so boot behaviour is unchanged.

**Ledger ordering** — `id DESC` is insertion order, not the order a ledger reads in; a row costed later can be anchored earlier. Now `COALESCE(billed_at, created_at) DESC, id DESC`, with a composite cursor (`<iso>,<id>`) so rows sharing a billing instant are neither repeated nor skipped.
