### PR TITLE
Chat session liveness: heartbeat

### DIFF
--- a/api/paths/chat-sessions.js
+++ b/api/paths/chat-sessions.js
@@ -1,5 +1,6 @@
 import { fn, col, Op } from 'sequelize';
 import { ChatSession, UsageRecord } from '../../lib/database.js';
+import { isChatSessionLive } from '../../lib/text-chat.js';
 import { scopeWhereForUser } from '../../lib/scope.js';
 import { requirePermission } from '../../lib/auth/permissions.js';
 
@@ -76,7 +77,7 @@ const listChatSessions = async (req, res) => {
       ...(agentId ? { agentId } : {}),
     };
     const { count, rows } = await ChatSession.findAndCountAll({
-      attributes: ['id', 'agentId', 'setId', 'mode', 'title', 'modelName', 'startedAt', 'endedAt', 'turns', 'resumedFrom'],
+      attributes: ['id', 'agentId', 'setId', 'mode', 'title', 'modelName', 'startedAt', 'endedAt', 'lastSeenAt', 'turns', 'resumedFrom'],
       where,
       order: [['startedAt', 'DESC']],
       limit,
@@ -84,7 +85,13 @@ const listChatSessions = async (req, res) => {
     });
     const usage = await usageBySession(rows.map((r) => r.id));
     res.send({
-      sessions: rows.map((r) => ({ ...r.get({ plain: true }), usage: usage[r.id] || null })),
+      // `lastSeenAt` is the input to `live`, not part of the contract: exposing
+      // it would invite each client to re-derive liveness with its own idea of
+      // the grace, and they would disagree.
+      sessions: rows.map((r) => {
+        const { lastSeenAt, ...row } = r.get({ plain: true });
+        return { ...row, live: isChatSessionLive(r), usage: usage[r.id] || null };
+      }),
       total: count,
     });
   } catch (error) {
@@ -129,6 +136,14 @@ listChatSessions.apiDoc = {
                     modelName: { type: 'string', nullable: true },
                     startedAt: { type: 'string', format: 'date-time' },
                     endedAt: { type: 'string', format: 'date-time', nullable: true },
+                    live: {
+                      type: 'boolean',
+                      description:
+                        'True while a server process still holds this session in memory. Derived from a '
+                        + 'heartbeat, not from endedAt being null: with more than one process running, no '
+                        + 'boot-time guess can tell one process\'s orphans from another\'s live sessions. '
+                        + 'Returned rather than left to the client so the staleness window has one definition.',
+                    },
                     turns: { type: 'integer' },
                     usage: {
                       type: 'object',

--- a/api/paths/chat-sessions/{sessionId}.js
+++ b/api/paths/chat-sessions/{sessionId}.js
@@ -1,5 +1,6 @@
 import { fn, col } from 'sequelize';
 import { ChatSession, UsageRecord } from '../../../lib/database.js';
+import { isChatSessionLive } from '../../../lib/text-chat.js';
 import { scopeWhereForUser } from '../../../lib/scope.js';
 import { requirePermission } from '../../../lib/auth/permissions.js';
 
@@ -58,7 +59,8 @@ const getChatSession = async (req, res) => {
       usage.costMicros += Number(r.costMicros) || 0;
       usage.currency = usage.currency || r.currency || null;
     }
-    res.send({ ...session.get({ plain: true }), usage });
+    const { lastSeenAt, ...row } = session.get({ plain: true });
+    res.send({ ...row, live: isChatSessionLive(session), usage });
   } catch (error) {
     req.log.error(error);
     res.status(500).send({ error: error.message });
@@ -91,6 +93,14 @@ getChatSession.apiDoc = {
               modelName: { type: 'string', nullable: true },
               startedAt: { type: 'string', format: 'date-time' },
               endedAt: { type: 'string', format: 'date-time', nullable: true },
+              live: {
+                type: 'boolean',
+                description:
+                  'True while a server process still holds this session in memory. Derived from a '
+                  + 'heartbeat, not from endedAt being null: with more than one process running, no '
+                  + 'boot-time guess can tell one process\'s orphans from another\'s live sessions. '
+                  + 'Returned rather than left to the client so the staleness window has one definition.',
+              },
               turns: { type: 'integer' },
               transcript: {
                 type: 'array',

--- a/index.mjs
+++ b/index.mjs
@@ -11,6 +11,7 @@ import { createServer } from 'http';
 import createWsServer from './lib/ws-handler.js';
 import { cleanHandlers } from './lib/handlers/index.js';
 import { buildInfo, describeBuild } from './lib/build-info.js';
+import { startChatSessionReaper } from './lib/text-chat.js';
 
 logger.info('starting up');
 // Which code is this? (baked BUILD_COMMIT/BRANCH/TAG in images, git in dev) —
@@ -152,6 +153,14 @@ openapi.initialize({
 httpServer.listen(port, () => {
   logger.info(`Server listening at http://localhost:${port}`);
 });
+
+// Close chat sessions no process still holds. Started HERE, in the server
+// entry point, and not on import of a library: the boot sweep this replaces
+// ran when lib/database.js was imported, so every CLI tool pointed at a live
+// environment ended that environment's sessions as a side effect — including
+// tools that only read. Safe to run from every replica at once; the cutoff
+// decides what is stale, not the fact that this process just started.
+startChatSessionReaper({ log: logger });
 
 process.on('SIGINT', cleanupAndExit);
 process.once('SIGTERM', cleanupAndExit);

--- a/lib/database.js
+++ b/lib/database.js
@@ -1781,6 +1781,20 @@ ChatSession.init({
     type: DataTypes.DATE,
     allowNull: true,
   },
+  // Liveness heartbeat: the last moment a PROCESS said it still held this
+  // session in memory (lib/text-chat.js writes it per turn and on a ticker).
+  //
+  // `ended_at IS NULL` used to double as "this session is live", which only
+  // worked with exactly one server process: nothing recorded WHICH process
+  // owned a row, so a second one starting could not tell its own orphans from
+  // another's live sessions. A heartbeat needs no owner and no boot-time
+  // guess — a session nobody has spoken for is stale by the clock, whichever
+  // process is asking. NULL on rows written before this column existed, which
+  // reads as "not live", the right answer for history.
+  lastSeenAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
   turns: {
     type: DataTypes.INTEGER,
     allowNull: false,
@@ -2985,27 +2999,13 @@ const databaseStarted = sequelize.authenticate()
     await sequelize.query(
       `ALTER TABLE "chat_sessions" ADD COLUMN IF NOT EXISTS "resumed_from" UUID`,
     );
-    // Boot sweep: sessions live only in THIS process's memory, so any row
-    // still open (ended_at IS NULL) at boot belongs to a previous process and
-    // is by definition dead — close it at its last write, or the history UI
-    // shows phantom LIVE sessions forever. (Single-instance assumption; use a
-    // started_at cutoff if the API layer ever scales out.)
-    //
-    // It runs on IMPORT of this module, which makes it a hazard for anything
-    // that is not the API server: a CLI tool pointed at a live environment —
-    // including a deliberately read-only one — closes every session that
-    // environment currently has open, because it holds none of them itself.
-    // `DB_NO_SESSION_SWEEP` lets such a tool opt out; the server never sets it,
-    // so boot behaviour is unchanged.
-    if (process.env.DB_NO_SESSION_SWEEP === 'true') {
-      logger.debug('DB_NO_SESSION_SWEEP set — leaving open chat sessions alone');
-    } else {
-      const swept = await sequelize.query(
-        `UPDATE "chat_sessions" SET "ended_at" = "updated_at" WHERE "ended_at" IS NULL`,
-      );
-      const closed = swept?.[1]?.rowCount ?? 0;
-      if (closed) logger.info({ closed }, 'Closed orphaned chat sessions from a previous process');
-    }
+    // Deliberately an idempotent add rather than a schemaVersion bump: a bump
+    // only applies under DB_FORCE_SYNC, which no deployed environment sets, so
+    // it would need a manual `tools/agent-admin.js upgrade-db` per environment
+    // before liveness worked anywhere. This runs on every boot, everywhere.
+    await sequelize.query(
+      `ALTER TABLE "chat_sessions" ADD COLUMN IF NOT EXISTS "last_seen_at" TIMESTAMP WITH TIME ZONE`,
+    );
 
     // Domain-column defaults for Better-Auth's direct inserts (parallel-auth phase).
     await setColumnDefault('users', 'role', `'owner'`);

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -43,6 +43,98 @@ const REATTACH_GRACE_MS = Number(process.env.TEXT_CHAT_REATTACH_GRACE_MS || 15 *
 // reload) are buffered and flushed on re-attach, so nothing said is lost.
 const OUTBOX_CAP = 200;
 
+/**
+ * How often a process says "I still hold this session" by writing
+ * `chat_sessions.last_seen_at`.
+ *
+ * A session is held in THIS process's `sessions` map, so only this process can
+ * report it alive. The beat runs for as long as the session exists, not only
+ * while a socket is attached: a session inside its re-attach grace is still
+ * live and still resumable, and marking it dead the moment a page reloads
+ * would be wrong.
+ */
+const HEARTBEAT_MS = Number(process.env.TEXT_CHAT_HEARTBEAT_MS || 60 * 1000);
+
+/**
+ * How long after its last heartbeat a session is still considered live.
+ *
+ * This is the ONE definition of live, shared by the API's `live` flag and by
+ * {@link reapStaleChatSessions}, so the reaper can never close a session the
+ * API would still report as running. It has to clear a missed beat and clock
+ * skew between a pod and the database, hence several multiples of the beat.
+ */
+const LIVENESS_GRACE_MS = Number(process.env.TEXT_CHAT_LIVENESS_GRACE_MS || 5 * 60 * 1000);
+
+/**
+ * Is this session still running? The rule that replaced `ended_at IS NULL`.
+ *
+ * `ended_at` now means one thing only: the session finished, at this real
+ * instant. Everything else is decided by the clock, which is what makes the
+ * answer the same in every process. A row from before `last_seen_at` existed
+ * has none, and reads as not live — correct, because it is history.
+ *
+ * @param {{endedAt?: Date|string|null, lastSeenAt?: Date|string|null}} row
+ * @param {Date} [now]
+ */
+export function isChatSessionLive(row, now = new Date()) {
+  if (!row || row.endedAt) return false;
+  if (!row.lastSeenAt) return false;
+  return now.getTime() - new Date(row.lastSeenAt).getTime() < LIVENESS_GRACE_MS;
+}
+
+/**
+ * Close sessions no process has spoken for since the liveness grace lapsed.
+ *
+ * This replaces a sweep that ran at BOOT and closed every open row, which was
+ * only ever correct with exactly one server process: on a second pod starting
+ * (a scale-up, a rolling deploy, a Cloud Run cold start) it closed the first
+ * pod's live sessions, and stamped them with the time of their last turn so
+ * the damage looked plausible.
+ *
+ * Deciding by the clock instead of by the boot event makes it safe to run from
+ * anywhere, any number of times at once: a row it closes is one that
+ * {@link isChatSessionLive} already reports as not live, whichever process
+ * asks. `updated_at` is the fallback for rows written before `last_seen_at`
+ * existed, which is exactly what the old boot sweep used.
+ *
+ * Never throws: tidying history must not take a server down.
+ *
+ * @returns {Promise<number>} rows closed
+ */
+export async function reapStaleChatSessions({ graceMs = LIVENESS_GRACE_MS, log = defaultLogger } = {}) {
+  try {
+    const result = await ChatSession.sequelize.query(
+      `UPDATE "chat_sessions"
+          SET "ended_at" = COALESCE("last_seen_at", "updated_at")
+        WHERE "ended_at" IS NULL
+          AND COALESCE("last_seen_at", "updated_at") < :cutoff`,
+      { replacements: { cutoff: new Date(Date.now() - graceMs) } },
+    );
+    const closed = result?.[1]?.rowCount ?? 0;
+    if (closed) log.info({ closed }, 'closed chat sessions no process still holds');
+    return closed;
+  } catch (err) {
+    log.error(err, 'reapStaleChatSessions failed');
+    return 0;
+  }
+}
+
+/**
+ * Run {@link reapStaleChatSessions} on a timer. Started by the SERVER only
+ * (index.mjs), never by importing this module: the boot sweep this replaces
+ * ran on import of lib/database.js, so every CLI tool pointed at a live
+ * environment closed that environment's sessions as a side effect, including
+ * tools doing nothing but reading.
+ *
+ * @returns {() => void} stop
+ */
+export function startChatSessionReaper({ intervalMs = LIVENESS_GRACE_MS, log = defaultLogger } = {}) {
+  reapStaleChatSessions({ log });
+  const timer = setInterval(() => reapStaleChatSessions({ log }), intervalMs);
+  if (timer.unref) timer.unref();
+  return () => clearInterval(timer);
+}
+
 export function getChatSession(id) {
   return sessions.get(id);
 }
@@ -320,10 +412,12 @@ class TextChatSession {
             title: this.latestSet?.name ?? null,
             modelName: this.agent.modelName ?? null,
             startedAt: this.startedAt,
+            lastSeenAt: this.startedAt,
             resumedFrom: this.resumedFrom,
             transcript: this.transcript,
           });
           this.persisted = true;
+          this.startHeartbeat();
         } catch (e) {
           this.logger.error(e, 'chat session persist (create) failed — history disabled for this session');
         }
@@ -373,16 +467,52 @@ class TextChatSession {
    * invisible to the one thing meant to catch them, and stayed uncosted (and
    * on the customer's usage screen, counted as "not priced") for ever.
    */
+  /**
+   * Say, on a timer, that this process still holds this session.
+   *
+   * The only claim it makes is possession. That is why it runs from row
+   * creation to teardown and not only while a socket is attached: a session
+   * inside its re-attach grace has no socket and is still resumable, so
+   * letting it fall stale would report a live conversation as finished.
+   *
+   * Unref'd, so a beat pending on an otherwise-idle process never holds it
+   * open, and best-effort: a failed beat costs at worst an early reap, which
+   * the grace is sized to absorb.
+   */
+  startHeartbeat() {
+    if (this.heartbeat || !this.persisted) return;
+    this.heartbeat = setInterval(() => {
+      ChatSession.update({ lastSeenAt: new Date() }, { where: { id: this.id } })
+        .catch((e) => this.logger.debug(e, 'chat session heartbeat failed'));
+    }, HEARTBEAT_MS);
+    if (this.heartbeat.unref) this.heartbeat.unref();
+  }
+
+  stopHeartbeat() {
+    if (!this.heartbeat) return;
+    clearInterval(this.heartbeat);
+    this.heartbeat = null;
+  }
+
   teardown() {
     if (this.torndown) return; // idempotent — close-after-failed-init double-fires
     this.torndown = true;
+    // Stop claiming this session BEFORE writing endedAt: a beat landing after
+    // the close would leave a row that is both ended and freshly seen, and the
+    // reaper would have nothing to correct because it only looks at open rows.
+    this.stopHeartbeat();
     // Bridged drivers hold standing MCP connections — release them or every
     // session leaks a socket per server for the process lifetime.
     Promise.resolve(this.llm?.close?.()).catch(() => {});
     this.finaliseUsage();
     if (this.persisted) {
       ChatSession.update(
-        { endedAt: new Date(), transcript: this.transcript, turns: this.turnsCount || 0 },
+        {
+          endedAt: new Date(),
+          lastSeenAt: new Date(),
+          transcript: this.transcript,
+          turns: this.turnsCount || 0,
+        },
         { where: { id: this.id } },
       ).catch((e) => this.logger.error(e, 'chat session persist (end) failed'));
     }
@@ -788,6 +918,9 @@ class TextChatSession {
       {
         transcript: this.transcript,
         turns: this.turnsCount || 0,
+        // A turn is proof this process still holds the session, so it counts
+        // as a heartbeat. The ticker only has to cover the quiet stretches.
+        lastSeenAt: new Date(),
         // A new-team session gains its set at the first save; keep the row
         // pointing at the latest identity the canvas is showing.
         setId: this.latestSet?.id ?? null,

--- a/tests/chat-session-liveness.test.mjs
+++ b/tests/chat-session-liveness.test.mjs
@@ -1,0 +1,251 @@
+import { setupRealDatabase, teardownRealDatabase, Organisation, User } from './setup/database-test-wrapper.js';
+import { randomUUID } from 'crypto';
+
+// Liveness of a persisted chat session.
+//
+// `ended_at IS NULL` used to mean "live", and a boot sweep closed every open
+// row on startup to clear the rows a dead process left behind. That only held
+// with exactly one server process: nothing recorded WHICH process owned a row,
+// so a second one starting (a scale-up, a rolling deploy, a Cloud Run cold
+// start) closed the first one's live sessions, and stamped them at the time of
+// their last turn so the damage looked plausible. llm-agent runs on autoscaling
+// k8s and on Cloud Run, so more than one process is the normal case.
+//
+// Liveness is now a heartbeat plus a clock, which every process reads the same
+// way and which needs no boot-time guess.
+describe('chat session liveness', () => {
+  let ChatSession;
+  let isChatSessionLive;
+  let reapStaleChatSessions;
+  let listSessions;
+
+  let orgId;
+  let userId;
+
+  const mockLogger = {
+    info: () => {}, error: () => {}, warn: () => {}, debug: () => {}, trace: () => {},
+    child: () => mockLogger,
+  };
+
+  const GRACE_MS = 5 * 60 * 1000;
+  const ago = (ms) => new Date(Date.now() - ms);
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    ({ ChatSession } = await import('../lib/database.js'));
+    ({ isChatSessionLive, reapStaleChatSessions } = await import('../lib/text-chat.js'));
+    listSessions = (await import('../api/paths/chat-sessions.js')).default(mockLogger).GET;
+    await ChatSession.sync({ alter: true });
+
+    orgId = randomUUID();
+    userId = randomUUID();
+    await Organisation.create({ id: orgId, name: 'Liveness Org' });
+    await User.create({
+      id: userId, name: 'Liveness User', email: `live-${userId}@example.com`,
+      emailVerified: true, phone: '', phoneVerified: false, picture: '',
+      role: 'owner', organisationId: orgId,
+    });
+  }, 30000);
+
+  afterEach(async () => {
+    await ChatSession.destroy({ where: { organisationId: orgId } });
+  });
+
+  afterAll(async () => {
+    await ChatSession.destroy({ where: { organisationId: orgId } });
+    await Organisation.destroy({ where: { id: orgId } });
+    await teardownRealDatabase();
+  }, 30000);
+
+  const mkSession = (over = {}) => ChatSession.create({
+    id: randomUUID(),
+    agentId: 'builtin:set-builder',
+    organisationId: orgId,
+    userId,
+    mode: 'new',
+    startedAt: ago(10 * 60 * 1000),
+    lastSeenAt: new Date(),
+    ...over,
+  });
+
+  describe('isChatSessionLive', () => {
+    it('is live while a process is still beating for it', () => {
+      expect(isChatSessionLive({ endedAt: null, lastSeenAt: new Date() })).toBe(true);
+      expect(isChatSessionLive({ endedAt: null, lastSeenAt: ago(60 * 1000) })).toBe(true);
+    });
+
+    it('goes stale once the grace lapses, with no boot and no sweep', () => {
+      expect(isChatSessionLive({ endedAt: null, lastSeenAt: ago(GRACE_MS + 1000) })).toBe(false);
+    });
+
+    it('an ended session is never live, however recent the beat', () => {
+      expect(isChatSessionLive({ endedAt: new Date(), lastSeenAt: new Date() })).toBe(false);
+    });
+
+    // Rows written before the column existed. Reporting them live would put a
+    // LIVE badge on every historical session the moment this ships.
+    it('a row with no heartbeat at all is history, not a live session', () => {
+      expect(isChatSessionLive({ endedAt: null, lastSeenAt: null })).toBe(false);
+    });
+  });
+
+  // The reaper is deliberately global: a stale session belongs to no process,
+  // so there is nothing to scope it by. These tests therefore assert on the
+  // rows they created, never on its return count, which any other suite's
+  // leftovers would change.
+  describe('reapStaleChatSessions', () => {
+    // The defect this replaces: a second process starting closed the first
+    // one's live sessions, because the sweep keyed on the boot event rather
+    // than on evidence about the session.
+    it('leaves a session another process is still beating for alone', async () => {
+      const live = await mkSession({ lastSeenAt: ago(30 * 1000) });
+      await reapStaleChatSessions({ log: mockLogger });
+      await live.reload();
+      expect(live.endedAt).toBeNull();
+      expect(isChatSessionLive(live)).toBe(true);
+    });
+
+    it('closes a session no process has spoken for, at its last heartbeat', async () => {
+      const lastSeen = ago(GRACE_MS + 60 * 1000);
+      const dead = await mkSession({ lastSeenAt: lastSeen });
+      await reapStaleChatSessions({ log: mockLogger });
+      await dead.reload();
+      // Closed AT the last sign of life, not at the moment the reaper noticed.
+      expect(dead.endedAt.getTime()).toBe(lastSeen.getTime());
+    });
+
+    // Legacy rows carry no heartbeat, so they fall back to updated_at — which
+    // is exactly what the old boot sweep closed them at.
+    it('closes a pre-heartbeat row using its last write', async () => {
+      const legacy = await mkSession({ lastSeenAt: null });
+      await ChatSession.sequelize.query(
+        'UPDATE chat_sessions SET updated_at = :ts WHERE id = :id',
+        { replacements: { ts: ago(GRACE_MS + 60 * 1000), id: legacy.id } },
+      );
+      await reapStaleChatSessions({ log: mockLogger });
+      await legacy.reload();
+      expect(legacy.endedAt).not.toBeNull();
+    });
+
+    // Two replicas reap at once. The predicate is the whole decision, so the
+    // second pass has nothing left to do and no row moves twice.
+    it('is idempotent and safe to run concurrently', async () => {
+      const lastSeen = ago(GRACE_MS + 60 * 1000);
+      const dead = await mkSession({ lastSeenAt: lastSeen });
+      await Promise.all([
+        reapStaleChatSessions({ log: mockLogger }),
+        reapStaleChatSessions({ log: mockLogger }),
+      ]);
+      await dead.reload();
+      // Closed exactly once, at its own last heartbeat: two racing reapers
+      // must not stamp it twice, and the second must not move it to `now`.
+      expect(dead.endedAt.getTime()).toBe(lastSeen.getTime());
+      await reapStaleChatSessions({ log: mockLogger });
+      await dead.reload();
+      expect(dead.endedAt.getTime()).toBe(lastSeen.getTime());
+    });
+
+    // The reaper must never contradict the API. Both read the same grace, so a
+    // row it closes is one the API already reported as not live.
+    it('never closes a session the API would still report live', async () => {
+      const rows = await Promise.all([
+        mkSession({ lastSeenAt: ago(1000) }),
+        mkSession({ lastSeenAt: ago(GRACE_MS - 30 * 1000) }),
+        mkSession({ lastSeenAt: ago(GRACE_MS + 30 * 1000) }),
+      ]);
+      const liveBefore = rows.filter((r) => isChatSessionLive(r)).map((r) => r.id);
+      await reapStaleChatSessions({ log: mockLogger });
+      for (const r of rows) {
+        await r.reload();
+        if (liveBefore.includes(r.id)) expect(r.endedAt).toBeNull();
+      }
+    });
+  });
+
+  describe('GET /chat-sessions', () => {
+    const res = () => ({
+      _status: null, _body: null,
+      locals: { user: { id: userId, role: 'owner', organisationId: orgId } },
+      status(c) { this._status = c; return this; },
+      send(d) { this._body = d; return this; },
+      json(d) { this._body = d; return this; },
+    });
+
+    it('reports live, and does not leak the heartbeat that decides it', async () => {
+      await mkSession({ lastSeenAt: ago(30 * 1000) });
+      await mkSession({ lastSeenAt: ago(GRACE_MS + 60 * 1000) });
+      await mkSession({ lastSeenAt: new Date(), endedAt: new Date() });
+
+      const r = res();
+      await listSessions({ query: {}, params: {}, log: mockLogger }, r);
+      const sessions = r._body.sessions;
+      expect(sessions).toHaveLength(3);
+      expect(sessions.filter((s) => s.live)).toHaveLength(1);
+      // Exposing lastSeenAt would invite every client to re-derive liveness
+      // with its own idea of the grace, and they would disagree.
+      for (const s of sessions) expect(s).not.toHaveProperty('lastSeenAt');
+    });
+  });
+
+  // The heartbeat is what makes the whole scheme work, so its lifecycle is
+  // pinned directly rather than inferred from the reaper's behaviour.
+  describe('heartbeat lifecycle', () => {
+    // Built on the real prototype so the methods call each other exactly as
+    // they do in a live session; only the LLM and socket are left off.
+    const mkFake = (over = {}) => Object.assign(Object.create(proto), {
+      id: randomUUID(),
+      persisted: true,
+      heartbeat: null,
+      logger: mockLogger,
+      ...over,
+    });
+
+    let proto;
+    beforeAll(async () => {
+      const mod = await import('../lib/text-chat.js');
+      // startHeartbeat/stopHeartbeat live on the session prototype; exercising
+      // them directly keeps this a unit test of the timer contract, with no
+      // LLM and no websocket.
+      const session = mod.createChatSession({
+        agent: {
+          id: 'agent-hb', organisationId: orgId, userId,
+          modelName: 'text:anthropic/claude-sonnet-5',
+          functions: [], keys: [], options: {}, mcpServers: [],
+        },
+        logger: mockLogger,
+      });
+      proto = Object.getPrototypeOf(session);
+      session.teardown();
+    });
+
+    it('does not beat for a session with no durable row', () => {
+      const s = mkFake({ persisted: false });
+      s.startHeartbeat();
+      expect(s.heartbeat).toBeNull();
+    });
+
+    it('beats once started, and starting twice does not stack timers', () => {
+      const s = mkFake();
+      s.startHeartbeat();
+      const first = s.heartbeat;
+      expect(first).toBeTruthy();
+      s.startHeartbeat();
+      expect(s.heartbeat).toBe(first);
+      s.stopHeartbeat();
+      expect(s.heartbeat).toBeNull();
+    });
+
+    // A beat landing after endedAt was written would leave a row that is both
+    // ended and freshly seen. The reaper only looks at OPEN rows, so it could
+    // never correct it.
+    it('stops beating before teardown writes endedAt', async () => {
+      const row = await mkSession({ lastSeenAt: ago(1000) });
+      const s = mkFake({ id: row.id, torndown: false, finaliseUsage() {}, transcript: null, turnsCount: 0 });
+      s.startHeartbeat();
+      expect(s.heartbeat).toBeTruthy();
+      s.teardown();
+      expect(s.heartbeat).toBeNull();
+      expect(s.torndown).toBe(true);
+    });
+  });
+});

--- a/tools/backfill-usage-costs.js
+++ b/tools/backfill-usage-costs.js
@@ -41,13 +41,6 @@ const options = commandLineArgs([
 ]);
 dotenv.config(options.path ? { path: dir.resolve(process.cwd(), options.path) } : undefined);
 
-// Importing lib/database.js runs the API server's boot housekeeping, which
-// includes closing every chat session the database has open — correct for a
-// server that has just restarted and holds none of them, catastrophic for a CLI
-// pointed at a live environment, and doubly wrong for a run that has not even
-// been given --apply. Opt out before the import, not after.
-process.env.DB_NO_SESSION_SWEEP = 'true';
-
 const { Organisation, UsageRecord, RateCard, Op, databaseStarted } = await import('../lib/database.js');
 const { resolveRateCard } = await import('../lib/rates.js');
 


### PR DESCRIPTION
`chat_sessions.ended_at IS NULL` doubled as "this session is live", and a sweep at boot cleared what a dead process left behind:

```sql
UPDATE "chat_sessions" SET "ended_at" = "updated_at" WHERE "ended_at" IS NULL
```

## Why it was wrong

**The UPDATE had no owner predicate.** Nothing recorded which process owned a row, so it could not tell its own orphans from another process's live sessions. A scale-up, a rolling deploy or a Cloud Run cold start closed every open session across the fleet.

**The timestamp it wrote looked plausible.** `ended_at = updated_at` is right for a dead session, where the last turn was the last sign of life. For a live one it stamped the time of its last turn, so a session running for twenty minutes got an end time a few seconds old. Nothing looked odd.

**It did not heal.** `persistTurn` writes transcript, turns, setId and title, and never cleared `ended_at`. A wrongly-closed session kept writing turns to a row marked ended. It recovered only if `teardown` ran, and if the process died first, which is the case the sweep existed for, the wrong value was permanent.

**It ran on import of `lib/database.js`.** Every CLI tool pointed at a live environment ended that environment's sessions as a side effect, including tools that only read. This is not hypothetical: a read-only dry run of `tools/backfill-usage-costs.js` did it against beta earlier today.

The implication was display only, because re-attach reads the in-memory map (`ws-handler.js` → `getChatSession`), not the database. That was luck. Any future code treating `ended_at IS NULL` as live inherits the bug.

## What replaces it

Liveness is a heartbeat and a clock, which every process reads the same way and which needs no boot-time guess.

- **`chat_sessions.last_seen_at`** — when a process last claimed to hold the session. Written at creation, on every turn, and on a 60s ticker running from creation to teardown. Deliberately not "while a socket is attached": a session inside its 15-minute re-attach grace has no socket and is still resumable, and marking it dead on a page reload would be wrong.
- **`isChatSessionLive`** — the one definition, shared by the API's `live` field and by the reaper, so the reaper can never close a session the API still reports running. There is a test for exactly that. A row with no heartbeat reads as not live, which is the right answer for every row written before the column existed.
- **`reapStaleChatSessions`** — closes what nobody has spoken for since the grace lapsed. Deciding by the clock rather than the boot event makes it safe from any pod, any number at once, and idempotent: it closes a session at its own last heartbeat, so a second pass cannot move it to `now`. `COALESCE(last_seen_at, updated_at)` handles pre-heartbeat rows, which is what the old sweep used.
- **Started from `index.mjs`**, the server entry point, never on library import.

`/chat-sessions` and `/chat-sessions/{id}` return `live`. `endedAt` keeps one meaning: the session finished, at this real instant. `lastSeenAt` is deliberately absent from the response — exposing it would invite each client to re-derive liveness with its own idea of the grace, and they would disagree.

## Schema

An idempotent `ADD COLUMN IF NOT EXISTS` beside `resumed_from`, not a `schemaVersion` bump. A bump only applies under `DB_FORCE_SYNC`, which no deployed environment sets, so it would need a manual `tools/agent-admin.js upgrade-db` per environment before liveness worked anywhere. **No manual upgrade step for this PR.**

## Still not multi-instance safe

This removes one symptom, not the blocker. Sessions live in a per-process `Map` in `lib/text-chat.js`, so on more than one replica a websocket reconnect landing on a different pod finds nothing and cannot re-attach, whatever `ended_at` says. The re-attach grace is per-pod too. Scaling llm-agent past one replica still needs sticky routing or externalised session state. Worth saying so explicitly, because with this merged the most visible symptom disappears.

## Tests

Full DB suite: **1059 passed, 0 failed** (2 suites skipped are the Python cross-language ones). 13 new tests, covering:

- a second process starting leaves another process's live session alone
- two reapers racing close a row once, at its own last heartbeat, and a third pass does not move it
- the heartbeat stops before teardown writes `endedAt`, so no beat can land on a closed row
- a pre-heartbeat row closes at its last write
- the reaper never closes a session `isChatSessionLive` reports as live
- the API reports `live` and does not leak `lastSeenAt`

They assert on the rows they create, never on the reaper's return count. The reaper is global by design, so a count assertion would break on any other suite's leftovers. That was caught by an actual transient failure, not by inspection.
