### PR TITLE
Progress notify: decide from the database, not a per-process memo

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -183,7 +183,50 @@ const LISTENER_CONNECTION = {
 };
 let listener = new Listener(LISTENER_CONNECTION);
 
-let streamIds = {};
+// Live progress fan-out: which calls have a viewer on `/progress/<instanceId>`.
+//
+// TransactionLog writes are relayed to the progress socket over Postgres
+// LISTEN/NOTIFY, which any process can receive. The decision to SEND a notify
+// used to read a plain per-process object that only Call.afterCreate wrote, so
+// only the process that created the Call row would ever notify. The livekit and
+// pipecat workers create the call with one HTTP request and write each log with
+// another, and with more than one server process those land on different
+// processes: the writer had no entry and stayed silent, and the live transcript
+// went dark for exactly the calls somebody was watching.
+//
+// So this is a memo, not the source of truth. callId -> instanceId when the
+// instance streams its log, false when it does not; a miss is answered from the
+// database (Call -> Instance.streamLog, which is fixed at activation) and
+// remembered either way. Bounded: a call is asked about for as long as it lasts
+// and then never again, so the oldest entries are the ones least worth keeping.
+const STREAM_TARGET_MEMO_MAX = 5000;
+const streamIds = new Map();
+
+function rememberStreamTarget(callId, target) {
+  if (!streamIds.has(callId) && streamIds.size >= STREAM_TARGET_MEMO_MAX) {
+    streamIds.delete(streamIds.keys().next().value);
+  }
+  streamIds.set(callId, target);
+}
+
+/**
+ * The instance id to notify for a call's transaction logs, or false when its
+ * instance does not stream (or the call is unknown). Same-process writers hit
+ * the memo Call.afterCreate warmed; any other process pays one indexed lookup
+ * per call and then hits its own memo.
+ */
+async function streamTargetFor(callId, options = {}) {
+  if (!callId) return false;
+  if (streamIds.has(callId)) return streamIds.get(callId);
+  const call = await Call.findByPk(callId, {
+    attributes: ['id', 'instanceId'],
+    include: [{ model: Instance, attributes: ['id', 'streamLog'] }],
+    transaction: options.transaction,
+  });
+  const target = call?.Instance?.streamLog ? call.Instance.id : false;
+  rememberStreamTarget(callId, target);
+  return target;
+}
 
 
 class Metadata extends Model {
@@ -1059,9 +1102,9 @@ Agent.hasMany(Instance, { foreignKey: 'agentId', onDelete: 'CASCADE', as: 'liste
 class Call extends Model {
   set streamLog(value) {
     if (value) {
-      streamIds[this.id] = value;
+      rememberStreamTarget(this.id, value);
     } else {
-      delete streamIds[this.id];
+      streamIds.delete(this.id);
     }
   }
   static async initIndex() {
@@ -1352,7 +1395,7 @@ Call.init({
         call.index = result.next_index;
       },
       afterCreate: async (call, options) => {
-        if ((await Instance.findByPk(call.instanceId, options)).streamLog) {
+        if ((await Instance.findByPk(call.instanceId, options))?.streamLog) {
           logger.debug(`Streaming logs for call ${call.id}`);
           call.streamLog = call.instanceId;
         }
@@ -1396,25 +1439,32 @@ class TransactionLog extends Model {
       await listener.stopListeningTo(tag);
     }
   }
-  static notify(transactionLog, options) {
-    let notify = streamIds[transactionLog.callId];
-    logger.debug({ transactionLog, notify, length: transactionLog?.data?.length }, `Notifying ${transactionLog.callId}`);
-    if (notify) {
-      let { type, data, callId, updatedAt,isFinal } = transactionLog;
-      if (data?.length >= MAX_NOTIFY_DATA) {
-        type = 'fetch$record';
-        data = transactionLog.id;
-      }
-      else {
-        try {
-          data = JSON.parse(transactionLog.data);
+  static async notify(transactionLog, options) {
+    try {
+      const notify = await streamTargetFor(transactionLog.callId, options);
+      logger.debug({ transactionLog, notify, length: transactionLog?.data?.length }, `Notifying ${transactionLog.callId}`);
+      if (notify) {
+        let { type, data, callId, updatedAt, isFinal } = transactionLog;
+        if (data?.length >= MAX_NOTIFY_DATA) {
+          type = 'fetch$record';
+          data = transactionLog.id;
         }
-        catch (e) {
-          data = transactionLog.data;
+        else {
+          try {
+            data = JSON.parse(transactionLog.data);
+          }
+          catch (e) {
+            data = transactionLog.data;
+          }
         }
+        logger.debug({ [type]: data }, `Notifying logs progress${notify.replace(/-/g, '')}`);
+        data && listener.notify(`progress${notify.replace(/-/g, '')}`, { [type]: data, isFinal, callId, timestamp: updatedAt });
       }
-      logger.debug({ [type]: data }, `Notifying logs progress${notify.replace(/-/g, '')}`);
-      data && listener.notify(`progress${notify.replace(/-/g, '')}`, { [type]: data, isFinal, callId, timestamp: updatedAt });
+    }
+    catch (err) {
+      // Fan-out is best-effort: neither the lookup nor the notify may fail the
+      // write that carries the transcript.
+      logger.warn({ err: err?.message, callId: transactionLog?.callId }, 'transaction log notify skipped');
     }
     return transactionLog;
   }

--- a/lib/database.js
+++ b/lib/database.js
@@ -1436,7 +1436,10 @@ class TransactionLog extends Model {
 
       await listener.listenTo(tag);
     } else {
-      await listener.stopListeningTo(tag);
+      // Drop this process's handlers for the channel as well as the LISTEN:
+      // a later subscriber to the same instance must not replay to dead ones.
+      listener.notifications.removeAllListeners(tag);
+      await listener.unlisten(tag);
     }
   }
   static async notify(transactionLog, options) {
@@ -1458,7 +1461,9 @@ class TransactionLog extends Model {
           }
         }
         logger.debug({ [type]: data }, `Notifying logs progress${notify.replace(/-/g, '')}`);
-        data && listener.notify(`progress${notify.replace(/-/g, '')}`, { [type]: data, isFinal, callId, timestamp: updatedAt });
+        if (data) {
+          await listener.notify(`progress${notify.replace(/-/g, '')}`, { [type]: data, isFinal, callId, timestamp: updatedAt });
+        }
       }
     }
     catch (err) {

--- a/tests/fixtures/progress-log-writer.mjs
+++ b/tests/fixtures/progress-log-writer.mjs
@@ -1,0 +1,31 @@
+// Writes transaction logs from a SEPARATE server process, for
+// tests/progress-notify-cross-process.test.mjs.
+//
+// Usage: node tests/fixtures/progress-log-writer.mjs '<json>'
+//   json = { logs: [{ callId, userId, organisationId, type, data, isFinal }] }
+//
+// Connects with the POSTGRES_* variables it is given, writes each log in
+// order through the real model (so the afterCreate hook runs here, in a
+// process that never saw the Call row being created), then closes the
+// database and exits 0. Any failure exits non-zero with the error on stderr.
+const spec = JSON.parse(process.argv[2] || '{}');
+
+try {
+  const { TransactionLog, databaseStarted, stopDatabase } = await import('../../lib/database.js');
+  await databaseStarted;
+  for (const log of spec.logs || []) {
+    // eslint-disable-next-line no-await-in-loop
+    await TransactionLog.create(log);
+  }
+  // Every write is committed, and NOTIFY goes out with the commit, so nothing
+  // here waits on the reader. Close politely, but never hang the test on it.
+  await Promise.race([
+    stopDatabase(),
+    new Promise((resolve) => { setTimeout(resolve, 5000).unref?.(); }),
+  ]);
+  process.exit(0);
+}
+catch (err) {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+}

--- a/tests/progress-notify-cross-process.test.mjs
+++ b/tests/progress-notify-cross-process.test.mjs
@@ -1,0 +1,173 @@
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomUUID } from 'crypto';
+import {
+  setupRealDatabase,
+  teardownRealDatabase,
+  Organisation,
+  User,
+  Agent,
+  Instance,
+  Call,
+  TransactionLog,
+} from './setup/database-test-wrapper.js';
+
+// Live call progress has to cross processes.
+//
+// The `/progress/<instanceId>` socket (Handler.handleUpdates) subscribes with
+// TransactionLog.on, a Postgres LISTEN, and every transaction log write is
+// relayed to it with NOTIFY from the afterCreate hook. The relay itself has
+// always been cross-process. The gate in front of it was not: whether to
+// notify was read from a per-process object that only Call.afterCreate wrote,
+// so only the process that created the Call row ever notified. The livekit and
+// pipecat workers create a call with one HTTP request and write every log with
+// another, and with more than one server process those land on different
+// processes, so the live transcript went dark for exactly the calls somebody
+// was watching.
+//
+// These tests write the logs from a genuinely separate node process (the
+// fixture in tests/fixtures/progress-log-writer.mjs) against the same
+// database, and read them here on the LISTEN this process holds. A
+// single-process stand-in would pass with the old code.
+describe('transaction log progress notify across processes', () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const writer = join(here, 'fixtures', 'progress-log-writer.mjs');
+
+  let orgId;
+  let userId;
+  let agentId;
+  let streaming; // { instanceId, callId } — Instance.streamLog true
+  let silent;    // { instanceId, callId } — Instance.streamLog false
+  let heard;     // payloads for the streaming instance
+  let heardSilent;
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    orgId = randomUUID();
+    userId = randomUUID();
+    await Organisation.create({ id: orgId, name: 'Progress Org' });
+    await User.create({
+      id: userId, name: 'Progress User', email: `progress-${userId}@example.com`,
+      emailVerified: true, phone: '', phoneVerified: false, picture: '',
+      role: 'owner', organisationId: orgId,
+    });
+    const agent = await Agent.create({
+      name: 'Progress agent',
+      description: 't',
+      modelName: 'livekit:ultravox/ultravox-v0.7',
+      prompt: 'You are a test agent.',
+      options: { tts: { language: 'any', voice: 'Ciara' } },
+      functions: {},
+      keys: [],
+      userId,
+      organisationId: orgId,
+    });
+    agentId = agent.id;
+    streaming = await createCall({ streamLog: true });
+    silent = await createCall({ streamLog: false });
+
+    // Subscribe exactly as the progress socket does.
+    heard = [];
+    heardSilent = [];
+    await TransactionLog.on(streaming.instanceId, (payload) => heard.push(payload));
+    await TransactionLog.on(silent.instanceId, (payload) => heardSilent.push(payload));
+  }, 60000);
+
+  afterAll(async () => {
+    // Whatever beforeAll managed, the database must be closed at the end or
+    // jest sits on the open LISTEN connection and never exits.
+    try {
+      if (streaming) await TransactionLog.on(streaming.instanceId, null);
+      if (silent) await TransactionLog.on(silent.instanceId, null);
+      await TransactionLog.destroy({ where: { organisationId: orgId } });
+      await Call.destroy({ where: { organisationId: orgId } });
+      await Instance.destroy({ where: { organisationId: orgId } });
+      await Agent.destroy({ where: { organisationId: orgId } });
+      await User.destroy({ where: { id: userId } });
+      await Organisation.destroy({ where: { id: orgId } });
+    }
+    finally {
+      await teardownRealDatabase();
+    }
+  }, 60000);
+
+  // The Call row is created in THIS process, as it is on whichever server
+  // process takes the worker's POST /agent-db/call. Hooks on: afterCreate is
+  // what warms the creating process's memo, the one path the old code had.
+  async function createCall({ streamLog }) {
+    const instance = await Instance.create({
+      agentId, type: 'pipecat', key: 'k', userId, organisationId: orgId, streamLog,
+    });
+    const call = await Call.create({
+      id: randomUUID(), userId, organisationId: orgId, instanceId: instance.id, agentId,
+      platform: 'pipecat', modelName: 'livekit:ultravox/ultravox-v0.7',
+    });
+    return { instanceId: instance.id, callId: call.id };
+  }
+
+  function logFor(target, type, data) {
+    return { userId, organisationId: orgId, callId: target.callId, type, data, isFinal: true };
+  }
+
+  // A second server process: same database, empty memo, no knowledge of who
+  // created the Call.
+  function writeFromAnotherProcess(logs) {
+    const env = { ...process.env, NODE_ENV: 'test', LOGLEVEL: 'silent' };
+    // The writer must not alter-sync the schema under a running suite.
+    delete env.DB_FORCE_SYNC;
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [writer, JSON.stringify({ logs })], {
+        env, stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let out = '';
+      let err = '';
+      child.stdout.on('data', (d) => { out += d; });
+      child.stderr.on('data', (d) => { err += d; });
+      child.on('error', reject);
+      child.on('close', (code) => (code === 0
+        ? resolve(out)
+        : reject(new Error(`log writer exited ${code}: ${err || out}`))));
+    });
+  }
+
+  async function waitFor(pred, what, timeoutMs = 20000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (pred()) return;
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => { setTimeout(r, 50); });
+    }
+    throw new Error(`timed out waiting for ${what}`);
+  }
+
+  test('a log written by the process that created the call is relayed (the path that always worked)', async () => {
+    await TransactionLog.create(logFor(streaming, 'agent', 'said here, in the creating process'));
+    await waitFor(() => heard.some((p) => p.agent === 'said here, in the creating process'), 'same-process notify');
+    const payload = heard.find((p) => p.agent === 'said here, in the creating process');
+    expect(payload.callId).toBe(streaming.callId);
+    expect(payload.isFinal).toBe(true);
+  });
+
+  test('a log written by ANOTHER process is relayed to the subscriber here', async () => {
+    await writeFromAnotherProcess([logFor(streaming, 'user', 'said in a different process')]);
+    await waitFor(() => heard.some((p) => p.user === 'said in a different process'), 'cross-process notify');
+    const payload = heard.find((p) => p.user === 'said in a different process');
+    expect(payload.callId).toBe(streaming.callId);
+  }, 60000);
+
+  test('a call whose instance does not stream stays silent, from any process', async () => {
+    // Both writes go through one writer in this order. Notifications arrive on
+    // one connection in commit order, so once the marker for the streaming
+    // call is here, anything wrongly sent for the silent call is here too.
+    await writeFromAnotherProcess([
+      logFor(silent, 'agent', 'nobody is watching this call'),
+      logFor(streaming, 'agent', 'marker after the silent write'),
+    ]);
+    await waitFor(() => heard.some((p) => p.agent === 'marker after the silent write'), 'marker notify');
+    expect(heardSilent).toEqual([]);
+    // And the silent write itself landed: silence is the gate, not a lost row.
+    const rows = await TransactionLog.findAll({ where: { callId: silent.callId } });
+    expect(rows.map((r) => r.type)).toEqual(['agent']);
+  }, 60000);
+});


### PR DESCRIPTION
## What

Live call progress (the `/progress/<instanceId>` socket) is relayed from `TransactionLog` writes with Postgres NOTIFY, which any server process can receive. The decision to send the NOTIFY read a per-process object that only `Call.afterCreate` populated, so only the process that created the Call row would ever notify. The livekit and pipecat workers create a call with one HTTP request and write each log with another. With more than one server process those requests land on different processes, the writer has no entry, and the live transcript goes dark for exactly the calls someone is watching.

`TransactionLog.notify` now resolves the target from the database when this process has no memo for the call (`Call -> Instance.streamLog`, fixed at activation) and remembers the answer either way. The memo is bounded. Same-process writers still hit the memo that `Call.afterCreate` warms, so nothing changes for them.

## Also fixed on the way

- `TransactionLog.notify` fired `listener.notify()` without awaiting it. A failure surfaced as an unhandled rejection, and a process closing its connection right after a write could cut the NOTIFY off mid-flight. It is awaited inside the hook's try/catch now. Fan-out stays best-effort and never fails the write that carries the transcript.
- `TransactionLog.on(id, null)` called `listener.stopListeningTo`, which pg-listen does not have, so unsubscribing has always thrown. It now removes the channel handlers and calls `unlisten`.
- `Call.afterCreate` dereferenced the Instance without a null check.

## Test

`tests/progress-notify-cross-process.test.mjs` writes the logs from a separate node process (`tests/fixtures/progress-log-writer.mjs`) against the same database while the jest process holds the LISTEN, and asserts that the notification arrives here. A call whose instance does not stream must stay silent from any process, and the row must still land.

Control run against the previous code: the same-process case passes, the two cross-process cases time out waiting for the notification, and teardown throws on the missing pg-listen method. With this change all three pass. Full DB suite: 97 suites, 1079 tests passed.

## Not changed

`TransactionLog.bulkCreate` (the end-of-call batch in `agent-db/call/{callId}/end`) runs no per-row hooks, so it never notified. Unchanged here.
