### PR TITLE
Give each jest worker its own database, and stop serialising

### DIFF
--- a/docs/ci-testing.md
+++ b/docs/ci-testing.md
@@ -53,13 +53,36 @@ docker-compose -f docker-compose.ci.yml down -v
    - `1` = Tests failed or setup failed
 5. **Cleanup**: Containers are automatically stopped and removed
 
+## One database per jest worker
+
+The suite runs in parallel (`maxWorkers` in `jest.config.db.js`, overridable
+with `JEST_WORKERS`). Every DB-backed suite boots `lib/database.js` under
+`DB_FORCE_SYNC`, which runs the whole schema upgrade chain, so the workers
+cannot share one schema.
+
+`tests/setup/global-setup.js` therefore drops and recreates one database per
+worker, `llmvoicetest_1` upwards, before any worker starts, and
+`tests/setup/database-test-wrapper.js` points `lib/database.js` at the one
+belonging to its own worker. Connection details live in
+`tests/setup/test-db-config.js`.
+
+Two consequences worth knowing:
+
+- Every suite that reaches Postgres must go through `database-test-wrapper.js`.
+  A suite that imports `lib/database.js` on its own gets no database name and
+  will not connect. The wrapper is the only place that assigns one.
+- The databases are recreated on every run, so a rerun no longer inherits rows
+  from the last one. Starting from a clean volume is no longer needed to avoid
+  phantom failures.
+
 ## Environment Variables
 
 The test runner container uses these environment variables:
 
 - `POSTGRES_HOST=postgres` (internal Docker network)
 - `POSTGRES_PORT=5432`
-- `POSTGRES_DB=llmvoicetest`
+- `POSTGRES_DB=llmvoicetest` (the bootstrap database only, see below: suites run
+  against `llmvoicetest_<worker>`)
 - `POSTGRES_USER=testuser`
 - `POSTGRES_PASSWORD=testpass`
 - `CREDENTIALS_KEY=test-secret-key-for-comprehensive-tests`

--- a/jest.config.db.js
+++ b/jest.config.db.js
@@ -12,7 +12,10 @@ export default {
   setupFilesAfterEnv: [],
   globalSetup: './tests/setup/global-setup.js',
   testTimeout: 60000,
-  maxWorkers: 1, // Run tests sequentially to avoid database conflicts
+  // One database per worker (see tests/setup/test-db-config.js), so the suite
+  // no longer has to serialise. Override with JEST_WORKERS; global-setup.js
+  // reads the resolved value and creates exactly that many databases.
+  maxWorkers: Number(process.env.JEST_WORKERS) || 4,
   verbose: true,
   collectCoverage: true,
   coverageDirectory: 'coverage/db',

--- a/jest.config.no-db.js
+++ b/jest.config.no-db.js
@@ -14,7 +14,10 @@ export default {
   setupFilesAfterEnv: [],
   globalSetup: './tests/setup/global-setup.js',
   testTimeout: 30000,
-  maxWorkers: 1,
+  // One database per worker (see tests/setup/test-db-config.js), so the suite
+  // no longer has to serialise. Override with JEST_WORKERS; global-setup.js
+  // reads the resolved value and creates exactly that many databases.
+  maxWorkers: Number(process.env.JEST_WORKERS) || 4,
   verbose: true,
   collectCoverage: true,
   coverageDirectory: 'coverage/no-db',

--- a/tests/setup/database-test-wrapper.js
+++ b/tests/setup/database-test-wrapper.js
@@ -5,19 +5,20 @@
 // Set environment variables immediately when this module is imported
 // This ensures they are available when database.js is imported
 
-if (process.env.USE_CONTAINER_NETWORKING === 'true') {
-  process.env.POSTGRES_HOST = 'postgres';
-  process.env.POSTGRES_PORT = '5432';
-}
-else {
-  process.env.POSTGRES_HOST = 'localhost';
-  process.env.POSTGRES_PORT = '5433';
-}
+import { testDbConnection, workerDatabase } from './test-db-config.js';
 
+process.env.POSTGRES_HOST = testDbConnection.host;
+process.env.POSTGRES_PORT = String(testDbConnection.port);
 
-process.env.POSTGRES_DB = 'llmvoicetest';
-process.env.POSTGRES_USER = 'testuser';
-process.env.POSTGRES_PASSWORD = 'testpass';
+// Each jest worker gets its own database, which is what lets the suite run
+// with maxWorkers > 1. Every DB-backed suite boots lib/database.js under
+// DB_FORCE_SYNC, so it runs the whole schema upgrade chain; sharing one
+// database across workers would have those chains altering the same tables at
+// the same time. tests/setup/global-setup.js creates the databases, one per
+// worker, before any worker starts.
+process.env.POSTGRES_DB = workerDatabase();
+process.env.POSTGRES_USER = testDbConnection.user;
+process.env.POSTGRES_PASSWORD = testDbConnection.password;
 process.env.CREDENTIALS_KEY = process.env.CREDENTIALS_KEY || 'test-secret-key-for-encryption';
 
 // If environment variables are already set (e.g., in Docker), don't override them

--- a/tests/setup/global-setup.js
+++ b/tests/setup/global-setup.js
@@ -3,6 +3,8 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import dotenv from 'dotenv';
+import pg from 'pg';
+import { testDbConnection, bootstrapDatabase, workerDatabase } from './test-db-config.js';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const livekitRegistryDist = join(
@@ -10,7 +12,56 @@ const livekitRegistryDist = join(
   'agents/livekit/dist/lib/livekit-model-registry.js',
 );
 
-export default () => {
+/**
+ * Open a connection to the bootstrap database, retrying while the container
+ * comes up. `docker compose` gates the test runner on a healthcheck, but a
+ * local `yarn test:setup` does not, and the first connection used to be a race
+ * that a sleep in the runbook papered over.
+ */
+async function connectToBootstrap({ attempts = 20, delayMs = 500 } = {}) {
+  let lastError;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const client = new pg.Client({ ...testDbConnection, database: bootstrapDatabase });
+    try {
+      await client.connect();
+      return client;
+    } catch (error) {
+      lastError = error;
+      await client.end().catch(() => {});
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error(
+    `test Postgres not reachable on ${testDbConnection.host}:${testDbConnection.port} `
+    + `after ${attempts} attempts: ${lastError?.message}`,
+  );
+}
+
+/**
+ * One database per jest worker, so the suite can run with maxWorkers > 1.
+ *
+ * They are dropped and recreated rather than reused. lib/database.js syncs
+ * with `alter`, never `force`, so tables and their rows outlive a run: a rerun
+ * against the same volume inherits whatever the last one left behind, which
+ * has produced failures that disappear on a clean volume.
+ */
+async function createWorkerDatabases(workers) {
+  const client = await connectToBootstrap();
+  try {
+    for (let workerId = 1; workerId <= workers; workerId++) {
+      const name = workerDatabase(String(workerId));
+      // FORCE terminates connections a crashed earlier run left behind, which
+      // would otherwise make the drop fail. Postgres 13+; both compose files
+      // pin postgres:15.
+      await client.query(`DROP DATABASE IF EXISTS "${name}" WITH (FORCE)`);
+      await client.query(`CREATE DATABASE "${name}"`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+export default async (globalConfig) => {
   // The livekit registry is only needed by suites that import it. In single-agent
   // container builds (e.g. the jambonz image) the agents/livekit source tree isn't
   // present, so attempting `yarn build` there fails with a bogus spawn ENOENT
@@ -29,5 +80,9 @@ export default () => {
       delete process.env[key];
     }
   });
+
+  // After the env is cleaned, so the connection details come from
+  // test-db-config.js and never from a stray .env in the checkout.
+  await createWorkerDatabases(globalConfig?.maxWorkers ?? 1);
 };
 

--- a/tests/setup/test-db-config.js
+++ b/tests/setup/test-db-config.js
@@ -1,0 +1,26 @@
+// Connection details for the containerised test Postgres.
+//
+// Kept in one place because two things have to agree on them: global-setup.js,
+// which creates one database per jest worker before any worker starts, and
+// database-test-wrapper.js, which points lib/database.js at the database its
+// own worker owns.
+
+const inContainer = process.env.USE_CONTAINER_NETWORKING === 'true';
+
+export const testDbConnection = {
+  host: inContainer ? 'postgres' : 'localhost',
+  port: inContainer ? 5432 : 5433,
+  user: 'testuser',
+  password: 'testpass',
+};
+
+// The database the container creates on boot. Nothing runs against it: it is
+// only there to give global-setup.js a connection from which to create and
+// drop the per-worker databases.
+export const bootstrapDatabase = 'llmvoicetest';
+
+// The database a given jest worker owns. JEST_WORKER_ID is 1-based, and is set
+// in each worker process (it is absent, so treated as 1, when jest runs a
+// single file in band).
+export const workerDatabase = (workerId = process.env.JEST_WORKER_ID || '1') =>
+  `${bootstrapDatabase}_${workerId}`;


### PR DESCRIPTION
## Why

`jest.config.db.js` ran `maxWorkers: 1`, commented "Run tests sequentially to
avoid database conflicts". That was correct: every DB-backed suite boots
`lib/database.js` under `DB_FORCE_SYNC`, so it runs the whole schema upgrade
chain, and all 58 of them pointed at one hardwired database name. Two workers
would have been altering the same tables at the same time.

That serialisation is now the largest leg of the staging build: **jest is 256s
of a 386s Test step**, in a build that takes about 13 minutes. It has also been
growing faster than the file count, because the per-suite cost went up over the
same period:

| | March | 1 Jul | 20 Aug | Now |
|---|---|---|---|---|
| Test files | 13 | 41 | 74 | 97 |
| `sync({ alter: true })` calls in the boot chain | | 23 | 24 | 27 |

Between 20 Aug and 8 Sep the file count rose 32% and jest time rose 76%.

## What changed

`tests/setup/test-db-config.js` is new and holds the connection details in one
place, since two things now have to agree on them.

`tests/setup/global-setup.js` drops and recreates one database per worker,
`llmvoicetest_1` upwards, before any worker starts. It reads the resolved
`maxWorkers` from the jest config it was given, so the number of databases
always matches the number of workers, including when someone passes
`--maxWorkers` on the command line. It also retries the first connection while
the container comes up, which removes the `sleep` the local runbook needed.

`tests/setup/database-test-wrapper.js` points `lib/database.js` at
`llmvoicetest_${JEST_WORKER_ID}` instead of the shared name. This is the only
place any suite gets a database name, which is what makes the change safe: a
suite that imports `lib/database.js` on its own gets no name and does not
connect.

`maxWorkers` becomes `Number(process.env.JEST_WORKERS) || 4` in both configs.

Recreating the databases rather than reusing them also fixes a standing local
annoyance. The sync is `alter`, never `force`, so tables and rows outlived a
run and a rerun against the same volume inherited them, producing failures that
vanished on a clean volume. Reruns are now clean by construction.

## Measurements

96 suites, 1078 tests, on this machine:

| Workers | Wall | User CPU |
|---|---|---|
| 1 | 67.3s | 41.6s |
| 4 | 21.4s | 41.0s |

**3.1x**, with user CPU time unchanged. The win is overlapping Postgres round
trips during the boot migration, not extra CPU, so it should carry to the
2-vCPU build worker, though at a lower ratio: expect roughly 2x there, not 3x.
`JEST_WORKERS` is there to tune the default of 4 once there are real numbers
from a build.

## Verification

The containerised CI path, which is what Cloud Build runs:

```
docker compose -f docker-compose.ci.yml up --exit-code-from test-runner
Test Suites: 2 skipped, 94 passed, 94 of 96 total
Tests:       5 skipped, 1073 passed, 1078 total
Time:        21.42 s        (was 67s on the same path at one worker)
```

Three further runs at four workers, all green, 13.1s / 18.8s / 18.6s. Worker
assignment differs between runs, so those exercise different groupings.

**That nothing bypasses the wrapper was checked, not assumed.** With the
bootstrap `llmvoicetest` database dropped and recreated empty, a full run
leaves it with **zero** tables, so every suite that reaches Postgres went
through the wrapper and into its own worker's database. Reading the tree agrees:
of the 39 suites that do not import the wrapper, five mock `lib/database.js`
outright and one only mentions it in a comment.

## Notes

Independent of #294. That one touches the Dockerfile, compose build section and
the staging Cloud Build config; this one touches the jest harness. No shared
lines, so they can merge in either order.

`tests/setup/real-database-test.js` is dead code (nothing imports it) and holds
its own stale copy of the connection details, including the old single database
name. Left alone here rather than half-fixed; worth deleting separately.
