### PR TITLE
Boot: do not reach the database before dotenv.config() runs

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -11,7 +11,6 @@ import { createServer } from 'http';
 import createWsServer from './lib/ws-handler.js';
 import { cleanHandlers } from './lib/handlers/index.js';
 import { buildInfo, describeBuild } from './lib/build-info.js';
-import { startChatSessionReaper } from './lib/text-chat.js';
 
 logger.info('starting up');
 // Which code is this? (baked BUILD_COMMIT/BRANCH/TAG in images, git in dev) —
@@ -160,6 +159,16 @@ httpServer.listen(port, () => {
 // environment ended that environment's sessions as a side effect — including
 // tools that only read. Safe to run from every replica at once; the cutoff
 // decides what is stale, not the fact that this process just started.
+//
+// Imported DYNAMICALLY, and that is load-bearing: lib/text-chat.js pulls in
+// lib/database.js, which builds its Sequelize instance and pg-listen
+// connection string from process.env.POSTGRES_* at module evaluation. Static
+// imports are all evaluated before this module's body runs, so a static import
+// here would reach the database layer before `dotenv.config()` above has
+// decoded SECRETENV_BUNDLE into the environment — and the process would exit
+// with `TypeError: Invalid URL` before it could listen. lib/ws-handler.js
+// avoids the same trap the same way, and says so.
+const { startChatSessionReaper } = await import('./lib/text-chat.js');
 startChatSessionReaper({ log: logger });
 
 process.on('SIGINT', cleanupAndExit);

--- a/tests/boot-import-order.test.mjs
+++ b/tests/boot-import-order.test.mjs
@@ -1,0 +1,85 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// The boot contract: NOTHING index.mjs imports statically may need the
+// environment, because `dotenv.config()` runs in index.mjs's BODY and every
+// static import is evaluated before that. In the containers `dotenv.config()`
+// is what decodes SECRETENV_BUNDLE, so until it runs the environment really is
+// empty — an import that reads process.env at module scope sees nothing.
+//
+// lib/database.js is the one that bites: it builds its Sequelize instance and
+// pg-listen connection string from POSTGRES_* at module evaluation, so
+// importing it early exits the process with `TypeError: Invalid URL` before it
+// can listen. That is not hypothetical — it shipped, and llm-agent failed to
+// start from 61645b7 until it was fixed. lib/ws-handler.js documents the same
+// trap and imports text-chat lazily to avoid it.
+//
+// Every module that needs the environment must therefore be imported
+// DYNAMICALLY, after dotenv.config().
+
+/** The specifiers index.mjs imports statically, in source order. */
+function staticImportsOfIndex() {
+  const src = readFileSync(join(repoRoot, 'index.mjs'), 'utf8');
+  // Only top-level `import ... from '...'` lines; `await import()` is exactly
+  // what this test is checking people use instead, so it must not match.
+  return [...src.matchAll(/^import\s[^;]*?from\s+['"]([^'"]+)['"]/gm)].map((m) => m[1]);
+}
+
+/**
+ * Import one specifier in a child process with a scrubbed environment, the way
+ * the container starts. Returns null on success, or the failure output.
+ */
+function importWithEmptyEnv(specifier) {
+  try {
+    execFileSync(
+      process.execPath,
+      ['--input-type=module', '-e', `await import(${JSON.stringify(specifier)})`],
+      {
+        cwd: repoRoot,
+        // PATH and HOME only: enough for node to run and resolve modules,
+        // nothing that a module could mistake for configuration.
+        env: { PATH: process.env.PATH, HOME: process.env.HOME },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 60000,
+      },
+    );
+    return null;
+  } catch (e) {
+    return `${e.stdout || ''}${e.stderr || ''}`.split('\n').filter(Boolean).slice(0, 6).join('\n');
+  }
+}
+
+describe('boot import order', () => {
+  const specifiers = staticImportsOfIndex().filter((s) => s.startsWith('.'));
+
+  it('index.mjs statically imports something local (the test is wired up)', () => {
+    expect(specifiers.length).toBeGreaterThan(3);
+  });
+
+  it.each(specifiers)('%s survives being imported with an empty environment', (specifier) => {
+    const failure = importWithEmptyEnv(specifier);
+    if (failure) {
+      // Thrown rather than asserted so the remedy travels with the failure —
+      // the next person to hit this needs to know what to do, not just that a
+      // value was not null.
+      throw new Error(
+        `index.mjs imports ${specifier} statically, so it is evaluated BEFORE `
+        + 'dotenv.config() and must not need the environment. Import it dynamically '
+        + 'after dotenv.config() instead (see the startChatSessionReaper import at '
+        + `the bottom of index.mjs).\n\n${failure}`,
+      );
+    }
+    expect(failure).toBeNull();
+  }, 70000);
+
+  // Pins the reason the rule exists. If lib/database.js ever stops connecting
+  // at import, this test starts failing and the whole precaution can be
+  // reconsidered — which is a better outcome than it silently going stale.
+  it('lib/database.js does need the environment at import (the reason for the rule)', () => {
+    expect(importWithEmptyEnv('./lib/database.js')).not.toBeNull();
+  }, 70000);
+});


### PR DESCRIPTION
**llm-agent has failed to start since `61645b7`** (my merge of #291, chat session liveness). This restores it.

Reported by Rob and traced by the "Make llm-agent safe above one replica" session; I verified the diagnosis independently before fixing.

## Cause

#291 added to `index.mjs`:

```js
import { startChatSessionReaper } from './lib/text-chat.js';
```

`lib/text-chat.js` imports `lib/database.js`, which builds its Sequelize instance and pg-listen connection string from `process.env.POSTGRES_*` **at module evaluation**. Every static import is evaluated before the importing module's body, so this ran before `dotenv.config()` on line 20 — and in the containers `dotenv.config()` is what decodes `SECRETENV_BUNDLE` into the environment (`dotenv` here is the secretenv fork, `github:rjp44/secretenv#v1.0.5`). Until it runs the environment really is empty, so the connection string was built from `undefined` and the process exited with `TypeError: Invalid URL` before it could listen.

`lib/ws-handler.js:31` already documented this exact trap and avoids it:

> Imported lazily: text-chat pulls in the DB layer, and ws-handler is imported by index.mjs *before* dotenv.config() runs — a static import would evaluate database.js (which connects at import) before .env loads.

#291 walked into it anyway. Reproduce on `next`:

```
env -i PATH="$PATH" HOME="$HOME" node --input-type=module -e "await import('./lib/text-chat.js')"
```

## Fix

Import text-chat **dynamically**, after `dotenv.config()`, where the reaper is started — the same pattern `ws-handler` already uses, with a comment saying why it is load-bearing.

Deliberately **not** the structural alternative of moving env loading to the first import. `lib/logger.js` also reads `process.env` at module scope (`LOGLEVEL`) and is imported before `dotenv.config()` today, so making the environment available earlier would change production log verbosity as a side effect. That is worth doing on its own merits, not under an outage.

## The test that would have caught it

`tests/boot-import-order.test.mjs` takes `index.mjs`'s static imports and imports each one in a child process with a **scrubbed environment**, which is the state the container is actually in at that moment. It fails with the remedy in the message rather than just a null assertion.

I verified it catches the real fault by reintroducing the exact static import: it fails on `./lib/text-chat.js` and passes again when reverted.

It also pins *why* the rule exists — asserting `lib/database.js` does need the environment at import — so if that ever stops being true the test fails and the precaution gets reconsidered instead of going quietly stale.

The jest suites missed this because `tests/setup/database-test-wrapper.js` sets `POSTGRES_*` before anything imports `database.js`.

## Verified end to end

Empty shell environment, config only from `.env`, which is the container's ordering:

| | reaches "Server listening" | `TypeError: Invalid URL` |
|---|---|---|
| `947946d` (current `next`) | no | yes |
| this branch | **yes** | no |

Full DB suite: **1085 of 1085 passing**.

One caveat worth recording rather than hiding: on the first of three full runs, `agent-registration-workflow` failed. It passes in isolation and passed on both subsequent full runs, and it touches nothing this branch changes. I have no cause for it. It is the first flake I have seen since #296 made the suite parallel (4 workers, a database each), so it may be worth watching, but I am not attributing it to #296 without evidence.

## Coordination

aplisay/llm-agent#295 (chat session ownership) adds two more names to the same static import line and so carries the same fault. That session has asked to rebase onto this once it lands and follow this pattern, so I have not touched #295.
