### PR TITLE
Boot: run the start-up schema work under a cross-process lock

### DIFF
--- a/docs/running.md
+++ b/docs/running.md
@@ -38,7 +38,7 @@ The essentials, by group:
 | Group | Variables | Notes |
 |---|---|---|
 | Core | `WS_PORT`, `LOGLEVEL` | HTTP + WebSocket listen port, default `4000`; pino level |
-| Database | `POSTGRES_HOST/PORT/DB/USER/PASSWORD` | Optional mTLS via `POSTGRES_CA/CERT/KEY`. In `NODE_ENV=development` the schema syncs automatically; in production upgrades run through the internal schema-version gate — never set `DB_FORCE_SYNC` there |
+| Database | `POSTGRES_HOST/PORT/DB/USER/PASSWORD` | Optional mTLS via `POSTGRES_CA/CERT/KEY`. In `NODE_ENV=development` the schema syncs automatically; in production upgrades run through the internal schema-version gate — never set `DB_FORCE_SYNC` there. The schema work every process runs at start is serialised across processes by a Postgres advisory lock (`lib/boot-lock.js`), so replicas starting together take turns rather than racing |
 | Secrets at rest | `CREDENTIALS_KEY` | Encrypts stored SIP passwords and key material. Unset ⇒ plaintext with a logged warning; set it (`openssl rand -base64 32`) in every real deployment |
 | Auth | `AUTHENTICATE_USERS=NO` for a local instance | Real deployments use Firebase (legacy) or better-auth (`BETTER_AUTH_*`), plus org-scoped API keys |
 | LLM providers | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_PROJECT_ID` + `GOOGLE_APPLICATION_CREDENTIALS`, `ULTRAVOX_API_KEY` | Enable only what this deployment uses |

--- a/lib/boot-lock.js
+++ b/lib/boot-lock.js
@@ -1,0 +1,51 @@
+/**
+ * A cross-process mutex around the schema work every server process runs when
+ * it starts (lib/database.js: enum values, table and column adds, column
+ * defaults, data heals). Each step is idempotent, but Postgres does not make
+ * two processes running the same DDL at once safe: concurrent
+ * `CREATE TABLE IF NOT EXISTS` or `ADD COLUMN IF NOT EXISTS` can fail on a
+ * catalogue race, and the boot chain treats any failure as fatal. Two pods
+ * starting together (a scale-up, a rolling deploy) could take one down once.
+ *
+ * The lock is a Postgres session-level advisory lock on a fixed key, held on
+ * a dedicated connection for the duration of the boot chain. Postgres queues
+ * other takers until it is released, and releases it itself if the holder
+ * dies, so a crashed boot never wedges the rest. The connection is separate
+ * from the Sequelize pool on purpose: a session lock belongs to one
+ * connection, and pooled queries may run on any.
+ */
+import pg from 'pg';
+
+// Any fixed 64-bit value: it only has to be the same in every process.
+export const BOOT_LOCK_KEY = '4207189273618255201';
+
+/**
+ * Take the boot lock, waiting for another process to finish if it holds it.
+ * @param {object} connection pg client config (connectionString, ssl)
+ * @returns {Promise<{ release: () => Promise<void> }>}
+ */
+export async function acquireBootLock(connection, { log } = {}) {
+  const client = new pg.Client(connection);
+  await client.connect();
+  try {
+    const { rows } = await client.query('SELECT pg_try_advisory_lock($1::bigint) AS held', [BOOT_LOCK_KEY]);
+    if (!rows[0]?.held) {
+      log?.info?.('another process is running the boot-time schema work; waiting for it to finish');
+      await client.query('SELECT pg_advisory_lock($1::bigint)', [BOOT_LOCK_KEY]);
+    }
+  }
+  catch (err) {
+    await client.end().catch(() => {});
+    throw err;
+  }
+  return {
+    async release() {
+      try {
+        await client.query('SELECT pg_advisory_unlock($1::bigint)', [BOOT_LOCK_KEY]);
+      }
+      finally {
+        await client.end().catch(() => {});
+      }
+    },
+  };
+}

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,6 +1,7 @@
 import { Sequelize, Model, DataTypes, Op, Transaction } from 'sequelize';
 import { createHash, randomBytes, createCipheriv, createDecipheriv } from 'crypto';
 import Listener from 'pg-listen';
+import { acquireBootLock } from './boot-lock.js';
 import logger from './logger.js';
 import { getHandler } from './handlers/index.js';
 import Voices from './voices/index.js';
@@ -2859,7 +2860,15 @@ async function dropTariffOverlapConstraint() {
   }
 }
 
+// Held for the boot-time schema work below, so processes starting together
+// run it one at a time (lib/boot-lock.js). Released before the listener
+// connects; a process that dies mid-boot releases it by disconnecting.
+let bootLock = null;
+
 const databaseStarted = sequelize.authenticate()
+  .then(async () => {
+    bootLock = await acquireBootLock(LISTENER_CONNECTION, { log: logger });
+  })
   .then(async () => {
     logger.debug({ POSTGRES_DB, forceSync, dbVersion, schemaVersion }, 'Database connected');
     await addEnumValueIfMissing('enum_instances_type', 'pipecat');
@@ -3018,6 +3027,12 @@ const databaseStarted = sequelize.authenticate()
     );
     const healed = healResult?.[1]?.rowCount ?? healResult?.[1] ?? 0;
     if (healed) logger.info({ healed }, 'Activated legacy users.status (provisional -> active)');
+  })
+  .then(async () => {
+    // Schema work done: let the next process in.
+    const lock = bootLock;
+    bootLock = null;
+    await lock?.release();
   })
   .then(() =>
     logger.debug({ POSTGRES_DB }, 'Connection has been established successfully.'))

--- a/tests/boot-lock.test.mjs
+++ b/tests/boot-lock.test.mjs
@@ -1,0 +1,66 @@
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+// Importing the wrapper sets the POSTGRES_* variables for the test database
+// (before anything imports lib/database.js) and gives the peer processes the
+// same target through the environment they inherit.
+import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
+
+// The boot-time schema work runs in every server process, and processes start
+// together on a scale-up or a rolling deploy. lib/boot-lock.js makes them run
+// it one at a time. These tests use real second processes against the same
+// database: one that holds the lock the way a booting server does, to show
+// this process's boot waits for it; and several booting at once, to show they
+// all come up.
+describe('boot lock', () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const holder = join(here, 'fixtures', 'hold-boot-lock.mjs');
+  const booter = join(here, 'fixtures', 'boot-database.mjs');
+  const childEnv = () => {
+    const env = { ...process.env, NODE_ENV: 'test', LOGLEVEL: 'silent' };
+    delete env.DB_FORCE_SYNC; // peers must not alter-sync the schema under the suite
+    return env;
+  };
+  const sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+  afterAll(async () => {
+    await teardownRealDatabase();
+  }, 60000);
+
+  test("this process's boot waits while another process holds the lock, then completes", async () => {
+    // Another process takes the lock first.
+    const held = spawn(process.execPath, [holder], { env: childEnv(), stdio: ['pipe', 'pipe', 'pipe'] });
+    let err = '';
+    held.stderr.on('data', (d) => { err += d; });
+    await new Promise((resolve, reject) => {
+      held.stdout.on('data', (d) => { if (String(d).includes('locked')) resolve(); });
+      held.on('close', (code) => reject(new Error(`lock holder exited early (${code}): ${err}`)));
+    });
+
+    // Now boot here. The chain must not get past the lock while it is held.
+    const started = setupRealDatabase();
+    const outcome = await Promise.race([started.then(() => 'started'), sleep(2000).then(() => 'still waiting')]);
+    expect(outcome).toBe('still waiting');
+
+    // Release, and the boot goes through.
+    held.stdin.write('go\n');
+    const exit = new Promise((resolve) => { held.on('close', resolve); });
+    await started;
+    expect(await exit).toBe(0);
+  }, 60000);
+
+  test('several processes booting at once all come up', async () => {
+    const runs = [1, 2, 3].map(() => new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [booter], { env: childEnv(), stdio: ['ignore', 'pipe', 'pipe'] });
+      let out = '';
+      let err = '';
+      child.stdout.on('data', (d) => { out += d; });
+      child.stderr.on('data', (d) => { err += d; });
+      child.on('error', reject);
+      child.on('close', (code) => (code === 0 && out.includes('started')
+        ? resolve(code)
+        : reject(new Error(`boot exited ${code}: ${err || out}`))));
+    }));
+    await expect(Promise.all(runs)).resolves.toEqual([0, 0, 0]);
+  }, 90000);
+});

--- a/tests/fixtures/boot-database.mjs
+++ b/tests/fixtures/boot-database.mjs
@@ -1,0 +1,18 @@
+// Boots lib/database.js in a SEPARATE process, for tests/boot-lock.test.mjs:
+// what a server does on start, and nothing else. Prints "started" once the
+// boot chain has run and exits 0; any failure exits non-zero with the error
+// on stderr.
+try {
+  const { databaseStarted, stopDatabase } = await import('../../lib/database.js');
+  await databaseStarted;
+  process.stdout.write('started\n');
+  await Promise.race([
+    stopDatabase(),
+    new Promise((resolve) => { setTimeout(resolve, 5000).unref?.(); }),
+  ]);
+  process.exit(0);
+}
+catch (err) {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+}

--- a/tests/fixtures/hold-boot-lock.mjs
+++ b/tests/fixtures/hold-boot-lock.mjs
@@ -1,0 +1,30 @@
+// Holds the boot lock from a SEPARATE process, for tests/boot-lock.test.mjs.
+//
+// Connects with the POSTGRES_* variables it is given, takes the boot lock the
+// way a booting server does, prints "locked", and keeps holding it until
+// anything arrives on stdin (or stdin closes). Then it unlocks and exits 0.
+import pg from 'pg';
+import { BOOT_LOCK_KEY } from '../../lib/boot-lock.js';
+
+const { POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB } = process.env;
+const client = new pg.Client({
+  connectionString: `postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}`,
+});
+
+try {
+  await client.connect();
+  await client.query('SELECT pg_advisory_lock($1::bigint)', [BOOT_LOCK_KEY]);
+  process.stdout.write('locked\n');
+  await new Promise((resolve) => {
+    process.stdin.once('data', resolve);
+    process.stdin.once('end', resolve);
+    process.stdin.resume();
+  });
+  await client.query('SELECT pg_advisory_unlock($1::bigint)', [BOOT_LOCK_KEY]);
+  await client.end();
+  process.exit(0);
+}
+catch (err) {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+}


### PR DESCRIPTION
## Why

Every server process runs the same schema work when it starts (`lib/database.js`: enum values, `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, column defaults, data heals, and under `DB_FORCE_SYNC` the alter chain). Each step is idempotent on its own, but Postgres does not make two processes running the same DDL at the same moment safe: concurrent `CREATE TABLE IF NOT EXISTS` or `ADD COLUMN IF NOT EXISTS` can fail on a catalogue race, and the boot chain treats any failure as fatal (`process.exit(1)`). Two pods starting together, on a scale-up or a rolling deploy, could take one of them down once. It restarts and comes up, but it is noise, and the `DB_FORCE_SYNC` path would not be safe at all.

## What

`lib/boot-lock.js`: a Postgres session-level advisory lock on a fixed key, held on a dedicated `pg` connection for the duration of the boot chain and released before the LISTEN connection is made. Other processes queue on it; a process that dies mid-boot releases it by disconnecting. The connection is separate from the Sequelize pool on purpose: a session lock belongs to one connection, and pooled queries may run on any. Advisory locks are per database, so processes on different databases do not wait on each other.

A process that finds the lock taken logs that it is waiting for another process's boot work.

## Tests

`tests/boot-lock.test.mjs`, against real second processes sharing the test database: one holds the lock the way a booting server does, and this process's own boot is shown to wait until it lets go and then complete; and three processes booting at once all come up.

## Not changed

The boot chain itself. Nothing here needs a schema change or an environment change.
