### PR TITLE
Calls: number concurrent creates without duplicates, and never leak a transaction

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -1057,6 +1057,21 @@ Agent.hasMany(Instance, { foreignKey: 'agentId', onDelete: 'CASCADE', as: 'liste
 
 
 class Call extends Model {
+  /**
+   * Every create runs inside a transaction: the caller's when one is passed,
+   * otherwise one managed here for the duration of the create. The
+   * per-organisation numbering in beforeCreate needs to be atomic with the
+   * INSERT, and a failure anywhere (the insert, a hook) must roll the whole
+   * thing back. The hooks used to open a transaction themselves and commit it
+   * in afterCreate, so a hook that threw left an open transaction on a pooled
+   * connection for good; with the numbering lock inside that transaction the
+   * leak would also have stalled every later call for the organisation.
+   */
+  static async create(values, options = {}) {
+    if (options.transaction) return super.create(values, options);
+    return sequelize.transaction((transaction) => super.create(values, { ...options, transaction }));
+  }
+
   set streamLog(value) {
     if (value) {
       streamIds[this.id] = value;
@@ -1343,11 +1358,25 @@ Call.init({
     collate: 'utf8_general_ci',
     hooks: {
       beforeCreate: async (call, options = {}) => {
-        if (!options.transaction) {
-          options.transaction = await sequelize.transaction();
-          options.syntheticTransaction = options.transaction;
+        // The per-organisation call number is MAX(index) + 1, which two calls
+        // starting at once would both compute alike (nothing else orders them,
+        // and index has no unique constraint). A transaction-scoped advisory
+        // lock keyed on the organisation makes concurrent creates for one
+        // organisation queue behind each other's commit, in this process or
+        // any other, while calls for other organisations are unaffected. The
+        // lock goes with the transaction (Call.create always supplies one),
+        // so nothing is left to release.
+        const org = call.organisationId == null ? null : String(call.organisationId);
+        if (options.transaction) {
+          await sequelize.query(
+            'SELECT pg_advisory_xact_lock(hashtext(:org))',
+            { replacements: { org: org ?? '' }, transaction: options.transaction },
+          );
         }
-        const [result] = await sequelize.query(`(SELECT COALESCE(MAX(index), 0) + 1 as next_index FROM calls WHERE organisation_id = '${call.organisationId}')`, { type: sequelize.QueryTypes.SELECT, transaction: options.transaction });
+        const [result] = await sequelize.query(
+          'SELECT COALESCE(MAX(index), 0) + 1 AS next_index FROM calls WHERE organisation_id = :org',
+          { type: sequelize.QueryTypes.SELECT, replacements: { org }, transaction: options.transaction },
+        );
         logger.debug({ result }, 'index result');
         call.index = result.next_index;
       },
@@ -1355,9 +1384,6 @@ Call.init({
         if ((await Instance.findByPk(call.instanceId, options)).streamLog) {
           logger.debug(`Streaming logs for call ${call.id}`);
           call.streamLog = call.instanceId;
-        }
-        if (options.syntheticTransaction) {
-          await options.syntheticTransaction.commit();
         }
       }
     }

--- a/tests/call-index-concurrency.test.mjs
+++ b/tests/call-index-concurrency.test.mjs
@@ -1,0 +1,131 @@
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomUUID } from 'node:crypto';
+import {
+  setupRealDatabase,
+  teardownRealDatabase,
+  Organisation,
+  User,
+  Agent,
+  Instance,
+  Call,
+} from './setup/database-test-wrapper.js';
+
+// Agent.create validates the model against the roster, which needs the key.
+process.env.ANTHROPIC_API_KEY ||= 'test-key';
+
+// A call's per-organisation number (`calls.index`) is MAX + 1 at create time.
+// Two calls starting at once, in one process or in several, used to compute
+// the same number: nothing ordered the creates, and the column has no unique
+// constraint to refuse the second. The hook now takes a per-organisation
+// advisory lock for the transaction, so concurrent creates queue behind each
+// other's commit. This test creates calls for one organisation from THIS
+// process and from two other real processes at the same time, and expects the
+// numbers to come out unique and gap-free.
+describe('call index under concurrent creates', () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const writer = join(here, 'fixtures', 'call-index-writer.mjs');
+  const PER_WRITER = 12;
+
+  let orgId;
+  let userId;
+  let instanceId;
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    orgId = randomUUID();
+    userId = randomUUID();
+    await Organisation.create({ id: orgId, name: 'Call Index Org' });
+    await User.create({
+      id: userId, name: 'Call Index User', email: `calls-${userId}@example.com`,
+      emailVerified: true, phone: '', phoneVerified: false, picture: '',
+      role: 'owner', organisationId: orgId,
+    });
+    // Calls belong to a listener; afterCreate reads its streamLog flag.
+    const agent = await Agent.create({
+      name: 'Call index agent', type: 'text', modelName: 'text:anthropic/claude-sonnet-5',
+      prompt: 'You are a test agent.', userId, organisationId: orgId,
+    });
+    const instance = await Instance.create({ agentId: agent.id, type: 'pipecat', key: 'k', userId, organisationId: orgId });
+    instanceId = instance.id;
+  }, 60000);
+
+  afterAll(async () => {
+    await Call.destroy({ where: { organisationId: orgId } });
+    await Instance.destroy({ where: { organisationId: orgId } });
+    await Agent.destroy({ where: { organisationId: orgId } });
+    await User.destroy({ where: { id: userId } });
+    await Organisation.destroy({ where: { id: orgId } });
+    await teardownRealDatabase();
+  }, 60000);
+
+  function writeFromAnotherProcess(count) {
+    const env = { ...process.env, NODE_ENV: 'test', LOGLEVEL: 'silent' };
+    delete env.DB_FORCE_SYNC; // never alter-sync the schema under a running suite
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [writer, JSON.stringify({ organisationId: orgId, userId, instanceId, count })], {
+        env, stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let out = '';
+      let err = '';
+      child.stdout.on('data', (d) => { out += d; });
+      child.stderr.on('data', (d) => { err += d; });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code !== 0) return reject(new Error(`call writer exited ${code}: ${err || out}`));
+        try {
+          resolve(JSON.parse(out.trim().split('\n').pop()).indexes);
+        } catch {
+          reject(new Error(`call writer output was not JSON: ${out}\n${err}`));
+        }
+      });
+    });
+  }
+
+  test('calls created at once from three processes get unique, gap-free numbers', async () => {
+    const [here1, other1, other2] = await Promise.all([
+      Promise.all(Array.from({ length: PER_WRITER }, () => Call.create({
+        organisationId: orgId, userId, instanceId, platform: 'test', calledId: '441000000000', callerId: '441000000001',
+      }))).then((calls) => calls.map((c) => c.index)),
+      writeFromAnotherProcess(PER_WRITER),
+      writeFromAnotherProcess(PER_WRITER),
+    ]);
+    const all = [...here1, ...other1, ...other2].sort((a, b) => a - b);
+    expect(all).toHaveLength(3 * PER_WRITER);
+    expect(all).toEqual(Array.from({ length: 3 * PER_WRITER }, (_, i) => i + 1));
+    // And the rows say the same.
+    const rows = await Call.findAll({ where: { organisationId: orgId }, attributes: ['index'], raw: true });
+    expect(rows.map((r) => r.index).sort((a, b) => a - b)).toEqual(all);
+  }, 90000);
+
+  test('a create that fails rolls back and leaves no lock behind for the next one', async () => {
+    // A row the database refuses (no such instance): the hook has already
+    // taken the organisation's lock by then. With the transaction managed by
+    // Call.create the failure rolls it back, and the next create for the
+    // organisation must not wait on anything.
+    const missingInstance = randomUUID();
+    await expect(Call.create({
+      organisationId: orgId, userId, instanceId: missingInstance, platform: 'test', calledId: '4410', callerId: '4411',
+    })).rejects.toThrow();
+    const t0 = Date.now();
+    const next = await Call.create({ organisationId: orgId, userId, instanceId, platform: 'test', calledId: '4410', callerId: '4411' });
+    expect(Date.now() - t0).toBeLessThan(5000);
+    expect(next.index).toBe(3 * PER_WRITER + 1);
+  }, 30000);
+
+  test('numbers for other organisations are unaffected by the lock', async () => {
+    const otherOrg = randomUUID();
+    await Organisation.create({ id: otherOrg, name: 'Other Org' });
+    try {
+      const [a, b] = await Promise.all([
+        Call.create({ organisationId: otherOrg, userId, instanceId, platform: 'test', calledId: '4410', callerId: '4411' }),
+        Call.create({ organisationId: otherOrg, userId, instanceId, platform: 'test', calledId: '4410', callerId: '4411' }),
+      ]);
+      expect([a.index, b.index].sort()).toEqual([1, 2]);
+    } finally {
+      await Call.destroy({ where: { organisationId: otherOrg } });
+      await Organisation.destroy({ where: { id: otherOrg } });
+    }
+  });
+});

--- a/tests/fixtures/call-index-writer.mjs
+++ b/tests/fixtures/call-index-writer.mjs
@@ -1,0 +1,34 @@
+// Creates calls from a SEPARATE process, all at once, for
+// tests/call-index-concurrency.test.mjs.
+//
+// Usage: node tests/fixtures/call-index-writer.mjs '<json>'
+//   json = { organisationId, userId, instanceId, count }
+//
+// Connects with the POSTGRES_* variables it is given, fires `count` Call
+// creates concurrently through the real model (so the beforeCreate hook that
+// numbers them runs here), prints the indexes it was given as one JSON line,
+// and exits 0. Any failure exits non-zero with the error on stderr.
+const spec = JSON.parse(process.argv[2] || '{}');
+
+try {
+  const { Call, databaseStarted, stopDatabase } = await import('../../lib/database.js');
+  await databaseStarted;
+  const calls = await Promise.all(Array.from({ length: spec.count || 0 }, () => Call.create({
+    organisationId: spec.organisationId,
+    userId: spec.userId,
+    instanceId: spec.instanceId,
+    platform: 'test',
+    calledId: '441000000000',
+    callerId: '441000000001',
+  })));
+  console.log(JSON.stringify({ indexes: calls.map((c) => c.index) }));
+  await Promise.race([
+    stopDatabase(),
+    new Promise((resolve) => { setTimeout(resolve, 5000).unref?.(); }),
+  ]);
+  process.exit(0);
+}
+catch (err) {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+}


### PR DESCRIPTION
## Why

A call's per-organisation number (`calls.index`) is `MAX(index) + 1`, computed in `beforeCreate`. Nothing ordered concurrent creates and the column has no unique constraint, so two calls starting at once for one organisation got the same number, in one process or across several. The hook also opened its own transaction and committed it in `afterCreate`, so a hook that threw (or an insert the database refused) left an open transaction on a pooled connection for good.

## What

- `Call.create` runs the create in a transaction: the caller's when one is passed, otherwise one managed for the duration of the create, so a failure anywhere rolls the whole thing back. The hooks no longer open or commit transactions.
- `beforeCreate` takes a transaction-scoped advisory lock keyed on the organisation (`pg_advisory_xact_lock(hashtext(org))`) before reading `MAX(index)`. Concurrent creates for one organisation queue behind each other's commit, in this process or any other; calls for other organisations are unaffected; the lock goes with the transaction, so there is nothing to release.
- The `MAX(index)` query uses a bound parameter rather than interpolating the organisation id into the SQL.

A unique index on `(organisation_id, index)` would be the hard guard. It is not added here: existing rows may already carry duplicates from past races, so it needs a data audit first.

## Tests

`tests/call-index-concurrency.test.mjs`: 36 calls for one organisation created at the same time from this process and from two other real node processes (`tests/fixtures/call-index-writer.mjs`) come out numbered 1 to 36 with no gaps, and the rows agree; a create the database refuses rolls back and the next create for the organisation does not wait on anything; other organisations are unaffected. Control run against the previous hook: duplicate numbers.
