### PR TITLE
Chat sessions: one holder at a time, and it can change

### DIFF
--- a/api/paths/agents/{agentId}/chat.js
+++ b/api/paths/agents/{agentId}/chat.js
@@ -1,4 +1,4 @@
-import { createChatSession } from '../../../../lib/text-chat.js';
+import { openChatSession } from '../../../../lib/text-chat.js';
 import { resolveAgentForUser } from '../../../../lib/builtin-agents.js';
 import { requirePermission } from '../../../../lib/auth/permissions.js';
 import { isModelAllowed } from '../../../../lib/auth/model-access.js';
@@ -74,11 +74,15 @@ const agentChat = async (req, res) => {
       }
       agent.modelName = model;
     }
-    const session = createChatSession({ agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger: req.log });
+    // The session is a row from here on: whichever server process receives
+    // the websocket upgrade for `/chat/<id>` claims it and builds the
+    // conversation there (lib/text-chat.js), so this request and the socket
+    // need not land on the same process.
+    const { id } = await openChatSession({ agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger: req.log });
     log.info(
-      { agentId, sessionId: session.id, edit: !!set, diagnose: !!testResult, subjectAgent: !!subjectAgent, knowledge: !!knowledge, headless: !!headless, model: model || undefined, resume: Array.isArray(history) ? history.length : undefined, resumedFrom: resumedFrom || undefined },
+      { agentId, sessionId: id, edit: !!set, diagnose: !!testResult, subjectAgent: !!subjectAgent, knowledge: !!knowledge, headless: !!headless, model: model || undefined, resume: Array.isArray(history) ? history.length : undefined, resumedFrom: resumedFrom || undefined },
       'agent chat session started');
-    res.send({ id: session.id, socket: `/chat/${session.id}` });
+    res.send({ id, socket: `/chat/${id}` });
   }
   catch (err) {
     req.log.error(err, 'starting agent chat');

--- a/api/paths/chat-sessions.js
+++ b/api/paths/chat-sessions.js
@@ -73,6 +73,9 @@ const listChatSessions = async (req, res) => {
     const offset = Math.max(0, parseInt(req.query.offset) || 0);
     const where = {
       ...scopeWhereForUser(res.locals.user),
+      // A tenant text agent's own conversation has a row only while it is
+      // live (so it can move between server processes); it is not history.
+      ephemeral: false,
       ...(setId ? { setId } : {}),
       ...(agentId ? { agentId } : {}),
     };

--- a/api/paths/chat-sessions/{sessionId}.js
+++ b/api/paths/chat-sessions/{sessionId}.js
@@ -59,7 +59,9 @@ const getChatSession = async (req, res) => {
       usage.costMicros += Number(r.costMicros) || 0;
       usage.currency = usage.currency || r.currency || null;
     }
-    const { lastSeenAt, ...row } = session.get({ plain: true });
+    // `owner` and `state` are how the session moves between server
+    // processes; neither is part of the contract.
+    const { lastSeenAt, owner, state, ...row } = session.get({ plain: true });
     res.send({ ...row, live: isChatSessionLive(session), usage });
   } catch (error) {
     req.log.error(error);

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Index of the docs in this directory. Start with the first table if you're new; t
 | [auxiliary-stt.md](auxiliary-stt.md) | Side STT engines: a second opinion on the caller (`options.stt.aux` → `user-aux`, `stt-aux`) and an audit of what the agent actually said (`options.tts.output` → `agent-speech`, `stt-output`) |
 | [ultravox-vendor-specific-options.md](ultravox-vendor-specific-options.md) | Ultravox model variants and tuning options |
 | [agent-concurrency-limits.md](agent-concurrency-limits.md) | Per-agent/user/organisation concurrency caps |
+| [chat-session-ownership.md](chat-session-ownership.md) | How an interactive chat session is held by one server process and moves to another on reconnect or shutdown |
 | [agent-failover.md](agent-failover.md) | Automatic fallback agents and numbers |
 | [voices-deprecation.md](voices-deprecation.md) | Deprecation notes for the legacy voices surface |
 

--- a/docs/chat-session-ownership.md
+++ b/docs/chat-session-ownership.md
@@ -1,0 +1,105 @@
+# Chat session ownership across server processes
+
+Interactive text-agent chat (`POST /agents/{agentId}/chat`, then the
+`/chat/<id>` websocket) runs on a server that has more than one process:
+autoscaled Kubernetes pods and Cloud Run instances. The websocket for a
+session can reach any of them, on the first connect and on every reconnect.
+This document describes how a session moves between processes. The code is in
+`lib/text-chat.js`.
+
+## The model
+
+A session is a row in `chat_sessions`. Exactly one process holds it in memory
+at a time, and the row says which one (`owner`, a process id from
+`lib/process-id.js`: pod name or hostname, pid, and a random boot suffix).
+
+- `POST /agents/{agentId}/chat` writes the row with `owner = NULL` and the
+  seed (the set to edit, a test result, a knowledge block, a resume history)
+  in `state.seed`. Nothing is built at this point.
+- The process that receives the websocket upgrade claims the row (a
+  conditional `UPDATE ... WHERE owner IS NULL`), builds the driver there and
+  runs the conversation.
+- At every turn boundary the holder writes a snapshot to `state`: the
+  driver's replayable conversation (`exportConversation()` on
+  `lib/models/*`), a paused interactive ask, frames buffered while no socket
+  was attached, the set being worked on, and whether the opening turn has
+  completed.
+- Every write the holder makes is conditional on `owner = <its id>`. A write
+  that changes no row means another process has taken the session, and the
+  holder drops it locally without ending anything.
+
+## Reconnect on another process
+
+When a socket for a session arrives at a process that does not hold it:
+
+1. If the row is unowned, or its holder's heartbeat (`last_seen_at`) is
+   stale, the process claims it at once and rehydrates the driver from the
+   snapshot (`importConversation()`). The client sees one `attached` frame
+   with `resumed: true`.
+2. If the holder is alive, the process sends it a `release` request over
+   Postgres `LISTEN/NOTIFY` (channel `chat_control`) and waits for the row to
+   become unowned, polling every 100 ms. The client is sent a provisional
+   `attached {resumed: true, busy: true}` frame straight away, because
+   polite-ai's client gives a re-attach five seconds to prove itself; the
+   real `attached` follows once the session is rehydrated and corrects the
+   busy indicator.
+3. A holder at rest releases immediately: it writes its final snapshot and
+   `owner = NULL` in one conditional write, closes its driver (and any
+   standing MCP connections), tells any socket it still has that it was
+   superseded, and forgets the session. A holder mid-turn answers `busy`,
+   finishes the turn, and releases at the turn boundary; the waiting process
+   extends its wait so the turn's reply is kept.
+4. A holder that has not released when the wait runs out is treated as gone
+   and the row is taken from it. Its next conditional write tells it so.
+
+Replaying a byte-identical conversation is what lets the provider prompt
+cache serve the prefix: a handover costs cache reads, not a rebuilt seed.
+
+## Shutdown
+
+On `SIGTERM` a process releases every session it holds
+(`releaseAllChatSessions`). The clients whose sockets die with it reconnect
+through the load balancer to another process, which claims the unowned rows
+and carries on. A rolling deploy therefore hands sessions over rather than
+losing them; a turn in flight at that moment loses its reply, and nothing
+else.
+
+## Retention
+
+Builder sessions (the `builtin:set-builder`, or an org-pushed builder marked
+`[polite:agent-builder]`) are history: their rows stay, with the transcript,
+after the session ends. Every other text agent's conversation is a tenant's
+own end-user data. Its row exists only while the session is live
+(`ephemeral = true`), is deleted when the session ends, and is never listed
+by `GET /chat-sessions`. The reaper (`reapStaleChatSessions`) removes ended
+ephemeral rows an owner never got to.
+
+The snapshot is cleared (`state = NULL`) when a session ends. `owner` and
+`state` are not part of the API.
+
+## Configuration
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `POD_NAME` | `HOSTNAME`, else the machine hostname | The human-readable part of the process id in `owner`. Kubernetes sets `HOSTNAME` to the pod name, so this is optional. |
+| `TEXT_CHAT_HANDOFF_WAIT_MS` | `5000` | How long a claim waits for a live holder to release before taking the row. |
+| `TEXT_CHAT_HANDOFF_BUSY_WAIT_MS` | `90000` | The wait when the holder has answered `busy` (a turn in flight). |
+| `TEXT_CHAT_STATE_MAX_BYTES` | `4194304` | Snapshot size cap. Over it the conversation is left out and a takeover resumes from the transcript. |
+| `TEXT_CHAT_LIVENESS_GRACE_MS` | `300000` | Existing: a holder whose heartbeat is older than this is treated as dead. This is also the window in which a session whose process died can still be taken over; after it the reaper ends the row and the client falls back to a fresh session. |
+| `TEXT_CHAT_REATTACH_GRACE_MS` | `900000` | Existing: how long a holder keeps a session after its socket drops. |
+
+## Schema
+
+Columns on `chat_sessions`, added idempotently at boot
+(`ADD COLUMN IF NOT EXISTS`, the same way `last_seen_at` was): `owner`
+(varchar), `state` (jsonb), `ephemeral` (boolean, not null, default false).
+No `schemaVersion` bump, so no manual upgrade step per environment.
+
+## Tests
+
+`tests/chat-session-handoff.test.mjs` runs the protocol against a second,
+real node process (`tests/fixtures/chat-peer.mjs`) sharing the test
+database: first attach, live takeover with the conversation intact, the
+return trip, a dead holder, an unresponsive holder, the fencing write, and
+retention. `tests/fixtures/fake-chat-llm.mjs` stands in for a provider and
+implements the same export/import contract the real drivers do.

--- a/index.mjs
+++ b/index.mjs
@@ -168,8 +168,12 @@ httpServer.listen(port, () => {
 // decoded SECRETENV_BUNDLE into the environment — and the process would exit
 // with `TypeError: Invalid URL` before it could listen. lib/ws-handler.js
 // avoids the same trap the same way, and says so.
-const { startChatSessionReaper } = await import('./lib/text-chat.js');
+const { startChatSessionReaper, startChatOwnershipListener, releaseAllChatSessions } = await import('./lib/text-chat.js');
 startChatSessionReaper({ log: logger });
+// Answer other processes asking for a chat session this one holds (a client
+// reconnected through the load balancer to a different pod). Server only,
+// for the same reason as the reaper.
+startChatOwnershipListener({ log: logger });
 
 process.on('SIGINT', cleanupAndExit);
 process.once('SIGTERM', cleanupAndExit);
@@ -177,6 +181,10 @@ process.on('SIGUSR2', cleanupAndExit);
 
 async function cleanup() {
   logger.debug({}, `beforeExit: applications running`);
+  // Hand every chat session this process holds back to the database first, so
+  // the clients whose sockets die with this process re-attach on another one
+  // and carry on, instead of starting over.
+  await releaseAllChatSessions({ log: logger });
   await cleanHandlers();
   logger.debug({}, `cleanup: applications cleaned`);
 }

--- a/lib/database.js
+++ b/lib/database.js
@@ -1887,6 +1887,33 @@ ChatSession.init({
     type: DataTypes.JSONB,
     allowNull: true,
   },
+  // The server process currently holding this session in memory
+  // (lib/process-id.js), or NULL when no process does: a session that has been
+  // opened but not yet attached, or one released for another process to pick
+  // up. Every write the owner makes to the row is conditional on this column,
+  // so a process that has lost a session to another finds out on its next
+  // write and drops it, instead of two processes driving one conversation.
+  owner: {
+    type: DataTypes.STRING,
+    allowNull: true,
+  },
+  // Everything a process needs to carry this conversation on where another
+  // left it (lib/text-chat.js snapshotState): the driver's replayable
+  // conversation, a paused interactive ask, frames buffered while no socket
+  // was attached, the set being worked on, and before the first attach, the
+  // seed the opener supplied. Written at every turn boundary by the owner.
+  state: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  },
+  // True for a tenant text agent's own conversation: the row exists only so
+  // the live session can move between processes, and is deleted when the
+  // session ends. Builder sessions are false and are kept as history.
+  ephemeral: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  },
   // Lineage: the session this one RESUMED after an interruption (server
   // restart, lapsed re-attach grace). The client re-seeds a fresh session
   // with the prior conversation and names its predecessor here, so the
@@ -3096,6 +3123,13 @@ const databaseStarted = sequelize.authenticate()
     await sequelize.query(
       `ALTER TABLE "chat_sessions" ADD COLUMN IF NOT EXISTS "last_seen_at" TIMESTAMP WITH TIME ZONE`,
     );
+    // Session ownership across processes (lib/text-chat.js): the same
+    // idempotent adds, for the same reason.
+    await sequelize.query(`ALTER TABLE "chat_sessions" ADD COLUMN IF NOT EXISTS "owner" VARCHAR(255)`);
+    await sequelize.query(`ALTER TABLE "chat_sessions" ADD COLUMN IF NOT EXISTS "state" JSONB`);
+    await sequelize.query(
+      `ALTER TABLE "chat_sessions" ADD COLUMN IF NOT EXISTS "ephemeral" BOOLEAN NOT NULL DEFAULT false`,
+    );
 
     // Domain-column defaults for Better-Auth's direct inserts (parallel-auth phase).
     await setColumnDefault('users', 'role', `'owner'`);
@@ -3138,6 +3172,25 @@ const databaseStarted = sequelize.authenticate()
     logger.error(error, 'Unable to connect to the database:');
     process.exit(1);
   });
+
+/**
+ * Cross-process signalling over the dedicated LISTEN/NOTIFY connection, for
+ * modules that coordinate between server processes (lib/text-chat.js session
+ * ownership). Same connection and semantics as TransactionLog.on: a payload
+ * is JSON, capped by Postgres at 8000 bytes, and delivered to every process
+ * listening on the channel, this one included.
+ */
+export const pgNotify = (channel, payload) => listener.notify(channel, payload);
+
+export async function pgListen(channel, handler) {
+  listener.notifications.on(channel, handler);
+  await listener.listenTo(channel);
+}
+
+export async function pgUnlisten(channel) {
+  listener.notifications.removeAllListeners(channel);
+  await listener.unlisten(channel);
+}
 
 const stopDatabase = async () => {
   // We could actually still be starting, so wait for that promise chain to complete

--- a/lib/models/anthropic.js
+++ b/lib/models/anthropic.js
@@ -435,6 +435,17 @@ class Anthropic extends Llm {
     return this.rawCompletion(null, callBack);
   }
 
+  /** The messages array is the whole replayable history (system/tools rebuild from the agent). */
+  exportConversation() {
+    return { driver: 'anthropic', messages: this.gpt.messages };
+  }
+
+  importConversation(conversation) {
+    if (conversation?.driver !== 'anthropic' || !Array.isArray(conversation.messages)) return false;
+    this.gpt.messages = conversation.messages;
+    return true;
+  }
+
   /**
    * Called by the TURN OWNER when a turn aborted between a completion that
    * returned tool_use blocks and the callResult that would answer them: the

--- a/lib/models/gemini.js
+++ b/lib/models/gemini.js
@@ -107,6 +107,18 @@ class Gemini extends Llm {
    * unserialised voice path a dangling call may be legitimately in flight,
    * and pre-answering it corrupts history and invites double tool execution.
    */
+  /** contents is the history; pendingParts are bridged results held mid-turn. */
+  exportConversation() {
+    return { driver: 'gemini', contents: this.contents, pendingParts: this.pendingParts || null };
+  }
+
+  importConversation(conversation) {
+    if (conversation?.driver !== 'gemini' || !Array.isArray(conversation.contents)) return false;
+    this.contents = conversation.contents;
+    this.pendingParts = Array.isArray(conversation.pendingParts) ? conversation.pendingParts : null;
+    return true;
+  }
+
   abandonTurn() {
     const held = this.pendingParts || [];
     this.pendingParts = null;

--- a/lib/models/llm.js
+++ b/lib/models/llm.js
@@ -124,6 +124,29 @@ class Llm {
    * @property {Objectn} error any errors that occured
    * @memberof Llm
    */
+  /**
+   * The conversation so far, as a plain JSON value this driver can later load
+   * with {@link importConversation} to carry on exactly where it left off.
+   * Provider-shaped on purpose: the same driver class reads it back, and a
+   * byte-identical replay is what lets a provider prompt cache serve the
+   * prefix. Drivers that keep no replayable history return null, and the
+   * caller falls back to resuming from a transcript.
+   * @returns {object|null}
+   */
+  exportConversation() {
+    return null;
+  }
+
+  /**
+   * Load a conversation produced by {@link exportConversation} on another
+   * instance of the same driver. Returns true when the history was taken.
+   * @param {object|null} conversation
+   * @returns {boolean}
+   */
+  importConversation(conversation) { // eslint-disable-line no-unused-vars
+    return false;
+  }
+
   async completion(input, callBack) {
     let { text, calls, error, usage } = await this.rawCompletion(input);
     let opts = { text, calls, error, usage };

--- a/lib/models/openai-compatible.js
+++ b/lib/models/openai-compatible.js
@@ -340,6 +340,21 @@ class OpenAiCompatible extends Llm {
   }
 
   /**
+   * The messages array (system prompt first) is the whole history. Tagged with
+   * the concrete provider class so a kimi conversation is never loaded into an
+   * openrouter driver.
+   */
+  exportConversation() {
+    return { driver: this.constructor.name, messages: this.gpt.messages };
+  }
+
+  importConversation(conversation) {
+    if (conversation?.driver !== this.constructor.name || !Array.isArray(conversation.messages)) return false;
+    this.gpt.messages = conversation.messages;
+    return true;
+  }
+
+  /**
    * Called by the TURN OWNER when a turn aborted between a completion that
    * returned tool_calls and the callResult that would answer them: history
    * ends with dangling tool_call ids, and the provider 400s every subsequent

--- a/lib/models/openai.js
+++ b/lib/models/openai.js
@@ -339,6 +339,17 @@ class OpenAi extends Llm {
     return this.rawCompletion(null, callBack);
   }
 
+  /** With store:false the replayed input array IS the conversation. */
+  exportConversation() {
+    return { driver: 'openai', input: this.gpt.input };
+  }
+
+  importConversation(conversation) {
+    if (conversation?.driver !== 'openai' || !Array.isArray(conversation.input)) return false;
+    this.gpt.input = conversation.input;
+    return true;
+  }
+
   /**
    * Called by the TURN OWNER when a turn aborted between a completion that
    * returned function_call items and the callResult that would answer them:

--- a/lib/process-id.js
+++ b/lib/process-id.js
@@ -1,0 +1,18 @@
+/**
+ * Identity of THIS server process, for state that one process holds in memory
+ * on behalf of others (today: interactive chat sessions, `chat_sessions.owner`).
+ *
+ * The name is for humans reading a row: the pod name where Kubernetes sets one
+ * (POD_NAME via the downward API, else HOSTNAME, which Kubernetes also sets to
+ * the pod name), else the machine's hostname. The pid and the random suffix are
+ * what make it unique: a pod that restarts keeps its name, and a process must
+ * never mistake the previous incarnation's rows for its own.
+ */
+import os from 'node:os';
+import { randomBytes } from 'node:crypto';
+
+const name = process.env.POD_NAME || process.env.HOSTNAME || os.hostname();
+
+export const PROCESS_ID = `${name}:${process.pid}:${randomBytes(4).toString('hex')}`;
+
+export default PROCESS_ID;

--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -1,11 +1,27 @@
 /**
  * Interactive, turn-by-turn chat sessions for `text` type agents.
  *
- * Unlike a voice listener there is no audio leg, no telephony and nothing worth
- * persisting, so a chat session is held in memory (not as a DB `Instance`) and
- * keyed by a generated id. The flow mirrors `listen`: a caller creates a session
- * and gets back a websocket path (`/chat/<id>`); the ws upgrade in
- * `ws-handler.js` looks the session up here and hands it the socket.
+ * A session is a `chat_sessions` row that exactly ONE server process holds in
+ * memory at a time. POST /agents/{id}/chat opens the row (unowned, carrying the
+ * seed) and returns the websocket path (`/chat/<id>`). The upgrade may reach
+ * any process: the one that gets it claims the row (`owner` = this process,
+ * lib/process-id.js), builds the driver and runs the conversation. At every
+ * turn boundary the owner writes a snapshot to the row (the driver's replayable
+ * conversation, a paused ask, buffered frames, the set in hand), and every
+ * write it makes is conditional on still being the owner.
+ *
+ * A reconnect that lands on another process claims the row from here: if the
+ * holder is alive it is asked over LISTEN/NOTIFY to let go at its next turn
+ * boundary, and then the new process rehydrates the driver from the snapshot,
+ * so the conversation continues where it was, at prompt-cache prices, instead
+ * of re-paying the whole opening seed. A holder that died (stale heartbeat) or
+ * never answers has the row taken from it; its own next write tells it so and
+ * it drops the session locally. On shutdown a process releases everything it
+ * holds, so a rolling deploy hands sessions over rather than losing them.
+ *
+ * The live resources (driver, standing MCP connections, the socket) are what
+ * cannot cross processes, which is why ownership MOVES rather than being
+ * shared: they are rebuilt on the claiming side and closed on the releasing one.
  *
  * Each user message drives the same LLM/tool loop the headless subagent uses
  * (`llm.completion` → dispatch tools via `functionHandler` → `llm.callResult`),
@@ -21,16 +37,33 @@ import { llmFunctions, runSubagentById } from './subagent.js';
 import { createAgentSetForAgent, updateAgentSetForAgent, patchAgentSetForAgent } from './agent-set-service.js';
 import { maskToolResultIds } from './mask-ids.js';
 import { recordLlmTokens, recordSubagentUsage, finaliseSession } from './usage.js';
-import { ChatSession } from './database.js';
+import { Op } from 'sequelize';
+import { ChatSession, Agent, databaseStarted, pgNotify, pgListen, pgUnlisten } from './database.js';
+import { PROCESS_ID } from './process-id.js';
+import { isBuiltinAgentId, getBuiltinAgent } from './builtin-agents.js';
 
 // Persisted transcripts are capped: keep the newest entries (with an elision
 // marker) so a marathon session can't grow a row without bound.
 const TRANSCRIPT_MAX_ENTRIES = 500;
 
+// The sessions THIS process holds (chat_sessions.owner = PROCESS_ID). A cache
+// of live objects for rows this process owns, never a registry of every
+// session there is: a session missing here may well be alive on another
+// process, and attachChatSession finds out from the row.
 const sessions = new Map();
-// A session is created when the chat is opened and consumed when the client's
-// websocket connects shortly after; expire it if that never happens.
-const PENDING_TTL_MS = Number(process.env.TEXT_CHAT_PENDING_TTL_MS || 120000);
+// The channel other processes use to ask this one for a session it holds.
+const CHAT_CONTROL_CHANNEL = 'chat_control';
+// How long a claim waits for a live holder to hand a session over before
+// taking it. A holder at rest answers within milliseconds; one that has not
+// answered by now is treated as gone. A holder mid-turn says so, and the wait
+// stretches to the busy bound so the turn can finish and its reply is kept.
+const HANDOFF_WAIT_MS = Number(process.env.TEXT_CHAT_HANDOFF_WAIT_MS || 5000);
+const HANDOFF_BUSY_WAIT_MS = Number(process.env.TEXT_CHAT_HANDOFF_BUSY_WAIT_MS || 90 * 1000);
+const HANDOFF_POLL_MS = 100;
+// Ceiling on the per-turn snapshot. Over it, the conversation is left out and
+// a process taking the session over resumes from the transcript instead.
+const STATE_MAX_BYTES = Number(process.env.TEXT_CHAT_STATE_MAX_BYTES || 4 * 1024 * 1024);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 // Hard ceiling on tool round-trips within a single user turn.
 const MAX_TOOL_HOPS = Number(process.env.TEXT_CHAT_MAX_TOOL_HOPS || 16);
 // After the websocket drops, the session (and its whole LLM conversation)
@@ -112,6 +145,11 @@ export async function reapStaleChatSessions({ graceMs = LIVENESS_GRACE_MS, log =
     );
     const closed = result?.[1]?.rowCount ?? 0;
     if (closed) log.info({ closed }, 'closed chat sessions no process still holds');
+    // A tenant text agent's row exists only while its session lives (see
+    // openChatSession). The owner deletes it at teardown; this catches the
+    // ones an owner never got to.
+    const gone = await ChatSession.destroy({ where: { ephemeral: true, endedAt: { [Op.ne]: null } } });
+    if (gone) log.info({ gone }, 'removed ended ephemeral chat session rows');
     return closed;
   } catch (err) {
     log.error(err, 'reapStaleChatSessions failed');
@@ -135,6 +173,7 @@ export function startChatSessionReaper({ intervalMs = LIVENESS_GRACE_MS, log = d
   return () => clearInterval(timer);
 }
 
+/** The session `id` if THIS process holds it; undefined otherwise (see attachChatSession). */
 export function getChatSession(id) {
   return sessions.get(id);
 }
@@ -176,20 +215,317 @@ export function sanitizeHistory(history) {
   return kept;
 }
 
+let llmFactory = null;
 /**
- * Create a chat session for a text agent (a DB row or an in-memory definition)
- * and register it. Returns the session; read `session.id` / `/chat/${id}` for
- * the websocket path.
+ * Replace how sessions build their driver. For tests, which cannot call a
+ * provider: the factory receives the session and returns a driver honouring
+ * the lib/models/llm.js contract (rawCompletion, callResult, export/import
+ * Conversation, abandonTurn, close). null restores the real drivers.
  */
-export function createChatSession({ agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger = defaultLogger }) {
+export function setChatLlmFactory(factory) {
+  llmFactory = factory;
+}
+
+/**
+ * Builder sessions are kept as history; every other text agent's conversation
+ * is a tenant's own end-user data and must not be silently retained. The
+ * builder is the builtin, or an org row polite-ai pushes (courtesy marker in
+ * the description: polite-ai resolves builders by id, but for retention
+ * gating the marker plus the builtin id cover the intended scope).
+ */
+export function isBuilderAgent(agent) {
+  return agent?.id === 'builtin:set-builder'
+    || String(agent?.description || '').includes('[polite:agent-builder]');
+}
+
+/**
+ * Open a chat session for a text agent: write its row, unowned, carrying the
+ * seed. Nothing is built here. The process that receives the websocket
+ * upgrade for `/chat/<id>` claims the row and builds the session there, so
+ * the opener and the socket need not share a process.
+ * @returns {Promise<{id: string}>}
+ */
+export async function openChatSession({ agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger = defaultLogger }) {
   const id = crypto.randomUUID();
-  const session = new TextChatSession({ id, agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger });
-  sessions.set(id, session);
-  session.expiry = setTimeout(() => {
-    if (!session.connected) sessions.delete(id);
-  }, PENDING_TTL_MS);
-  if (session.expiry.unref) session.expiry.unref();
+  const ephemeral = !isBuilderAgent(agent);
+  const seedHistory = sanitizeHistory(history);
+  const now = new Date();
+  await ChatSession.create({
+    id,
+    agentId: agent.id ?? null,
+    organisationId: agent.organisationId ?? null,
+    userId: agent.userId ?? null,
+    // UUID columns: a junk value would fail the INSERT and take the session
+    // with it, so both are gated.
+    setId: typeof set?.id === 'string' && UUID_RE.test(set.id) ? set.id : null,
+    resumedFrom: typeof resumedFrom === 'string' && UUID_RE.test(resumedFrom) ? resumedFrom : null,
+    mode: testResult ? 'troubleshoot' : set ? 'edit' : 'new',
+    title: set?.name ?? null,
+    modelName: agent.modelName ?? null,
+    startedAt: now,
+    lastSeenAt: now,
+    ephemeral,
+    owner: null,
+    // A resumed session's durable record starts with a marker rather than a
+    // copy of the seed history: the predecessor row already holds that
+    // conversation, and `resumedFrom` is the join.
+    transcript: ephemeral
+      ? null
+      : (seedHistory
+        ? [{ role: 'system', text: '[resumed an interrupted earlier session — its transcript continues here]', at: now.toISOString() }]
+        : []),
+    state: {
+      v: 1,
+      everConnected: false,
+      headless: !!headless,
+      seed: {
+        set: set ?? null,
+        testResult: testResult ?? null,
+        subjectAgent: subjectAgent ?? null,
+        knowledge: typeof knowledge === 'string' && knowledge.trim() ? knowledge : null,
+        history: seedHistory,
+      },
+    },
+  });
+  logger.debug({ id, agentId: agent.id, ephemeral }, 'chat session opened');
+  return { id };
+}
+
+/**
+ * Open a session AND hold it on this process at once, with the agent given
+ * (no re-resolution from the row). For single-process callers and tests; the
+ * API path opens with {@link openChatSession} and lets the upgrade claim.
+ * @returns {Promise<TextChatSession>}
+ */
+export async function createChatSession(opts) {
+  const { id } = await openChatSession(opts);
+  const session = await claimChatSession(id, { logger: opts.logger || defaultLogger, agent: opts.agent });
+  if (!session) throw new Error(`chat session ${id} could not be held by this process`);
   return session;
+}
+
+/**
+ * Is there a session to attach to? True when this process holds it, or its
+ * row is still open (it is claimed on attach). The upgrade path answers 404
+ * on false, so a client probing a lapsed session fails over at once.
+ */
+export async function probeChatSession(id) {
+  if (!id || !UUID_RE.test(id)) return false;
+  if (sessions.has(id)) return true;
+  const row = await ChatSession.findByPk(id, { attributes: ['id', 'endedAt'] });
+  return !!row && !row.endedAt;
+}
+
+/**
+ * Attach a websocket to session `id` on THIS process, claiming the session
+ * first when another process holds it, or nobody does. Resolves when the
+ * attach sequence has run (for a fresh session, after its opening turn).
+ */
+export async function attachChatSession(id, ws, { logger = defaultLogger } = {}) {
+  const local = sessions.get(id);
+  if (local) return local.handleChat(ws);
+  // Frames the client sends before the claim completes are kept for the
+  // session's own handler, and the socket is kept alive meanwhile.
+  const buffered = [];
+  const buffer = (data) => buffered.push(data);
+  ws.on('message', buffer);
+  const keepalive = setInterval(() => { try { ws.ping(); } catch { /* dying socket */ } }, 25000);
+  if (keepalive.unref) keepalive.unref();
+  try {
+    const session = await claimChatSession(id, {
+      logger,
+      // A live holder elsewhere means a wait. polite-ai's client gives a
+      // re-attach five seconds to prove itself with an `attached` frame, so
+      // say so now (busy, pending the real state) and let the session's own
+      // `attached` correct the indicator once it is here.
+      onWaiting: () => {
+        try { ws.send(JSON.stringify({ type: 'attached', resumed: true, busy: true })); } catch { /* dying socket */ }
+      },
+    });
+    ws.off('message', buffer);
+    if (!session) {
+      try { ws.send(JSON.stringify({ type: 'error', code: 'not_found', message: 'This session has ended.' })); } catch { /* dying socket */ }
+      try { ws.close(); } catch { /* dying socket */ }
+      return undefined;
+    }
+    if (ws.readyState !== ws.OPEN) {
+      // The client gave up during the claim. The session is ours now; hold
+      // it for the re-attach grace like any other dropped socket.
+      session.armGrace();
+      return undefined;
+    }
+    const attached = session.handleChat(ws);
+    for (const data of buffered) ws.emit('message', data);
+    return attached;
+  } finally {
+    clearInterval(keepalive);
+  }
+}
+
+// One claim per id per process: two sockets for the same session arriving
+// together share the claim, and the second attaches to what the first built.
+const claims = new Map();
+// Claims waiting on a live holder, so a `busy` answer can stretch their wait.
+const handoffWaiters = new Map();
+const sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+async function claimChatSession(id, opts) {
+  if (claims.has(id)) {
+    await claims.get(id).catch(() => {});
+    return sessions.get(id) || null;
+  }
+  const claim = doClaim(id, opts).finally(() => claims.delete(id));
+  claims.set(id, claim);
+  return claim;
+}
+
+async function doClaim(id, { logger, onWaiting, agent: knownAgent = null }) {
+  let row = await ChatSession.findByPk(id);
+  if (!row || row.endedAt) return null;
+  let observed = row.owner || null;
+  let forced = false;
+  if (observed && observed !== PROCESS_ID && isChatSessionLive(row)) {
+    // Somebody alive holds it. Ask them to let go, then wait for the row to
+    // come free. A holder mid-turn answers `busy` and finishes the turn
+    // first, so the wait stretches; one that never answers is treated as
+    // gone when the wait runs out, and the row is taken from it.
+    onWaiting?.();
+    const waiter = { busyUntil: 0 };
+    handoffWaiters.set(id, waiter);
+    let deadline = Date.now() + HANDOFF_WAIT_MS;
+    try {
+      await pgNotify(CHAT_CONTROL_CHANNEL, { type: 'release', id, owner: observed, to: PROCESS_ID });
+      while (Date.now() < deadline) {
+        await sleep(HANDOFF_POLL_MS);
+        row = await ChatSession.findByPk(id);
+        if (!row || row.endedAt) return null;
+        if (!row.owner) break;
+        if (waiter.busyUntil > deadline) deadline = waiter.busyUntil;
+      }
+    } finally {
+      handoffWaiters.delete(id);
+    }
+    if (row.owner && row.owner !== observed) {
+      // Somebody else took it while we waited: theirs now, and a live
+      // holder at that. The client reconnects and asks them.
+      logger.info({ id, owner: row.owner }, 'chat session claim lost: another process took the session meanwhile');
+      return null;
+    }
+    if (row.owner) {
+      forced = true;
+      logger.warn({ id, owner: observed }, 'chat session holder did not release in time; taking the session');
+    } else {
+      observed = null;
+    }
+  }
+  // Take a free row, or the row of the holder observed above (stale, or
+  // unresponsive). Conditional, so two processes racing for one session
+  // cannot both win; the loser's client simply reconnects.
+  const [count, rows] = await ChatSession.update(
+    { owner: PROCESS_ID, lastSeenAt: new Date() },
+    {
+      where: {
+        id,
+        endedAt: null,
+        ...(observed ? { [Op.or]: [{ owner: null }, { owner: observed }] } : { owner: null }),
+      },
+      returning: true,
+    },
+  );
+  if (!count) {
+    logger.info({ id }, 'chat session claim lost to another process');
+    return null;
+  }
+  const fresh = rows[0];
+  const agent = knownAgent || await agentForRow(fresh, logger);
+  if (!agent) {
+    logger.warn({ id, agentId: fresh.agentId }, 'chat session agent no longer exists; ending the session');
+    await ChatSession.update({ owner: null, endedAt: new Date() }, { where: { id, owner: PROCESS_ID } }).catch(() => {});
+    return null;
+  }
+  const session = TextChatSession.fromRow(fresh, agent, logger);
+  sessions.set(id, session);
+  logger.info({ id, from: observed, forced, resumed: !!fresh.state?.everConnected }, 'chat session claimed');
+  return session;
+}
+
+/**
+ * The agent a row was opened for, resolved afresh: a builtin bound to the
+ * row's user and organisation (so its org-scoped tools act in the right
+ * org), or the stored agent. The opener's per-session model override lives on
+ * the row and is applied in memory only, exactly as the opener applied it.
+ */
+async function agentForRow(row, logger) {
+  let agent = null;
+  if (isBuiltinAgentId(row.agentId)) {
+    agent = getBuiltinAgent(row.agentId, { id: row.userId, organisationId: row.organisationId });
+  } else if (row.agentId) {
+    agent = await Agent.findByPk(row.agentId);
+    if (agent && row.organisationId && agent.organisationId && agent.organisationId !== row.organisationId) {
+      logger.warn({ id: row.id, agentId: row.agentId }, 'chat session row and agent disagree on organisation; refusing');
+      return null;
+    }
+  }
+  if (!agent) return null;
+  if (row.modelName) agent.modelName = row.modelName;
+  return agent;
+}
+
+let controlListening = null;
+
+/**
+ * Listen for other processes asking for sessions this one holds. Started by
+ * the SERVER only (index.mjs), like the reaper: a CLI tool must never take
+ * part in session ownership.
+ */
+export function startChatOwnershipListener({ log = defaultLogger } = {}) {
+  if (!controlListening) {
+    controlListening = databaseStarted
+      .then(() => pgListen(CHAT_CONTROL_CHANNEL, (payload) => onControlMessage(payload, log)))
+      .catch((err) => {
+        controlListening = null;
+        log.error(err, 'chat ownership listener failed to start');
+      });
+  }
+  return controlListening;
+}
+
+export async function stopChatOwnershipListener() {
+  controlListening = null;
+  await pgUnlisten(CHAT_CONTROL_CHANNEL);
+}
+
+function onControlMessage(payload, log) {
+  if (!payload || typeof payload !== 'object') return;
+  if (payload.type === 'release' && payload.owner === PROCESS_ID) {
+    const session = sessions.get(payload.id);
+    if (session) {
+      session.requestRelease({ to: payload.to });
+    } else {
+      // The row names this process but nothing here holds it (the write that
+      // should have cleared it was lost): let it go.
+      ChatSession.update({ owner: null }, { where: { id: payload.id, owner: PROCESS_ID } })
+        .catch((err) => log.warn({ err: err?.message, id: payload.id }, 'could not free an unheld chat session row'));
+    }
+  } else if (payload.type === 'busy' && payload.to === PROCESS_ID) {
+    const waiter = handoffWaiters.get(payload.id);
+    if (waiter) waiter.busyUntil = Date.now() + HANDOFF_BUSY_WAIT_MS;
+  }
+}
+
+/**
+ * Hand every session this process holds back to the database, for another
+ * process to pick up. Run at shutdown: the clients whose sockets die with
+ * this process reconnect elsewhere and carry on.
+ * @returns {Promise<number>} sessions released
+ */
+export async function releaseAllChatSessions({ log = defaultLogger } = {}) {
+  const held = [...sessions.values()];
+  if (!held.length) return 0;
+  log.info({ count: held.length }, 'releasing chat sessions for other processes to pick up');
+  await Promise.all(held.map((session) => session.release({ force: true })
+    .catch((err) => log.warn({ err: err?.message, id: session.id }, 'chat session release failed'))));
+  return held.length;
 }
 
 function interactiveSystemPrompt(agent) {
@@ -201,7 +537,7 @@ function interactiveSystemPrompt(agent) {
 }
 
 class TextChatSession {
-  constructor({ id, agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, logger }) {
+  constructor({ id, agent, set, testResult, subjectAgent, knowledge, history, resumedFrom, headless, ephemeral = false, startedAt = null, logger }) {
     Object.assign(this, { id, agent, logger });
     // Headless caller (e.g. polite.ai's independent reviewer): drives the agent
     // programmatically over the socket, so SKIP the builder opening turn — the
@@ -212,7 +548,7 @@ class TextChatSession {
     // Billing anchor for this text session: the interaction start. Stamped on
     // every usage row (metadata.startedAt) so cost resolution has a billing
     // instant for rows that have no Call (Q-E). Fixed for the session's life.
-    this.startedAt = new Date();
+    this.startedAt = startedAt ? new Date(startedAt) : new Date();
     // Optional seed. `latestSet` is the set the builder is currently working on —
     // primed from an edit/diagnose seed here, then kept current by onToolResults.
     // It also lets `test_agent` resolve a member label to a real agent id.
@@ -246,6 +582,20 @@ class TextChatSession {
       ? agent.functions
       : Object.values(agent.functions || {});
     this.connected = false;
+    // The row exists from openChatSession on, and this process holds it for
+    // as long as `sessions` has it (chat_sessions.owner says so).
+    this.persisted = true;
+    // A tenant text agent's conversation is not history: its row is deleted
+    // when the session ends (see openChatSession).
+    this.ephemeral = !!ephemeral;
+    this.transcript = this.ephemeral
+      ? null
+      : (this.seedHistory
+        ? [{ role: 'system', text: '[resumed an interrupted earlier session — its transcript continues here]', at: this.startedAt.toISOString() }]
+        : []);
+    // Kept in the snapshot until the opening turn has run, so a process that
+    // claims the row before then can still open the session properly.
+    this.seed = { set: set ?? null, testResult: testResult ?? null, subjectAgent: subjectAgent ?? null, knowledge: this.seedKnowledge, history: this.seedHistory };
     // Tool invokers, scoped to this agent's organisation.
     this.functionOptions = {
       invokeSubagent: (targetId, args, md) => runSubagentById({
@@ -304,14 +654,16 @@ class TextChatSession {
     this.ws = ws;
     this.connected = true;
     this.everConnected = true;
-    clearTimeout(this.expiry);
     clearTimeout(this.graceTimer);
     if (!this.send) {
-      this.outbox = [];
+      // A session claimed from another process arrives with that process's
+      // outbox already in place.
+      this.outbox = this.outbox || [];
       // One canonical sender for the session's lifetime: every turn closure
       // routes through it, so output from a turn that spans a reconnect lands
       // on the CURRENT socket (or the outbox) instead of a dead one.
       this.send = (msg) => {
+        if (this.released) return; // the conversation continues on another process
         if (!this.connected || !this.ws || this.ws.readyState !== this.ws.OPEN) {
           this.outbox.push(msg);
           if (this.outbox.length > OUTBOX_CAP) this.outbox.shift();
@@ -363,14 +715,29 @@ class TextChatSession {
       clearInterval(heartbeat); // superseded sockets clear their own timer too
       if (this.ws !== ws) return; // superseded by a newer socket
       this.connected = false;
-      this.graceTimer = setTimeout(() => this.teardown(), REATTACH_GRACE_MS);
-      if (this.graceTimer.unref) this.graceTimer.unref();
+      this.armGrace();
     });
     ws.on('error', (e) => this.logger.error(e, 'chat ws error'));
 
-    if (firstAttach) {
-      try {
+    if (!this.llm) {
+      // First attach on THIS process: the opener's, or one that has just
+      // claimed the row from another. Build the driver, then hand it the
+      // conversation the previous holder left in the row, if there is one.
+      this.initialising = (async () => {
         await this.buildLlm();
+        if (this.restoredConversation) {
+          const taken = !!this.llm.importConversation?.(this.restoredConversation);
+          if (!taken) {
+            // The driver keeps no replayable history (or the snapshot had to
+            // leave it out): the best it can do is read the transcript.
+            this.resumeFromTranscript = true;
+            this.logger.warn({ id: this.id, model: this.agent.modelName }, 'chat conversation not importable; resuming from the transcript');
+          }
+          this.restoredConversation = null;
+        }
+      })();
+      try {
+        await this.initialising;
       } catch (e) {
         this.logger.error(e, 'chat agent init failed');
         send({ type: 'error', message: `Could not start agent: ${e.message}` });
@@ -379,50 +746,11 @@ class TextChatSession {
         // rather than leaving an llm-less zombie in the registry forever.
         this.teardown();
         return;
-      }
-      // Durable record of the session (best-effort — persistence must never
-      // block the chat): backs the builder's session-history API, and joins
-      // token usage on usage_records.session_id. ONLY builder sessions are
-      // persisted: this endpoint also serves a tenant's own text agents, and
-      // their end-user conversations must not be silently retained (there is
-      // no TTL or deletion surface yet). The builder is the builtin, or an
-      // org row polite-ai pushes (courtesy marker in the description — the
-      // polite-ai dashboard resolves builders by id, but for retention gating
-      // the marker + builtin id cover the intended scope).
-      const isBuilder =
-        this.agent.id === 'builtin:set-builder' ||
-        String(this.agent.description || '').includes('[polite:agent-builder]');
-      // A resumed session's durable record starts with a marker rather than
-      // a copy of the seed history — the predecessor row already holds that
-      // conversation, and `resumedFrom` is the join.
-      this.transcript = isBuilder
-        ? (this.seedHistory
-          ? [{ role: 'system', text: '[resumed an interrupted earlier session — its transcript continues here]', at: new Date().toISOString() }]
-          : [])
-        : null;
-      if (isBuilder) {
-        try {
-          await ChatSession.create({
-            id: this.id,
-            agentId: this.agent.id ?? null,
-            organisationId: this.agent.organisationId ?? null,
-            userId: this.agent.userId ?? null,
-            setId: this.latestSet?.id ?? null,
-            mode: this.seedTestResult ? 'troubleshoot' : this.latestSet ? 'edit' : 'new',
-            title: this.latestSet?.name ?? null,
-            modelName: this.agent.modelName ?? null,
-            startedAt: this.startedAt,
-            lastSeenAt: this.startedAt,
-            resumedFrom: this.resumedFrom,
-            transcript: this.transcript,
-          });
-          this.persisted = true;
-          this.startHeartbeat();
-        } catch (e) {
-          this.logger.error(e, 'chat session persist (create) failed — history disabled for this session');
-        }
+      } finally {
+        this.initialising = null;
       }
     }
+    this.startHeartbeat();
 
     // `busy` lets a re-attaching client restore its thinking indicator when a
     // turn is still running from before the drop.
@@ -438,6 +766,25 @@ class TextChatSession {
       // A paused interactive ask was emitted to the old socket — re-emit it so
       // the restored UI shows the question/test card again.
       if (this.pending?.frame) send(this.pending.frame);
+      if (this.resumeFromTranscript) {
+        // Taken over from another process without a replayable conversation:
+        // the same resume the client performs after a lost session, done here.
+        this.resumeFromTranscript = false;
+        const history = sanitizeHistory((this.transcript || []).map(({ role, text }) => ({ role, text })));
+        if (history) {
+          this.seedHistory = history;
+          await this.turn(this.resumePrompt(), send, true);
+        }
+        this.opened = true;
+      } else if (this.continueOpening) {
+        // Taken over while the previous holder's opening turn was in flight:
+        // the opening prompt is in the conversation, unanswered. Let the model
+        // answer it here.
+        this.continueOpening = false;
+        await this.turn(null, send, true);
+        this.opened = true;
+        this.persistTurn();
+      }
       return;
     }
 
@@ -445,7 +792,11 @@ class TextChatSession {
     // message itself (e.g. the independent reviewer's task). Auto-running the
     // build/edit/diagnose greeting here would poison a non-builder agent's
     // context and waste a turn.
-    if (this.headless) return;
+    if (this.headless) {
+      this.opened = true;
+      this.persistTurn(); // the row learns the session has been attached
+      return;
+    }
 
     // Open with a hidden turn whose prompt depends on how the session was seeded
     // (build from scratch / edit an existing set / diagnose a test result — or
@@ -454,6 +805,9 @@ class TextChatSession {
     const base = this.seedHistory ? this.resumePrompt() : this.openingPrompt();
     const opening = this.seedKnowledge ? `${base}\n\n${this.seedKnowledge}` : base;
     await this.turn(opening, send, true);
+    // The seed has done its work; the row can stop carrying it.
+    this.opened = true;
+    this.persistTurn();
   }
 
   /**
@@ -482,7 +836,9 @@ class TextChatSession {
   startHeartbeat() {
     if (this.heartbeat || !this.persisted) return;
     this.heartbeat = setInterval(() => {
-      ChatSession.update({ lastSeenAt: new Date() }, { where: { id: this.id } })
+      if (this.released || this.torndown) return;
+      ChatSession.update({ lastSeenAt: new Date() }, { where: { id: this.id, owner: PROCESS_ID } })
+        .then(([count]) => { if (!count) this.lostOwnership('heartbeat'); })
         .catch((e) => this.logger.debug(e, 'chat session heartbeat failed'));
     }, HEARTBEAT_MS);
     if (this.heartbeat.unref) this.heartbeat.unref();
@@ -501,22 +857,207 @@ class TextChatSession {
     // the close would leave a row that is both ended and freshly seen, and the
     // reaper would have nothing to correct because it only looks at open rows.
     this.stopHeartbeat();
+    clearTimeout(this.graceTimer);
     // Bridged drivers hold standing MCP connections — release them or every
     // session leaks a socket per server for the process lifetime.
     Promise.resolve(this.llm?.close?.()).catch(() => {});
+    sessions.delete(this.id);
+    if (this.released) return; // another process holds the conversation; nothing here to end
     this.finaliseUsage();
-    if (this.persisted) {
-      ChatSession.update(
+    if (!this.persisted) return;
+    // Conditional on ownership, like every write: a row another process has
+    // since taken over is that process's to end.
+    const where = { id: this.id, owner: PROCESS_ID };
+    const done = this.ephemeral
+      // Not history: the row only ever existed so the live session could
+      // move between processes.
+      ? ChatSession.destroy({ where })
+      : ChatSession.update(
         {
           endedAt: new Date(),
           lastSeenAt: new Date(),
           transcript: this.transcript,
           turns: this.turnsCount || 0,
+          // The snapshot exists for a handover, and there is nothing left to hand over.
+          state: null,
+          owner: null,
         },
-        { where: { id: this.id } },
-      ).catch((e) => this.logger.error(e, 'chat session persist (end) failed'));
+        { where },
+      ).then(([count]) => count);
+    done
+      .then((count) => { if (!count) this.logger.warn({ id: this.id }, 'chat session end: the row was not held by this process'); })
+      .catch((e) => this.logger.error(e, 'chat session persist (end) failed'));
+  }
+
+  /** Start (or restart) the re-attach grace: the socket is gone, the session waits. */
+  armGrace() {
+    clearTimeout(this.graceTimer);
+    this.graceTimer = setTimeout(() => this.teardown(), REATTACH_GRACE_MS);
+    if (this.graceTimer.unref) this.graceTimer.unref();
+  }
+
+  /**
+   * Everything another process needs to carry this session on: the driver's
+   * replayable conversation, a paused ask, frames not yet delivered, the set
+   * in hand, and (until the opening turn has run) the seed.
+   */
+  snapshotState() {
+    let conversation = null;
+    try {
+      conversation = this.llm?.exportConversation?.() ?? null;
+    } catch (err) {
+      this.logger.warn({ err: err?.message, id: this.id }, 'chat conversation export failed; the snapshot has no conversation');
     }
+    const pendingFrame = this.pending?.frame;
+    const state = {
+      v: 1,
+      everConnected: !!this.everConnected,
+      headless: this.headless,
+      turnsCount: this.turnsCount || 0,
+      conversation,
+      pending: this.pending || null,
+      // The pause frame is re-sent from `pending` on attach, so it is left out
+      // of the outbox here: the identity check the flush relies on does not
+      // survive a round trip through JSON.
+      outbox: (this.outbox || []).filter((m) => m !== pendingFrame),
+      latestSet: this.latestSet || null,
+      opened: !!this.opened,
+      seed: this.opened ? null : this.seed,
+    };
+    if (conversation && JSON.stringify(state).length > STATE_MAX_BYTES) {
+      this.logger.warn({ id: this.id }, 'chat conversation snapshot is over the size cap; a process taking over would resume from the transcript');
+      state.conversation = null;
+    }
+    return state;
+  }
+
+  /** The row fields the holder refreshes at every turn boundary. */
+  rowValues() {
+    return {
+      transcript: this.transcript,
+      turns: this.turnsCount || 0,
+      // A new-team session gains its set at the first save; keep the row
+      // pointing at the latest identity the canvas is showing.
+      setId: typeof this.latestSet?.id === 'string' && UUID_RE.test(this.latestSet.id) ? this.latestSet.id : null,
+      title: this.latestSet?.name ?? null,
+      state: this.snapshotState(),
+    };
+  }
+
+  /**
+   * Another process wants this session (a client reconnected there). Let go
+   * at the next turn boundary; mid-turn, tell them so they wait for it.
+   */
+  requestRelease({ to } = {}) {
+    if (this.released || this.torndown) return;
+    if (this.busy || this.initialising) {
+      this.releaseRequested = true;
+      if (to) {
+        pgNotify(CHAT_CONTROL_CHANNEL, { type: 'busy', id: this.id, to })
+          .catch((err) => this.logger.debug({ err: err?.message }, 'busy notify failed'));
+      }
+      return;
+    }
+    this.release().catch((err) => this.logger.error(err, 'chat session release failed'));
+  }
+
+  /**
+   * Hand the session back to the database for another process to claim: the
+   * final snapshot goes into the row and the owner is cleared, in one write
+   * conditional on still being the owner. Local resources go with it. The
+   * conversation itself is not ended, so usage is not finalised here.
+   * `force` releases mid-turn (process shutdown): the in-flight turn's reply
+   * is lost, which beats losing the whole conversation with the process.
+   */
+  async release({ force = false } = {}) {
+    if (this.released || this.torndown) return;
+    if (!force && (this.busy || this.initialising)) {
+      this.releaseRequested = true;
+      return;
+    }
+    this.released = true;
+    this.releaseRequested = false;
+    this.stopHeartbeat();
+    clearTimeout(this.graceTimer);
+    try {
+      const [count] = await ChatSession.update(
+        { ...this.rowValues(), owner: null, lastSeenAt: new Date() },
+        { where: { id: this.id, owner: PROCESS_ID } },
+      );
+      if (count) this.logger.info({ id: this.id }, 'chat session released');
+      else this.logger.warn({ id: this.id }, 'chat session release: this process was no longer the holder');
+    } catch (err) {
+      this.logger.error(err, 'chat session release write failed');
+    }
+    this.detachLocal();
+  }
+
+  /** A conditional write found another holder on the row: drop the session here, ending nothing. */
+  lostOwnership(where) {
+    if (this.released || this.torndown) return;
+    this.logger.warn({ id: this.id, where }, 'chat session is now held by another process; dropping it here');
+    this.released = true;
+    this.stopHeartbeat();
+    clearTimeout(this.graceTimer);
+    this.detachLocal();
+  }
+
+  /** Free everything this process holds for the session, without touching the row. */
+  detachLocal() {
+    this.torndown = true;
+    if (this.ws && this.ws.readyState === this.ws.OPEN) {
+      // `code` lets the client tell a handover from an ordinary drop: it must
+      // NOT auto-reconnect (that would pull the session straight back).
+      try { this.ws.send(JSON.stringify({ type: 'error', code: 'superseded', message: 'This session was reconnected elsewhere.' })); } catch { /* dead socket */ }
+      try { this.ws.close(); } catch { /* dead socket */ }
+    }
+    this.connected = false;
+    Promise.resolve(this.llm?.close?.()).catch(() => {});
     sessions.delete(this.id);
+  }
+
+  /**
+   * Rebuild a session from its row on the process that has just claimed it.
+   * Before the first attach the row carries the seed and this is an ordinary
+   * opening; after it, the snapshot's conversation is handed to the driver
+   * in handleChat and the attach is a resume.
+   */
+  static fromRow(row, agent, logger) {
+    const state = row.state || {};
+    const seed = state.seed || {};
+    const session = new TextChatSession({
+      id: row.id,
+      agent,
+      logger,
+      set: seed.set,
+      testResult: seed.testResult,
+      subjectAgent: seed.subjectAgent,
+      knowledge: seed.knowledge,
+      history: seed.history,
+      resumedFrom: row.resumedFrom,
+      headless: state.headless,
+      ephemeral: row.ephemeral,
+      startedAt: row.startedAt,
+    });
+    if (!row.ephemeral && Array.isArray(row.transcript)) session.transcript = row.transcript;
+    // A row attached before but with neither a conversation nor a completed
+    // opening turn has nothing to continue: open it afresh, seed and all.
+    if (state.everConnected && (state.conversation || state.opened)) {
+      session.everConnected = true;
+      session.opened = !!state.opened;
+      session.turnsCount = state.turnsCount || 0;
+      session.pending = state.pending || null;
+      session.outbox = Array.isArray(state.outbox) ? state.outbox : [];
+      if (state.latestSet) session.latestSet = state.latestSet;
+      session.restoredConversation = state.conversation || null;
+      // No conversation to replay (driver without one, or dropped for size):
+      // resume from the transcript on attach.
+      session.resumeFromTranscript = !state.conversation;
+      // The opening turn was in flight on the previous holder: its prompt is
+      // in the conversation and still unanswered.
+      session.continueOpening = !!state.conversation && !state.opened && !state.headless;
+    }
+    return session;
   }
 
   // The leg-by-leg analysis guidance shared by the opening troubleshoot seed
@@ -672,6 +1213,10 @@ class TextChatSession {
   }
 
   async buildLlm() {
+    if (llmFactory) {
+      this.llm = await llmFactory(this);
+      return;
+    }
     const { getHandler } = await handlers();
     const Handler = getHandler(this.agent.modelName);
     if (!Handler) throw new Error(`Unknown model name: ${this.agent.modelName}`);
@@ -718,6 +1263,7 @@ class TextChatSession {
   }
 
   async runTurn(userText, send, hidden = false, claimed = null) {
+    if (this.released || this.torndown) return; // the conversation continues on another process
     this.busy = true;
     if (!hidden) {
       this.turnsCount = (this.turnsCount || 0) + 1;
@@ -893,7 +1439,13 @@ class TextChatSession {
       this.queuedTurns = Math.max(0, (this.queuedTurns || 1) - 1);
       this.busy = false;
       send({ type: 'turn_complete' });
-      this.persistTurn(); // fire-and-forget — history must never block the chat
+      if (this.releaseRequested) {
+        // Another process asked for this session mid-turn. The turn is done,
+        // so the handover snapshot IS this turn's persist.
+        this.release().catch((e) => this.logger.error(e, 'chat session release failed'));
+      } else {
+        this.persistTurn(); // fire-and-forget — history must never block the chat
+      }
     }
   }
 
@@ -911,23 +1463,25 @@ class TextChatSession {
     }
   }
 
-  /** Best-effort per-turn flush of the durable session record. */
+  /**
+   * Best-effort per-turn flush of the row: transcript, and the snapshot
+   * another process would need to carry the session on. Conditional on
+   * ownership; a row that has moved tells this process to let go.
+   */
   persistTurn() {
-    if (!this.persisted) return;
-    ChatSession.update(
+    if (!this.persisted || this.released || this.torndown) return Promise.resolve();
+    this.lastPersist = ChatSession.update(
       {
-        transcript: this.transcript,
-        turns: this.turnsCount || 0,
+        ...this.rowValues(),
         // A turn is proof this process still holds the session, so it counts
         // as a heartbeat. The ticker only has to cover the quiet stretches.
         lastSeenAt: new Date(),
-        // A new-team session gains its set at the first save; keep the row
-        // pointing at the latest identity the canvas is showing.
-        setId: this.latestSet?.id ?? null,
-        title: this.latestSet?.name ?? null,
       },
-      { where: { id: this.id } },
-    ).catch((e) => this.logger.error(e, 'chat session persist (update) failed'));
+      { where: { id: this.id, owner: PROCESS_ID } },
+    )
+      .then(([count]) => { if (!count) this.lostOwnership('persist'); })
+      .catch((e) => this.logger.error(e, 'chat session persist (update) failed'));
+    return this.lastPersist;
   }
 
   /**

--- a/lib/ws-handler.js
+++ b/lib/ws-handler.js
@@ -25,17 +25,26 @@ const handleUpgrade = async ({ req, socket, head, logger, restrict }) => {
   const [, type, id] = [...url.path.matchAll(/\/(progress|audio|chat)\/([0-9a-zA-Z-]*)$/g)][0] || [];
   logger.debug({ url, type, id }, `WS request received for ${url.path}`);
 
-  // Text-agent chat sessions live in memory (no DB Instance) and are resolved
-  // straight from the chat registry; voice progress/audio resolve via Instance.
+  // Text-agent chat sessions are rows in chat_sessions that ONE process holds
+  // in memory at a time. The upgrade may land on any process: if this one
+  // holds the session it attaches directly, otherwise it claims the row (from
+  // nobody, from a dead process, or by asking the live owner to hand it over)
+  // and carries the conversation on from the state the row holds. Voice
+  // progress/audio resolve via Instance.
   if (type === 'chat') {
     // Imported lazily: text-chat pulls in the DB layer, and ws-handler is
     // imported by index.mjs *before* dotenv.config() runs — a static import
     // would evaluate database.js (which connects at import) before .env loads.
-    const { getChatSession } = await import('./text-chat.js');
-    const session = id && getChatSession(id);
-    if (session && (!restrict || restrict === 'chat')) {
+    const { probeChatSession, attachChatSession } = await import('./text-chat.js');
+    const found = id && await probeChatSession(id);
+    if (found && (!restrict || restrict === 'chat')) {
       const wss = new WebSocketServer({ noServer: true });
-      wss.on('connection', (ws) => session.handleChat(ws));
+      wss.on('connection', (ws) => {
+        attachChatSession(id, ws, { logger }).catch((err) => {
+          logger.error({ err, id }, 'chat attach failed');
+          try { ws.close(); } catch { /* already gone */ }
+        });
+      });
       wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req));
     } else {
       // Refuse the upgrade OUTRIGHT: leaving it unanswered parks the browser

--- a/tests/agent-chat-model-override.test.mjs
+++ b/tests/agent-chat-model-override.test.mjs
@@ -1,7 +1,8 @@
 // POST /agents/{agentId}/chat `model` override: a per-SESSION model choice
 // (e.g. a user's builder-model preference) validated against the text
 // catalogue and the caller's model allow-list, then applied in-memory to the
-// resolved agent so the LLM build and the persisted session both reflect it.
+// resolved agent and recorded on the session row, which is what the process
+// that later receives the websocket builds the LLM from.
 import { setupRealDatabase, teardownRealDatabase } from './setup/database-test-wrapper.js';
 
 // Provider keys must exist BEFORE the endpoint (and its driver imports)
@@ -16,8 +17,7 @@ process.env.OPENROUTER_KEY ||= 'test-key';
 import { randomUUID } from 'node:crypto';
 
 const chatModule = (await import('../api/paths/agents/{agentId}/chat.js')).default;
-const { getChatSession } = await import('../lib/text-chat.js');
-const { Agent, Organisation } = await import('../lib/database.js');
+const { Agent, Organisation, ChatSession } = await import('../lib/database.js');
 
 const mockLogger = {
   info() {}, warn() {}, error() {}, debug() {},
@@ -87,9 +87,10 @@ describe('POST /agents/{agentId}/chat model override', () => {
     }), res);
     expect(res._status).toBeNull(); // 200 via plain send
     expect(res._body.id).toBeDefined();
-    const session = getChatSession(res._body.id);
-    expect(session.agent.modelName).toBe('text:kimi/kimi-k2.6');
-    session.teardown();
+    const sessionRow = await ChatSession.findByPk(res._body.id);
+    expect(sessionRow.modelName).toBe('text:kimi/kimi-k2.6');
+    expect(sessionRow.owner).toBeNull(); // nothing built until a socket arrives
+    await ChatSession.destroy({ where: { id: sessionRow.id } });
   });
 
   test('no model key leaves the builder default untouched', async () => {
@@ -100,9 +101,9 @@ describe('POST /agents/{agentId}/chat model override', () => {
       body: {},
     }), res);
     expect(res._body.id).toBeDefined();
-    const session = getChatSession(res._body.id);
-    expect(session.agent.modelName).toBe(SET_BUILDER_MODEL);
-    session.teardown();
+    const sessionRow = await ChatSession.findByPk(res._body.id);
+    expect(sessionRow.modelName).toBe(SET_BUILDER_MODEL);
+    await ChatSession.destroy({ where: { id: sessionRow.id } });
   });
 
   test('a stored (DB-row) agent takes the override in-memory and the ROW is never saved', async () => {
@@ -122,10 +123,10 @@ describe('POST /agents/{agentId}/chat model override', () => {
         body: { model: 'text:kimi/kimi-k2.6' },
       }), res);
       expect(res._body.id).toBeDefined();
-      const session = getChatSession(res._body.id);
+      const sessionRow = await ChatSession.findByPk(res._body.id);
       // The session runs the override…
-      expect(session.agent.modelName).toBe('text:kimi/kimi-k2.6');
-      session.teardown();
+      expect(sessionRow.modelName).toBe('text:kimi/kimi-k2.6');
+      await ChatSession.destroy({ where: { id: sessionRow.id } });
       // …but the stored definition is untouched (the mutation is in-memory only).
       const reloaded = await Agent.findByPk(row.id);
       expect(reloaded.modelName).toBe('text:anthropic/claude-sonnet-5');

--- a/tests/agent-model-entitlement.test.mjs
+++ b/tests/agent-model-entitlement.test.mjs
@@ -14,9 +14,8 @@ process.env.OPENROUTER_KEY ||= 'test-key';
 const chatModule = (await import('../api/paths/agents/{agentId}/chat.js')).default;
 const invokeModule = (await import('../api/paths/agents/{agentId}/invoke.js')).default;
 const subagentModule = (await import('../api/paths/agent-db/subagent.js')).default;
-const { getChatSession } = await import('../lib/text-chat.js');
 const { runSubagentById, SubagentError } = await import('../lib/subagent.js');
-const { Agent, Organisation } = await import('../lib/database.js');
+const { Agent, Organisation, ChatSession } = await import('../lib/database.js');
 
 const mockLogger = {
   info() {}, warn() {}, error() {}, debug() {},
@@ -96,7 +95,7 @@ describe('chat endpoint model entitlement', () => {
     const res = createMockResponse(unrestrictedUser());
     await agentChat(createMockRequest({ params: { agentId: agentRow.id }, body: {} }), res);
     expect(res._body.id).toBeDefined();
-    getChatSession(res._body.id).teardown();
+    await ChatSession.destroy({ where: { id: res._body.id } });
   });
 
   test('builtins stay gated by their builtin: id, not their model', async () => {
@@ -105,7 +104,7 @@ describe('chat endpoint model entitlement', () => {
     const res = createMockResponse(restrictedUser());
     await agentChat(createMockRequest({ params: { agentId: 'builtin:set-builder' }, body: {} }), res);
     expect(res._body.id).toBeDefined();
-    getChatSession(res._body.id).teardown();
+    await ChatSession.destroy({ where: { id: res._body.id } });
   });
 
   test('the org-pushed builder row is NOT exempt: its description marker is tenant-forgeable, so it is gated like any stored agent', async () => {

--- a/tests/chat-session-handoff.test.mjs
+++ b/tests/chat-session-handoff.test.mjs
@@ -1,0 +1,303 @@
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { randomUUID } from 'node:crypto';
+import {
+  setupRealDatabase,
+  teardownRealDatabase,
+  Organisation,
+  User,
+  Agent,
+} from './setup/database-test-wrapper.js';
+import { FakeChatLlm } from './fixtures/fake-chat-llm.mjs';
+import { FakeWs } from './fixtures/fake-ws.mjs';
+
+// Short handover wait so the "holder never answers" case does not dominate
+// the run. Read at module load by lib/text-chat.js, in this process and in
+// the peer processes it spawns (they inherit the environment).
+process.env.TEXT_CHAT_HANDOFF_WAIT_MS = '3000';
+const HANDOFF_WAIT_MS = 3000;
+// Agent.create validates the model against the roster, which needs the key.
+process.env.ANTHROPIC_API_KEY ||= 'test-key';
+
+// A chat session is held by ONE server process at a time, and moves.
+//
+// The websocket for `/chat/<id>` can reach any process behind the load
+// balancer, on the first attach and on every reconnect. The row in
+// chat_sessions says who holds the session; a process that receives a socket
+// for a session it does not hold claims the row, asking a live holder to let
+// go at its next turn boundary, and carries the conversation on from the
+// snapshot in the row. A holder that has died, or does not answer, has the
+// row taken from it and drops the session on its next write.
+//
+// The other process here is real: tests/fixtures/chat-peer.mjs, a separate
+// node process against the same database. A single-process stand-in could not
+// show that the LISTEN/NOTIFY request, the conditional writes and the
+// rehydration work across processes, which is the whole point.
+describe('chat session ownership across processes', () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const peer = join(here, 'fixtures', 'chat-peer.mjs');
+
+  const mockLogger = {
+    info() {}, warn() {}, error() {}, debug() {}, trace() {},
+    child() { return this; },
+  };
+
+  let textChat;
+  let ChatSession;
+  let PROCESS_ID;
+  let orgId;
+  let userId;
+  let agent;        // a tenant text agent: its sessions are ephemeral
+  let builderAgent; // an org-pushed builder: its sessions are history
+
+  // State carried between the ordered tests below.
+  const shared = {};
+
+  beforeAll(async () => {
+    await setupRealDatabase();
+    textChat = await import('../lib/text-chat.js');
+    ({ ChatSession } = await import('../lib/database.js'));
+    ({ PROCESS_ID } = await import('../lib/process-id.js'));
+    await ChatSession.sync({ alter: true });
+    textChat.setChatLlmFactory(() => new FakeChatLlm({ tag: 'A' }));
+    await textChat.startChatOwnershipListener({ log: mockLogger });
+
+    orgId = randomUUID();
+    userId = randomUUID();
+    await Organisation.create({ id: orgId, name: 'Handoff Org' });
+    await User.create({
+      id: userId, name: 'Handoff User', email: `handoff-${userId}@example.com`,
+      emailVerified: true, phone: '', phoneVerified: false, picture: '',
+      role: 'owner', organisationId: orgId,
+    });
+    agent = await Agent.create({
+      name: 'Handoff agent', type: 'text', modelName: 'text:anthropic/claude-sonnet-5',
+      prompt: 'You are a test agent.', userId, organisationId: orgId,
+    });
+    builderAgent = await Agent.create({
+      name: 'Pushed builder', description: 'Team builder [polite:agent-builder]', type: 'text',
+      modelName: 'text:anthropic/claude-sonnet-5', prompt: 'You build teams.', userId, organisationId: orgId,
+    });
+  }, 60000);
+
+  afterAll(async () => {
+    try {
+      await textChat.releaseAllChatSessions({ log: mockLogger });
+      await textChat.stopChatOwnershipListener();
+      await ChatSession.destroy({ where: { organisationId: orgId } });
+      await Agent.destroy({ where: { organisationId: orgId } });
+      await User.destroy({ where: { id: userId } });
+      await Organisation.destroy({ where: { id: orgId } });
+    } finally {
+      await teardownRealDatabase();
+    }
+  }, 60000);
+
+  // A browser reconnecting through the load balancer to ANOTHER server
+  // process: the peer claims the session, optionally sends one message, and
+  // reports what it saw. By default it releases on exit, as a server does on
+  // SIGTERM; with `keep` it exits still holding the row, like a crash.
+  function runPeer(spec) {
+    const env = { ...process.env, NODE_ENV: 'test', LOGLEVEL: 'silent' };
+    delete env.DB_FORCE_SYNC; // never alter-sync the schema under a running suite
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [peer, JSON.stringify(spec)], { env, stdio: ['ignore', 'pipe', 'pipe'] });
+      let out = '';
+      let err = '';
+      child.stdout.on('data', (d) => { out += d; });
+      child.stderr.on('data', (d) => { err += d; });
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code !== 0) return reject(new Error(`chat peer exited ${code}: ${err || out}`));
+        try {
+          resolve(JSON.parse(out.trim().split('\n').pop()));
+        } catch {
+          reject(new Error(`chat peer output was not JSON: ${out}\n${err}`));
+        }
+      });
+    });
+  }
+
+  async function waitFor(pred, what, timeoutMs = 20000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      // eslint-disable-next-line no-await-in-loop
+      if (await pred()) return;
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((r) => { setTimeout(r, 50); });
+    }
+    throw new Error(`timed out waiting for ${what}`);
+  }
+
+  const open = (over = {}) => textChat.openChatSession({ agent, logger: mockLogger, ...over }).then((r) => r.id);
+  const attach = (id, ws) => textChat.attachChatSession(id, ws, { logger: mockLogger });
+  const row = (id) => ChatSession.findByPk(id);
+
+  test('opening a session writes an unowned row and builds nothing anywhere', async () => {
+    const id = await open();
+    const r = await row(id);
+    expect(r.owner).toBeNull();
+    expect(r.ephemeral).toBe(true);
+    expect(r.state).toMatchObject({ v: 1, everConnected: false });
+    expect(r.state.seed).toBeDefined();
+    expect(textChat.getChatSession(id)).toBeUndefined();
+    expect(await textChat.probeChatSession(id)).toBe(true);
+    expect(await textChat.probeChatSession(randomUUID())).toBe(false);
+    expect(await textChat.probeChatSession('not-a-uuid')).toBe(false);
+    shared.id = id;
+  });
+
+  test('the process that receives the socket claims the row and snapshots the conversation per turn', async () => {
+    const { id } = shared;
+    const ws = new FakeWs();
+    await attach(id, ws);
+    // The opening turn ran here, as a first attach.
+    expect(ws.ofType('attached')).toEqual([{ type: 'attached', resumed: false, busy: false }]);
+    expect(ws.ofType('agent')).toHaveLength(1);
+    ws.say('hello from A');
+    await ws.waitFor((f) => f.type === 'agent' && /hello from A/.test(f.text), { what: 'reply to A' });
+    const session = textChat.getChatSession(id);
+    await session.lastPersist;
+    const r = await row(id);
+    expect(r.owner).toBe(PROCESS_ID);
+    expect(r.state.everConnected).toBe(true);
+    expect(r.state.seed).toBeNull(); // spent
+    expect(r.state.conversation).toMatchObject({ driver: 'fake' });
+    expect(r.state.conversation.messages).toHaveLength(session.llm.messages.length);
+    shared.ws = ws;
+    shared.count = session.llm.messages.length;
+    shared.llmA = session.llm;
+  });
+
+  test('a reconnect on ANOTHER process takes the session over, live, with the conversation intact', async () => {
+    const { id, ws, count, llmA } = shared;
+    ws.close(); // the browser went away; this process keeps the session for the re-attach grace
+    const out = await runPeer({ id, say: 'hello from B', tag: 'B' });
+    expect(out.held).toBe(true);
+    expect(out.ownerAfterClaim).toBe(out.processId);
+    // B started from A's conversation, not from scratch...
+    expect(out.imported).toBe(count);
+    expect(out.messages).toBe(count + 2);
+    // ...answered the reconnect at once (provisional) and again once rehydrated...
+    expect(out.frames.filter((f) => f.type === 'attached')).toEqual([
+      { type: 'attached', resumed: true, busy: true },
+      { type: 'attached', resumed: true, busy: false },
+    ]);
+    expect(out.frames.some((f) => f.type === 'agent' && /hello from B/.test(f.text))).toBe(true);
+    // ...and did not have to wait the holder out: this process let go when asked.
+    expect(out.attachedMs).toBeLessThan(HANDOFF_WAIT_MS);
+    // This process let the session go: nothing held, the driver's connections closed,
+    // and once B exited (releasing, as a server does on SIGTERM) the row is free.
+    expect(textChat.getChatSession(id)).toBeUndefined();
+    expect(llmA.closed).toBe(true);
+    const r = await row(id);
+    expect(r.owner).toBeNull();
+    expect(r.endedAt).toBeNull();
+    expect(r.state.conversation.messages).toHaveLength(count + 2);
+    shared.count = count + 2;
+  }, 60000);
+
+  test('and back: this process re-attaches to the conversation B left in the row', async () => {
+    const { id, count } = shared;
+    const ws = new FakeWs();
+    await attach(id, ws);
+    // Unowned row: no wait, so no provisional frame.
+    expect(ws.ofType('attached')).toEqual([{ type: 'attached', resumed: true, busy: false }]);
+    const session = textChat.getChatSession(id);
+    expect(session.llm.imported).toBe(count);
+    ws.say('and again from A');
+    await ws.waitFor((f) => f.type === 'agent' && /and again from A/.test(f.text), { what: 'reply after resume' });
+    await session.lastPersist;
+    expect((await row(id)).owner).toBe(PROCESS_ID);
+    shared.ws = ws;
+    shared.count = count + 2;
+  });
+
+  test('a session whose holder has died is taken at once', async () => {
+    const { id } = shared;
+    await textChat.getChatSession(id).release();
+    expect(textChat.getChatSession(id)).toBeUndefined();
+    // A holder that stopped beating ten minutes ago.
+    await ChatSession.update({ owner: 'ghost:1:dead', lastSeenAt: new Date(Date.now() - 10 * 60 * 1000) }, { where: { id } });
+    const ws = new FakeWs();
+    const t0 = Date.now();
+    await attach(id, ws);
+    expect(Date.now() - t0).toBeLessThan(2000);
+    expect(ws.ofType('attached')).toEqual([{ type: 'attached', resumed: true, busy: false }]);
+    expect((await row(id)).owner).toBe(PROCESS_ID);
+    shared.ws = ws;
+  });
+
+  test('a holder that does not answer loses the session when the wait runs out', async () => {
+    const { id } = shared;
+    await textChat.getChatSession(id).release();
+    // B takes the session and exits without releasing: to the row, a fresh,
+    // live holder that will never answer.
+    const out = await runPeer({ id, keep: true, tag: 'B2' });
+    expect(out.held).toBe(true);
+    expect((await row(id)).owner).toBe(out.processId);
+    const ws = new FakeWs();
+    const t0 = Date.now();
+    await attach(id, ws);
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeGreaterThanOrEqual(HANDOFF_WAIT_MS - 200);
+    expect(elapsed).toBeLessThan(HANDOFF_WAIT_MS + 5000);
+    expect(ws.ofType('attached').map((f) => f.resumed)).toEqual([true, true]);
+    expect((await row(id)).owner).toBe(PROCESS_ID);
+    expect(textChat.getChatSession(id).llm.imported).toBe(shared.count);
+    shared.ws = ws;
+  }, 60000);
+
+  test('a process whose row was taken drops the session on its next write, ending nothing', async () => {
+    const { id, ws } = shared;
+    const session = textChat.getChatSession(id);
+    // Another process has taken the row (as a forced claim does).
+    await ChatSession.update({ owner: 'thief:2:x' }, { where: { id } });
+    await session.persistTurn();
+    expect(session.released).toBe(true);
+    expect(textChat.getChatSession(id)).toBeUndefined();
+    expect(session.llm.closed).toBe(true);
+    expect(ws.frames.at(-1)).toMatchObject({ type: 'error', code: 'superseded' });
+    const r = await row(id);
+    expect(r.owner).toBe('thief:2:x');
+    expect(r.endedAt).toBeNull();
+    await ChatSession.destroy({ where: { id } });
+  });
+
+  test("an ephemeral session's row goes when the session ends; a builder session's stays as history", async () => {
+    const id = await open();
+    let ws = new FakeWs();
+    await attach(id, ws);
+    textChat.getChatSession(id).teardown();
+    await waitFor(async () => !(await row(id)), 'ephemeral row deletion');
+    expect(await textChat.probeChatSession(id)).toBe(false);
+
+    const { id: bid } = await textChat.openChatSession({ agent: builderAgent, logger: mockLogger });
+    expect((await row(bid)).ephemeral).toBe(false);
+    ws = new FakeWs();
+    await attach(bid, ws);
+    ws.say('build me a team');
+    await ws.waitFor((f) => f.type === 'agent' && /build me a team/.test(f.text), { what: 'builder reply' });
+    const session = textChat.getChatSession(bid);
+    await session.lastPersist;
+    session.teardown();
+    await waitFor(async () => !!(await row(bid))?.endedAt, 'builder row end');
+    const r = await row(bid);
+    expect(r.owner).toBeNull();
+    expect(r.state).toBeNull(); // nothing left to hand over
+    expect(r.turns).toBe(1);
+    expect(r.transcript.map((e) => e.role)).toEqual(['agent', 'user', 'agent']);
+  });
+
+  test('the reaper removes ended ephemeral rows', async () => {
+    const id = randomUUID();
+    const ago = new Date(Date.now() - 60 * 60 * 1000);
+    await ChatSession.create({
+      id, agentId: agent.id, organisationId: orgId, userId, startedAt: ago, lastSeenAt: ago, endedAt: ago,
+      ephemeral: true, turns: 0,
+    });
+    await textChat.reapStaleChatSessions({ log: mockLogger });
+    expect(await row(id)).toBeNull();
+  });
+});

--- a/tests/chat-session-liveness.test.mjs
+++ b/tests/chat-session-liveness.test.mjs
@@ -69,22 +69,22 @@ describe('chat session liveness', () => {
   });
 
   describe('isChatSessionLive', () => {
-    it('is live while a process is still beating for it', () => {
+    it('is live while a process is still beating for it', async () => {
       expect(isChatSessionLive({ endedAt: null, lastSeenAt: new Date() })).toBe(true);
       expect(isChatSessionLive({ endedAt: null, lastSeenAt: ago(60 * 1000) })).toBe(true);
     });
 
-    it('goes stale once the grace lapses, with no boot and no sweep', () => {
+    it('goes stale once the grace lapses, with no boot and no sweep', async () => {
       expect(isChatSessionLive({ endedAt: null, lastSeenAt: ago(GRACE_MS + 1000) })).toBe(false);
     });
 
-    it('an ended session is never live, however recent the beat', () => {
+    it('an ended session is never live, however recent the beat', async () => {
       expect(isChatSessionLive({ endedAt: new Date(), lastSeenAt: new Date() })).toBe(false);
     });
 
     // Rows written before the column existed. Reporting them live would put a
     // LIVE badge on every historical session the moment this ships.
-    it('a row with no heartbeat at all is history, not a live session', () => {
+    it('a row with no heartbeat at all is history, not a live session', async () => {
       expect(isChatSessionLive({ endedAt: null, lastSeenAt: null })).toBe(false);
     });
   });
@@ -206,7 +206,7 @@ describe('chat session liveness', () => {
       // startHeartbeat/stopHeartbeat live on the session prototype; exercising
       // them directly keeps this a unit test of the timer contract, with no
       // LLM and no websocket.
-      const session = mod.createChatSession({
+      const session = await mod.createChatSession({
         agent: {
           id: 'agent-hb', organisationId: orgId, userId,
           modelName: 'text:anthropic/claude-sonnet-5',
@@ -218,13 +218,13 @@ describe('chat session liveness', () => {
       session.teardown();
     });
 
-    it('does not beat for a session with no durable row', () => {
+    it('does not beat for a session with no durable row', async () => {
       const s = mkFake({ persisted: false });
       s.startHeartbeat();
       expect(s.heartbeat).toBeNull();
     });
 
-    it('beats once started, and starting twice does not stack timers', () => {
+    it('beats once started, and starting twice does not stack timers', async () => {
       const s = mkFake();
       s.startHeartbeat();
       const first = s.heartbeat;

--- a/tests/fixtures/chat-peer.mjs
+++ b/tests/fixtures/chat-peer.mjs
@@ -1,0 +1,65 @@
+// A second server process for tests/chat-session-handoff.test.mjs.
+//
+// Usage: node tests/fixtures/chat-peer.mjs '<json>'
+//   json = { id, say?, keep?, tag? }
+//
+// Connects to the same database with the POSTGRES_* variables it is given,
+// listens for ownership requests like a server does, and then does what a
+// browser reconnecting through the load balancer to THIS process would cause:
+// attaches a socket to session `id`, which makes this process claim the
+// session (asking the current owner to hand it over if one is alive). With
+// `say` it then sends one user message and waits for the turn to finish. It
+// prints one JSON line describing what happened and exits. By default it
+// releases its sessions on the way out, as a server does on SIGTERM; with
+// `keep` it exits still holding the row, which is what a crash looks like.
+const spec = JSON.parse(process.argv[2] || '{}');
+
+try {
+  const { FakeChatLlm } = await import('./fake-chat-llm.mjs');
+  const { FakeWs } = await import('./fake-ws.mjs');
+  const { databaseStarted, stopDatabase, ChatSession } = await import('../../lib/database.js');
+  const {
+    setChatLlmFactory, attachChatSession, getChatSession,
+    startChatOwnershipListener, stopChatOwnershipListener, releaseAllChatSessions,
+  } = await import('../../lib/text-chat.js');
+  const { PROCESS_ID } = await import('../../lib/process-id.js');
+
+  await databaseStarted;
+  setChatLlmFactory(() => new FakeChatLlm({ tag: spec.tag || 'peer' }));
+  await startChatOwnershipListener();
+
+  const ws = new FakeWs();
+  const t0 = Date.now();
+  await attachChatSession(spec.id, ws);
+  const attachedMs = Date.now() - t0;
+  const session = getChatSession(spec.id);
+  const rowAfterClaim = await ChatSession.findByPk(spec.id, { attributes: ['owner'] });
+
+  if (spec.say && session) {
+    ws.say(spec.say);
+    await ws.waitFor((f) => f.type === 'turn_complete', { what: 'turn_complete' });
+  }
+
+  const out = {
+    processId: PROCESS_ID,
+    attachedMs,
+    held: !!session,
+    imported: session?.llm?.imported ?? null,
+    messages: session?.llm?.messages?.length ?? null,
+    ownerAfterClaim: rowAfterClaim?.owner ?? null,
+    frames: ws.frames,
+  };
+
+  if (!spec.keep) await releaseAllChatSessions();
+  await stopChatOwnershipListener().catch(() => {});
+  console.log(JSON.stringify(out));
+  await Promise.race([
+    stopDatabase(),
+    new Promise((resolve) => { setTimeout(resolve, 5000).unref?.(); }),
+  ]);
+  process.exit(0);
+}
+catch (err) {
+  console.error(err?.stack || String(err));
+  process.exit(1);
+}

--- a/tests/fixtures/fake-chat-llm.mjs
+++ b/tests/fixtures/fake-chat-llm.mjs
@@ -1,0 +1,47 @@
+// A stand-in text driver for chat-session tests: no provider, deterministic
+// replies, and the same conversation export/import contract the real drivers
+// implement (lib/models/llm.js), so a session can be carried between processes
+// and the test can see exactly what history the new process received.
+export class FakeChatLlm {
+  constructor({ tag = 'fake' } = {}) {
+    this.tag = tag;
+    this.messages = [];
+    this.closed = false;
+    // Number of messages taken from an imported conversation, or null when
+    // this instance started fresh.
+    this.imported = null;
+  }
+
+  async rawCompletion(input) {
+    if (input) this.messages.push({ role: 'user', content: input });
+    const n = this.messages.filter((m) => m.role === 'assistant').length + 1;
+    const text = `${this.tag} reply ${n} to: ${String(input ?? '').slice(0, 60)}`;
+    this.messages.push({ role: 'assistant', content: text });
+    // No usage: keeps the metering path out of these tests.
+    return { text, calls: [] };
+  }
+
+  async callResult(results) {
+    this.messages.push({ role: 'user', content: results });
+    return this.rawCompletion(null);
+  }
+
+  exportConversation() {
+    return { driver: 'fake', messages: this.messages };
+  }
+
+  importConversation(conversation) {
+    if (conversation?.driver !== 'fake' || !Array.isArray(conversation.messages)) return false;
+    this.messages = conversation.messages;
+    this.imported = conversation.messages.length;
+    return true;
+  }
+
+  abandonTurn() {}
+
+  async close() {
+    this.closed = true;
+  }
+}
+
+export default FakeChatLlm;

--- a/tests/fixtures/fake-ws.mjs
+++ b/tests/fixtures/fake-ws.mjs
@@ -1,0 +1,58 @@
+import { EventEmitter } from 'node:events';
+
+// The slice of the `ws` WebSocket surface lib/text-chat.js touches, recording
+// every frame the server sends so a test can assert on the protocol.
+export class FakeWs extends EventEmitter {
+  constructor() {
+    super();
+    this.OPEN = 1;
+    this.CLOSED = 3;
+    this.readyState = this.OPEN;
+    this.frames = [];
+  }
+
+  send(json) {
+    this.frames.push(JSON.parse(json));
+  }
+
+  // The server's liveness ping: answer at once, as a browser would.
+  ping() {
+    setImmediate(() => this.emit('pong'));
+  }
+
+  close() {
+    if (this.readyState === this.CLOSED) return;
+    this.readyState = this.CLOSED;
+    this.emit('close');
+  }
+
+  terminate() {
+    this.close();
+  }
+
+  /** What the browser does when the user types. */
+  say(text) {
+    this.emit('message', Buffer.from(JSON.stringify({ type: 'user', text })));
+  }
+
+  /** Frames of one type, in order. */
+  ofType(type) {
+    return this.frames.filter((f) => f.type === type);
+  }
+
+  /** Resolve when a frame satisfies `pred`; reject on timeout. */
+  waitFor(pred, { timeoutMs = 20000, what = 'frame' } = {}) {
+    return new Promise((resolve, reject) => {
+      const deadline = Date.now() + timeoutMs;
+      const tick = () => {
+        const hit = this.frames.find(pred);
+        if (hit) return resolve(hit);
+        if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${what}`));
+        setTimeout(tick, 25);
+      };
+      tick();
+    });
+  }
+}
+
+export default FakeWs;

--- a/tests/text-chat-id-masking.test.mjs
+++ b/tests/text-chat-id-masking.test.mjs
@@ -42,8 +42,8 @@ afterAll(async () => {
 });
 
 /** A session whose function list names the set tools, so platformOf resolves. */
-function makeSession() {
-  const session = createChatSession({ agent, logger });
+async function makeSession() {
+  const session = await createChatSession({ agent, logger });
   session.functions = [
     { name: 'patch_agent_set', platform: 'patch_agent_set' },
     { name: 'notify_email_team', platform: 'notify' },
@@ -52,8 +52,8 @@ function makeSession() {
 }
 
 describe('slimResults keeps internal ids out of the conversation', () => {
-  test('a failed save reaches the model without the id', () => {
-    const session = makeSession();
+  test('a failed save reaches the model without the id', async () => {
+    const session = await makeSession();
     const [out] = session.slimResults([
       { name: 'patch_agent_set', result: JSON.stringify({ error: `Agent set ${ID} not found` }) },
     ]);
@@ -62,9 +62,9 @@ describe('slimResults keeps internal ids out of the conversation', () => {
     expect(JSON.parse(out.result).error).toBe('Agent set not found');
   });
 
-  test('a successful save keeps the ids label resolution produced', () => {
+  test('a successful save keeps the ids label resolution produced', async () => {
     // test_agent resolves a label to an agent id from exactly this stub.
-    const session = makeSession();
+    const session = await makeSession();
     const [out] = session.slimResults([
       {
         name: 'patch_agent_set',
@@ -80,19 +80,19 @@ describe('slimResults keeps internal ids out of the conversation', () => {
     expect(parsed.members[0]).toMatchObject({ label: 'front', id: '00000000-0000-4000-8000-000000000002' });
   });
 
-  test('a failure from a NON-set tool is masked too', () => {
+  test('a failure from a NON-set tool is masked too', async () => {
     // The leak is not specific to set saves: any tool error the model reads is
     // one it can relay. Masking runs before the set-platform branch.
-    const session = makeSession();
+    const session = await makeSession();
     const [out] = session.slimResults([
       { name: 'notify_email_team', result: JSON.stringify({ error: `agent ${ID} has no verified members` }) },
     ]);
     expect(out.result).not.toMatch(ID_SHAPE);
   });
 
-  test('results with nothing to mask are passed through by identity', () => {
+  test('results with nothing to mask are passed through by identity', async () => {
     // Rebuilding every result would churn the array for no reason.
-    const session = makeSession();
+    const session = await makeSession();
     const input = [{ name: 'notify_email_team', result: JSON.stringify({ ok: true }) }];
     expect(session.slimResults(input)[0]).toBe(input[0]);
   });

--- a/tests/text-chat-reattach.test.mjs
+++ b/tests/text-chat-reattach.test.mjs
@@ -53,8 +53,8 @@ function makeWs() {
   return ws;
 }
 
-function makeSession() {
-  const session = createChatSession({ agent, logger });
+async function makeSession() {
+  const session = await createChatSession({ agent, logger });
   const turns = [];
   session.buildLlm = async () => {}; // no LLM in these tests
   session.runTurn = (text, send, hidden = false, claimed = null) => {
@@ -66,7 +66,7 @@ function makeSession() {
 
 describe('text-chat session re-attach', () => {
   test('first attach announces itself and runs the opening turn once', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     const ws = makeWs();
     await session.handleChat(ws);
     expect(ws.sent[0]).toEqual({ type: 'attached', resumed: false, busy: false });
@@ -75,7 +75,7 @@ describe('text-chat session re-attach', () => {
   });
 
   test('re-attach after a drop rebinds without a new opening turn and flushes the outbox', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     const ws1 = makeWs();
     await session.handleChat(ws1);
     expect(turns).toHaveLength(1);
@@ -96,7 +96,7 @@ describe('text-chat session re-attach', () => {
   });
 
   test('re-attach re-emits a pending interactive ask', async () => {
-    const { session } = makeSession();
+    const { session } = await makeSession();
     const ws1 = makeWs();
     await session.handleChat(ws1);
     const frame = { type: 'question', id: 'toolu_q', question: 'Which channel?', options: [], multiSelect: false };
@@ -110,7 +110,7 @@ describe('text-chat session re-attach', () => {
   });
 
   test('a second concurrent socket TAKES OVER (newest wins; half-open old sockets must not block)', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     const ws1 = makeWs();
     await session.handleChat(ws1);
     const ws2 = makeWs();
@@ -124,7 +124,7 @@ describe('text-chat session re-attach', () => {
   });
 
   test('a pause reached while detached is delivered exactly once on re-attach', async () => {
-    const { session } = makeSession();
+    const { session } = await makeSession();
     const ws1 = makeWs();
     await session.handleChat(ws1);
     ws1.readyState = 3;
@@ -140,7 +140,7 @@ describe('text-chat session re-attach', () => {
   });
 
   test('buildLlm failure tears the session down instead of leaving a zombie', async () => {
-    const { session } = makeSession();
+    const { session } = await makeSession();
     session.buildLlm = async () => { throw new Error('no such model'); };
     const ws = makeWs();
     await session.handleChat(ws);
@@ -148,7 +148,7 @@ describe('text-chat session re-attach', () => {
   });
 
   test('teardown finalises and removes the session', async () => {
-    const { session } = makeSession();
+    const { session } = await makeSession();
     const ws = makeWs();
     await session.handleChat(ws);
     session.teardown();
@@ -157,7 +157,7 @@ describe('text-chat session re-attach', () => {
 });
 
 describe('list_voices payload bound', () => {
-  test('long descriptions are capped and oversized vendor lists truncated with a note', () => {
+  test('long descriptions are capped and oversized vendor lists truncated with a note', async () => {
     const voices = Array.from({ length: 70 }, (_, i) => ({
       name: `voice-${i}`,
       gender: 'female',
@@ -171,14 +171,14 @@ describe('list_voices payload bound', () => {
     expect(out.voiceStack).toBe('pipeline');
   });
 
-  test('locale-list results (no vendors) pass through untouched', () => {
+  test('locale-list results (no vendors) pass through untouched', async () => {
     const result = { locales: ['en-GB', 'any'], voiceStack: 'realtime' };
     expect(trimVoicesResult(result)).toBe(result);
   });
 });
 
 describe('list_voices search (ranked word-start union)', () => {
-  test('normalizeSearchTerms tokenises arrays and strings, lowercases and de-dupes', () => {
+  test('normalizeSearchTerms tokenises arrays and strings, lowercases and de-dupes', async () => {
     expect(normalizeSearchTerms(['British', 'english'])).toEqual(['british', 'english']);
     expect(normalizeSearchTerms('British English robotic')).toEqual(['british', 'english', 'robotic']);
     expect(normalizeSearchTerms(['british english', 'robotic'])).toEqual(['british', 'english', 'robotic']);
@@ -187,7 +187,7 @@ describe('list_voices search (ranked word-start union)', () => {
     expect(normalizeSearchTerms(['', '  '])).toEqual([]);
   });
 
-  test('returns the UNION of matches across vendors, tagging non-"any" locales and matched terms', () => {
+  test('returns the UNION of matches across vendors, tagging non-"any" locales and matched terms', async () => {
     const tree = {
       ultravox: {
         any: [
@@ -209,7 +209,7 @@ describe('list_voices search (ranked word-start union)', () => {
     expect(termMatches).toEqual({ british: 1, robotic: 1 });
   });
 
-  test('terms match at word starts only — "male" never matches "female", prefixes still work', () => {
+  test('terms match at word starts only — "male" never matches "female", prefixes still work', async () => {
     const tree = {
       ultravox: {
         any: [
@@ -233,7 +233,7 @@ describe('list_voices search (ranked word-start union)', () => {
     expect(accent.vendors.ultravox).toHaveLength(1);
   });
 
-  test('ranks multi-term matches first — the Irish female surfaces at the top, misses are explicit', () => {
+  test('ranks multi-term matches first — the Irish female surfaces at the top, misses are explicit', async () => {
     // The 2026-07-23 staging failure: Louisamay sat at ~position 53 of 152
     // anywhere-substring matches and the builder model never saw it.
     const tree = {
@@ -255,20 +255,20 @@ describe('list_voices search (ranked word-start union)', () => {
     expect(termMatches).toEqual({ irish: 2, female: 4, dynamic: 0, male: 2 });
   });
 
-  test('matches on the locale key too, and tags the voice with that locale', () => {
+  test('matches on the locale key too, and tags the voice with that locale', async () => {
     const tree = { google: { 'en-GB': [{ name: 'en-GB-Neural2-A', description: 'en-GB-Neural2-A', gender: 'female' }] } };
     const { vendors } = filterVoiceTreeBySearch(tree, ['en-gb']);
     expect(vendors.google).toHaveLength(1);
     expect(vendors.google[0].locale).toBe('en-GB');
   });
 
-  test('empty terms match nothing — never dumps the whole catalogue', () => {
+  test('empty terms match nothing — never dumps the whole catalogue', async () => {
     const tree = { ultravox: { any: [{ name: 'X', description: 'y', gender: 'unknown' }] } };
     expect(filterVoiceTreeBySearch(tree, []).vendors).toEqual({});
     expect(filterVoiceTreeBySearch(tree, normalizeSearchTerms('   ')).vendors).toEqual({});
   });
 
-  test('trimSearchVoicesResult caps ranked matches per vendor and spells out unmatched terms', () => {
+  test('trimSearchVoicesResult caps ranked matches per vendor and spells out unmatched terms', async () => {
     const voices = Array.from({ length: 70 }, (_, i) => ({
       name: `voice-${i}`,
       description: 'd'.repeat(300),

--- a/tests/text-chat-resume.test.mjs
+++ b/tests/text-chat-resume.test.mjs
@@ -38,7 +38,7 @@ afterAll(async () => {
 });
 
 describe('sanitizeHistory', () => {
-  test('keeps user/agent/system entries and drops everything else', () => {
+  test('keeps user/agent/system entries and drops everything else', async () => {
     const out = sanitizeHistory([
       { role: 'user', text: 'hello' },
       { role: 'agent', text: 'hi' },
@@ -55,13 +55,13 @@ describe('sanitizeHistory', () => {
     ]);
   });
 
-  test('returns null for non-arrays and for arrays with nothing usable', () => {
+  test('returns null for non-arrays and for arrays with nothing usable', async () => {
     expect(sanitizeHistory(undefined)).toBeNull();
     expect(sanitizeHistory('hello')).toBeNull();
     expect(sanitizeHistory([{ role: 'user', text: '' }])).toBeNull();
   });
 
-  test('caps entry count keeping the newest, with an elision marker', () => {
+  test('caps entry count keeping the newest, with an elision marker', async () => {
     const many = Array.from({ length: 250 }, (_, i) => ({ role: 'user', text: `m${i}` }));
     const out = sanitizeHistory(many);
     // 200 kept + 1 marker.
@@ -71,7 +71,7 @@ describe('sanitizeHistory', () => {
     expect(out[out.length - 1].text).toBe('m249');
   });
 
-  test('caps total characters by dropping the oldest entries', () => {
+  test('caps total characters by dropping the oldest entries', async () => {
     const big = 'x'.repeat(4000);
     const entries = Array.from({ length: 20 }, () => ({ role: 'agent', text: big }));
     const out = sanitizeHistory(entries);
@@ -80,7 +80,7 @@ describe('sanitizeHistory', () => {
     expect(out[0]).toEqual({ role: 'system', text: '[… earlier conversation trimmed …]' });
   });
 
-  test('truncates a single oversized entry', () => {
+  test('truncates a single oversized entry', async () => {
     const out = sanitizeHistory([{ role: 'user', text: 'y'.repeat(9000) }]);
     expect(out).toHaveLength(1);
     expect(out[0].text).toHaveLength(4000);
@@ -94,8 +94,8 @@ describe('resume seeding', () => {
     { role: 'agent', text: 'Should I build this Article Guide? (options: Yes — build as proposed / Change it)' },
   ];
 
-  test('a session seeded with history opens with the resume prompt', () => {
-    const session = createChatSession({
+  test('a session seeded with history opens with the resume prompt', async () => {
+    const session = await createChatSession({
       agent,
       set: { id: 'set-1', name: 'Article Summary Line', agents: [] },
       history,
@@ -116,13 +116,13 @@ describe('resume seeding', () => {
     expect(prompt).toContain('NEVER call create_agent_set');
   });
 
-  test('a non-uuid resumedFrom is dropped (the column is UUID-typed)', () => {
-    const session = createChatSession({ agent, history, resumedFrom: 'not-a-uuid', logger });
+  test('a non-uuid resumedFrom is dropped (the column is UUID-typed)', async () => {
+    const session = await createChatSession({ agent, history, resumedFrom: 'not-a-uuid', logger });
     expect(session.resumedFrom).toBeNull();
   });
 
-  test('a set with members resumes with patch-style save rules', () => {
-    const session = createChatSession({
+  test('a set with members resumes with patch-style save rules', async () => {
+    const session = await createChatSession({
       agent,
       set: { id: 'set-1', name: 'Team', agents: [{ label: 'reception', name: 'Reception' }] },
       history,
@@ -133,8 +133,8 @@ describe('resume seeding', () => {
     expect(prompt).not.toContain('NEVER call create_agent_set');
   });
 
-  test('a troubleshoot resume re-embeds the test result', () => {
-    const session = createChatSession({
+  test('a troubleshoot resume re-embeds the test result', async () => {
+    const session = await createChatSession({
       agent,
       testResult: { legs: [{ agentLabel: 'reception', transcript: [] }] },
       history,
@@ -147,8 +147,8 @@ describe('resume seeding', () => {
 });
 
 describe('named-placeholder opening prompt (no resume)', () => {
-  test('an already-named empty set keeps its name instead of the name dance', () => {
-    const session = createChatSession({
+  test('an already-named empty set keeps its name instead of the name dance', async () => {
+    const session = await createChatSession({
       agent,
       set: { id: 'set-1', name: 'Article Summary Line', agents: [] },
       logger,
@@ -158,8 +158,8 @@ describe('named-placeholder opening prompt (no resume)', () => {
     expect(prompt).not.toContain('propose a real name');
   });
 
-  test('an Untitled placeholder still gets the name proposal instruction', () => {
-    const session = createChatSession({
+  test('an Untitled placeholder still gets the name proposal instruction', async () => {
+    const session = await createChatSession({
       agent,
       set: { id: 'set-1', name: 'Untitled team', agents: [] },
       logger,

--- a/tests/text-chat-review-result.test.mjs
+++ b/tests/text-chat-review-result.test.mjs
@@ -36,8 +36,8 @@ afterAll(async () => {
   await teardownRealDatabase();
 });
 
-function makeSession() {
-  const session = createChatSession({ agent, logger });
+async function makeSession() {
+  const session = await createChatSession({ agent, logger });
   const turns = [];
   session.runTurn = (text, send, hidden = false, claimed = null) => {
     turns.push({ text, hidden, claimed });
@@ -50,7 +50,7 @@ const findings = '{"overall":"Solid, but no transfers.","findings":[{"severity":
 
 describe('text-chat review_result frame', () => {
   test('matching id claims the pending at enqueue and resumes as a hidden turn', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' };
     await session.reviewResult({ type: 'review_result', id: 'toolu_1', result: findings }, () => {});
     expect(turns).toEqual([
@@ -65,7 +65,7 @@ describe('text-chat review_result frame', () => {
   });
 
   test('mismatched id is ignored (a stale frame cannot hijack another turn)', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' };
     await session.reviewResult({ type: 'review_result', id: 'toolu_2', result: findings }, () => {});
     expect(turns).toEqual([]);
@@ -73,20 +73,20 @@ describe('text-chat review_result frame', () => {
   });
 
   test('missing id is ignored (no id-less form for reviews)', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' };
     await session.reviewResult({ type: 'review_result', result: findings }, () => {});
     expect(turns).toEqual([]);
   });
 
   test('no pending tool call is a no-op', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     await session.reviewResult({ type: 'review_result', id: 'toolu_1', result: findings }, () => {});
     expect(turns).toEqual([]);
   });
 
   test('duplicate frame after the claim is ignored', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'request_review' };
     await session.reviewResult({ type: 'review_result', id: 'toolu_1', result: findings }, () => {});
     await session.reviewResult({ type: 'review_result', id: 'toolu_1', result: findings }, () => {});

--- a/tests/text-chat-test-result.test.mjs
+++ b/tests/text-chat-test-result.test.mjs
@@ -38,8 +38,8 @@ afterAll(async () => {
   await teardownRealDatabase();
 });
 
-function makeSession() {
-  const session = createChatSession({ agent, logger });
+async function makeSession() {
+  const session = await createChatSession({ agent, logger });
   const turns = [];
   // turn() claims the pending and enqueues runTurn — stub the run itself so
   // the claim semantics are exercised without an LLM.
@@ -52,7 +52,7 @@ function makeSession() {
 
 describe('text-chat test_result frame', () => {
   test('matching id claims the pending at enqueue and resumes as a hidden turn', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' };
     await session.testResult({ type: 'test_result', id: 'toolu_1', result: '{"ok":true,"legs":[]}' }, () => {});
     expect(turns).toEqual([
@@ -68,7 +68,7 @@ describe('text-chat test_result frame', () => {
   });
 
   test('mismatched id is ignored (a stale frame cannot hijack another turn)', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' };
     await session.testResult({ type: 'test_result', id: 'toolu_2', result: '{"ok":true}' }, () => {});
     expect(turns).toEqual([]);
@@ -76,20 +76,20 @@ describe('text-chat test_result frame', () => {
   });
 
   test('missing id is ignored', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' };
     await session.testResult({ type: 'test_result', result: '{"ok":true}' }, () => {});
     expect(turns).toEqual([]);
   });
 
   test('no pending tool call is a no-op', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     await session.testResult({ type: 'test_result', id: 'toolu_1', result: '{"ok":false}' }, () => {});
     expect(turns).toEqual([]);
   });
 
   test('duplicate frame after the claim is ignored', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     session.pending = { toolUseId: 'toolu_1', otherResults: [], platform: 'test_agent' };
     await session.testResult({ type: 'test_result', id: 'toolu_1', result: '{"ok":true}' }, () => {});
     await session.testResult({ type: 'test_result', id: 'toolu_1', result: '{"ok":true}' }, () => {});
@@ -97,7 +97,7 @@ describe('text-chat test_result frame', () => {
   });
 
   test('legacy protocol: a plain user turn claims the pending at enqueue', async () => {
-    const { session, turns } = makeSession();
+    const { session, turns } = await makeSession();
     session.pending = { toolUseId: 'toolu_9', otherResults: [], platform: 'ask_user' };
     await session.turn('the answer', () => {});
     expect(turns).toEqual([
@@ -129,8 +129,8 @@ describe('text-chat slimResults', () => {
     ],
   });
 
-  test('a save result is replaced with a stub carrying the post-save identities', () => {
-    const session = createChatSession({ agent: setAgent, logger });
+  test('a save result is replaced with a stub carrying the post-save identities', async () => {
+    const session = await createChatSession({ agent: setAgent, logger });
     const [slim] = session.slimResults([{ name: 'create_agent_set', result: fullSet }]);
     const parsed = JSON.parse(slim.result);
     expect(parsed).toEqual({
@@ -145,8 +145,8 @@ describe('text-chat slimResults', () => {
     expect(slim.result.length).toBeLessThan(fullSet.length / 10);
   });
 
-  test('save FAILURES and non-set tools pass through verbatim', () => {
-    const session = createChatSession({ agent: setAgent, logger });
+  test('save FAILURES and non-set tools pass through verbatim', async () => {
+    const session = await createChatSession({ agent: setAgent, logger });
     const error = JSON.stringify({ error: 'validation failed: agents[0].functions[0] …' });
     const voices = JSON.stringify({ locales: ['en-GB'] });
     const results = session.slimResults([

--- a/tests/text-chat-tool-start-frames.test.mjs
+++ b/tests/text-chat-tool-start-frames.test.mjs
@@ -38,15 +38,15 @@ afterAll(async () => {
   await teardownRealDatabase();
 });
 
-function sessionWithLlm(rawCompletion) {
-  const session = createChatSession({ agent, logger });
+async function sessionWithLlm(rawCompletion) {
+  const session = await createChatSession({ agent, logger });
   session.llm = { rawCompletion };
   return session;
 }
 
 describe('streaming tool_use_start → early tool_call frame', () => {
   test('a driver tool_use_start emits {type:tool_call, streaming:true} before the reply', async () => {
-    const session = sessionWithLlm(async (text, cb) => {
+    const session = await sessionWithLlm(async (text, cb) => {
       cb({ tool_use_start: { name: 'update_agent_set' } });
       return { text: 'Saved the team.', calls: [] };
     });
@@ -66,7 +66,7 @@ describe('streaming tool_use_start → early tool_call frame', () => {
   });
 
   test('a nameless tool_use_start and the final-result callback emit no frame', async () => {
-    const session = sessionWithLlm(async (text, cb) => {
+    const session = await sessionWithLlm(async (text, cb) => {
       cb({ tool_use_start: {} }); // malformed — no name
       const round = { text: 'ok', calls: [] };
       cb(round); // drivers echo the final round through the same callback
@@ -78,7 +78,7 @@ describe('streaming tool_use_start → early tool_call frame', () => {
   });
 
   test('mcp_tool_use events keep their existing frame shape alongside', async () => {
-    const session = sessionWithLlm(async (text, cb) => {
+    const session = await sessionWithLlm(async (text, cb) => {
       cb({ mcp_tool_use: { name: 'read_doc', server: 'aplisay' } });
       cb({ tool_use_start: { name: 'patch_agent_set' } });
       return { text: 'done', calls: [] };


### PR DESCRIPTION
Replaces #295, which GitHub closed when its base branch (#293's) was deleted on merge. Same change, rebased onto `next` with #293, #297, #298 and #299 in.

## Why

Interactive chat sessions lived in a per-process `Map` (`lib/text-chat.js`). The websocket for `/chat/<id>` can reach any server process behind the load balancer, on the first connect as well as on every reconnect, so with more than one process most first attaches answered 404 and no re-attach could cross processes. The server runs on autoscaled Kubernetes and Cloud Run; one replica was the only reason this did not show.

## What

A session is now a `chat_sessions` row that exactly one process holds at a time, and the holder can change. `docs/chat-session-ownership.md` describes the model; in short:

- `POST /agents/{agentId}/chat` writes the row unowned, with the seed. Nothing is built until a socket arrives; the process that receives the upgrade claims the row and builds the session there.
- The holder snapshots the session into the row at every turn boundary: the driver's replayable conversation (new `exportConversation` / `importConversation` on the text drivers), a paused ask, frames buffered while detached, the set in hand. Every write it makes is conditional on `owner`, so a process that has lost a session finds out on its next write and drops it without ending anything.
- A reconnect on another process claims the row: at once from nobody or from a dead holder (stale heartbeat), or by asking a live holder over `LISTEN/NOTIFY` to release at its next turn boundary. The new holder rehydrates the driver from the snapshot, so the conversation continues where it was; replaying an identical prefix means a handover is served from the provider prompt cache rather than re-paying the opening seed. The client is answered with a provisional `attached` frame while a live holder is asked, because polite-ai's client gives a re-attach five seconds to prove itself.
- A holder that never answers loses the row when the wait runs out (`TEXT_CHAT_HANDOFF_WAIT_MS`, 5 s; longer when the holder reports a turn in flight).
- On `SIGTERM` a process releases every session it holds, so a rolling deploy hands sessions over instead of losing them.
- Retention: builder sessions remain history as before. Other text agents' sessions now have a row while live (they need one to move), marked `ephemeral`; it is deleted when the session ends and never listed.

Schema: `owner`, `state`, `ephemeral` on `chat_sessions`, added with `ADD COLUMN IF NOT EXISTS` at boot, like `last_seen_at`. No `schemaVersion` bump.

## Tests

`tests/chat-session-handoff.test.mjs` drives a second real node process (`tests/fixtures/chat-peer.mjs`) against the same database: open, first attach, live takeover with the conversation intact (the peer imports exactly the messages the first process had), the return trip, a dead holder claimed at once, an unresponsive holder taken after the wait, the fencing write, retention for ephemeral and builder rows, and the reaper. Existing text-chat suites are updated for the now-async `createChatSession`, which opens and holds a session in one step for single-process callers. Full DB suite green.

## Not in this change

- polite-ai needs no change; the socket protocol is unchanged.
- Beta stays at `replicas: 1` until this is deployed; the point of the change is that it no longer has to.
- `POD_NAME` is optional for the process id (Kubernetes sets `HOSTNAME` to the pod name).
