### PR TITLE
Only create test databases for configs that use one

### DIFF
--- a/jest.config.db.js
+++ b/jest.config.db.js
@@ -11,6 +11,9 @@ export default {
   ],
   setupFilesAfterEnv: [],
   globalSetup: './tests/setup/global-setup.js',
+  // Opt in to the per-worker databases created by tests/setup/global-setup.js.
+  // That file is shared with the jambonz image build, which has no database.
+  globals: { provisionWorkerDatabases: true },
   testTimeout: 60000,
   // One database per worker (see tests/setup/test-db-config.js), so the suite
   // no longer has to serialise. Override with JEST_WORKERS; global-setup.js

--- a/jest.config.js
+++ b/jest.config.js
@@ -198,7 +198,11 @@ export default {
     'ts-jest': {
       useESM: true,
     },
-    crypto: import('crypto')
+    crypto: import('crypto'),
+    // Opt in to the per-worker databases created by
+    // tests/setup/global-setup.js. That file is shared with the jambonz image
+    // build, which runs its own jest config and has no database.
+    provisionWorkerDatabases: true,
 
   },
   transform: {

--- a/jest.config.no-db.js
+++ b/jest.config.no-db.js
@@ -13,6 +13,9 @@ export default {
   ],
   setupFilesAfterEnv: [],
   globalSetup: './tests/setup/global-setup.js',
+  // Opt in to the per-worker databases created by tests/setup/global-setup.js.
+  // That file is shared with the jambonz image build, which has no database.
+  globals: { provisionWorkerDatabases: true },
   testTimeout: 30000,
   // One database per worker (see tests/setup/test-db-config.js), so the suite
   // no longer has to serialise. Override with JEST_WORKERS; global-setup.js

--- a/tests/setup/global-setup.js
+++ b/tests/setup/global-setup.js
@@ -61,7 +61,7 @@ async function createWorkerDatabases(workers) {
   }
 }
 
-export default async (globalConfig) => {
+export default async (globalConfig, projectConfig) => {
   // The livekit registry is only needed by suites that import it. In single-agent
   // container builds (e.g. the jambonz image) the agents/livekit source tree isn't
   // present, so attempting `yarn build` there fails with a bogus spawn ENOENT
@@ -81,8 +81,16 @@ export default async (globalConfig) => {
     }
   });
 
+  // Opt-in, because this file is shared. agents/jambonz/Dockerfile copies this
+  // directory into the jambonz image and runs `yarn test` during the image
+  // build, against agents/jambonz/jest.config.js and with no database anywhere:
+  // its suite needs none. Provisioning unconditionally broke that build. Only a
+  // config whose suites actually reach Postgres sets the flag.
+  //
   // After the env is cleaned, so the connection details come from
   // test-db-config.js and never from a stray .env in the checkout.
-  await createWorkerDatabases(globalConfig?.maxWorkers ?? 1);
+  if (projectConfig?.globals?.provisionWorkerDatabases) {
+    await createWorkerDatabases(globalConfig?.maxWorkers ?? 1);
+  }
 };
 


### PR DESCRIPTION
Fixes the jambonz image build, broken by my #296.

## What broke

`tests/setup/global-setup.js` is shared. `agents/jambonz/Dockerfile` copies it into the jambonz image (line 36) and runs `yarn test` during the image build, against `agents/jambonz/jest.config.js`, which points at the same `globalSetup`. Its one suite needs no database, and a docker build has none.

#296 made that setup call `createWorkerDatabases` unconditionally, so the build now spends twenty retries failing to reach `localhost:5433` and then dies. Every `jambonz-agent-europe-west1-staging` build since 947946d has failed (SUCCESS on a332576, then FAILURE on 947946d, 84a2eed, cca9359, eaf8ee0, 465fd89, d68ae85), leaving the service on `jambonz-agent-staging-00313-zn5`.

## Fix

Provisioning becomes opt-in. `globalSetup` takes the `projectConfig` jest already passes as its second argument and only creates databases when the config asks, via `globals.provisionWorkerDatabases`. `jest.config.db.js`, `jest.config.no-db.js` and `jest.config.js` set it. `agents/jambonz/jest.config.js` does not, and is untouched.

Opt-in rather than opt-out because the failure mode matters: a config that needs a database and forgets the flag fails loudly on connection, whereas skipping when Postgres merely looks unreachable would turn a genuinely down database into a confusing pile of suite failures.

## Verification

Built the jambonz image locally, the exact path that was failing:

```
#21 [16/16] RUN yarn test
#21 0.188 $ LOGLEVEL=error node --experimental-vm-modules node_modules/.bin/jest
#21 3.115 Test Suites: 1 passed, 1 total
#21 3.115 Tests:       14 passed, 14 total
EXIT=0
```

And confirmed the main suite still provisions, by dropping the worker databases first and checking they come back: 101 suites, 1102 tests, 21.0s, worker database count 0 to 4 across the run.

Reported by the "Make llm-agent safe above one replica" session, whose diagnosis this confirms.