### PR TITLE
Test databases: one set per checkout, not per machine

### DIFF
--- a/tests/setup/test-db-config.js
+++ b/tests/setup/test-db-config.js
@@ -5,6 +5,12 @@
 // database-test-wrapper.js, which points lib/database.js at the database its
 // own worker owns.
 
+import { createHash } from 'node:crypto';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
 const inContainer = process.env.USE_CONTAINER_NETWORKING === 'true';
 
 export const testDbConnection = {
@@ -19,8 +25,40 @@ export const testDbConnection = {
 // drop the per-worker databases.
 export const bootstrapDatabase = 'llmvoicetest';
 
+/**
+ * Per-CHECKOUT tag, so two checkouts sharing this container do not share
+ * database names.
+ *
+ * global-setup.js drops every worker database it is about to create, WITH
+ * (FORCE), which terminates whatever is connected to them. With one set of
+ * names per machine, a second run starting mid-way through a first one
+ * destroys the first one's databases underneath it: the losing side fails at
+ * its first query, often with an empty error, sometimes `database
+ * "llmvoicetest_N" does not exist`, and lib/database.js's pg-listen error
+ * handler then exits the process.
+ *
+ * That is not theoretical. On 2026-09-08 two sessions ran the suite on this
+ * machine at once — six global setups inside 65 seconds — and the resulting
+ * failures were indistinguishable from flakes. One was reported as a flake.
+ * A red run that is really a collision is worse than a slow one: it teaches
+ * people to re-run until green, which is how a real regression gets through.
+ *
+ * Derived from the checkout path rather than a random value, so a given
+ * checkout keeps the same names across runs and its databases are reused
+ * rather than accumulating. Worktrees each get their own, which is the point.
+ * `TEST_DB_TAG` overrides it where something outside needs to pin the name.
+ * Truncated to 8 hex characters: the whole identifier has to stay inside
+ * Postgres's 63-byte limit, and collisions between two paths on one laptop are
+ * not a real risk.
+ */
+const checkoutTag = process.env.TEST_DB_TAG
+  || createHash('sha1').update(repoRoot).digest('hex').slice(0, 8);
+
 // The database a given jest worker owns. JEST_WORKER_ID is 1-based, and is set
 // in each worker process (it is absent, so treated as 1, when jest runs a
 // single file in band).
 export const workerDatabase = (workerId = process.env.JEST_WORKER_ID || '1') =>
-  `${bootstrapDatabase}_${workerId}`;
+  `${bootstrapDatabase}_${checkoutTag}_${workerId}`;
+
+/** The checkout tag in use, so a failure can say which checkout owns what. */
+export const testDbTag = checkoutTag;


### PR DESCRIPTION
Since #296 gave each jest worker its own database, `tests/setup/global-setup.js` drops every worker database it is about to create, `WITH (FORCE)`, which terminates whatever is connected. The names are per-**machine**, so a second run starting mid-way through a first one destroys the first one's databases underneath it.

## It does not look like a collision

The losing side fails at its first query, often with an empty error line, sometimes `database "llmvoicetest_N" does not exist`, and `lib/database.js`'s pg-listen error handler then calls `process.exit(1)`.

It cost two sessions time last night, and I reported one instance as "a flake with no cause" before the session working on #295 traced it in the container's statement log: six global setups on `llmvoicetest_1` inside 65 seconds, spanning the run that failed.

**A red run that is really a collision is worse than a slow one.** It teaches people to re-run until green, which is how a real regression gets through.

## Reproduced, both directions

Two checkouts, full suites, started 5.3 seconds apart.

**Before** — the run that started *first* loses:

| | started | result |
|---|---|---|
| A | 23:50:18 | **hung over 5 minutes**, killed (normal is ~65s) |
| B | 23:50:23 | 1088 passed, green |

Postgres logged `relation "phone_registrations" does not exist` and `type "enum_instances_type" does not exist` at 23:50:25, immediately after B's setup dropped and recreated A's databases under A's connected workers.

**After** — same pair, both carrying this change, tags `a1a120bd` and `c79e2e96`:

| | result |
|---|---|
| A (first) | **1097 passed, 0 failed** — survives where it previously hung |
| B (second) | 1096 passed, 1 unrelated failure (see below) |

The drop pattern is clean too: each run dropped only its own four databases, in one burst at its own setup, no interleaving.

Worth recording that concurrency alone is **not** sufficient to reproduce this. Two short runs both passed. The second setup has to land while the first run's workers are still connected, which is why full suites are where it bites.

## The change

`tests/setup/test-db-config.js` only — one file, so it cannot conflict with the `global-setup.js` work in flight to unbreak the jambonz image build.

```
llmvoicetest_<sha1(repoRoot)[0:8]>_<workerId>     // TEST_DB_TAG overrides
```

Derived from the checkout path rather than random, so a checkout keeps its names across runs and reuses its databases instead of accumulating them. Worktrees each get their own, which is the point. 23 characters against Postgres's 63-byte limit. Exports `testDbTag` so a failure can say which checkout owns what.

Child-process fixtures need no change: they take the database from the `POSTGRES_*` variables the wrapper sets, so they follow the tag automatically. The Docker CI path gets one stable tag from its fixed `repoRoot`.

## Not fixed here

Run B above had one failure in `tests/rates.test.mjs`. It is **not** a collision — the log shows no cross-drop and the tags were distinct. It passes in isolation (27/27), and a subsequent full run on the same checkout was green (1097 passed). So it is a separate intermittent in a file I wrote, seen once, not yet characterised. I am not bundling a guess at it into this PR.

Diagnosis credit to the session working on #295, which found it in the statement log and handed it over.
