### PR TITLE
Chat session reaper: wait for the boot chain before the first sweep

### DIFF
--- a/lib/text-chat.js
+++ b/lib/text-chat.js
@@ -167,10 +167,23 @@ export async function reapStaleChatSessions({ graceMs = LIVENESS_GRACE_MS, log =
  * @returns {() => void} stop
  */
 export function startChatSessionReaper({ intervalMs = LIVENESS_GRACE_MS, log = defaultLogger } = {}) {
-  reapStaleChatSessions({ log });
-  const timer = setInterval(() => reapStaleChatSessions({ log }), intervalMs);
-  if (timer.unref) timer.unref();
-  return () => clearInterval(timer);
+  let timer = null;
+  let stopped = false;
+  // Not before the boot chain has finished: the columns the sweep reads are
+  // added there (ADD COLUMN IF NOT EXISTS), so a sweep that ran as soon as the
+  // server listened failed once, on the first deploy after each column was
+  // added, with "column does not exist". The sweep is best-effort and logged
+  // rather than threw, but a first run that cannot run is not a first run.
+  databaseStarted.then(() => {
+    if (stopped) return;
+    reapStaleChatSessions({ log });
+    timer = setInterval(() => reapStaleChatSessions({ log }), intervalMs);
+    if (timer.unref) timer.unref();
+  });
+  return () => {
+    stopped = true;
+    if (timer) clearInterval(timer);
+  };
 }
 
 /** The session `id` if THIS process holds it; undefined otherwise (see attachChatSession). */


### PR DESCRIPTION
## What

`startChatSessionReaper` now waits for the boot chain (`databaseStarted`) before its first sweep and before starting its timer.

## Why

`index.mjs` starts the reaper as soon as the server is listening, and the reaper's first sweep ran at once. The columns the sweep reads are added by the boot chain (`ADD COLUMN IF NOT EXISTS`), which may still be running at that moment. On the first staging deploy after #300 the first sweep ran 30 s into boot and failed with `column "ephemeral" does not exist`; the sweep is best-effort, so it logged an ERROR and the next tick, five minutes later, ran clean. Harmless in effect, and a one-off per column added this way, but a first run that cannot run is not a first run. The ownership listener already waits the same way.

Full DB suite green (101 suites, 1100 tests).
