### PR TITLE
Schema 67: the digest HA1 pair beside a registrar account's sealed password

### DIFF
--- a/lib/database-models/phone-registration.js
+++ b/lib/database-models/phone-registration.js
@@ -1,5 +1,22 @@
 import { Model, DataTypes } from 'sequelize';
+import { createHash } from 'crypto';
 import { encryptSecret, decryptSecret, PHONE_REGISTRATION_STATE_VALUES, PHONE_REGISTRATION_STATUS_VALUES, PHONE_REGISTRATION_MODE_VALUES, PHONE_REGISTRATION_KIND_VALUES, PHONE_REGISTRATION_SCHEMA_VERSION } from '../utils/credentials.js';
+
+const md5 = (value) => createHash('md5').update(value, 'utf8').digest('hex');
+
+/**
+ * The digest HA1 pair of a registrar account (RFC 2617): MD5 of
+ * `username:realm:password`, and the `ha1b` form for a client that presents
+ * `username@realm` as its digest username. The realm is the row's own
+ * `registrar` column, which is permanent, so the hashes are stable for the
+ * life of the password.
+ */
+export function registrarHA1(username, realm, password) {
+  return {
+    ha1: md5(`${username}:${realm}:${password}`),
+    ha1b: md5(`${username}@${realm}:${realm}:${password}`)
+  };
+}
 
 class PhoneRegistration extends Model {}
 
@@ -127,6 +144,18 @@ export function initPhoneRegistration(sequelize, types = DataTypes) {
     bindingsUpdatedAt: {
       type: types.DATE,
       allowNull: true
+    },
+    // Registrar rows only: the digest HA1 pair for the sealed password, so
+    // the Kamailio edge can verify credentials without the key that opens
+    // `password`. Written by the beforeSave hook below whenever a registrar
+    // row's password is set; null on client rows. Never returned by the API.
+    ha1: {
+      type: types.STRING(32),
+      allowNull: true
+    },
+    ha1b: {
+      type: types.STRING(32),
+      allowNull: true
     }
   }, {
     sequelize,
@@ -136,6 +165,23 @@ export function initPhoneRegistration(sequelize, types = DataTypes) {
     collate: 'utf8_general_ci',
     modelName: 'PhoneRegistration',
     tableName: 'phone_registrations',
+    hooks: {
+      // The HA1 pair follows the password: computed on mint and on rotate,
+      // and on any save of a registrar row that has none yet (the backfill).
+      // The getter yields the plaintext the setter sealed a moment ago; a
+      // password that will not decrypt leaves the hashes untouched rather
+      // than writing a hash of nothing, and the account is refused at the
+      // edge until it is rotated.
+      beforeSave(instance) {
+        if (instance.mode !== 'registrar') return;
+        if (!instance.changed('password') && instance.ha1) return;
+        const password = instance.password;
+        if (!password || !instance.username || !instance.registrar) return;
+        const { ha1, ha1b } = registrarHA1(instance.username, instance.registrar, password);
+        instance.ha1 = ha1;
+        instance.ha1b = ha1b;
+      }
+    },
     indexes: [
       // One realm per deployment means an issued username has to be unique
       // across every organisation, not per (registrar, organisation) as the

--- a/lib/database.js
+++ b/lib/database.js
@@ -20,7 +20,13 @@ import { createAgentConcurrencyLimits } from './concurrency/agent-concurrency-li
 // policy module (which imports this file).
 import { validateOutboundCallFilter } from './outbound-filter.js';
 
-const schemaVersion = 66;  // 66: registrar accounts (regserver) — `phone_registrations.mode` ('client' |
+const schemaVersion = 67;  // 67: `phone_registrations.ha1` and `ha1b` beside the sealed password of a
+                           //     registrar account: MD5 of user:realm:password and of
+                           //     user@realm:realm:password, written by the model whenever a registrar
+                           //     row's password is set (mint and rotate) and backfilled on upgrade, so
+                           //     the Kamailio edge (aplisay-b2bua sipedge/PLAN.md section 3) verifies
+                           //     digest credentials without ever holding CREDENTIALS_KEY. Never exposed.
+                           // 66: registrar accounts (regserver) — `phone_registrations.mode` ('client' |
                            //     'registrar'), `kind` ('pbx'), `bindings` JSONB and `bindings_updated_at`, plus
                            //     the partial unique index `phone_registrations_registrar_username` (username
                            //     WHERE mode = 'registrar': one realm per deployment, so an issued username is
@@ -2888,6 +2894,40 @@ async function encryptAgentKeysAtRest() {
   }
 }
 
+/**
+ * Schema 67: every registrar account gets its HA1 pair. The model's beforeSave
+ * hook computes them whenever a registrar row's password is set; this covers
+ * the rows minted before the columns existed. Idempotent: a row with a hash
+ * is left alone, and a row whose password will not decrypt (no key, or the
+ * wrong one) is skipped and logged rather than written with a hash of null.
+ */
+async function backfillRegistrarHA1() {
+  try {
+    const rows = await PhoneRegistration.findAll({
+      where: { mode: 'registrar', ha1: null },
+      attributes: ['id', 'registrar', 'username', 'password', 'mode', 'ha1', 'ha1b'],
+    });
+    let written = 0;
+    let skipped = 0;
+    for (const row of rows) {
+      if (!row.password) {
+        skipped += 1;
+        continue;
+      }
+      // The hook recomputes from the plaintext the getter yields; saving the
+      // password field re-seals the same value.
+      row.set('password', row.password);
+      await row.save({ fields: ['password', 'ha1', 'ha1b'] });
+      written += 1;
+    }
+    if (written || skipped) {
+      logger.info({ written, skipped }, 'Backfilled registrar account HA1');
+    }
+  } catch (err) {
+    logger.warn({ err: err?.message }, 'backfillRegistrarHA1: ignoring');
+  }
+}
+
 // Rate cards intentionally have NO period-overlap constraint (schema v59), for
 // the same reason tariffs lost theirs at v53. resolveRateCard is deterministic —
 // the card with the greatest start_date <= billedAt wins — so overlapping (or two
@@ -3047,6 +3087,7 @@ const databaseStarted = sequelize.authenticate()
     .then(() => migratePhoneNumbersIdentity())
     .then(() => PhoneNumber.sync({ alter: true }))
     .then(() => PhoneRegistration.sync({ alter: true }))
+    .then(() => backfillRegistrarHA1())
     .then(() => NumberReservation.sync({ alter: true }))
     .then(() => TrunkOrganisation.sync({ alter: true }))
     .then(() => AuthKey.sync({ alter: true }))
@@ -3404,5 +3445,6 @@ export {
   databaseStarted,
   stopDatabase,
   encryptAgentKeysAtRest,
+  backfillRegistrarHA1,
 };
 export { AgentConcurrencyLimitExceededError } from './concurrency/agent-concurrency-limits.js';

--- a/tests/registrar-accounts.test.mjs
+++ b/tests/registrar-accounts.test.mjs
@@ -7,9 +7,15 @@
  * Design: aplisay-strategy implementation/regserver-tactical-spec.md §2.
  */
 import { setupRealDatabase, teardownRealDatabase, PhoneRegistration, User, Organisation, Trunk, Op } from './setup/database-test-wrapper.js';
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 
 const REALM = 'sip.test.polite.ai';
+
+// The digest HA1 pair the Kamailio edge verifies against, computed here
+// independently of the model (schema 67).
+const md5 = (v) => createHash('md5').update(v).digest('hex');
+const ha1Of = (username, password) => md5(`${username}:${REALM}:${password}`);
+const ha1bOf = (username, password) => md5(`${username}@${REALM}:${REALM}:${password}`);
 
 describe('registrar accounts', () => {
   let testOrgId;
@@ -108,6 +114,9 @@ describe('registrar accounts', () => {
     expect(row.state).toBe('initial');
     expect(row.b2buaId).toBeNull();
     expect(row.bindings).toBeNull();
+    // Schema 67: the HA1 pair beside the sealed password, for the edge.
+    expect(row.ha1).toBe(ha1Of(r._body.username, r._body.password));
+    expect(row.ha1b).toBe(ha1bOf(r._body.username, r._body.password));
   });
 
   test('refuses an identity supplied by the caller', async () => {
@@ -208,6 +217,10 @@ describe('registrar accounts', () => {
     expect(row.password).toBe(rotate._body.password);
     expect(row.state).toBe('initial');
     expect(row.error).toBeNull();
+    // The HA1 pair follows the rotated password.
+    expect(row.ha1).toBe(ha1Of(createdRes._body.username, rotate._body.password));
+    expect(row.ha1).not.toBe(ha1Of(createdRes._body.username, createdRes._body.password));
+    expect(row.ha1b).toBe(ha1bOf(createdRes._body.username, rotate._body.password));
 
     const line = res();
     await createPhoneEndpoint(req({ body: { type: 'phone-registration', name: 'Line', registrar: 'sip.example.com', username: 'u2', password: 'p2' } }), line);
@@ -218,6 +231,45 @@ describe('registrar accounts', () => {
     const lineRotate = res();
     await rotateCredentials(req({ params: { identifier: line._body.id } }), lineRotate);
     expect(lineRotate._status).toBe(404);
+  });
+
+  test('the HA1 pair is registrar-only, never exposed, and backfilled for rows that predate it', async () => {
+    const { backfillRegistrarHA1 } = await import('../lib/database.js');
+
+    // A client-mode line carries no hashes: its password is the customer's
+    // and the edge never verifies it.
+    const line = res();
+    await createPhoneEndpoint(req({ body: { type: 'phone-registration', name: 'Line', registrar: 'sip.example.com', username: 'u3', password: 'p3' } }), line);
+    expect(line._status).toBe(201);
+    const lineRow = await PhoneRegistration.findByPk(line._body.id);
+    expect(lineRow.ha1).toBeNull();
+    expect(lineRow.ha1b).toBeNull();
+
+    // An account minted before the columns existed: the hook did not run,
+    // so the hashes are null until the upgrade's backfill fills them from
+    // the sealed password.
+    const account = await createAccount();
+    const id = account._body.id;
+    await PhoneRegistration.update({ ha1: null, ha1b: null }, { where: { id } });
+    expect((await PhoneRegistration.findByPk(id)).ha1).toBeNull();
+    await backfillRegistrarHA1();
+    const filled = await PhoneRegistration.findByPk(id);
+    expect(filled.ha1).toBe(ha1Of(account._body.username, account._body.password));
+    expect(filled.ha1b).toBe(ha1bOf(account._body.username, account._body.password));
+    expect(filled.password).toBe(account._body.password);
+    // Running it again is a no-op.
+    await backfillRegistrarHA1();
+    expect((await PhoneRegistration.findByPk(id)).ha1).toBe(filled.ha1);
+
+    // Neither reveal nor the read shape carries the hashes.
+    const reveal = res();
+    await revealCredentials(req({ params: { identifier: id } }), reveal);
+    expect(reveal._body.ha1).toBeUndefined();
+    const read = res();
+    await getPhoneEndpoint(req({ params: { identifier: id } }), read);
+    expect(read._status).toBe(200);
+    expect(read._body.ha1).toBeUndefined();
+    expect(read._body.ha1b).toBeUndefined();
   });
 
   test('refuses reveal to another organisation and to a caller without update', async () => {


### PR DESCRIPTION
Schema 67: `phone_registrations.ha1` and `ha1b` beside a registrar account's sealed password.

The Kamailio edge (aplisay/aplisay-b2bua#48, `sipedge/PLAN.md` section 3) verifies REGISTER, INVITE and SUBSCRIBE digests against these two hashes (MD5 of `user:realm:password`, and the `user@realm:realm:password` form), because the password column is AES-GCM sealed with a key the edge must not hold. The realm is the row's `registrar` column and is permanent, so the pair is stable for the life of the password.

- A `beforeSave` hook on `PhoneRegistration` computes both whenever a registrar row's password is set, which covers the mint (`POST /phone-endpoints`) and the rotate (`POST /phone-endpoints/{id}/credentials`) without touching either route. A password that will not decrypt leaves the hashes untouched rather than writing a hash of nothing.
- `backfillRegistrarHA1()` after the `PhoneRegistration` alter in the upgrade chain fills rows minted before the columns existed; idempotent.
- Client rows carry nulls. Nothing returns the hashes: the read shape and the reveal route are unchanged.
- `schemaVersion` 67; applied with the manual `upgrade-db` as 66 was. The sipedge runbook's cutover step 1 checks no registrar row has a null `ha1`.

Verified: `tests/registrar-accounts.test.mjs` extended (the pair on create, the pair following a rotate, nulls on a client line, the backfill and its idempotence, nothing exposed); the phone-registration, credentials-sweep, phone-endpoints-comprehensive, agent-db-phone-endpoints, registrar-accounts-validation and b2bua-node-regserver suites pass (Node 24, the local test database).

Not in this change: the database role grant the edge needs (a column-scoped SELECT on `id, username, ha1, ha1b, status, mode, b2bua_id`), which is a runbook step in aplisay-b2bua.
