### PR TITLE
fix(pipecat): stop the pause stretcher delaying GPT-Live audio without limit

### DIFF
--- a/agents/pipecat/pipecat_aplisay/output_cushion.py
+++ b/agents/pipecat/pipecat_aplisay/output_cushion.py
@@ -60,6 +60,11 @@ experiment below says the depth was never the binding constraint.
 Do not "fix" this by keying the release point to the target without re-running
 that measurement. If the knob's name is the problem, rename the knob.
 
+Until 2026-09-11 the target was compared with this track's queue, which never
+gets near it, so in practice the stretcher had no ceiling at all. It is now
+compared with the whole output backlog. See WHY THE CEILING COUNTS THE WHOLE
+BACKLOG below.
+
 WHAT THE RELEASE POINT IS *NOT* FOR
 -----------------------------------
 Tested directly (staging, 2026-08-26): ``WEBRTC_OUTPUT_CUSHION_MS=300`` with
@@ -82,8 +87,50 @@ MANUFACTURES slack that does not otherwise exist.
   60 ms release + pause-stretch           1              0.06
   ================================  =========  ==============
 
+WHY THE CEILING COUNTS THE WHOLE BACKLOG (staging, 2026-09-11)
+-------------------------------------------------------------
+A repeated chunk is 10 ms that the track plays and the source never sent, so it
+delays all the audio behind it by 10 ms. That delay goes away only when the
+source stops sending and the queue empties. Ultravox stops between turns, so its
+queue empties and the delay is gone before the next turn starts.
+
+GPT-Live never stops. It streams audio at real-time pace, silence included
+(pipecat marks this with ``SpeechOutputAudioRawFrame``), so the queue never
+empties and every repeated chunk stays as delay. The ceiling counted only this
+track's queue, so it never engaged, and the extra audio waited in the
+transport's unbounded queue instead. One test call stretched 1800 chunks in
+109 s. Frames queued behind that audio reached the end of the pipeline 7.8 s
+late at 42 s into the call and 14.9 s late at 74 s, and each reply started later
+than the one before. The transcript does not wait in that queue, so it arrived
+long before the audio.
+
+So the ceiling now counts the whole output backlog: this track's queue plus the
+audio ``OutputCushionInterrupt`` has forwarded that the transport has not yet
+handed to the track. The stretcher runs only while that total is under
+``WEBRTC_OUTPUT_TARGET_MS``, so it can add at most that much delay to any
+source. On GPT-Live the backlog settles at the target, so the target is the
+delay the cushion adds there, in exchange for that much protection against late
+audio. In a long Ultravox turn the stretcher used to add about 67 ms per second
+of speech until the turn ended; it now stops at the target there too.
+
+TRIMMING A SPEECH STREAM BACK TO THE TARGET
+-------------------------------------------
+The backlog can still pass the target without the stretcher: a source that
+delivers late and then catches up in a burst leaves the burst queued. On a
+continuous speech stream nothing ever empties the queue, so that would be extra
+delay for the rest of the call. Once the backlog passes ``WEBRTC_OUTPUT_MAX_MS``
+(500), one quiet chunk in ``WEBRTC_TRIM_EVERY`` (3) is dropped until the backlog
+is back at the target. As with the stretcher, voiced audio is never touched, and
+neither is the chunk that carries the producer's future.
+
+Only speech streams are trimmed. TTS audio (Ultravox, OpenAI Realtime, Gemini
+Live and the TTS services) arrives faster than real time and waits ahead of the
+playhead, so a large backlog there is speech made early, not delay, and
+shortening its pauses would gain nothing.
+
 ``WEBRTC_OUTPUT_CUSHION_MS=0`` restores the stock lock-step behaviour;
-``WEBRTC_STRETCH_EVERY=0`` keeps the hard cushion but disables stretching.
+``WEBRTC_STRETCH_EVERY=0`` keeps the hard cushion but disables stretching;
+``WEBRTC_TRIM_EVERY=0`` disables trimming.
 """
 
 from __future__ import annotations
@@ -94,15 +141,30 @@ from typing import Any, Optional
 
 import numpy as np
 from loguru import logger
-from pipecat.frames.frames import Frame, InterruptionFrame, OutputAudioRawFrame
+from pipecat.frames.frames import (
+    Frame,
+    InterruptionFrame,
+    OutputAudioRawFrame,
+    SpeechOutputAudioRawFrame,
+)
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
 DEFAULT_CUSHION_MS = 60
 DEFAULT_TARGET_MS = 300
+#: On a continuous speech stream, a whole-output backlog above this is trimmed
+#: back down to the target.
+DEFAULT_MAX_MS = 500
 DEFAULT_STRETCH_QUIET_DBFS = -50.0
 #: Duplicate one quiet chunk in every N — a ~33% stretch of pause regions, which
 #: is what the measurement below is sized against.
 DEFAULT_STRETCH_EVERY = 3
+#: While trimming, drop one quiet chunk in every N: pauses shrink by a third,
+#: the reverse of the stretch.
+DEFAULT_TRIM_EVERY = 3
+
+# What _pause_action can decide for a chunk.
+_STRETCH = "stretch"
+_TRIM = "trim"
 
 
 def cushioned(base: type) -> type:
@@ -113,14 +175,33 @@ def cushioned(base: type) -> type:
             super().__init__(*a, **kw)
             ms = float(os.environ.get("WEBRTC_OUTPUT_CUSHION_MS", DEFAULT_CUSHION_MS))
             chunk_ms = 1000.0 * self._samples_per_10ms / max(1, self._sample_rate)
+            self._chunk_ms = chunk_ms
             self._cushion_chunks = max(0, int(round(ms / chunk_ms)))
             target = float(os.environ.get("WEBRTC_OUTPUT_TARGET_MS", DEFAULT_TARGET_MS))
             self._target_chunks = max(self._cushion_chunks, int(round(target / chunk_ms)))
+            self._target_ms = self._target_chunks * chunk_ms
+            ceiling = float(os.environ.get("WEBRTC_OUTPUT_MAX_MS", DEFAULT_MAX_MS))
+            self._max_ms = max(self._target_ms, ceiling)
             db = float(os.environ.get("WEBRTC_STRETCH_QUIET_DBFS", DEFAULT_STRETCH_QUIET_DBFS))
             self._quiet_peak = 32767.0 * (10.0 ** (db / 20.0))
             self._stretch_every = max(0, int(os.environ.get("WEBRTC_STRETCH_EVERY", DEFAULT_STRETCH_EVERY)))
+            self._trim_every = max(0, int(os.environ.get("WEBRTC_TRIM_EVERY", DEFAULT_TRIM_EVERY)))
             self._quiet_seen = 0
+            self._trimming = False
             self.stretched_chunks = 0
+            self.trimmed_chunks = 0
+            #: The largest whole-output backlog seen, in ms, for the per-call line.
+            self.peak_backlog_ms = 0.0
+            #: True while the audio reaching the transport is a continuous speech
+            #: stream. OutputCushionInterrupt sets it from each frame's type.
+            self.speech_stream = False
+            # The transport's share of the backlog (see upstream_ms). The
+            # instrumented base defines the probe as well; define it here too so
+            # the cushion still works with the instrumentation switched off.
+            if not hasattr(self, "inflight_probe"):
+                self.inflight_probe = None
+            self._handed_ms = 0.0
+            self._upstream_offset_ms = 0.0
 
         def add_audio_bytes(self, audio_bytes: bytes):  # noqa: ANN201
             cushion = self._cushion_chunks
@@ -138,6 +219,8 @@ def cushioned(base: type) -> type:
                 # Same contract as the parent — an odd-sized write is a bug
                 # upstream and must not be silently repacked.
                 raise ValueError("Audio bytes must be a multiple of 10ms size.")
+            # This audio has left the transport's queue for ours.
+            self._handed_ms += 1000.0 * (len(audio_bytes) / 2) / max(1, self._sample_rate)
 
             future = asyncio.get_running_loop().create_future()
             step = self._bytes_per_10ms
@@ -146,21 +229,37 @@ def cushioned(base: type) -> type:
                 future.set_result(True)
                 return future
 
+            # The whole output backlog once this batch is queued. Stretching and
+            # trimming are decided against this, never against our queue alone:
+            # see WHY THE CEILING COUNTS THE WHOLE BACKLOG.
+            backlog = self.backlog_ms() + len(chunks) * self._chunk_ms
+            if backlog > self.peak_backlog_ms:
+                self.peak_backlog_ms = backlog
+
             # Hand the future to the chunk that leaves `cushion` behind it, so
             # the producer wakes while the queue still has that much to play.
             release = max(0, len(chunks) - 1 - cushion)
             for i, chunk in enumerate(chunks):
+                action = self._pause_action(chunk, backlog)
+                if action == _TRIM and i != release:
+                    # A speech stream has fallen behind: shorten this pause. The
+                    # chunk carrying the future is always kept, because the
+                    # producer waits on it.
+                    backlog -= self._chunk_ms
+                    self.trimmed_chunks += 1
+                    continue
                 self._chunk_queue.append((chunk, future if i == release else None))
-                # Build the cushion out of the agent's own pauses. A quarter of
-                # in-turn agent audio is pause (measured: 60 s in 240 s, ~360
-                # runs of >=40 ms), so repeating one quiet chunk in three banks
-                # ~67 ms of cushion per second of audio — 13x what a flat 95%
-                # playout rate would yield, and inaudible, because a repeated
-                # near-silent frame has no pitch to shift and no transient to
-                # smear. Voiced audio is never touched: that would need WSOLA,
-                # and these pods have little CPU to spare.
-                if self._should_stretch(chunk):
+                if action == _STRETCH:
+                    # Build the cushion out of the agent's own pauses. A quarter
+                    # of in-turn agent audio is pause (measured: 60 s in 240 s,
+                    # ~360 runs of >=40 ms), so repeating one quiet chunk in three
+                    # banks ~67 ms of cushion per second of audio: 13x what a
+                    # flat 95% playout rate would yield, and inaudible, because a
+                    # repeated near-silent frame has no pitch to shift and no
+                    # transient to smear. Voiced audio is never touched: that
+                    # would need WSOLA, and these pods have little CPU to spare.
                     self._chunk_queue.append((chunk, None))
+                    backlog += self._chunk_ms
                     self.stretched_chunks += 1
 
             # While the queue is still shallower than the cushion, do not hold
@@ -170,16 +269,82 @@ def cushioned(base: type) -> type:
                 future.set_result(True)
             return future
 
-        def _should_stretch(self, chunk: bytes) -> bool:
-            """May this chunk be repeated to lengthen a pause?"""
-            if self._stretch_every <= 0 or len(self._chunk_queue) >= self._target_chunks:
-                return False
+        def _pause_action(self, chunk: bytes, backlog_ms: float) -> Optional[str]:
+            """Repeat this chunk to lengthen a pause, drop it to shorten one, or neither.
+
+            Only quiet chunks are ever touched, and only one in N of a run of
+            them, so pauses change length and speech does not.
+            """
+            trim = self._trim_due(backlog_ms)
+            stretch = self._stretch_every > 0 and backlog_ms < self._target_ms
+            if not (trim or stretch):
+                return None
             samples = np.frombuffer(chunk, dtype=np.int16)
             if samples.size == 0 or np.abs(samples).max() > self._quiet_peak:
-                self._quiet_seen = 0          # voiced: never stretch, and reset
-                return False
+                self._quiet_seen = 0          # voiced: never touched, and reset
+                return None
             self._quiet_seen += 1
-            return self._quiet_seen % self._stretch_every == 0
+            if trim:
+                return _TRIM if self._quiet_seen % self._trim_every == 0 else None
+            return _STRETCH if self._quiet_seen % self._stretch_every == 0 else None
+
+        def _trim_due(self, backlog_ms: float) -> bool:
+            """Is a speech stream far enough behind to trim at this backlog?
+
+            Trimming starts above the max and runs until the backlog is back at
+            the target. The gap between the two stops the stretcher and the
+            trimmer from taking turns on the same few chunks.
+            """
+            if self._trim_every <= 0 or not self.speech_stream:
+                self._trimming = False
+            elif backlog_ms > self._max_ms:
+                self._trimming = True
+            elif backlog_ms <= self._target_ms:
+                self._trimming = False
+            return self._trimming
+
+        def upstream_ms(self) -> float:
+            """Audio forwarded towards this track that it has not been handed yet.
+
+            That is the audio in the transport's own queue: the total forwarded,
+            from OutputCushionInterrupt's probe, less what has reached this
+            track, less the offset set when the count was last anchored.
+            """
+            probe = self.inflight_probe
+            if probe is None:
+                return 0.0
+            try:
+                ahead = probe() - self._handed_ms - self._upstream_offset_ms
+            except Exception:  # noqa: BLE001
+                return 0.0
+            if ahead < 0.0:
+                # More reached us than was forwarded: the transport pads a turn's
+                # last chunk with silence, and it can hand over a chunk after an
+                # interruption anchored the count. It cannot hold less than
+                # nothing, so anchor again here instead of keeping the error.
+                self._upstream_offset_ms += ahead
+                return 0.0
+            return ahead
+
+        def backlog_ms(self) -> float:
+            """The whole output backlog: this track's queue plus the transport's."""
+            return len(self._chunk_queue) * self._chunk_ms + self.upstream_ms()
+
+        def anchor_upstream(self) -> None:
+            """Count nothing as in flight from here on.
+
+            Called when the probe is wired, because audio forwarded before this
+            track existed was dropped by the transport and never reached a
+            track, and on an interruption, because the transport empties its
+            queue then.
+            """
+            probe = self.inflight_probe
+            if probe is None:
+                return
+            try:
+                self._upstream_offset_ms = probe() - self._handed_ms
+            except Exception:  # noqa: BLE001
+                pass
 
         def clear(self) -> int:
             """Drop everything queued — the caller has interrupted.
@@ -189,6 +354,9 @@ def cushioned(base: type) -> type:
             the agent talks over the caller for longer. Any future still riding a
             dropped chunk MUST be resolved here or write_audio_frame waits on it
             for ever and the leg goes silent.
+
+            The transport empties its own queue on the same interruption, so the
+            count of audio in flight starts again from zero.
             """
             n = len(self._chunk_queue)
             for _chunk, fut in self._chunk_queue:
@@ -196,6 +364,8 @@ def cushioned(base: type) -> type:
                     fut.set_result(True)
             self._chunk_queue.clear()
             self._quiet_seen = 0
+            self._trimming = False
+            self.anchor_upstream()
             return n
 
     _CushionedRawAudioTrack.__name__ = "CushionedRawAudioTrack"
@@ -223,6 +393,12 @@ class OutputCushionInterrupt(FrameProcessor):
     the audio EXIST and we failed to move it, or had it not arrived at all? The
     two have opposite fixes, so the same class does both jobs rather than
     resolving the track twice.
+
+    The same number is half of the whole output backlog that the track's
+    stretcher and trimmer steer by. The track anchors the count when the probe
+    is wired and on each interruption. This processor also tells the track what
+    kind of audio is arriving: a ``SpeechOutputAudioRawFrame`` is part of a
+    continuous speech stream (GPT-Live), the only kind the track may trim.
     """
 
     def __init__(self, *, output_transport: Any, **kwargs: Any) -> None:
@@ -245,15 +421,28 @@ class OutputCushionInterrupt(FrameProcessor):
             return
         if hasattr(track, "inflight_probe"):
             track.inflight_probe = lambda: self._forwarded_ms
+            # Audio forwarded before this track existed never reached it.
+            anchor = getattr(track, "anchor_upstream", None)
+            if callable(anchor):
+                anchor()
             self._wired = track
+
+    def _note_audio(self, frame: OutputAudioRawFrame) -> None:
+        """Count a frame on its way to the transport and tell the track its kind."""
+        # Wire first: a new track anchors on the total so far, and this frame
+        # then counts as in flight to it.
+        self._wire_probe()
+        rate = getattr(frame, "sample_rate", 0) or 0
+        if rate:
+            self._forwarded_ms += 1000.0 * (len(frame.audio) / 2) / rate
+        track = self._wired
+        if track is not None and hasattr(track, "speech_stream"):
+            track.speech_stream = isinstance(frame, SpeechOutputAudioRawFrame)
 
     async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
         await super().process_frame(frame, direction)
         if isinstance(frame, OutputAudioRawFrame) and frame.audio:
-            rate = getattr(frame, "sample_rate", 0) or 0
-            if rate:
-                self._forwarded_ms += 1000.0 * (len(frame.audio) / 2) / rate
-            self._wire_probe()
+            self._note_audio(frame)
         if isinstance(frame, InterruptionFrame):
             track = self._track()
             clear = getattr(track, "clear", None)

--- a/agents/pipecat/pipecat_aplisay/output_underrun.py
+++ b/agents/pipecat/pipecat_aplisay/output_underrun.py
@@ -197,7 +197,14 @@ def instrumented(base: type) -> type:
                     probe = self.inflight_probe
                     if probe is not None:
                         try:
-                            inflight = max(0.0, probe() - self.queued_ms)
+                            # The cushion anchors this count across track changes
+                            # and interruptions; use its figure when it is there,
+                            # so this line reports what the stretcher steered by.
+                            upstream = getattr(self, "upstream_ms", None)
+                            if callable(upstream):
+                                inflight = upstream()
+                            else:
+                                inflight = max(0.0, probe() - self.queued_ms)
                             st.inflight_at_starve.append(inflight)
                             st.max_inflight_at_starve = max(
                                 st.max_inflight_at_starve, inflight
@@ -240,11 +247,21 @@ def instrumented(base: type) -> type:
                 # report them; ride the one per-call line rather than add a
                 # second. Without this there is no way to tell the stretcher
                 # fired at all, short of inferring it from the depth histogram.
+                # The trims and the peak backlog ride the same line: the peak is
+                # the number that shows whether the output fell behind at all.
+                chunk_ms = self.underrun.chunk_ms
                 banked = getattr(self, "stretched_chunks", 0)
+                trimmed = getattr(self, "trimmed_chunks", 0)
+                peak = getattr(self, "peak_backlog_ms", 0.0)
                 extra = ""
                 if banked:
-                    extra = (f"; stretched {banked} chunks "
-                             f"({banked * self.underrun.chunk_ms:.0f} ms banked from pauses)")
+                    extra += (f"; stretched {banked} chunks "
+                              f"({banked * chunk_ms:.0f} ms banked from pauses)")
+                if trimmed:
+                    extra += (f"; trimmed {trimmed} quiet chunks "
+                              f"({trimmed * chunk_ms:.0f} ms of backlog recovered)")
+                if peak:
+                    extra += f"; peak output backlog {peak:.0f} ms"
                 logger.info(f"track finished — {self.underrun.summary()}{extra}")
             return super().stop()
 

--- a/agents/pipecat/tests/test_output_cushion.py
+++ b/agents/pipecat/tests/test_output_cushion.py
@@ -11,11 +11,19 @@ released while audio remains queued, and a stall the cushion is sized for is
 absorbed without a single silent frame. Plus the shape of the parent's queue,
 because we append to it directly and an upstream change there would break us
 quietly.
+
+They also pin the ceiling (2026-09-11). The stretcher counts the whole output
+backlog, so a source that never stops sending (GPT-Live) cannot push its audio
+further and further behind, and a speech stream that has fallen behind is
+trimmed back to the target.
 """
 
 from __future__ import annotations
 
 import asyncio
+from collections import deque
+from dataclasses import dataclass
+from typing import Optional
 
 import pytest
 from pipecat.transports.smallwebrtc.transport import RawAudioTrack
@@ -361,6 +369,10 @@ class TestInflightProbe:
     (upstream's to deliver). Every OutputAudioRawFrame passes through the
     processor and everything the track holds passed through it first, so the
     difference between the two counters is exactly what is sitting in between.
+
+    The track anchors that count when the probe is wired, since audio forwarded
+    before a track existed was dropped by the transport. So these tests wire
+    first and forward after, as the processor does.
     """
 
     def _mk(self, monkeypatch: pytest.MonkeyPatch):
@@ -379,8 +391,8 @@ class TestInflightProbe:
     ) -> None:
         async def run() -> None:
             track, proc = self._mk(monkeypatch)
-            proc._forwarded_ms = 100.0          # 100 ms forwarded downstream...
             proc._wire_probe()
+            proc._forwarded_ms += 100.0         # 100 ms forwarded downstream...
             track.add_audio_bytes(_audio(3))    # ...of which 30 ms reached the track
             for _ in range(3):
                 await track.recv()
@@ -399,8 +411,8 @@ class TestInflightProbe:
 
         async def run() -> None:
             track, proc = self._mk(monkeypatch)
-            proc._forwarded_ms = 30.0
             proc._wire_probe()
+            proc._forwarded_ms += 30.0
             track.add_audio_bytes(_audio(3))    # all 30 ms handed over
             for _ in range(3):
                 await track.recv()
@@ -415,12 +427,13 @@ class TestInflightProbe:
         from pipecat.frames.frames import OutputAudioRawFrame
 
         async def run() -> None:
-            _track_, proc = self._mk(monkeypatch)
+            track, proc = self._mk(monkeypatch)
             f = OutputAudioRawFrame(audio=_audio(5), sample_rate=RATE, num_channels=1)
-            # count directly rather than driving a pipeline: process_frame needs
-            # a running processor, and the arithmetic is what matters here
-            proc._forwarded_ms += 1000.0 * (len(f.audio) / 2) / f.sample_rate
+            # _note_audio is what process_frame runs for each audio frame; call
+            # it directly, since process_frame needs a running processor
+            proc._note_audio(f)
             assert proc._forwarded_ms == pytest.approx(50.0)
+            assert track.upstream_ms() == pytest.approx(50.0), "the frame is in flight"
 
         asyncio.run(run())
 
@@ -453,3 +466,377 @@ class TestStretcherIsVisible:
             assert "banked from pauses" in banked[0]
         finally:
             logger.remove(sink)
+
+    def test_the_per_call_line_reports_trims_and_the_peak_backlog(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The peak backlog is the number that shows whether the output fell
+        behind at all; the trims show how much of it was recovered."""
+        from loguru import logger
+
+        from pipecat_aplisay.output_underrun import instrumented
+
+        monkeypatch.setenv("WEBRTC_OUTPUT_CUSHION_MS", "60")
+        lines: list[str] = []
+        sink = logger.add(lines.append, format="{message}", level="INFO")
+        try:
+            t = cushioned(instrumented(RawAudioTrack))(sample_rate=RATE)
+
+            async def run() -> None:
+                forwarded = _wire(t)
+                forwarded[0] += 1000.0          # a second of audio already waiting
+                t.speech_stream = True
+                for _ in range(3):
+                    t.add_audio_bytes(_quiet(3))
+                await t.recv()
+
+            asyncio.run(run())
+            assert t.trimmed_chunks == 3
+            t.stop()
+            (line,) = [l for l in lines if "track finished" in l]
+            assert "trimmed 3 quiet chunks" in line, line
+            assert "peak output backlog 1000 ms" in line, line
+        finally:
+            logger.remove(sink)
+
+
+def _quiet(chunks: int) -> bytes:
+    return b"\x05\x00" * PER_CHUNK * chunks      # ~-76 dBFS: a pause
+
+
+def _wire(track) -> list[float]:
+    """Wire a forwarded-audio counter to the track, as OutputCushionInterrupt
+    does. Add to the returned counter to put audio in the transport's queue."""
+    forwarded = [0.0]
+    track.inflight_probe = lambda: forwarded[0]
+    track.anchor_upstream()
+    return forwarded
+
+
+@dataclass
+class _Played:
+    backlog: list[float]                 # whole output backlog after each step, ms
+    first_voiced_step: Optional[int]     # when the first voiced chunk played
+
+
+async def _play(track, steps: int, source) -> _Played:
+    """Drive a track the way the transport and the pacer do, 10 ms per step.
+
+    ``source(step)`` returns the audio the model delivers at that step, or b"".
+    The transport splits it into 40 ms pieces in its own queue, hands the track
+    one piece at a time, and waits on the future each hand-over returns. The
+    pacer plays one chunk per step.
+    """
+    forwarded = _wire(track)
+    piece = 4 * PER_CHUNK * 2
+    waiting: deque[bytes] = deque()      # the transport's own queue
+    held = None                          # the future the transport waits on
+    backlog: list[float] = []
+    first_voiced = None
+    for step in range(steps):
+        audio = source(step)
+        if audio:
+            for i in range(0, len(audio), piece):
+                waiting.append(audio[i : i + piece])
+            forwarded[0] += 1000.0 * (len(audio) / 2) / RATE
+        while waiting and (held is None or held.done()):
+            held = track.add_audio_bytes(waiting.popleft())
+        if track._chunk_queue:
+            chunk, fut = track._chunk_queue.popleft()
+            if fut is not None and not fut.done():
+                fut.set_result(True)
+            if first_voiced is None and chunk[:2] == b"\x11\x11":
+                first_voiced = step
+        backlog.append(track.backlog_ms())
+    return _Played(backlog, first_voiced)
+
+
+class TestContinuousSpeechStreams:
+    """GPT-Live streams audio at real-time pace, silence included, and never stops.
+
+    Staging, 2026-09-11: the stretcher's ceiling counted only this track's queue,
+    which backpressure holds at 6-10 chunks, so it never engaged. Every repeated
+    chunk stayed in the transport's queue as delay: 1800 chunks in a 109 s call,
+    and the replies reached the caller many seconds after their transcript.
+    """
+
+    @staticmethod
+    def _stream(reply_at: Optional[int] = None):
+        """40 ms frames at real-time pace: silence, then speech from ``reply_at``."""
+
+        def source(step: int) -> bytes:
+            if step % 4:
+                return b""
+            if reply_at is not None and step >= reply_at:
+                return _audio(4)
+            return _quiet(4)
+
+        return source
+
+    def test_the_backlog_settles_at_the_target_instead_of_growing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.speech_stream = True
+            played = await _play(t, 110 * 100, self._stream())
+            # Counting only the track's queue, this grew by a quarter of the
+            # elapsed time: over 27 s after 110 s of silence.
+            assert max(played.backlog) <= 300 + 60, max(played.backlog)
+            assert t.stretched_chunks <= 40, t.stretched_chunks
+
+        asyncio.run(run())
+
+    def test_a_reply_after_a_minute_plays_within_the_target(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The number the caller hears: how long after the model speaks the
+        audio plays, however long the call has run."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.speech_stream = True
+            reply_at = 60 * 100
+            played = await _play(t, reply_at + 200, self._stream(reply_at))
+            assert played.first_voiced_step is not None, "the reply never played"
+            delay_ms = (played.first_voiced_step - reply_at) * 10
+            assert delay_ms <= 300 + 60, delay_ms
+
+        asyncio.run(run())
+
+    def test_audio_waiting_in_the_transport_stops_the_stretcher(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            forwarded = _wire(t)
+            forwarded[0] += 400.0                # already more than the target
+            t.add_audio_bytes(_quiet(9))
+            assert t.stretched_chunks == 0
+            assert len(t._chunk_queue) == 9
+
+        asyncio.run(run())
+
+
+class TestTurnBasedSources:
+    """Ultravox and the TTS services stop sending between turns, so the queue
+    empties and a stretch never outlives its turn. That must keep working."""
+
+    def test_a_turn_still_builds_its_cushion_and_the_gap_empties_it(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def source(step: int) -> bytes:
+            if step % 4 or (step // 500) % 2:    # 5 s turns, then 5 s gaps
+                return b""
+            # a quarter of each turn is pause, as measured on Ultravox
+            return _quiet(4) if (step // 40) % 4 == 3 else _audio(4)
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            played = await _play(t, 2000, source)
+            assert t.stretched_chunks > 0, "the stretcher must still build a cushion"
+            assert max(played.backlog) <= 300 + 60, max(played.backlog)
+            assert played.backlog[999] == 0.0, "the gap between turns empties the queue"
+
+        asyncio.run(run())
+
+
+class TestTrimming:
+    """A speech stream that has fallen behind is brought back to the target."""
+
+    def test_a_burst_on_a_speech_stream_is_trimmed_back_to_the_target(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Late audio that arrives in a burst would otherwise stay queued as delay
+        for the rest of the call, because the stream never stops."""
+
+        def source(step: int) -> bytes:
+            if step == 0:
+                return _quiet(100)               # a second of audio at once
+            return _quiet(4) if step % 4 == 0 else b""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.speech_stream = True
+            played = await _play(t, 1000, source)
+            assert played.backlog[0] > 500
+            assert t.trimmed_chunks > 0
+            assert max(played.backlog[500:]) <= 300 + 60, max(played.backlog[500:])
+
+        asyncio.run(run())
+
+    def test_voiced_audio_is_never_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.speech_stream = True
+            forwarded = _wire(t)
+            forwarded[0] += 1000.0
+            t.add_audio_bytes(_audio(9))
+            assert t.trimmed_chunks == 0
+            assert len(t._chunk_queue) == 9
+
+        asyncio.run(run())
+
+    def test_the_chunk_carrying_the_future_is_kept(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The transport waits on that future. Dropping its chunk would hold the
+        producer for ever and the call would go silent."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            t.speech_stream = True
+            forwarded = _wire(t)
+            forwarded[0] += 1000.0
+            t.add_audio_bytes(_audio(10))        # a full queue: the producer is held
+            t._quiet_seen = 2                    # the next quiet chunk is due a trim
+            fut = t.add_audio_bytes(_quiet(4))   # ...and that chunk carries the future
+            assert t.trimmed_chunks == 1, "the fourth chunk goes instead"
+            assert not fut.done()
+            assert any(f is fut for _chunk, f in t._chunk_queue), "the future was dropped"
+            while t._chunk_queue:
+                _chunk, f = t._chunk_queue.popleft()
+                if f is not None and not f.done():
+                    f.set_result(True)
+            assert fut.done()
+
+        asyncio.run(run())
+
+    def test_tts_audio_is_not_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """TTS arrives faster than real time, so a deep queue there is speech
+        made early. Shortening its pauses would gain nothing."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)          # speech_stream stays False
+            forwarded = _wire(t)
+            forwarded[0] += 1000.0
+            t.add_audio_bytes(_quiet(9))
+            assert t.trimmed_chunks == 0
+            assert len(t._chunk_queue) == 9
+
+        asyncio.run(run())
+
+    def test_disabled_by_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def run() -> None:
+            monkeypatch.setenv("WEBRTC_TRIM_EVERY", "0")
+            t = _track(monkeypatch, 60)
+            t.speech_stream = True
+            forwarded = _wire(t)
+            forwarded[0] += 1000.0
+            t.add_audio_bytes(_quiet(9))
+            assert t.trimmed_chunks == 0
+
+        asyncio.run(run())
+
+    def test_trimming_runs_on_to_the_target(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """It starts above the max and stops at the target, so the stretcher
+        and the trimmer do not take turns on the same chunks."""
+        t = _track(monkeypatch, 60)
+        t.speech_stream = True
+        assert t._trim_due(600.0) is True        # over the max: start
+        assert t._trim_due(400.0) is True        # between the two: keep going
+        assert t._trim_due(300.0) is False       # at the target: stop
+        assert t._trim_due(400.0) is False       # between again: stay stopped
+
+
+class TestInFlightCount:
+    """The transport's share of the backlog is the difference of two running
+    totals, so each way they can drift apart has to be handled."""
+
+    def test_audio_forwarded_before_the_track_existed_is_not_counted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The transport drops audio while it has no track. Counting it would
+        read as seconds of backlog for the whole call."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            forwarded = [5000.0]
+            t.inflight_probe = lambda: forwarded[0]
+            t.anchor_upstream()
+            assert t.upstream_ms() == 0.0
+            forwarded[0] += 40.0
+            assert t.upstream_ms() == pytest.approx(40.0)
+
+        asyncio.run(run())
+
+    def test_an_interruption_starts_the_count_again(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The transport empties its queue on an interruption, so what was
+        waiting there will never arrive."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            forwarded = _wire(t)
+            forwarded[0] += 800.0
+            assert t.upstream_ms() == pytest.approx(800.0)
+            t.clear()
+            assert t.upstream_ms() == 0.0
+            forwarded[0] += 40.0
+            assert t.upstream_ms() == pytest.approx(40.0)
+
+        asyncio.run(run())
+
+    def test_more_arriving_than_was_forwarded_reads_as_nothing_waiting(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The transport pads a turn's last chunk with silence, so a little more
+        can reach the track than was forwarded. Later counts must not come up
+        short because of it."""
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            forwarded = _wire(t)
+            forwarded[0] += 30.0
+            t.add_audio_bytes(_audio(4))         # 40 ms arrived: 10 ms of padding
+            assert t.upstream_ms() == 0.0
+            forwarded[0] += 100.0
+            assert t.upstream_ms() == pytest.approx(100.0)
+
+        asyncio.run(run())
+
+    def test_the_processor_anchors_a_new_track_before_counting_the_frame(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from types import SimpleNamespace
+
+        from pipecat.frames.frames import OutputAudioRawFrame
+
+        from pipecat_aplisay.output_cushion import OutputCushionInterrupt
+
+        async def run() -> None:
+            client = SimpleNamespace(_audio_output_track=None)
+            proc = OutputCushionInterrupt(output_transport=SimpleNamespace(_client=client))
+            frame = OutputAudioRawFrame(audio=_quiet(4), sample_rate=RATE, num_channels=1)
+            proc._note_audio(frame)              # no track yet: the transport drops it
+            t = _track(monkeypatch, 60)
+            client._audio_output_track = t
+            proc._note_audio(frame)
+            assert t.upstream_ms() == pytest.approx(40.0), "only the second frame is waiting"
+
+        asyncio.run(run())
+
+
+class TestFrameKinds:
+    def test_speech_stream_frames_mark_the_track_and_tts_frames_do_not(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from types import SimpleNamespace
+
+        from pipecat.frames.frames import SpeechOutputAudioRawFrame, TTSAudioRawFrame
+
+        from pipecat_aplisay.output_cushion import OutputCushionInterrupt
+
+        async def run() -> None:
+            t = _track(monkeypatch, 60)
+            transport = SimpleNamespace(_client=SimpleNamespace(_audio_output_track=t))
+            proc = OutputCushionInterrupt(output_transport=transport)
+            proc._note_audio(
+                SpeechOutputAudioRawFrame(audio=_quiet(4), sample_rate=RATE, num_channels=1)
+            )
+            assert t.speech_stream is True
+            proc._note_audio(TTSAudioRawFrame(audio=_quiet(4), sample_rate=RATE, num_channels=1))
+            assert t.speech_stream is False
+
+        asyncio.run(run())

--- a/docs/release-notes/changes-since-0.9.53.md
+++ b/docs/release-notes/changes-since-0.9.53.md
@@ -94,6 +94,14 @@ Pipecat), and **ci** (build and release pipeline).
   and queue depth during agent speech.
 - **[pipecat] Output cushioning** adds configurable queue target/cushioning and
   pause stretching to reduce mid-speech starvation without changing voiced audio.
+- **[pipecat] Output backlog ceiling**: the pause stretcher stops once the whole
+  output backlog (the track's queue plus audio still in the transport's queue)
+  reaches `WEBRTC_OUTPUT_TARGET_MS`. It used to compare the target with the
+  track's queue alone, so on a source that never stops sending (GPT-Live) the
+  added delay grew for the whole call. On a continuous speech stream, a backlog
+  above `WEBRTC_OUTPUT_MAX_MS` is trimmed back to the target by dropping one
+  quiet chunk in `WEBRTC_TRIM_EVERY`. The per-call `track finished` line reports
+  trimmed chunks and the peak output backlog.
 - **[pipecat + sipbridge] Underrun logging** is summarised once per call, with
   optional per-event logging via `WEBRTC_UNDERRUN_LOG_MS`.
 - **[pipecat] Trickle ICE routing** forwards ICE PATCHes to the node that owns the
@@ -339,10 +347,10 @@ Pipecat), and **ci** (build and release pipeline).
   `REGCLIENT_UNSUPPORTED_TTL_MS`, `TRACE_PROXY_TIMEOUT_MS`,
   `B2BUA_HEARTBEAT_TOKEN`, `EMAIL_BRANDS`, and `EMAIL_BRANDS_FILE`.
 - **[pipecat] New optional environment**: `WEBRTC_OUTPUT_CUSHION_MS`,
-  `WEBRTC_OUTPUT_TARGET_MS`, `WEBRTC_STRETCH_EVERY`, `WEBRTC_UNDERRUN_STATS`,
-  `WEBRTC_UNDERRUN_LOG_MS`, `WEBRTC_PEER_HOST`, `GRACEFUL_SHUTDOWN_SECONDS`,
-  `LIFECYCLE_DRAIN_SECONDS`, `HEALTHZ_MAX_TASKS`, and
-  `HEALTHZ_MAX_GATEWAY_ENTRIES`.
+  `WEBRTC_OUTPUT_TARGET_MS`, `WEBRTC_OUTPUT_MAX_MS`, `WEBRTC_STRETCH_EVERY`,
+  `WEBRTC_TRIM_EVERY`, `WEBRTC_UNDERRUN_STATS`, `WEBRTC_UNDERRUN_LOG_MS`,
+  `WEBRTC_PEER_HOST`, `GRACEFUL_SHUTDOWN_SECONDS`, `LIFECYCLE_DRAIN_SECONDS`,
+  `HEALTHZ_MAX_TASKS`, and `HEALTHZ_MAX_GATEWAY_ENTRIES`.
 - **[sipbridge] New optional environment**: `SIPBRIDGE_RTP_SILENCE_FILL`.
 - **[pipecat] `OPENAI_API_KEY`** on the Pipecat worker must belong to an OpenAI
   project with GPT-Live access for `pipecat:openai/gpt-live-1` calls to start.


### PR DESCRIPTION
## Problem

On `pipecat:openai/gpt-live-1` calls over WebRTC, the agent's audio falls further behind its transcript as the call goes on. In a 109 s test call the replies started 1.7 s, 4.9 s, 7.8 s and then 13.7 s after the caller stopped speaking, while the transcript arrived on time.

The cause is the pause stretcher in `output_cushion.py`. It repeats one quiet 10 ms chunk in three to build a cushion, and each repeat delays the audio behind it by 10 ms. That delay goes away only when the source stops sending and the queue empties, which Ultravox does between turns. GPT-Live never stops: it streams audio at real-time pace, silence included (`SpeechOutputAudioRawFrame`), so every repeated chunk stays as delay.

The stretcher has a ceiling (`WEBRTC_OUTPUT_TARGET_MS`, 300 ms), but it was compared with the track's own queue, which backpressure holds at 6-10 chunks, so it never engaged. The extra audio waited in the output transport's unbounded queue instead. The call's per-call line showed `stretched 1800 chunks (18000 ms banked from pauses)` over 109 s. Frames queued behind that audio reached the assistant aggregator 7.8 s late at 42 s into the call and 14.9 s late at 74 s.

## Change

- The stretcher's ceiling counts the whole output backlog: the track's queue plus the audio `OutputCushionInterrupt` has forwarded that the transport has not yet handed to the track. The stretcher runs only while that total is under the target, so it can add at most `WEBRTC_OUTPUT_TARGET_MS` of delay on any source.
- On a continuous speech stream (`SpeechOutputAudioRawFrame`; in the pinned pipecat that is the OpenAI Live service), a backlog above `WEBRTC_OUTPUT_MAX_MS` (default 500) is trimmed back to the target by dropping one quiet chunk in `WEBRTC_TRIM_EVERY` (default 3; 0 disables). Voiced audio and the chunk carrying the producer's future are never dropped. TTS frames (Ultravox, OpenAI Realtime, Gemini Live, the TTS services) are never trimmed: a deep queue there is speech made early, not delay.
- The in-flight count is anchored when the probe is wired (the transport drops audio forwarded before a track exists) and on each interruption (the transport empties its queue). It re-anchors if more reaches the track than was forwarded (the transport pads a turn's last chunk). The underrun instrument now reports the same anchored figure.
- The per-call `track finished` line adds the trimmed chunks and the peak output backlog.
- Release notes updated, including the two new variables.

## Behaviour after the change

Simulated with pipecat's real `RawAudioTrack`, driven the way the transport drives it: 40 ms pieces, one hand-over at a time, waiting on each future, with the pacer playing one chunk per 10 ms.

| GPT-Live-like stream: reply made at | before: plays after | after: plays after |
|---|---|---|
| 10 s | 3330 ms | 290 ms |
| 40 s | 9990 ms | 290 ms |
| 70 s | 16650 ms | 290 ms |
| 100 s | 23310 ms | 290 ms |

Over 110 s the stretcher added 2497 chunks before and 37 after. For Ultravox-like 10 s turns with a quarter pause, the worst in-turn backlog goes from 810 ms to 310 ms, and the queue still empties between turns.

On GPT-Live the backlog now settles at the target, so `WEBRTC_OUTPUT_TARGET_MS` is the delay the cushion adds there (300 ms by default), in exchange for that much protection against late audio. Lowering it trades protection for latency.

## Tests

- `tests/test_output_cushion.py`: 16 new tests covering a continuous stream (the backlog settles at the target; a reply after a minute plays within it; audio waiting in the transport stops the stretcher), a turn-based source (it still stretches; the queue empties between turns), trimming (a burst is trimmed back; voiced audio is kept; the chunk carrying the future is kept; TTS is not trimmed; the variable turns it off; it runs on to the target), the in-flight count (audio from before the track, an interruption, padding, the processor anchoring before it counts), and frame kinds.
- Three existing in-flight probe tests now wire the probe before forwarding audio, which is the order the processor uses.
- Full worker suite, rebased on current `next`: 550 passed.

## What to check after deploy

On a GPT-Live WebRTC call, the `track finished` line should show a `peak output backlog` near 300 ms and a few dozen stretched chunks, not thousands.
