### PR TITLE
GPT-Live voices: describe accents and genders so list_voices search finds them

### DIFF
--- a/docs/gpt-live.md
+++ b/docs/gpt-live.md
@@ -180,6 +180,45 @@ coral, delta, echo, gleam, marin, meridian, quartz, ripple, sage, shimmer,
 stone, tempo, verse, vesper and willow. The default is `marin`. The list
 differs from OpenAI Realtime's, and a Realtime-only name is rejected.
 
+Every voice sits under `any`, so the locale says nothing about accent. Each
+row carries a `gender`, and a `description` that names the accent. The
+`list_voices` builtin's `search` matches both. A search for `british`, `brit`
+or `uk` finds vesper (British English) and the two Irish English voices,
+stone and willow, whose descriptions say "more British (UK)".
+
+The two Southern US voices, cinder and delta, say "US (American, USA)", so a
+search for `us`, `usa` or `american` finds them. `american` also finds the two
+North American voices, gleam and meridian.
+
+| Voice | Gender | Accent |
+|---|---|---|
+| alloy | female | none given |
+| ash | male | none given |
+| ballad | male | none given |
+| beacon | male | Filipino English |
+| bossa | female | Brazilian Portuguese |
+| cedar | male | none given |
+| cinder | male | Southern US English |
+| coral | female | none given |
+| delta | female | Southern US English |
+| echo | male | none given |
+| gleam | female | North American English |
+| marin (default) | female | none given |
+| meridian | male | North American English |
+| quartz | female | Australian English |
+| ripple | male | Australian English |
+| sage | female | none given |
+| shimmer | female | none given |
+| stone | male | Irish English |
+| tempo | male | Brazilian Portuguese |
+| verse | male | none given |
+| vesper | male | British English |
+| willow | female | Irish English |
+
+The accents of the twelve voices added with GPT-Live follow OpenAI's
+descriptions. OpenAI gives no accent for the other ten, and their gender is
+Aplisay's label.
+
 `options.tts.vendor` must be unset or `openai`. There is no text-output mode
 (`hasExternalTts` is false), so an external TTS vendor is rejected.
 

--- a/docs/release-notes/changes-since-0.9.53.md
+++ b/docs/release-notes/changes-since-0.9.53.md
@@ -235,7 +235,9 @@ Pipecat), and **ci** (build and release pipeline).
   `delegate` function.
 - **[core] GPT-Live voices**: the voices endpoints list the GPT-Live voice set
   under `OpenAI` for the row (default `marin`); `options.tts.vendor` must be
-  unset or `openai`.
+  unset or `openai`. Each voice carries a `gender` and a `description` naming
+  its accent, so a `list_voices` search for `british`, `brit` or `uk` finds
+  vesper (British English) and the Irish English voices stone and willow.
 - **[core] Agent sets** resolve `label:` references in `delegate` functions and
   reject a voice member and its in-set delegate declaring a function of the same
   name.

--- a/lib/voices/openai-live.js
+++ b/lib/voices/openai-live.js
@@ -20,33 +20,49 @@ export const OPENAI_LIVE_DEFAULT_VOICE = 'marin';
 export const OPENAI_LIVE_VENDOR = 'OpenAI';
 
 /**
- * @typedef {{ name: string, description: string, gender?: string }} VoiceRow
+ * @typedef {{ name: string, description: string, gender: 'male' | 'female' }} VoiceRow
  */
 
-/** @type {VoiceRow[]} */
+/**
+ * Each description names the voice's presentation and accent. Every GPT-Live
+ * voice sits under the `any` locale, and the list_voices search
+ * (lib/model-voices.js) matches only name, description, gender and locale, so
+ * the description is the only place an accent can be found. The accents of the
+ * twelve voices added with GPT-Live follow OpenAI's descriptions. OpenAI gives
+ * no accent for the other ten, and their gender is Aplisay's label.
+ *
+ * Vesper is the British English voice. Stone and Willow are Irish English and
+ * are described as "more British (UK)". All three say "British (UK)", so a
+ * search for "british", "brit" or "uk" finds them. The two Southern US voices
+ * say "US (American, USA)", so each of those words finds them. No description
+ * names another accent to compare with: "than US voices" would make a "us"
+ * search find the Irish voices.
+ *
+ * @type {VoiceRow[]}
+ */
 export const OPENAI_LIVE_VOICES = [
-  { name: 'alloy', description: 'Alloy', gender: 'female' },
-  { name: 'ash', description: 'Ash', gender: 'male' },
-  { name: 'ballad', description: 'Ballad', gender: 'male' },
-  { name: 'beacon', description: 'Beacon' },
-  { name: 'bossa', description: 'Bossa' },
-  { name: 'cedar', description: 'Cedar', gender: 'male' },
-  { name: 'cinder', description: 'Cinder' },
-  { name: 'coral', description: 'Coral', gender: 'female' },
-  { name: 'delta', description: 'Delta' },
-  { name: 'echo', description: 'Echo', gender: 'male' },
-  { name: 'gleam', description: 'Gleam' },
-  { name: 'marin', description: 'Marin (default)', gender: 'female' },
-  { name: 'meridian', description: 'Meridian' },
-  { name: 'quartz', description: 'Quartz' },
-  { name: 'ripple', description: 'Ripple' },
-  { name: 'sage', description: 'Sage', gender: 'female' },
-  { name: 'shimmer', description: 'Shimmer', gender: 'female' },
-  { name: 'stone', description: 'Stone' },
-  { name: 'tempo', description: 'Tempo' },
-  { name: 'verse', description: 'Verse', gender: 'male' },
-  { name: 'vesper', description: 'Vesper' },
-  { name: 'willow', description: 'Willow' },
+  { name: 'alloy', description: 'Female-labelled by Aplisay, with no regional accent specified by OpenAI.', gender: 'female' },
+  { name: 'ash', description: 'Male-labelled by Aplisay, with no regional accent specified by OpenAI.', gender: 'male' },
+  { name: 'ballad', description: 'Male-labelled by Aplisay, with no regional accent specified by OpenAI.', gender: 'male' },
+  { name: 'beacon', description: 'Masculine presentation with Filipino English influence.', gender: 'male' },
+  { name: 'bossa', description: 'Feminine presentation with Brazilian Portuguese influence.', gender: 'female' },
+  { name: 'cedar', description: 'Male-labelled by Aplisay, with no regional accent specified by OpenAI.', gender: 'male' },
+  { name: 'cinder', description: 'Masculine presentation with Southern US (American, USA) English influence.', gender: 'male' },
+  { name: 'coral', description: 'Female-labelled by Aplisay, with no regional accent specified by OpenAI.', gender: 'female' },
+  { name: 'delta', description: 'Feminine presentation with Southern US (American, USA) English influence.', gender: 'female' },
+  { name: 'echo', description: 'Male-labelled by Aplisay, with no regional accent specified by OpenAI.', gender: 'male' },
+  { name: 'gleam', description: 'Feminine presentation with North American English influence.', gender: 'female' },
+  { name: 'marin', description: "GPT-Live's default voice, female-labelled by Aplisay, with no regional accent specified by OpenAI.", gender: 'female' },
+  { name: 'meridian', description: 'Masculine presentation with North American English influence.', gender: 'male' },
+  { name: 'quartz', description: 'Feminine presentation with Australian English influence.', gender: 'female' },
+  { name: 'ripple', description: 'Masculine presentation with Australian English influence.', gender: 'male' },
+  { name: 'sage', description: 'Female-labelled by Aplisay, with no regional accent specified by OpenAI.', gender: 'female' },
+  { name: 'shimmer', description: 'Female-labelled by Aplisay, with no regional accent specified by OpenAI.', gender: 'female' },
+  { name: 'stone', description: 'Masculine presentation with Irish English influence; more British (UK).', gender: 'male' },
+  { name: 'tempo', description: 'Masculine presentation with Brazilian Portuguese influence.', gender: 'male' },
+  { name: 'verse', description: 'Male-labelled by Aplisay, with no regional accent specified by OpenAI.', gender: 'male' },
+  { name: 'vesper', description: 'Masculine presentation with British (UK) English influence.', gender: 'male' },
+  { name: 'willow', description: 'Feminine presentation with Irish English influence; more British (UK).', gender: 'female' },
 ];
 
 /**

--- a/tests/gpt-live-model.test.mjs
+++ b/tests/gpt-live-model.test.mjs
@@ -5,10 +5,12 @@ import PipecatModel, {
   pipecatModelSupportsExternalTts,
 } from '../lib/models/pipecat.js';
 import {
+  filterVoiceTreeBySearch,
   getTtsVendorsForAgentValidation,
   getVoiceNamesForAgentValidation,
   modelSupportsDelegation,
   modelSupportsExternalTts,
+  normalizeSearchTerms,
 } from '../lib/model-voices.js';
 import { OPENAI_LIVE_DEFAULT_VOICE, OPENAI_LIVE_VOICES, openaiLiveVoiceTree } from '../lib/voices/openai-live.js';
 import { buildRateComponents, isMinuteBilledModel } from '../lib/rate-components.js';
@@ -127,6 +129,39 @@ describe('GPT-Live voices', () => {
   test('the only TTS vendor a GPT-Live row accepts is openai', async () => {
     const vendors = await getTtsVendorsForAgentValidation({ modelName: GPT_LIVE, Handler, voicesInstance });
     expect([...vendors]).toEqual(['openai']);
+  });
+
+  // The list_voices search over the GPT-Live block, ranked as the builtin returns it.
+  const searchNames = (terms) =>
+    (filterVoiceTreeBySearch(openaiLiveVoiceTree(), normalizeSearchTerms(terms)).vendors.OpenAI ?? []).map((v) => v.name);
+
+  test('every voice has a gender and a description beyond its name', () => {
+    for (const v of OPENAI_LIVE_VOICES) {
+      expect(['male', 'female']).toContain(v.gender);
+      expect(v.description.length).toBeGreaterThan(v.name.length);
+    }
+  });
+
+  test('a British search finds vesper and the two Irish voices, and nothing else', () => {
+    for (const term of ['british', 'brit', 'uk']) {
+      expect(searchNames([term])).toEqual(['stone', 'vesper', 'willow']);
+    }
+    expect(searchNames(['irish'])).toEqual(['stone', 'willow']);
+  });
+
+  test('a US search finds the Southern US voices by "us", "usa" or "american", and never the Irish voices', () => {
+    // No description names another accent to compare with, so "us" stays on the US voices.
+    expect(searchNames(['us'])).toEqual(['cinder', 'delta']);
+    expect(searchNames(['usa'])).toEqual(['cinder', 'delta']);
+    // "North American" also matches "american".
+    expect(searchNames(['american'])).toEqual(['cinder', 'delta', 'gleam', 'meridian']);
+  });
+
+  test('a British search with a gender puts the British voices of that gender first', () => {
+    expect(searchNames(['british', 'female'])[0]).toBe('willow');
+    expect(searchNames(['british', 'english', 'female'])[0]).toBe('willow');
+    expect(searchNames(['british', 'male']).slice(0, 2)).toEqual(['stone', 'vesper']);
+    expect(searchNames(['uk', 'english', 'male']).slice(0, 2)).toEqual(['stone', 'vesper']);
   });
 });
 


### PR DESCRIPTION
## What

`lib/voices/openai-live.js`: every GPT-Live voice now has a `gender` and a `description` that names its presentation and accent. Before, 12 of the 22 voices had no gender, and every description only repeated the voice name.

Every GPT-Live voice sits under the `any` locale, and the `list_voices` search matches only name, description, gender and locale. So a search by accent found nothing.

## Search results now

| Search | Finds |
|---|---|
| `british`, `brit`, `uk` | stone, vesper, willow |
| `irish` | stone, willow |
| `us`, `usa` | cinder, delta |
| `american` | cinder, delta, gleam, meridian |
| `british female` | willow first |
| `british male` | stone, then vesper |

- vesper is British English. stone and willow are Irish English, described as "more British (UK)".
- cinder and delta are Southern US and also say "American" and "USA".
- No description compares itself with another accent, so `us` does not find the Irish voices.
- The twelve voices added with GPT-Live follow OpenAI's descriptions. OpenAI gives no accent for the other ten, and their gender is Aplisay's label.

## Also

- `docs/gpt-live.md`: a voice, gender and accent table under Voices.
- `docs/release-notes/changes-since-0.9.53.md`: one line added to the GPT-Live voices entry.
- `tests/gpt-live-model.test.mjs`: four tests that pin the genders and the search results.

## Note for API clients

`description` used to repeat the voice name (`Alloy`, `Marin (default)`). A client that shows `description` as a voice's label will now show the longer text. Field names and voice names are unchanged, so saved agents are not affected.

## Testing

Full DB suite (`jest.config.db.js`): 104 suites passed (2 skipped), 1147 tests passed (5 skipped).
