### PR TITLE
fix(pipecat): open a handed-over call with a handover turn, not a greeting

### DIFF
--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -1760,6 +1760,7 @@ class CallSession:
             )
             from pipecat.services.settings import LLMSettings
 
+            from .transfer_prompts import HANDOVER_OPENING_INSTRUCTION
             from .voice_session import _register_tools_on_llm
 
             tools = self._build_tools_for(new_agent)
@@ -1784,9 +1785,14 @@ class CallSession:
                     ),
                     # Replace the context wholesale: history is carried (when
                     # requested) inside the prompt itself, so the incoming
-                    # agent starts from a clean message list either way.
+                    # agent starts from a clean message list either way. The
+                    # second message makes its first turn a handover opening
+                    # rather than a greeting.
                     LLMMessagesUpdateFrame(
-                        [{"role": "developer", "content": system_prompt}],
+                        [
+                            {"role": "developer", "content": system_prompt},
+                            {"role": "developer", "content": HANDOVER_OPENING_INSTRUCTION},
+                        ],
                         run_llm=False,
                     ),
                     # New tool surface on the context (and forwarded to

--- a/agents/pipecat/pipecat_aplisay/call_session.py
+++ b/agents/pipecat/pipecat_aplisay/call_session.py
@@ -662,6 +662,7 @@ class CallSession:
             on_output_usage=self._on_output_usage,
             gpt_live=gpt_live_session,
             history=history,
+            handover=self._is_handover_generation,
         )
         # Stash the context handle so ``get_parent_transcript`` (used by
         # the consultative-transfer flow) can walk the chat history.
@@ -789,7 +790,14 @@ class CallSession:
     async def _wire_greeting(
         self, transport, task, agent: dict, mode: str, model_name: str
     ) -> None:
-        """Register ``on_client_connected`` to emit the opening greeting."""
+        """Register ``on_client_connected`` to emit the opening greeting.
+
+        On the first generation after a ``transfer_agent`` full-stack handover
+        (``_is_handover_generation``) the incoming agent's greeting is not
+        used, because the caller was greeted when the call started. The agent
+        opens with ``HANDOVER_OPENING_INSTRUCTION`` instead, which tells it to
+        introduce itself and continue the call.
+        """
         # Ultravox handles greetings natively via the /calls API's
         # ``firstSpeakerSettings.agent`` parameter — see the Ultravox
         # branch of ``voice_session._build_realtime``. The model-agnostic
@@ -797,13 +805,17 @@ class CallSession:
         # ``LLMRunFrame`` / ``TTSSpeakFrame``, none of which Ultravox's
         # ``process_frame`` consumes (they'd just pass through as
         # no-ops). Skip wiring on Ultravox so we don't queue dead frames
-        # at connect time.
+        # at connect time. The handover opening is native there too
+        # (``voice_session._ultravox_one_shot_params``).
+        from .transfer_prompts import HANDOVER_OPENING_INSTRUCTION
         from .voice_mode import model_id_from_name
 
         if model_id_from_name(model_name).startswith("ultravox/"):
             return
         from pipecat.frames.frames import LLMMessagesAppendFrame as _AppendFrame
         from pipecat.frames.frames import LLMRunFrame as _RunFrame
+
+        handover = self._is_handover_generation
 
         if is_gpt_live_model_id(model_id_from_name(model_name)):
             # GPT-Live: the ``LLMRunFrame`` starts the session from the context,
@@ -813,7 +825,11 @@ class CallSession:
             # first). The wording is best-effort: the model paraphrases. With
             # no greeting configured the platform instruction keeps the
             # "agent speaks first" contract.
-            opening = greeting_opening_instruction(agent)
+            opening = (
+                HANDOVER_OPENING_INSTRUCTION
+                if handover
+                else greeting_opening_instruction(agent)
+            )
 
             @transport.event_handler("on_client_connected")
             async def _on_client_connected_gpt_live(*_args, **_kwargs) -> None:
@@ -849,7 +865,20 @@ class CallSession:
         @transport.event_handler("on_client_connected")
         async def _on_client_connected(*_args, **_kwargs) -> None:
             try:
-                if greeting_text:
+                if handover:
+                    # A handover: the caller was already greeted. Run the
+                    # incoming agent's first turn from the handover
+                    # instruction; its greeting is for a new call.
+                    await task.queue_frames(
+                        [
+                            LLMMessagesAppendFrame(
+                                [{"role": "developer", "content": HANDOVER_OPENING_INSTRUCTION}],
+                                run_llm=False,
+                            ),
+                            LLMRunFrame(),
+                        ]
+                    )
+                elif greeting_text:
                     if mode == "pipeline" and TTSSpeakFrame is not None:
                         # Pipeline: push the text to TTS directly so the
                         # exact words are spoken — no LLM in the loop.

--- a/agents/pipecat/pipecat_aplisay/transfer_prompts.py
+++ b/agents/pipecat/pipecat_aplisay/transfer_prompts.py
@@ -23,20 +23,23 @@ from __future__ import annotations
 from typing import Iterable, Optional
 
 
-# The opening turn of the incoming agent after a ``transfer_agent`` full-stack
-# handover, used in place of that agent's greeting. The caller was greeted
-# when the call started, so the new agent introduces itself and continues
-# rather than answering as if the call were new. Ultravox takes it as
-# ``firstSpeakerSettings.agent.prompt`` (voice_session); the other model paths
-# get it as a developer message before the first run
-# (call_session._wire_greeting).
+# The opening turn of the incoming agent after a ``transfer_agent`` handover,
+# used in place of that agent's greeting. The caller was greeted when the call
+# started, so the new agent introduces itself and continues rather than
+# answering as if the call were new. It is worded as the first message because
+# on most paths it stays in the context for the rest of the call. Ultravox
+# takes it as ``firstSpeakerSettings.agent.prompt`` (voice_session); the other
+# model paths get it as a developer message before the first run
+# (call_session._wire_greeting, and _apply_agent_transfer for an in-place
+# handover).
 HANDOVER_OPENING_INSTRUCTION = (
-    "You have just taken over this call from another agent. The caller has "
-    "already been greeted, so do not greet them as if this were a new call, "
-    "and do not repeat anything the previous agent already told them. "
-    "Introduce yourself in one short sentence. If you have a handover summary "
-    "or the conversation so far, say briefly what you understand the caller "
-    "needs and continue from there. Otherwise ask how you can help."
+    "This is your first message after taking over this call from another "
+    "agent. The caller has already been greeted, so do not greet them as if "
+    "this were a new call, and do not repeat anything the previous agent "
+    "already told them. Introduce yourself in one short sentence. If you have "
+    "a handover summary or the conversation so far, say briefly what you "
+    "understand the caller needs and continue from there. Otherwise ask how "
+    "you can help."
 )
 
 

--- a/agents/pipecat/pipecat_aplisay/transfer_prompts.py
+++ b/agents/pipecat/pipecat_aplisay/transfer_prompts.py
@@ -13,11 +13,31 @@ present the same wire surface for consultative transfers:
 The default template below is byte-for-byte identical to the LiveKit
 default at ``agents/livekit/lib/transfer-handler.ts:615``. Keep the two
 in sync if either side changes.
+
+It also holds :data:`HANDOVER_OPENING_INSTRUCTION`, the first turn of an
+agent that takes over a live call through the ``transfer_agent`` builtin.
 """
 
 from __future__ import annotations
 
 from typing import Iterable, Optional
+
+
+# The opening turn of the incoming agent after a ``transfer_agent`` full-stack
+# handover, used in place of that agent's greeting. The caller was greeted
+# when the call started, so the new agent introduces itself and continues
+# rather than answering as if the call were new. Ultravox takes it as
+# ``firstSpeakerSettings.agent.prompt`` (voice_session); the other model paths
+# get it as a developer message before the first run
+# (call_session._wire_greeting).
+HANDOVER_OPENING_INSTRUCTION = (
+    "You have just taken over this call from another agent. The caller has "
+    "already been greeted, so do not greet them as if this were a new call, "
+    "and do not repeat anything the previous agent already told them. "
+    "Introduce yourself in one short sentence. If you have a handover summary "
+    "or the conversation so far, say briefly what you understand the caller "
+    "needs and continue from there. Otherwise ask how you can help."
+)
 
 
 # Byte-identical to ``defaultTransferPromptTemplate`` in

--- a/agents/pipecat/pipecat_aplisay/voice_session.py
+++ b/agents/pipecat/pipecat_aplisay/voice_session.py
@@ -45,6 +45,7 @@ from .output_cushion import OutputCushionInterrupt
 from .output_rate_guard import OutputRateGuard
 from .realtime_tts import external_tts_vendor, local_vad_required, text_output_enabled
 from .tool_log import log_tool_call, log_tool_result
+from .transfer_prompts import HANDOVER_OPENING_INSTRUCTION
 
 
 # Recording capture rate. The sipbridge WS carries 16 kHz in both
@@ -1024,6 +1025,7 @@ async def build_voice_session(
     on_output_usage: "Optional[Callable[[str, int, dict], None]]" = None,
     gpt_live: "Optional[GptLiveSession]" = None,
     history: "Optional[list[dict]]" = None,
+    handover: bool = False,
 ) -> tuple[PipelineTask, Optional[AudioBufferProcessor], LLMContext, Any]:
     """Construct a configured ``PipelineTask`` for the call.
 
@@ -1032,6 +1034,13 @@ async def build_voice_session(
     every other. ``history`` seeds the context with prior ``user`` /
     ``assistant`` turns (an agent handover onto GPT-Live carries the transcript
     as the session's startup history rather than inside the prompt).
+
+    ``handover`` marks the first generation after a ``transfer_agent``
+    full-stack handover. The incoming agent then opens with
+    :data:`~pipecat_aplisay.transfer_prompts.HANDOVER_OPENING_INSTRUCTION`
+    instead of its greeting. Only Ultravox needs it here, because it takes its
+    first turn at call creation; ``call_session._wire_greeting`` handles the
+    other models.
 
     ``on_aux_transcript`` / ``on_aux_usage`` receive the auxiliary STT's final
     transcripts and usage deltas (``unit, quantity, {vendor, model}``) when the
@@ -1105,6 +1114,7 @@ async def build_voice_session(
         task, context, llm = await _build_realtime(
             transport, model_name, agent, metadata, tools, system_prompt, audio_buffer, relay_endpoint, tone_injector,
             on_inactivity_hangup, aux_tap=aux_tap, output_tap=output_tap, gpt_live=gpt_live, history=history,
+            handover=handover,
         )
     else:
         task, context, llm = await _build_pipeline(
@@ -1212,7 +1222,12 @@ def _openai_realtime_session_properties(agent: dict, *, text_output: bool) -> An
 
 
 def _ultravox_one_shot_params(
-    agent: dict, system_prompt: str, ultravox_model: str, *, text_output: bool
+    agent: dict,
+    system_prompt: str,
+    ultravox_model: str,
+    *,
+    text_output: bool,
+    handover: bool = False,
 ) -> Any:
     """The ``OneShotInputParams`` for one Ultravox /calls request.
 
@@ -1220,6 +1235,9 @@ def _ultravox_one_shot_params(
     request body (greeting, inactivity, language hint, VAD settings, voice, and
     the text-output medium) is testable without a transport. ``text_output``
     is :func:`realtime_tts.text_output_enabled` for this session.
+    ``handover`` is true on the first generation after a ``transfer_agent``
+    full-stack handover; the opening turn is then the handover instruction,
+    not the agent's greeting.
     """
     import uuid as _uuid
 
@@ -1252,6 +1270,14 @@ def _ultravox_one_shot_params(
     #   no overrides — agent speaks first (interruptible) using its
     #   system prompt, matching the model-agnostic default in
     #   ``call_session._wire_greeting``.
+    # - A handover leg (``handover``: the first generation after a
+    #   ``transfer_agent`` full-stack handover) → ``firstSpeakerSettings.agent.prompt``
+    #   set to ``HANDOVER_OPENING_INSTRUCTION``, interruptible. The target's
+    #   greeting is not used, because the caller was greeted when the call
+    #   started. Without a prompt, Ultravox writes the first turn from its
+    #   own "(New Call) Respond as if you are answering the phone." message,
+    #   which overrides the handover context in the system prompt, and the
+    #   agent greets the caller as if the call were new.
     #
     # ``call_session._wire_greeting`` short-circuits for Ultravox so
     # those no-op frames are never queued; this branch is the sole
@@ -1265,7 +1291,9 @@ def _ultravox_one_shot_params(
     greeting_instructions = (greeting_instructions or "").strip()
 
     ultravox_first_speaker: dict[str, Any]
-    if greeting_text:
+    if handover:
+        ultravox_first_speaker = {"agent": {"prompt": HANDOVER_OPENING_INSTRUCTION}}
+    elif greeting_text:
         ultravox_first_speaker = {
             "agent": {
                 "text": greeting_text,
@@ -1365,6 +1393,7 @@ async def _build_realtime(
     output_tap: "Optional[Any]" = None,
     gpt_live: "Optional[GptLiveSession]" = None,
     history: "Optional[list[dict]]" = None,
+    handover: bool = False,
 ) -> tuple[PipelineTask, LLMContext, Any]:
     model_id = model_id_from_name(model_name)
     options = agent.get("options") or {}
@@ -1466,7 +1495,7 @@ async def _build_realtime(
         # (lib/models/ultravox.js ``modelData``: ``model.replace(/^.*\//, '')``).
         ultravox_model = model_id.rsplit("/", 1)[-1]
         params = _ultravox_one_shot_params(
-            agent, system_prompt, ultravox_model, text_output=text_output
+            agent, system_prompt, ultravox_model, text_output=text_output, handover=handover
         )
 
         # Ultravox needs the function schemas at construction time:

--- a/agents/pipecat/tests/test_handover_opening.py
+++ b/agents/pipecat/tests/test_handover_opening.py
@@ -195,3 +195,106 @@ def test_ultravox_wires_no_frames(handover):
     # Ultravox takes its first turn natively at call creation (tests above).
     frames = _opening_frames(_agent(), "realtime", "pipecat:ultravox/ultravox-v0.7", handover=handover)
     assert frames is None
+
+
+# --- CallSession wiring: the flag reaches the build of a handover generation ----
+
+
+def _call_record(call_id: str, agent_id: str):
+    from pipecat_aplisay import api_client
+
+    return api_client.CallRecord(
+        id=call_id,
+        userId="user-1",
+        organisationId="org-1",
+        instanceId="inst-1",
+        agentId=agent_id,
+        persisted=False,
+    )
+
+
+def _session(model_name: str = "pipecat:openai/gpt-4o-mini") -> CallSession:
+    class _StubGatewaySession:
+        transport = None
+
+        async def shutdown(self) -> None:  # pragma: no cover
+            return None
+
+    return CallSession(
+        session_id="s1",
+        agent={"id": "agent-1", "modelName": model_name, "prompt": "old", "options": {}},
+        instance={"streamLog": False},
+        sip_gateway=None,  # type: ignore[arg-type]
+        gateway_session=_StubGatewaySession(),  # type: ignore[arg-type]
+        call=_call_record("call-1", "agent-1"),
+    )
+
+
+def _record_builds(monkeypatch) -> list:
+    """Stub build_voice_session: record each build's ``handover`` and stop there."""
+    from pipecat_aplisay import call_session as cs
+
+    seen: list = []
+
+    async def fake_build(**kwargs):
+        seen.append(kwargs.get("handover"))
+        raise _Stop
+
+    monkeypatch.setattr(cs, "build_voice_session", fake_build)
+    return seen
+
+
+def test_first_build_is_not_a_handover(monkeypatch):
+    seen = _record_builds(monkeypatch)
+    session = _session()
+    with pytest.raises(_Stop):
+        asyncio.run(session.prepare_run(session.agent, session.agent["modelName"], "sys"))
+    assert seen == [False]
+
+
+def test_run_prepared_builds_the_handover_generation_with_the_flag(monkeypatch):
+    seen = _record_builds(monkeypatch)
+    session = _session()
+    runs: list = []
+
+    async def fake_run_once(task, max_duration_secs):
+        # The outgoing agent's pipeline ends with a full handover pending, as
+        # _begin_agent_handover leaves it.
+        runs.append(task)
+        if len(runs) == 1:
+            session._pending_agent_handover = {
+                "agent": {"id": "agent-2", "modelName": "pipecat:openai/gpt-4o-mini", "prompt": "new", "options": {}},
+                "system_prompt": "You are agent two.",
+                "call": _call_record("call-2", "agent-2"),
+                "transport": object(),
+                "history": None,
+            }
+
+    session._run_prepared_once = fake_run_once
+    with pytest.raises(_Stop):
+        asyncio.run(session.run_prepared(object(), None))
+    assert seen == [True]
+    assert session._is_handover_generation is True
+
+
+def test_in_place_handover_adds_the_opening_after_the_new_prompt():
+    from pipecat.frames.frames import LLMMessagesUpdateFrame
+
+    session = _session()
+    task = _Task()
+    session._task = task
+    session._llm_service = SimpleNamespace(
+        register_function=lambda *a, **k: None, unregister_function=lambda *a, **k: None
+    )
+    session._registered_tool_names = set()
+    session._build_tools_for = lambda agent, extra_builtins=None: []
+
+    new_agent = {"id": "agent-2", "modelName": "pipecat:openai/gpt-4o-mini", "prompt": "two"}
+    asyncio.run(session._apply_agent_transfer(new_agent, "You are agent two."))
+
+    [update] = [f for f in task.frames if isinstance(f, LLMMessagesUpdateFrame)]
+    assert update.messages == [
+        {"role": "developer", "content": "You are agent two."},
+        {"role": "developer", "content": HANDOVER_OPENING_INSTRUCTION},
+    ]
+    assert isinstance(task.frames[-1], LLMRunFrame)

--- a/agents/pipecat/tests/test_handover_opening.py
+++ b/agents/pipecat/tests/test_handover_opening.py
@@ -1,0 +1,197 @@
+"""The opening turn after a ``transfer_agent`` full-stack handover.
+
+The incoming agent's greeting is written for a new call. After a handover the
+caller has already been greeted, so the first generation opens with
+``transfer_prompts.HANDOVER_OPENING_INSTRUCTION`` instead:
+
+* Ultravox takes it at call creation as ``firstSpeakerSettings.agent.prompt``.
+  Before this, a handover leg sent ``firstSpeakerSettings: {"agent": {}}`` (or
+  the target's greeting), and Ultravox opened the turn with its own
+  "(New Call) Respond as if you are answering the phone." message, so the new
+  agent greeted the caller as if the call were new.
+* GPT-Live, OpenAI Realtime and pipeline models get it from
+  ``CallSession._wire_greeting`` as a developer message before the first run.
+
+Calls that are not handovers keep their greeting exactly as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pipecat.frames.frames import LLMMessagesAppendFrame, LLMRunFrame, TTSSpeakFrame
+
+from pipecat_aplisay import gpt_live, voice_session
+from pipecat_aplisay.call_session import CallSession
+from pipecat_aplisay.transfer_prompts import HANDOVER_OPENING_INSTRUCTION
+from pipecat_aplisay.voice_session import _ultravox_one_shot_params
+
+pytest.importorskip("pipecat.services.ultravox.llm")
+
+HANDOVER_FIRST_SPEAKER = {"agent": {"prompt": HANDOVER_OPENING_INSTRUCTION}}
+GREETINGS = [None, {"text": "Thanks for calling Acme."}, {"instructions": "Greet the caller warmly."}]
+
+
+def _agent(**options) -> dict:
+    return {"options": {k: v for k, v in options.items() if v is not None}}
+
+
+# --- Ultravox: firstSpeakerSettings on the /calls request ------------------------
+
+
+@pytest.mark.parametrize("greeting", GREETINGS)
+def test_ultravox_handover_leg_opens_with_the_handover_prompt(monkeypatch, greeting):
+    monkeypatch.setenv("ULTRAVOX_API_KEY", "test-key")
+    params = _ultravox_one_shot_params(
+        _agent(greeting=greeting), "sys", "ultravox-v0.7", text_output=False, handover=True
+    )
+    # The target's greeting is for a new call, so a handover never uses it.
+    assert params.extra["firstSpeakerSettings"] == HANDOVER_FIRST_SPEAKER
+    # The system prompt, which carries the handover summary and transcript, is unchanged.
+    assert params.system_prompt == "sys"
+
+
+def test_ultravox_handover_leg_in_text_output_mode(monkeypatch):
+    monkeypatch.setenv("ULTRAVOX_API_KEY", "test-key")
+    agent = _agent(tts={"vendor": "elevenlabs", "voice": "Rachel"}, greeting={"text": "Hello there"})
+    params = _ultravox_one_shot_params(agent, "sys", "ultravox-v0.7", text_output=True, handover=True)
+    assert params.extra["firstSpeakerSettings"] == HANDOVER_FIRST_SPEAKER
+    assert params.output_medium == "text"
+
+
+@pytest.mark.parametrize(
+    "greeting, expected",
+    [
+        (None, {"agent": {}}),
+        (GREETINGS[1], {"agent": {"text": "Thanks for calling Acme.", "uninterruptible": True}}),
+        (GREETINGS[2], {"agent": {"prompt": "Greet the caller warmly.", "uninterruptible": True}}),
+    ],
+)
+def test_ultravox_first_leg_keeps_its_greeting(monkeypatch, greeting, expected):
+    monkeypatch.setenv("ULTRAVOX_API_KEY", "test-key")
+    params = _ultravox_one_shot_params(_agent(greeting=greeting), "sys", "ultravox-v0.7", text_output=False)
+    assert params.extra["firstSpeakerSettings"] == expected
+
+
+class _Stop(Exception):
+    """Ends the session build once the Ultravox params have been requested."""
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_build_voice_session_passes_the_handover_flag_to_ultravox(monkeypatch, flag):
+    seen = {}
+
+    def fake_params(agent, system_prompt, ultravox_model, *, text_output, handover=False):
+        seen["handover"] = handover
+        raise _Stop
+
+    monkeypatch.setattr(voice_session, "_ultravox_one_shot_params", fake_params)
+    with pytest.raises(_Stop):
+        asyncio.run(
+            voice_session.build_voice_session(
+                transport=None,
+                model_name="pipecat:ultravox/ultravox-v0.7",
+                agent=_agent(),
+                metadata={},
+                tools=[],
+                system_prompt="sys",
+                handover=flag,
+            )
+        )
+    assert seen == {"handover": flag}
+
+
+# --- the other models: CallSession._wire_greeting --------------------------------
+
+
+class _Transport:
+    """Records the event handlers that _wire_greeting registers."""
+
+    def __init__(self):
+        self.handlers = {}
+
+    def event_handler(self, name):
+        def register(fn):
+            self.handlers[name] = fn
+            return fn
+
+        return register
+
+
+class _Task:
+    def __init__(self):
+        self.frames = []
+
+    async def queue_frames(self, frames):
+        self.frames.extend(frames)
+
+
+def _opening_frames(agent: dict, mode: str, model_name: str, *, handover: bool):
+    """Wire the greeting for one generation, connect the client, and return the
+    frames queued for the opening turn (None when nothing was wired)."""
+    session = SimpleNamespace(_is_handover_generation=handover)
+    transport, task = _Transport(), _Task()
+
+    async def run():
+        await CallSession._wire_greeting(session, transport, task, agent, mode, model_name)
+        handler = transport.handlers.get("on_client_connected")
+        if handler is None:
+            return None
+        await handler(transport, object())
+        return task.frames
+
+    return asyncio.run(run())
+
+
+def _developer_text(frames) -> list[str]:
+    return [
+        m["content"]
+        for f in frames
+        if isinstance(f, LLMMessagesAppendFrame)
+        for m in f.messages
+        if m.get("role") == "developer"
+    ]
+
+
+@pytest.mark.parametrize(
+    "mode, model_name",
+    [
+        ("pipeline", "pipecat:openai/gpt-4o-mini"),
+        ("realtime", "pipecat:openai/gpt-realtime"),
+        ("realtime", "pipecat:openai/gpt-live-1"),
+    ],
+)
+@pytest.mark.parametrize("greeting", GREETINGS)
+def test_handover_generation_opens_with_the_handover_instruction(mode, model_name, greeting):
+    frames = _opening_frames(_agent(greeting=greeting), mode, model_name, handover=True)
+    assert _developer_text(frames) == [HANDOVER_OPENING_INSTRUCTION]
+    assert isinstance(frames[-1], LLMRunFrame)
+    # The greeting text is never spoken on a handover.
+    assert not any(isinstance(f, TTSSpeakFrame) for f in frames)
+
+
+def test_first_generation_keeps_the_pipeline_greeting_text():
+    frames = _opening_frames(
+        _agent(greeting=GREETINGS[1]), "pipeline", "pipecat:openai/gpt-4o-mini", handover=False
+    )
+    assert [type(f) for f in frames] == [TTSSpeakFrame]
+    assert frames[0].text == "Thanks for calling Acme."
+
+
+def test_first_generation_without_a_greeting_just_runs_the_llm():
+    frames = _opening_frames(_agent(), "realtime", "pipecat:openai/gpt-realtime", handover=False)
+    assert [type(f) for f in frames] == [LLMRunFrame]
+
+
+def test_first_generation_on_gpt_live_keeps_the_platform_opening():
+    frames = _opening_frames(_agent(), "realtime", "pipecat:openai/gpt-live-1", handover=False)
+    assert _developer_text(frames) == [gpt_live.OPENING_INSTRUCTION]
+
+
+@pytest.mark.parametrize("handover", [True, False])
+def test_ultravox_wires_no_frames(handover):
+    # Ultravox takes its first turn natively at call creation (tests above).
+    frames = _opening_frames(_agent(), "realtime", "pipecat:ultravox/ultravox-v0.7", handover=handover)
+    assert frames is None

--- a/docs/gpt-live.md
+++ b/docs/gpt-live.md
@@ -231,7 +231,7 @@ Aplisay's label.
 | `inactivity` | Idle detection unchanged. The prompt is delivered as spoken context, so it is paraphrased. Repeat count and `hangup` unchanged. |
 | `maxDuration` | Unchanged. |
 | `dtmfTimeout`, `dtmfTerminator` | Digits go to the backend as typed input and to the voice model as context. In client delegation they are prepended to the next delegation's input. |
-| `transfer_agent` | Always a full restart of the agent stack with the transcript carried into the new agent. |
+| `transfer_agent` | Always a full restart of the agent stack with the transcript carried into the new agent. The incoming agent's greeting is not used: it opens with an instruction to introduce itself and continue the call. |
 | `transfer`, bridged transfers, `recording`, `stt.aux`, `tts.output` | Unchanged. |
 | `tts.language`, `stt.language` | Appended to the voice instructions as the language to speak. |
 | `temperature` | Ignored. The Live API takes no temperature for either layer. |

--- a/docs/livekit-agent-architecture.md
+++ b/docs/livekit-agent-architecture.md
@@ -257,6 +257,8 @@ The two keys are mutually exclusive; exactly one of `text` or `instructions` may
 
 The greeting contract is mode-independent. Implementations may differ in how the behavior lands per provider — for example Ultravox realtime drives uninterruptible greetings via its native `firstSpeakerSettings`, while other realtime providers and pipeline mode use TTS `say()` or LLM `generateReply` with explicit interruption suppression — but the contract is the behavior, not the mechanism.
 
+After a `transfer_agent` full-stack handover the caller has already been greeted, so the Pipecat worker does not use the incoming agent's greeting. Its first turn is a platform instruction to introduce itself and continue from the handover summary and the conversation so far (on Ultravox, sent as `firstSpeakerSettings.agent.prompt`). The LiveKit worker still asks the incoming agent to greet the caller according to its instructions.
+
 ### 4.6 Vendor-specific passthrough
 
 Some provider knobs are not normalised across the runtime abstraction. The LiveKit implementation surfaces these via a free-form `vendorSpecific` object on `agent.options`, passed through to the underlying model unchanged.

--- a/docs/livekit-agent-architecture.md
+++ b/docs/livekit-agent-architecture.md
@@ -257,7 +257,7 @@ The two keys are mutually exclusive; exactly one of `text` or `instructions` may
 
 The greeting contract is mode-independent. Implementations may differ in how the behavior lands per provider — for example Ultravox realtime drives uninterruptible greetings via its native `firstSpeakerSettings`, while other realtime providers and pipeline mode use TTS `say()` or LLM `generateReply` with explicit interruption suppression — but the contract is the behavior, not the mechanism.
 
-After a `transfer_agent` full-stack handover the caller has already been greeted, so the Pipecat worker does not use the incoming agent's greeting. Its first turn is a platform instruction to introduce itself and continue from the handover summary and the conversation so far (on Ultravox, sent as `firstSpeakerSettings.agent.prompt`). The LiveKit worker still asks the incoming agent to greet the caller according to its instructions.
+After a `transfer_agent` handover, in place or full-stack, the caller has already been greeted, so the Pipecat worker does not use the incoming agent's greeting. Its first turn is a platform instruction to introduce itself and continue from the handover summary and the conversation so far (on Ultravox, sent as `firstSpeakerSettings.agent.prompt`). The LiveKit worker still asks the incoming agent to greet the caller according to its instructions.
 
 ### 4.6 Vendor-specific passthrough
 

--- a/docs/multi-agent-api.md
+++ b/docs/multi-agent-api.md
@@ -116,8 +116,8 @@ Common to both modes:
 - The audio connection is uninterrupted — the caller stays on the same call throughout.
 - The new agent speaks next, so write its prompt to introduce itself on taking over.
   On Pipecat the new agent's greeting is not used, because the caller has already been
-  greeted. After a full-stack handover the agent is told to introduce itself briefly and
-  continue from the handover summary and the conversation so far.
+  greeted. The platform tells the agent to introduce itself briefly and continue from the
+  handover summary and the conversation so far.
 - The progress log (websocket / transaction log) records an `inject` entry of the form
   `Call transferred to agent <name>` so monitoring UIs can show the handover.
 - Transfers chain: the incoming agent's own `transfer_agent` functions work, so a caller

--- a/docs/multi-agent-api.md
+++ b/docs/multi-agent-api.md
@@ -115,6 +115,9 @@ Common to both modes:
 
 - The audio connection is uninterrupted — the caller stays on the same call throughout.
 - The new agent speaks next, so write its prompt to introduce itself on taking over.
+  On Pipecat the new agent's greeting is not used, because the caller has already been
+  greeted. After a full-stack handover the agent is told to introduce itself briefly and
+  continue from the handover summary and the conversation so far.
 - The progress log (websocket / transaction log) records an `inject` entry of the form
   `Call transferred to agent <name>` so monitoring UIs can show the handover.
 - Transfers chain: the incoming agent's own `transfer_agent` functions work, so a caller

--- a/docs/release-notes/changes-since-0.9.53.md
+++ b/docs/release-notes/changes-since-0.9.53.md
@@ -207,6 +207,12 @@ Pipecat), and **ci** (build and release pipeline).
   the advertised roster.
 - **[core] OpenAI hosted-MCP replay** now retains completed MCP results by
   rewriting them as function-call/output pairs on stateless replay.
+- **[pipecat] Agent handover opening**: after a `transfer_agent` full-stack
+  handover the incoming agent no longer greets the caller as if the call were
+  new. Its greeting is not used; it opens with an instruction to introduce
+  itself and continue from the handover summary and conversation so far. On
+  Ultravox this replaces the default first turn, which told the model to answer
+  as a new call.
 
 ## GPT-Live - core + pipecat
 

--- a/docs/release-notes/changes-since-0.9.53.md
+++ b/docs/release-notes/changes-since-0.9.53.md
@@ -207,9 +207,9 @@ Pipecat), and **ci** (build and release pipeline).
   the advertised roster.
 - **[core] OpenAI hosted-MCP replay** now retains completed MCP results by
   rewriting them as function-call/output pairs on stateless replay.
-- **[pipecat] Agent handover opening**: after a `transfer_agent` full-stack
-  handover the incoming agent no longer greets the caller as if the call were
-  new. Its greeting is not used; it opens with an instruction to introduce
+- **[pipecat] Agent handover opening**: after a `transfer_agent` handover, in
+  place or full-stack, the incoming agent no longer greets the caller as if the
+  call were new. Its greeting is not used; it opens with an instruction to introduce
   itself and continue from the handover summary and conversation so far. On
   Ultravox this replaces the default first turn, which told the model to answer
   as a new call.


### PR DESCRIPTION
## Problem

After a `transfer_agent` handover, the incoming agent's first turn was set up as if the call were new.

- **Ultravox:** `_ultravox_one_shot_params` sent `firstSpeakerSettings: {"agent": {}}` (or the target's greeting). Ultravox then starts the turn with its own user message, "(New Call) Respond as if you are answering the phone.", which overrides the handover summary and transcript in the system prompt. The new agent greets the caller as a new call and often repeats the previous agent's opening line.
- **Other models:** `CallSession._wire_greeting` did not know the generation was a handover. A target with `greeting.text` spoke it again, and a GPT-Live target was told "Greet the caller and ask how you can help." An in-place swap ran the new agent's first turn with no opening instruction at all.

`CallSession._is_handover_generation` was already set for the handover generation, but only the pipeline error alarm read it.

## Change

- New `transfer_prompts.HANDOVER_OPENING_INSTRUCTION`, worded as the incoming agent's first message after taking over: the caller has been greeted, so the agent introduces itself in one sentence and continues from the handover summary and the conversation so far, or asks how it can help if it has neither. It is worded for the first message because on most paths it stays in the context for the rest of the call.
- **Full-stack handover:** a `handover` flag goes from `_prepare_run_inner` through `build_voice_session` and `_build_realtime` to `_ultravox_one_shot_params`. On a handover leg Ultravox gets `firstSpeakerSettings: {"agent": {"prompt": HANDOVER_OPENING_INSTRUCTION}}` (interruptible), and the target's greeting is not used. On the other models, `_wire_greeting` queues the instruction as a developer message plus `LLMRunFrame` (on GPT-Live, as its opening instruction) instead of the greeting.
- **In-place handover:** `_apply_agent_transfer` adds the instruction as a second developer message after the new system prompt.
- First legs are unchanged.
- Docs: `multi-agent-api.md`, `gpt-live.md`, the greeting contract in `livekit-agent-architecture.md`, and the draft release notes.

## Testing

- New `agents/pipecat/tests/test_handover_opening.py` (26 tests):
  - Ultravox params with and without a greeting, and in text-output mode.
  - The flag reaching `_ultravox_one_shot_params` from `build_voice_session`.
  - A real `run_prepared` handover continuation building with `handover=True`, and a first build with `False`. With the `handover=` argument removed from `_prepare_run_inner`, both fail.
  - `_wire_greeting` on pipeline, OpenAI Realtime and GPT-Live models, and first-leg behaviour unchanged.
  - The in-place swap queueing the instruction after the new prompt.
- Pipecat suite: 543 passed, 1 skipped. DB jest suite: 104 suites, 1147 tests passed.
- Live Ultravox A/B test with the same handover system prompt:
  - `{"agent": {}}` (before), 2 calls: Ultravox inserted "(New Call) Respond as if you are answering the phone." and the agent repeated the previous agent's greeting word for word, both times.
  - `{"agent": {"prompt": HANDOVER_OPENING_INSTRUCTION}}`, 4 calls (2 for each wording of the instruction): no "(New Call)" message. The agent introduced itself and restated the caller's need from the summary every time.

## Not covered

- The LiveKit worker: its Ultravox handover still greets natively through `firstSpeakerSettings`, and its other stacks are told to "Greet the caller now according to your instructions."
- Human-to-agent takeover sessions (`setup_takeover_call`) are fresh sessions and still use the target's greeting.
- When the target agent has a greeting configured, the greeting mute (and GPT-Live's caller silence during a greeting) still covers the handover opening, so the caller cannot interrupt it. This is the same as before, when it covered the greeting.
