### PR TITLE
Hand-off Google sign-in: let the starter decide whether it may sign up

### DIFF
--- a/lib/auth/handoff-signup.js
+++ b/lib/auth/handoff-signup.js
@@ -1,0 +1,59 @@
+/**
+ * Whether a Google sign-in started through the hand-off may create an account.
+ *
+ * The hand-off start (lib/auth/oauth-handoff.js) is how a client system sends a
+ * browser to Google. That client decides whether the sign-in may create a new
+ * account: `?signup=1` on the start URL allows it. Without it, a Google account
+ * with no user here is refused before any row is written, and better-auth sends
+ * the browser to the errorCallbackURL with `?error=signup_disabled`, the same
+ * code its own `disableSignUp` option uses.
+ *
+ * The choice rides the OAuth state as `additionalData` and is read back by a
+ * user `create.before` database hook (lib/auth/index.js). better-auth treats
+ * additionalData as caller-supplied, and that is fine here: the flag can only
+ * REFUSE, only in the flow that carries it, and a caller that leaves it out
+ * gets the implicit sign-up every direct sign-in/social caller already has.
+ * Sign-ins started any other way are not affected.
+ */
+
+/** OAuth-state key the hand-off start sets (in additionalData). */
+export const HANDOFF_SIGNUP_KEY = 'handoffSignUp';
+
+/** Error code the browser is sent back with; the same as better-auth's own. */
+export const SIGNUP_DISABLED_CODE = 'signup_disabled';
+
+/** True when the hand-off start was asked to allow sign-up (`?signup=1`). */
+export function signUpRequested(query) {
+  return query?.signup === '1';
+}
+
+/** True when this OAuth state belongs to a hand-off sign-in that may not create an account. */
+export function refusesSignUp(state) {
+  return state != null && state[HANDOFF_SIGNUP_KEY] === false;
+}
+
+/**
+ * The user `create.before` database hook. `getOAuthState` and `APIError` come
+ * from better-auth/api; they are passed in so tests can drive the hook.
+ *
+ * It throws rather than returning false. better-auth turns a false into a
+ * generic "unable to create user", but it rethrows an APIError, and its OAuth
+ * callback sends an APIError's `code` to the errorCallbackURL.
+ */
+export function createHandoffSignUpHook({ getOAuthState, APIError }) {
+  return async function refuseHandoffSignUp() {
+    let state = null;
+    try {
+      state = await getOAuthState();
+    } catch {
+      // No request state: this is not an OAuth request, so there is nothing to refuse.
+      state = null;
+    }
+    if (refusesSignUp(state)) {
+      throw new APIError('FORBIDDEN', {
+        code: SIGNUP_DISABLED_CODE,
+        message: 'Sign-up is not allowed for this sign-in',
+      });
+    }
+  };
+}

--- a/lib/auth/index.js
+++ b/lib/auth/index.js
@@ -49,12 +49,13 @@ let auth = null;
 if (enabled) {
   const { betterAuth } = await import('better-auth');
   const { bearer, oneTimeToken } = await import('better-auth/plugins');
-  const { createAuthMiddleware, APIError } = await import('better-auth/api');
+  const { createAuthMiddleware, APIError, getOAuthState } = await import('better-auth/api');
   const { Pool } = await import('pg');
   const { createEmailClient } = await import('@aplisay/email');
   const { createSendBudget } = await import('./send-budget.js');
   const { createSendHooks } = await import('./email-hooks.js');
   const { loadBrands } = await import('./email-brands.js');
+  const { createHandoffSignUpHook } = await import('./handoff-signup.js');
 
   if (!BETTER_AUTH_SECRET) {
     logger.error('BETTER_AUTH_ENABLED=true but BETTER_AUTH_SECRET is unset — refusing to boot with broken token signing');
@@ -286,6 +287,19 @@ if (enabled) {
       accountLinking: {
         enabled: true,
         trustedProviders: ['google'],
+      },
+    },
+
+    // A Google sign-in started through the hand-off (lib/auth/oauth-handoff.js)
+    // creates an account only when the client that started it asked for one
+    // (?signup=1 on the start URL). The refusal happens here, before the user
+    // row is written. Every other sign-in path is unchanged. See
+    // lib/auth/handoff-signup.js.
+    databaseHooks: {
+      user: {
+        create: {
+          before: createHandoffSignUpHook({ getOAuthState, APIError }),
+        },
       },
     },
 

--- a/lib/auth/oauth-handoff.js
+++ b/lib/auth/oauth-handoff.js
@@ -27,11 +27,17 @@
  *    better-auth's state → this query param → the form body, and compared
  *    against polite-ai's httpOnly cookie). It is validated to a strict charset
  *    before being echoed into HTML.
+ *  - Sign-up is the starter's choice. `?signup=1` on the first hop lets the
+ *    sign-in create an account for a Google user we do not have. Without it,
+ *    that sign-in is refused before any user row is written, and the browser
+ *    goes to the errorCallbackURL with ?error=signup_disabled. See
+ *    lib/auth/handoff-signup.js.
  *  - Failures never strand the browser on this domain: they redirect to the
  *    polite-ai login page with a coarse error code.
  */
 import { auth } from './index.js';
 import { fromNodeHeaders } from 'better-auth/node';
+import { HANDOFF_SIGNUP_KEY, signUpRequested } from './handoff-signup.js';
 
 const CALLBACK_PATH = '/auth/google/callback';
 const NONCE_RE = /^[A-Za-z0-9_-]{16,128}$/;
@@ -49,8 +55,11 @@ function politeOrigin() {
 const escapeHtml = (s) =>
   String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 
-export default function mountOauthHandoff(server, logger, { limiter } = {}) {
-  if (!auth) return;
+/**
+ * `auth` defaults to the configured better-auth instance; tests pass their own.
+ */
+export default function mountOauthHandoff(server, logger, { limiter, auth: authInstance = auth } = {}) {
+  if (!authInstance) return;
   const origin = politeOrigin();
   if (!origin) {
     logger.error(
@@ -62,7 +71,10 @@ export default function mountOauthHandoff(server, logger, { limiter } = {}) {
   const loginError = (code) => `${origin}/login?error=${code}`;
 
   /**
-   * FIRST hop — GET /api/oauth-handoff/start?nonce=…
+   * FIRST hop — GET /api/oauth-handoff/start?nonce=…[&signup=1]
+   *
+   * `signup=1` allows this sign-in to create an account (see
+   * lib/auth/handoff-signup.js); without it only existing users can sign in.
    *
    * The browser must navigate THROUGH this origin to initiate: better-auth's
    * OAuth callback double-submit-checks a signed `state` cookie it sets on the
@@ -85,7 +97,7 @@ export default function mountOauthHandoff(server, logger, { limiter } = {}) {
     }
 
     try {
-      const { headers, response } = await auth.api.signInSocial({
+      const { headers, response } = await authInstance.api.signInSocial({
         body: {
           provider: 'google',
           // Relative → resolves against our own baseURL at the callback 302;
@@ -93,6 +105,9 @@ export default function mountOauthHandoff(server, logger, { limiter } = {}) {
           callbackURL: `/api/oauth-handoff?nonce=${nonce}`,
           errorCallbackURL: `${origin}${CALLBACK_PATH}`,
           disableRedirect: true,
+          // Whether this sign-in may create an account (?signup=1). The user
+          // create hook reads it back; see lib/auth/handoff-signup.js.
+          additionalData: { [HANDOFF_SIGNUP_KEY]: signUpRequested(req.query) },
         },
         returnHeaders: true,
       });
@@ -124,7 +139,7 @@ export default function mountOauthHandoff(server, logger, { limiter } = {}) {
       // moments ago by the OAuth callback on this same origin). No session →
       // better-auth throws UNAUTHORIZED. disableClientRequest does not apply
       // to server-side api calls, so only this route can mint tokens.
-      ({ token } = await auth.api.generateOneTimeToken({ headers: fromNodeHeaders(req.headers) }));
+      ({ token } = await authInstance.api.generateOneTimeToken({ headers: fromNodeHeaders(req.headers) }));
     } catch (err) {
       logger.warn({ err: err?.message, status: err?.status }, 'oauth-handoff: no session / generate failed');
       return res.redirect(302, loginError('oauth_retry'));

--- a/tests/oauth-handoff-signup.test.mjs
+++ b/tests/oauth-handoff-signup.test.mjs
@@ -1,0 +1,213 @@
+// Sign-up control for Google sign-ins started through the hand-off
+// (lib/auth/handoff-signup.js and lib/auth/oauth-handoff.js). No DB needed:
+// the end-to-end part runs a real better-auth instance on its memory adapter,
+// with only Google's token endpoint and profile faked.
+//
+// What must hold:
+//   - /api/oauth-handoff/start asks for sign-up only with ?signup=1;
+//   - a hand-off sign-in that did not ask is refused before any user, account
+//     or session row exists, and the browser goes to errorCallbackURL with
+//     ?error=signup_disabled;
+//   - an existing user still signs in, and sign-ins started any other way
+//     (and email sign-up) are untouched.
+import { jest } from '@jest/globals';
+import { betterAuth } from 'better-auth';
+import { memoryAdapter } from 'better-auth/adapters/memory';
+import { APIError, getOAuthState } from 'better-auth/api';
+import {
+  HANDOFF_SIGNUP_KEY,
+  SIGNUP_DISABLED_CODE,
+  createHandoffSignUpHook,
+  refusesSignUp,
+  signUpRequested,
+} from '../lib/auth/handoff-signup.js';
+
+const quietLogger = { info() { }, warn() { }, error() { } };
+
+describe('handoff-signup helpers', () => {
+  it('reads only signup=1 as a request for sign-up', () => {
+    expect(signUpRequested({ signup: '1' })).toBe(true);
+    for (const signup of [undefined, '', '0', 'true', 'yes', ['1', '1']]) {
+      expect(signUpRequested({ signup })).toBe(false);
+    }
+    expect(signUpRequested(undefined)).toBe(false);
+  });
+
+  it('refuses only a state that says no', () => {
+    expect(refusesSignUp({ [HANDOFF_SIGNUP_KEY]: false })).toBe(true);
+    expect(refusesSignUp({ [HANDOFF_SIGNUP_KEY]: true })).toBe(false);
+    expect(refusesSignUp({})).toBe(false);
+    expect(refusesSignUp(null)).toBe(false);
+    expect(refusesSignUp(undefined)).toBe(false);
+  });
+
+  it('lets the hook pass when there is no request state at all', async () => {
+    const hook = createHandoffSignUpHook({
+      getOAuthState: async () => { throw new Error('No request state found'); },
+      APIError,
+    });
+    await expect(hook()).resolves.toBeUndefined();
+  });
+});
+
+describe('hand-off start: who may sign up', () => {
+  let mountOauthHandoff;
+  beforeAll(async () => {
+    // Keep lib/auth/index.js inert: this test brings its own auth instance.
+    process.env.BETTER_AUTH_ENABLED = 'false';
+    process.env.POLITE_SITE_URL = 'https://client.example';
+    ({ default: mountOauthHandoff } = await import('../lib/auth/oauth-handoff.js'));
+  });
+
+  function response() {
+    const out = { cookies: [] };
+    out.set = () => out;
+    out.append = (_name, value) => { out.cookies.push(value); return out; };
+    out.redirect = (code, url) => { out.code = code; out.location = url; return out; };
+    return out;
+  }
+
+  async function start(query) {
+    const signInSocial = jest.fn(async () => ({
+      headers: new Headers(),
+      response: { url: 'https://accounts.google.com/o/oauth2/v2/auth?state=s' },
+    }));
+    const routes = {};
+    const server = { get: (path, ...handlers) => { routes[path] = handlers.at(-1); } };
+    mountOauthHandoff(server, quietLogger, { auth: { api: { signInSocial } } });
+    const res = response();
+    await routes['/api/oauth-handoff/start']({ query: { nonce: 'n'.repeat(32), ...query }, originalUrl: '/start' }, res);
+    return { body: signInSocial.mock.calls[0]?.[0]?.body, res };
+  }
+
+  it('asks for no sign-up by default', async () => {
+    const { body, res } = await start({});
+    expect(body.additionalData).toEqual({ [HANDOFF_SIGNUP_KEY]: false });
+    expect(res.code).toBe(302);
+    expect(res.location).toMatch(/^https:\/\/accounts\.google\.com\//);
+  });
+
+  it('asks for sign-up with signup=1', async () => {
+    const { body } = await start({ signup: '1' });
+    expect(body.additionalData).toEqual({ [HANDOFF_SIGNUP_KEY]: true });
+  });
+
+  it('treats any other signup value as no', async () => {
+    const { body } = await start({ signup: 'true' });
+    expect(body.additionalData).toEqual({ [HANDOFF_SIGNUP_KEY]: false });
+  });
+});
+
+describe('better-auth end to end: the Google callback', () => {
+  const realFetch = globalThis.fetch;
+  let profileEmail = 'new@example.com';
+
+  beforeAll(() => {
+    // Google's token endpoint is the only network call the callback makes; the
+    // profile comes from the getUserInfo override below.
+    globalThis.fetch = async (input, init) => {
+      // better-fetch hands over a URL object, not a string.
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith('https://oauth2.googleapis.com/token')) {
+        return new Response(
+          JSON.stringify({ access_token: 'access', expires_in: 3600, token_type: 'Bearer', scope: 'openid email profile' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return realFetch(input, init);
+    };
+  });
+  afterAll(() => { globalThis.fetch = realFetch; });
+
+  function makeAuth() {
+    const db = { user: [], session: [], account: [], verification: [] };
+    const auth = betterAuth({
+      baseURL: 'http://localhost:4000',
+      basePath: '/api/auth',
+      secret: 'handoff-signup-test-secret-0123456789abcdef',
+      database: memoryAdapter(db),
+      trustedOrigins: ['https://client.example'],
+      logger: { disabled: true },
+      emailAndPassword: { enabled: true },
+      socialProviders: {
+        google: {
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+          getUserInfo: async () => ({
+            user: { id: `sub-${profileEmail}`, email: profileEmail, name: 'Test Person', emailVerified: true },
+            data: { sub: `sub-${profileEmail}`, email: profileEmail, email_verified: true, name: 'Test Person' },
+          }),
+        },
+      },
+      account: { accountLinking: { enabled: true, trustedProviders: ['google'] } },
+      databaseHooks: {
+        user: { create: { before: createHandoffSignUpHook({ getOAuthState, APIError }) } },
+      },
+    });
+    return { auth, db };
+  }
+
+  async function signInWithGoogle(auth, email, additionalData) {
+    profileEmail = email;
+    const { headers, response } = await auth.api.signInSocial({
+      body: {
+        provider: 'google',
+        callbackURL: '/after',
+        errorCallbackURL: 'https://client.example/cb',
+        disableRedirect: true,
+        ...(additionalData ? { additionalData } : {}),
+      },
+      returnHeaders: true,
+    });
+    const state = new URL(response.url).searchParams.get('state');
+    const cookie = headers.getSetCookie().map((c) => c.split(';')[0]).join('; ');
+    const res = await auth.handler(new Request(
+      `http://localhost:4000/api/auth/callback/google?code=code-1&state=${encodeURIComponent(state)}`,
+      { headers: { cookie } },
+    ));
+    return { status: res.status, location: res.headers.get('location') };
+  }
+
+  it('refuses a new account when the hand-off did not ask for sign-up', async () => {
+    const { auth, db } = makeAuth();
+    const out = await signInWithGoogle(auth, 'new@example.com', { [HANDOFF_SIGNUP_KEY]: false });
+    expect(out.status).toBe(302);
+    const where = new URL(out.location);
+    expect(where.origin + where.pathname).toBe('https://client.example/cb');
+    expect(where.searchParams.get('error')).toBe(SIGNUP_DISABLED_CODE);
+    expect(db.user).toHaveLength(0);
+    expect(db.account).toHaveLength(0);
+    expect(db.session).toHaveLength(0);
+  });
+
+  it('creates the account when the hand-off asked for sign-up', async () => {
+    const { auth, db } = makeAuth();
+    const out = await signInWithGoogle(auth, 'invited@example.com', { [HANDOFF_SIGNUP_KEY]: true });
+    expect(out.status).toBe(302);
+    expect(out.location).toMatch(/\/after$/);
+    expect(db.user.map((u) => u.email)).toEqual(['invited@example.com']);
+  });
+
+  it('still signs in an existing user when sign-up was not asked for', async () => {
+    const { auth, db } = makeAuth();
+    const now = new Date();
+    db.user.push({ id: 'existing-user', email: 'known@example.com', emailVerified: true, name: 'Known', createdAt: now, updatedAt: now });
+    const out = await signInWithGoogle(auth, 'known@example.com', { [HANDOFF_SIGNUP_KEY]: false });
+    expect(out.location).toMatch(/\/after$/);
+    expect(db.user).toHaveLength(1);
+    expect(db.account.map((a) => a.userId)).toEqual(['existing-user']);
+  });
+
+  it('leaves a sign-in started any other way alone', async () => {
+    const { auth, db } = makeAuth();
+    const out = await signInWithGoogle(auth, 'direct@example.com');
+    expect(out.location).toMatch(/\/after$/);
+    expect(db.user.map((u) => u.email)).toEqual(['direct@example.com']);
+  });
+
+  it('leaves email sign-up alone', async () => {
+    const { auth, db } = makeAuth();
+    await auth.api.signUpEmail({ body: { email: 'mail@example.com', password: 'a-long-password-1', name: 'Mail' } });
+    expect(db.user.map((u) => u.email)).toEqual(['mail@example.com']);
+  });
+});


### PR DESCRIPTION
A client system that starts a Google sign-in through the hand-off can now say
whether that sign-in may create an account.

`GET /api/oauth-handoff/start?nonce=...&signup=1` allows sign-up. Without
`signup=1`, a Google account that has no user here is refused **before any user
row is written**, and better-auth redirects the browser to the caller's
`errorCallbackURL` with `?error=signup_disabled` (its own code for a refused
sign-up).

## How

- `lib/auth/handoff-signup.js` (new): the flag, the error code, and the
  `user.create.before` database hook that enforces it.
- `lib/auth/oauth-handoff.js`: the start hop puts the flag in the OAuth state
  (`additionalData`), and takes an `auth` option so tests can drive it.
- `lib/auth/index.js`: registers the hook in `databaseHooks`.

The flag only ever REFUSES, and only in the flow that carries it. A sign-in
started any other way (a direct `POST /api/auth/sign-in/social`), and email
sign-up, behave exactly as before: implicit sign-up still applies to them.

## Tests

`tests/oauth-handoff-signup.test.mjs`, no database needed:

- the helpers (only `signup=1` counts, only a state that says no refuses);
- what the start hop puts in the state, by intercepting `signInSocial`;
- a real better-auth instance on the memory adapter driven through the Google
  callback: refused with zero user, account and session rows and the
  `signup_disabled` redirect; created when `signup=1`; an existing user still
  signs in and links; a direct sign-in and an email sign-up untouched.

Also run: the four existing `auth-*` suites (61 tests green), and a boot smoke
check that the auth config still builds with the hook attached.

## Deploy

Deploy the client that sets `signup=1` first. An older client sends no flag, so
this build would refuse sign-ups it used to allow; a newer client against an
older build just sends a query parameter that is ignored.
